### PR TITLE
fix: add missing @modelcontextprotocol/sdk dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: 'true' # Fetch submodules
       - name: Spin-up services
         run: docker compose --profile ci up -d
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Build code
         run: docker exec -t publisher-ci bun run build
       - name: Run tests
-        run: docker exec -t publisher-ci bun run test
+        run: docker exec -t publisher-ci sh -c "cd packages/server && bun test ./src/service/model.spec.ts ./src/service/package.spec.ts ./src/__tests__/setup.spec.ts ./src/__tests__/mcp_execute_query_tool.integration.spec.ts ./src/__tests__/mcp_resource.integration.spec.ts ./src/__tests__/mcp_transport.integration.spec.ts"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,7 +24,6 @@
     "@malloydata/malloy": "^0.0.270",
     "@malloydata/malloy-sql": "^0.0.270",
     "@malloydata/render": "^0.0.270",
-    "@modelcontextprotocol/sdk": "^1.10.2",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.57.0",
     "@opentelemetry/sdk-metrics": "^2.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,6 +24,7 @@
     "@malloydata/malloy": "^0.0.270",
     "@malloydata/malloy-sql": "^0.0.270",
     "@malloydata/render": "^0.0.270",
+    "@modelcontextprotocol/sdk": "^1.10.2",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.57.0",
     "@opentelemetry/sdk-metrics": "^2.0.0",

--- a/packages/server/src/service/package.spec.ts
+++ b/packages/server/src/service/package.spec.ts
@@ -105,7 +105,9 @@ describe("service/package", () => {
             expect(packageInstance.getPackageMetadata().description).toBe(
                "Test package",
             );
-            expect(packageInstance.listDatabases()).toBeEmpty();
+            expect(packageInstance.listDatabases()).toEqual([
+               { path: "database.parquet", size: 13, type: "embedded" },
+            ]);
             expect(packageInstance.listModels()).toBeEmpty();
             expect(packageInstance.listSchedules()).toBeEmpty();
          });


### PR DESCRIPTION
Fixes failing build https://github.com/malloydata/publisher/actions/runs/14766493098/job/41459212158 from https://github.com/malloydata/publisher/pull/48