### PR TITLE
Update app -> SDK dep so HMR works

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
     "generate-api-types": ""
   },
   "dependencies": {
-    "@malloy-publisher/sdk": "^0.0.8",
+    "@malloy-publisher/sdk": "workspace:*",
     "@mui/icons-material": "^7.0.2",
     "@mui/material": "^7.0.2",
     "@vitejs/plugin-react": "^4.3.1",

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -4,16 +4,18 @@ import path from 'path';
 
 // https://vitejs.dev/config/
 export default ({ mode }) => {
+   const isDev = mode === "development";
+      // In Dev, Resolve the SDK locally as src, not /dist so it can hot reload
+      const resolve = isDev ? {
+      alias: {
+         '@malloy-publisher/sdk': path.resolve(__dirname, '../sdk/src'),
+      },
+   } : undefined;
    return defineConfig({
       plugins: [react()],
       define: {
          "process.env": JSON.stringify(mode),
       },
-      // Resolve the SDK locally as src, not /dist so it can hot reload
-      resolve: {
-         alias: {
-             '@malloy-publisher/sdk': path.resolve(__dirname, '../sdk/src'),
-         },
-     },
+      resolve
    });
 };

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import path from 'path';
 
 // https://vitejs.dev/config/
 export default ({ mode }) => {
@@ -8,5 +9,11 @@ export default ({ mode }) => {
       define: {
          "process.env": JSON.stringify(mode),
       },
+      // Resolve the SDK locally as src, not /dist so it can hot reload
+      resolve: {
+         alias: {
+             '@malloy-publisher/sdk': path.resolve(__dirname, '../sdk/src'),
+         },
+     },
    });
 };


### PR DESCRIPTION
`packages/app` now explicitly depends on `/sdk/src` in dev mode, so Hot reloading works (and the SDK code is not obfuscated)