### PR TITLE
Fix: Revert getQuery change and apply lint fixes

### DIFF
--- a/packages/server/src/__tests__/mcp_test_setup.ts
+++ b/packages/server/src/__tests__/mcp_test_setup.ts
@@ -32,7 +32,7 @@ export async function setupE2ETestEnvironment(): Promise<McpE2ETestEnvironment> 
    // The ProjectStore relies on SERVER_ROOT to find publisher.config.json.
    originalServerRoot = process.env.SERVER_ROOT; // Store original value
    // Resolve the path to 'packages/server' based on the location of this file (__dirname)
-   const serverPackageDir = path.resolve(__dirname, '../../'); // Go up two levels from .../packages/server/src/__tests__
+   const serverPackageDir = path.resolve(__dirname, "../../"); // Go up two levels from .../packages/server/src/__tests__
    process.env.SERVER_ROOT = serverPackageDir;
    console.log(
       `[E2E Test Setup] Temporarily set SERVER_ROOT=${process.env.SERVER_ROOT}`,

--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -3,324 +3,323 @@
  * Do not make direct changes to the file.
  */
 
-
 export interface paths {
-  "/projects": {
-    /** Returns a list of the Projects hosted on this server. */
-    get: operations["list-projects"];
-  };
-  "/projects/{projectName}": {
-    /** Returns metadata about the project. */
-    get: operations["get-project"];
-  };
-  "/projects/{projectName}/connections": {
-    /** Returns a list of the connections in the project. */
-    get: operations["list-connections"];
-  };
-  "/projects/{projectName}/connections/{connectionName}": {
-    /** Returns a connection. */
-    get: operations["get-connection"];
-  };
-  "/projects/{projectName}/connections/{connectionName}/test": {
-    /** Returns a test. */
-    get: operations["get-test"];
-  };
-  "/projects/{projectName}/connections/{connectionName}/sqlSource": {
-    /** Returns a SQL source. */
-    get: operations["get-sqlsource"];
-  };
-  "/projects/{projectName}/connections/{connectionName}/tableSource": {
-    /** Returns a table source. */
-    get: operations["get-tablesource"];
-  };
-  "/projects/{projectName}/connections/{connectionName}/queryData": {
-    /** Returns a query and its results. */
-    get: operations["get-querydata"];
-  };
-  "/projects/{projectName}/connections/{connectionName}/temporaryTable": {
-    /** Returns a temporary table. */
-    get: operations["get-temporarytable"];
-  };
-  "/projects/{projectName}/packages": {
-    /** Returns a list of the Packages hosted on this server. */
-    get: operations["list-packages"];
-  };
-  "/projects/{projectName}/packages/{packageName}": {
-    /** Returns the package metadata. */
-    get: operations["get-package"];
-  };
-  "/projects/{projectName}/packages/{packageName}/models": {
-    /** Returns a list of relative paths to the models in the package. */
-    get: operations["list-models"];
-  };
-  "/projects/{projectName}/packages/{packageName}/models/{path}": {
-    /** Returns a Malloy model. */
-    get: operations["get-model"];
-  };
-  "/projects/{projectName}/packages/{packageName}/queryResults/{path}": {
-    /** Returns a query and its results. */
-    get: operations["execute-query"];
-  };
-  "/projects/{projectName}/packages/{packageName}/databases": {
-    /** Returns a list of relative paths to the databases embedded in the package. */
-    get: operations["list-databases"];
-  };
-  "/projects/{projectName}/packages/{packageName}/schedules": {
-    /** Returns a list of running schedules. */
-    get: operations["list-schedules"];
-  };
+   "/projects": {
+      /** Returns a list of the Projects hosted on this server. */
+      get: operations["list-projects"];
+   };
+   "/projects/{projectName}": {
+      /** Returns metadata about the project. */
+      get: operations["get-project"];
+   };
+   "/projects/{projectName}/connections": {
+      /** Returns a list of the connections in the project. */
+      get: operations["list-connections"];
+   };
+   "/projects/{projectName}/connections/{connectionName}": {
+      /** Returns a connection. */
+      get: operations["get-connection"];
+   };
+   "/projects/{projectName}/connections/{connectionName}/test": {
+      /** Returns a test. */
+      get: operations["get-test"];
+   };
+   "/projects/{projectName}/connections/{connectionName}/sqlSource": {
+      /** Returns a SQL source. */
+      get: operations["get-sqlsource"];
+   };
+   "/projects/{projectName}/connections/{connectionName}/tableSource": {
+      /** Returns a table source. */
+      get: operations["get-tablesource"];
+   };
+   "/projects/{projectName}/connections/{connectionName}/queryData": {
+      /** Returns a query and its results. */
+      get: operations["get-querydata"];
+   };
+   "/projects/{projectName}/connections/{connectionName}/temporaryTable": {
+      /** Returns a temporary table. */
+      get: operations["get-temporarytable"];
+   };
+   "/projects/{projectName}/packages": {
+      /** Returns a list of the Packages hosted on this server. */
+      get: operations["list-packages"];
+   };
+   "/projects/{projectName}/packages/{packageName}": {
+      /** Returns the package metadata. */
+      get: operations["get-package"];
+   };
+   "/projects/{projectName}/packages/{packageName}/models": {
+      /** Returns a list of relative paths to the models in the package. */
+      get: operations["list-models"];
+   };
+   "/projects/{projectName}/packages/{packageName}/models/{path}": {
+      /** Returns a Malloy model. */
+      get: operations["get-model"];
+   };
+   "/projects/{projectName}/packages/{packageName}/queryResults/{path}": {
+      /** Returns a query and its results. */
+      get: operations["execute-query"];
+   };
+   "/projects/{projectName}/packages/{packageName}/databases": {
+      /** Returns a list of relative paths to the databases embedded in the package. */
+      get: operations["list-databases"];
+   };
+   "/projects/{projectName}/packages/{packageName}/schedules": {
+      /** Returns a list of running schedules. */
+      get: operations["list-schedules"];
+   };
 }
 
 export type webhooks = Record<string, never>;
 
 export interface components {
-  schemas: {
-    About: {
-      /** @description Readme markdown. */
-      readme?: string;
-    };
-    Project: {
-      /** @description Resource path to the project. */
-      resource?: string;
-      /** @description Project name. */
-      name?: string;
-      /** @description Project readme. */
-      readme?: string;
-    };
-    Package: {
-      /** @description Resource path to the package. */
-      resource?: string;
-      /** @description Package name. */
-      name?: string;
-      /** @description Package description. */
-      description?: string;
-    };
-    /** @description Malloy model def and result data.  Malloy model def and result data is Malloy version depdendent. */
-    Model: {
-      /** @description Resource path to the model. */
-      resource?: string;
-      /** @description Model's package Name */
-      packageName?: string;
-      /** @description Model's relative path in its package directory. */
-      path?: string;
-      /**
-       * @description Type of malloy model file -- source file or notebook file.
-       * @enum {string}
-       */
-      type?: "source" | "notebook";
-    };
-    /** @description Malloy model def and result data.  Malloy model def and result data is Malloy version depdendent. */
-    CompiledModel: {
-      /** @description Resource path to the model. */
-      resource?: string;
-      /** @description Model's package Name */
-      packageName?: string;
-      /** @description Model's relative path in its package directory. */
-      path?: string;
-      /**
-       * @description Type of malloy model file -- source file or notebook file.
-       * @enum {string}
-       */
-      type?: "source" | "notebook";
-      /** @description Version of the Malloy compiler that generated the model def and results fields. */
-      malloyVersion?: string;
-      /** @description Data style for rendering query results. */
-      dataStyles?: string;
-      /** @description Malloy model def. */
-      modelDef?: string;
-      /** @description Array of model sources. */
-      sources?: components["schemas"]["Source"][];
-      queries?: components["schemas"]["Query"][];
-      /** @description Array of notebook cells. */
-      notebookCells?: components["schemas"]["NotebookCell"][];
-    };
-    /** @description Model source. */
-    Source: {
-      /** @description Source's name. */
-      name?: string;
-      /** @description Annotations attached to source. */
-      annotations?: string[];
-      /** @description List of views in the source.\ */
-      views?: components["schemas"]["View"][];
-    };
-    /** @description Named model view. */
-    View: {
-      /** @description View's name. */
-      name?: string;
-      /** @description Annotations attached to view. */
-      annotations?: string[];
-    };
-    /** @description Named model query. */
-    Query: {
-      /** @description Query's name. */
-      name?: string;
-      /** @description Annotations attached to query. */
-      annotations?: string[];
-    };
-    /** @description Notebook cell. */
-    NotebookCell: {
-      /**
-       * @description Type of notebook cell.
-       * @enum {string}
-       */
-      type?: "markdown" | "code";
-      /** @description Text contents of the notebook cell. */
-      text?: string;
-      /** @description Name of query, if this is a named query.  Otherwise, empty. */
-      queryName?: string;
-      /** @description Malloy query results. Populated only if a code cell. */
-      queryResult?: string;
-    };
-    /** @description A Malloy query's results, its model def, and its data styles. */
-    QueryResult: {
-      /** @description Data style for rendering query results. */
-      dataStyles?: string;
-      /** @description Malloy model def. */
-      modelDef?: string;
-      /** @description Malloy query results. Populated only if a code cell. */
-      queryResult?: string;
-    };
-    /** @description An in-memory DuckDB database embedded in the package. */
-    Database: {
-      /** @description Resource path to the database. */
-      resource?: string;
-      /** @description Database's relative path in its package directory. */
-      path?: string;
-      /** @description Size of the embedded database in bytes. */
-      size?: number;
-      /**
-       * @description Type of database.
-       * @enum {string}
-       */
-      type?: "embedded" | "materialized";
-    };
-    /** @description A scheduled task. */
-    Schedule: {
-      /** @description Resource in the package that the schedule is attached to. */
-      resource?: string;
-      /** @description Schedule (cron format) for executing task. */
-      schedule?: string;
-      /** @description Action to execute. */
-      action?: string;
-      /** @description Connection to perform action on. */
-      connection?: string;
-      /** @description Timestamp in milliseconds of the last run. */
-      lastRunTime?: number;
-      /** @description Status of the last run. */
-      lastRunStatus?: string;
-    };
-    Connection: {
-      /** @description Resource path to the connection. */
-      resource?: string;
-      name?: string;
-      /** @enum {string} */
-      type?: "postgres" | "bigquery" | "snowflake" | "trino";
-      attributes?: components["schemas"]["ConnectionAttributes"];
-      postgresConnection?: components["schemas"]["PostgresConnection"];
-      bigqueryConnection?: components["schemas"]["BigqueryConnection"];
-      snowflakeConnection?: components["schemas"]["SnowflakeConnection"];
-      trinoConnection?: components["schemas"]["TrinoConnection"];
-    };
-    ConnectionAttributes: {
-      dialectName?: string;
-      isPool?: boolean;
-      canPersist?: boolean;
-      canStream?: boolean;
-    };
-    PostgresConnection: {
-      host?: string;
-      port?: number;
-      databaseName?: string;
-      userName?: string;
-      password?: string;
-      connectionString?: string;
-    };
-    BigqueryConnection: {
-      defaultProjectId?: string;
-      billingProjectId?: string;
-      location?: string;
-      serviceAccountKeyJson?: string;
-      maximumBytesBilled?: string;
-      queryTimeoutMilliseconds?: string;
-    };
-    SnowflakeConnection: {
-      account?: string;
-      username?: string;
-      password?: string;
-      warehouse?: string;
-      database?: string;
-      schema?: string;
-      responseTimeoutMilliseconds?: number;
-    };
-    TrinoConnection: {
-      server?: string;
-      port?: number;
-      catalog?: string;
-      schema?: string;
-      user?: string;
-      password?: string;
-    };
-    SqlSource: {
-      /** @description Resource path to the sql source. */
-      resource?: string;
-      source?: string;
-    };
-    TableSource: {
-      /** @description Resource path to the table source. */
-      resource?: string;
-      source?: string;
-    };
-    TemporaryTable: {
-      /** @description Resource path to the temporary table. */
-      resource?: string;
-      table?: string;
-    };
-    QueryData: {
-      /** @description Resource path to the query data. */
-      resource?: string;
-      data?: string;
-    };
-    Error: {
-      code?: string;
-      message?: string;
-    };
-  };
-  responses: {
-    /** @description The server encountered an internal error */
-    InternalServerError: {
-      content: {
-        "application/json": components["schemas"]["Error"];
+   schemas: {
+      About: {
+         /** @description Readme markdown. */
+         readme?: string;
       };
-    };
-    /** @description The specified resource was not found */
-    NotFoundError: {
-      content: {
-        "application/json": components["schemas"]["Error"];
+      Project: {
+         /** @description Resource path to the project. */
+         resource?: string;
+         /** @description Project name. */
+         name?: string;
+         /** @description Project readme. */
+         readme?: string;
       };
-    };
-    /** @description Not implemented */
-    NotImplementedError: {
-      content: {
-        "application/json": components["schemas"]["Error"];
+      Package: {
+         /** @description Resource path to the package. */
+         resource?: string;
+         /** @description Package name. */
+         name?: string;
+         /** @description Package description. */
+         description?: string;
       };
-    };
-    /** @description Unauthorized */
-    UnauthorizedError: {
-      content: {
-        "application/json": components["schemas"]["Error"];
+      /** @description Malloy model def and result data.  Malloy model def and result data is Malloy version depdendent. */
+      Model: {
+         /** @description Resource path to the model. */
+         resource?: string;
+         /** @description Model's package Name */
+         packageName?: string;
+         /** @description Model's relative path in its package directory. */
+         path?: string;
+         /**
+          * @description Type of malloy model file -- source file or notebook file.
+          * @enum {string}
+          */
+         type?: "source" | "notebook";
       };
-    };
-    /** @description Bad request */
-    BadRequestError: {
-      content: {
-        "application/json": components["schemas"]["Error"];
+      /** @description Malloy model def and result data.  Malloy model def and result data is Malloy version depdendent. */
+      CompiledModel: {
+         /** @description Resource path to the model. */
+         resource?: string;
+         /** @description Model's package Name */
+         packageName?: string;
+         /** @description Model's relative path in its package directory. */
+         path?: string;
+         /**
+          * @description Type of malloy model file -- source file or notebook file.
+          * @enum {string}
+          */
+         type?: "source" | "notebook";
+         /** @description Version of the Malloy compiler that generated the model def and results fields. */
+         malloyVersion?: string;
+         /** @description Data style for rendering query results. */
+         dataStyles?: string;
+         /** @description Malloy model def. */
+         modelDef?: string;
+         /** @description Array of model sources. */
+         sources?: components["schemas"]["Source"][];
+         queries?: components["schemas"]["Query"][];
+         /** @description Array of notebook cells. */
+         notebookCells?: components["schemas"]["NotebookCell"][];
       };
-    };
-  };
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+      /** @description Model source. */
+      Source: {
+         /** @description Source's name. */
+         name?: string;
+         /** @description Annotations attached to source. */
+         annotations?: string[];
+         /** @description List of views in the source.\ */
+         views?: components["schemas"]["View"][];
+      };
+      /** @description Named model view. */
+      View: {
+         /** @description View's name. */
+         name?: string;
+         /** @description Annotations attached to view. */
+         annotations?: string[];
+      };
+      /** @description Named model query. */
+      Query: {
+         /** @description Query's name. */
+         name?: string;
+         /** @description Annotations attached to query. */
+         annotations?: string[];
+      };
+      /** @description Notebook cell. */
+      NotebookCell: {
+         /**
+          * @description Type of notebook cell.
+          * @enum {string}
+          */
+         type?: "markdown" | "code";
+         /** @description Text contents of the notebook cell. */
+         text?: string;
+         /** @description Name of query, if this is a named query.  Otherwise, empty. */
+         queryName?: string;
+         /** @description Malloy query results. Populated only if a code cell. */
+         queryResult?: string;
+      };
+      /** @description A Malloy query's results, its model def, and its data styles. */
+      QueryResult: {
+         /** @description Data style for rendering query results. */
+         dataStyles?: string;
+         /** @description Malloy model def. */
+         modelDef?: string;
+         /** @description Malloy query results. Populated only if a code cell. */
+         queryResult?: string;
+      };
+      /** @description An in-memory DuckDB database embedded in the package. */
+      Database: {
+         /** @description Resource path to the database. */
+         resource?: string;
+         /** @description Database's relative path in its package directory. */
+         path?: string;
+         /** @description Size of the embedded database in bytes. */
+         size?: number;
+         /**
+          * @description Type of database.
+          * @enum {string}
+          */
+         type?: "embedded" | "materialized";
+      };
+      /** @description A scheduled task. */
+      Schedule: {
+         /** @description Resource in the package that the schedule is attached to. */
+         resource?: string;
+         /** @description Schedule (cron format) for executing task. */
+         schedule?: string;
+         /** @description Action to execute. */
+         action?: string;
+         /** @description Connection to perform action on. */
+         connection?: string;
+         /** @description Timestamp in milliseconds of the last run. */
+         lastRunTime?: number;
+         /** @description Status of the last run. */
+         lastRunStatus?: string;
+      };
+      Connection: {
+         /** @description Resource path to the connection. */
+         resource?: string;
+         name?: string;
+         /** @enum {string} */
+         type?: "postgres" | "bigquery" | "snowflake" | "trino";
+         attributes?: components["schemas"]["ConnectionAttributes"];
+         postgresConnection?: components["schemas"]["PostgresConnection"];
+         bigqueryConnection?: components["schemas"]["BigqueryConnection"];
+         snowflakeConnection?: components["schemas"]["SnowflakeConnection"];
+         trinoConnection?: components["schemas"]["TrinoConnection"];
+      };
+      ConnectionAttributes: {
+         dialectName?: string;
+         isPool?: boolean;
+         canPersist?: boolean;
+         canStream?: boolean;
+      };
+      PostgresConnection: {
+         host?: string;
+         port?: number;
+         databaseName?: string;
+         userName?: string;
+         password?: string;
+         connectionString?: string;
+      };
+      BigqueryConnection: {
+         defaultProjectId?: string;
+         billingProjectId?: string;
+         location?: string;
+         serviceAccountKeyJson?: string;
+         maximumBytesBilled?: string;
+         queryTimeoutMilliseconds?: string;
+      };
+      SnowflakeConnection: {
+         account?: string;
+         username?: string;
+         password?: string;
+         warehouse?: string;
+         database?: string;
+         schema?: string;
+         responseTimeoutMilliseconds?: number;
+      };
+      TrinoConnection: {
+         server?: string;
+         port?: number;
+         catalog?: string;
+         schema?: string;
+         user?: string;
+         password?: string;
+      };
+      SqlSource: {
+         /** @description Resource path to the sql source. */
+         resource?: string;
+         source?: string;
+      };
+      TableSource: {
+         /** @description Resource path to the table source. */
+         resource?: string;
+         source?: string;
+      };
+      TemporaryTable: {
+         /** @description Resource path to the temporary table. */
+         resource?: string;
+         table?: string;
+      };
+      QueryData: {
+         /** @description Resource path to the query data. */
+         resource?: string;
+         data?: string;
+      };
+      Error: {
+         code?: string;
+         message?: string;
+      };
+   };
+   responses: {
+      /** @description The server encountered an internal error */
+      InternalServerError: {
+         content: {
+            "application/json": components["schemas"]["Error"];
+         };
+      };
+      /** @description The specified resource was not found */
+      NotFoundError: {
+         content: {
+            "application/json": components["schemas"]["Error"];
+         };
+      };
+      /** @description Not implemented */
+      NotImplementedError: {
+         content: {
+            "application/json": components["schemas"]["Error"];
+         };
+      };
+      /** @description Unauthorized */
+      UnauthorizedError: {
+         content: {
+            "application/json": components["schemas"]["Error"];
+         };
+      };
+      /** @description Bad request */
+      BadRequestError: {
+         content: {
+            "application/json": components["schemas"]["Error"];
+         };
+      };
+   };
+   parameters: never;
+   requestBodies: never;
+   headers: never;
+   pathItems: never;
 }
 
 export type $defs = Record<string, never>;
@@ -328,406 +327,405 @@ export type $defs = Record<string, never>;
 export type external = Record<string, never>;
 
 export interface operations {
-
-  /** Returns a list of the Projects hosted on this server. */
-  "list-projects": {
-    responses: {
-      /** @description A list of the Projects names. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Project"][];
-        };
+   /** Returns a list of the Projects hosted on this server. */
+   "list-projects": {
+      responses: {
+         /** @description A list of the Projects names. */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Project"][];
+            };
+         };
+         401: components["responses"]["UnauthorizedError"];
+         500: components["responses"]["InternalServerError"];
       };
-      401: components["responses"]["UnauthorizedError"];
-      500: components["responses"]["InternalServerError"];
-    };
-  };
-  /** Returns metadata about the project. */
-  "get-project": {
-    parameters: {
-      query?: {
-        /** @description Load / reload the project before returning result */
-        reload?: boolean;
+   };
+   /** Returns metadata about the project. */
+   "get-project": {
+      parameters: {
+         query?: {
+            /** @description Load / reload the project before returning result */
+            reload?: boolean;
+         };
+         path: {
+            /** @description Name of project */
+            projectName: string;
+         };
       };
-      path: {
-        /** @description Name of project */
-        projectName: string;
+      responses: {
+         /** @description Metadata about the project. */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Project"];
+            };
+         };
+         401: components["responses"]["UnauthorizedError"];
+         404: components["responses"]["NotFoundError"];
+         500: components["responses"]["InternalServerError"];
       };
-    };
-    responses: {
-      /** @description Metadata about the project. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Project"];
-        };
+   };
+   /** Returns a list of the connections in the project. */
+   "list-connections": {
+      parameters: {
+         path: {
+            /** @description Name of project */
+            projectName: string;
+         };
       };
-      401: components["responses"]["UnauthorizedError"];
-      404: components["responses"]["NotFoundError"];
-      500: components["responses"]["InternalServerError"];
-    };
-  };
-  /** Returns a list of the connections in the project. */
-  "list-connections": {
-    parameters: {
-      path: {
-        /** @description Name of project */
-        projectName: string;
+      responses: {
+         /** @description A list of the connections in the project. */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Connection"][];
+            };
+         };
+         401: components["responses"]["UnauthorizedError"];
+         500: components["responses"]["InternalServerError"];
       };
-    };
-    responses: {
-      /** @description A list of the connections in the project. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Connection"][];
-        };
+   };
+   /** Returns a connection. */
+   "get-connection": {
+      parameters: {
+         path: {
+            /** @description Name of project */
+            projectName: string;
+            /** @description Name of connection */
+            connectionName: string;
+         };
       };
-      401: components["responses"]["UnauthorizedError"];
-      500: components["responses"]["InternalServerError"];
-    };
-  };
-  /** Returns a connection. */
-  "get-connection": {
-    parameters: {
-      path: {
-        /** @description Name of project */
-        projectName: string;
-        /** @description Name of connection */
-        connectionName: string;
+      responses: {
+         /** @description A connection. */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Connection"];
+            };
+         };
+         401: components["responses"]["UnauthorizedError"];
+         404: components["responses"]["NotFoundError"];
+         500: components["responses"]["InternalServerError"];
       };
-    };
-    responses: {
-      /** @description A connection. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Connection"];
-        };
+   };
+   /** Returns a test. */
+   "get-test": {
+      parameters: {
+         path: {
+            /** @description Name of project */
+            projectName: string;
+            /** @description Name of connection */
+            connectionName: string;
+         };
       };
-      401: components["responses"]["UnauthorizedError"];
-      404: components["responses"]["NotFoundError"];
-      500: components["responses"]["InternalServerError"];
-    };
-  };
-  /** Returns a test. */
-  "get-test": {
-    parameters: {
-      path: {
-        /** @description Name of project */
-        projectName: string;
-        /** @description Name of connection */
-        connectionName: string;
+      responses: {
+         /** @description Test passed. */
+         200: {
+            content: never;
+         };
+         401: components["responses"]["UnauthorizedError"];
+         404: components["responses"]["NotFoundError"];
+         500: components["responses"]["InternalServerError"];
       };
-    };
-    responses: {
-      /** @description Test passed. */
-      200: {
-        content: never;
+   };
+   /** Returns a SQL source. */
+   "get-sqlsource": {
+      parameters: {
+         query?: {
+            /** @description SQL statement */
+            sqlStatement?: string;
+         };
+         path: {
+            /** @description Name of project */
+            projectName: string;
+            /** @description Name of connection */
+            connectionName: string;
+         };
       };
-      401: components["responses"]["UnauthorizedError"];
-      404: components["responses"]["NotFoundError"];
-      500: components["responses"]["InternalServerError"];
-    };
-  };
-  /** Returns a SQL source. */
-  "get-sqlsource": {
-    parameters: {
-      query?: {
-        /** @description SQL statement */
-        sqlStatement?: string;
+      responses: {
+         /** @description A SQL source. */
+         200: {
+            content: {
+               "application/json": components["schemas"]["SqlSource"];
+            };
+         };
+         401: components["responses"]["UnauthorizedError"];
+         404: components["responses"]["NotFoundError"];
+         500: components["responses"]["InternalServerError"];
       };
-      path: {
-        /** @description Name of project */
-        projectName: string;
-        /** @description Name of connection */
-        connectionName: string;
+   };
+   /** Returns a table source. */
+   "get-tablesource": {
+      parameters: {
+         query?: {
+            /** @description Table key */
+            tableKey?: string;
+            /** @description Table path */
+            tablePath?: string;
+         };
+         path: {
+            /** @description Name of project */
+            projectName: string;
+            /** @description Name of connection */
+            connectionName: string;
+         };
       };
-    };
-    responses: {
-      /** @description A SQL source. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["SqlSource"];
-        };
+      responses: {
+         /** @description A table source. */
+         200: {
+            content: {
+               "application/json": components["schemas"]["TableSource"];
+            };
+         };
+         401: components["responses"]["UnauthorizedError"];
+         404: components["responses"]["NotFoundError"];
+         500: components["responses"]["InternalServerError"];
       };
-      401: components["responses"]["UnauthorizedError"];
-      404: components["responses"]["NotFoundError"];
-      500: components["responses"]["InternalServerError"];
-    };
-  };
-  /** Returns a table source. */
-  "get-tablesource": {
-    parameters: {
-      query?: {
-        /** @description Table key */
-        tableKey?: string;
-        /** @description Table path */
-        tablePath?: string;
+   };
+   /** Returns a query and its results. */
+   "get-querydata": {
+      parameters: {
+         query?: {
+            /** @description SQL statement */
+            sqlStatement?: string;
+            /** @description Options */
+            options?: string;
+         };
+         path: {
+            /** @description Name of project */
+            projectName: string;
+            /** @description Name of connection */
+            connectionName: string;
+         };
       };
-      path: {
-        /** @description Name of project */
-        projectName: string;
-        /** @description Name of connection */
-        connectionName: string;
+      responses: {
+         /** @description A query and its results. */
+         200: {
+            content: {
+               "application/json": components["schemas"]["QueryData"];
+            };
+         };
+         401: components["responses"]["UnauthorizedError"];
+         404: components["responses"]["NotFoundError"];
+         500: components["responses"]["InternalServerError"];
       };
-    };
-    responses: {
-      /** @description A table source. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["TableSource"];
-        };
+   };
+   /** Returns a temporary table. */
+   "get-temporarytable": {
+      parameters: {
+         query?: {
+            /** @description SQL statement */
+            sqlStatement?: string;
+         };
+         path: {
+            /** @description Name of project */
+            projectName: string;
+            /** @description Name of connection */
+            connectionName: string;
+         };
       };
-      401: components["responses"]["UnauthorizedError"];
-      404: components["responses"]["NotFoundError"];
-      500: components["responses"]["InternalServerError"];
-    };
-  };
-  /** Returns a query and its results. */
-  "get-querydata": {
-    parameters: {
-      query?: {
-        /** @description SQL statement */
-        sqlStatement?: string;
-        /** @description Options */
-        options?: string;
+      responses: {
+         /** @description A temporary table. */
+         200: {
+            content: {
+               "application/json": components["schemas"]["TemporaryTable"];
+            };
+         };
+         401: components["responses"]["UnauthorizedError"];
+         404: components["responses"]["NotFoundError"];
+         500: components["responses"]["InternalServerError"];
       };
-      path: {
-        /** @description Name of project */
-        projectName: string;
-        /** @description Name of connection */
-        connectionName: string;
+   };
+   /** Returns a list of the Packages hosted on this server. */
+   "list-packages": {
+      parameters: {
+         path: {
+            /** @description Name of project */
+            projectName: string;
+         };
       };
-    };
-    responses: {
-      /** @description A query and its results. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["QueryData"];
-        };
+      responses: {
+         /** @description A list of the Packages names. */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Package"][];
+            };
+         };
+         401: components["responses"]["UnauthorizedError"];
+         500: components["responses"]["InternalServerError"];
+         501: components["responses"]["NotImplementedError"];
       };
-      401: components["responses"]["UnauthorizedError"];
-      404: components["responses"]["NotFoundError"];
-      500: components["responses"]["InternalServerError"];
-    };
-  };
-  /** Returns a temporary table. */
-  "get-temporarytable": {
-    parameters: {
-      query?: {
-        /** @description SQL statement */
-        sqlStatement?: string;
+   };
+   /** Returns the package metadata. */
+   "get-package": {
+      parameters: {
+         query?: {
+            /** @description Version ID */
+            versionId?: string;
+            /** @description Load / reload the package before returning result */
+            reload?: boolean;
+         };
+         path: {
+            /** @description Name of project */
+            projectName: string;
+            /** @description Package name */
+            packageName: string;
+         };
       };
-      path: {
-        /** @description Name of project */
-        projectName: string;
-        /** @description Name of connection */
-        connectionName: string;
+      responses: {
+         /** @description Package metadata. */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Package"];
+            };
+         };
+         401: components["responses"]["UnauthorizedError"];
+         404: components["responses"]["NotFoundError"];
+         500: components["responses"]["InternalServerError"];
+         501: components["responses"]["NotImplementedError"];
       };
-    };
-    responses: {
-      /** @description A temporary table. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["TemporaryTable"];
-        };
+   };
+   /** Returns a list of relative paths to the models in the package. */
+   "list-models": {
+      parameters: {
+         query?: {
+            /** @description Version ID */
+            versionId?: string;
+         };
+         path: {
+            /** @description Name of project */
+            projectName: string;
+            /** @description Name of package */
+            packageName: string;
+         };
       };
-      401: components["responses"]["UnauthorizedError"];
-      404: components["responses"]["NotFoundError"];
-      500: components["responses"]["InternalServerError"];
-    };
-  };
-  /** Returns a list of the Packages hosted on this server. */
-  "list-packages": {
-    parameters: {
-      path: {
-        /** @description Name of project */
-        projectName: string;
+      responses: {
+         /** @description A list of relative paths to the models in the package. */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Model"][];
+            };
+         };
+         401: components["responses"]["UnauthorizedError"];
+         404: components["responses"]["NotFoundError"];
+         500: components["responses"]["InternalServerError"];
+         501: components["responses"]["NotImplementedError"];
       };
-    };
-    responses: {
-      /** @description A list of the Packages names. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Package"][];
-        };
+   };
+   /** Returns a Malloy model. */
+   "get-model": {
+      parameters: {
+         query?: {
+            /** @description Version ID */
+            versionId?: string;
+         };
+         path: {
+            /** @description Name of project */
+            projectName: string;
+            /** @description Name of package. */
+            packageName: string;
+            /** @description Path to model wihin the package. */
+            path: string;
+         };
       };
-      401: components["responses"]["UnauthorizedError"];
-      500: components["responses"]["InternalServerError"];
-      501: components["responses"]["NotImplementedError"];
-    };
-  };
-  /** Returns the package metadata. */
-  "get-package": {
-    parameters: {
-      query?: {
-        /** @description Version ID */
-        versionId?: string;
-        /** @description Load / reload the package before returning result */
-        reload?: boolean;
+      responses: {
+         /** @description A Malloy model. */
+         200: {
+            content: {
+               "application/json": components["schemas"]["CompiledModel"];
+            };
+         };
+         401: components["responses"]["UnauthorizedError"];
+         404: components["responses"]["NotFoundError"];
+         500: components["responses"]["InternalServerError"];
+         501: components["responses"]["NotImplementedError"];
       };
-      path: {
-        /** @description Name of project */
-        projectName: string;
-        /** @description Package name */
-        packageName: string;
+   };
+   /** Returns a query and its results. */
+   "execute-query": {
+      parameters: {
+         query?: {
+            /** @description Query string to execute on the model.  If the query is paramter is set, the queryName parameter must be empty. */
+            query?: string;
+            /** @description Name of the source in the model to use for queryName, search, and topValue requests. */
+            sourceName?: string;
+            /** @description Name of a query to execute on a source in the model.  Requires the sourceName parameter is set.  If the queryName is paramter is set, the query parameter must be empty. */
+            queryName?: string;
+            /** @description Version ID */
+            versionId?: string;
+         };
+         path: {
+            /** @description Name of project */
+            projectName: string;
+            /** @description Name of package */
+            packageName: string;
+            /** @description Path to model within the package. */
+            path: string;
+         };
       };
-    };
-    responses: {
-      /** @description Package metadata. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Package"];
-        };
+      responses: {
+         /** @description A query and its results. */
+         200: {
+            content: {
+               "application/json": components["schemas"]["QueryResult"];
+            };
+         };
+         400: components["responses"]["BadRequestError"];
+         401: components["responses"]["UnauthorizedError"];
+         404: components["responses"]["NotFoundError"];
+         500: components["responses"]["InternalServerError"];
+         501: components["responses"]["NotImplementedError"];
       };
-      401: components["responses"]["UnauthorizedError"];
-      404: components["responses"]["NotFoundError"];
-      500: components["responses"]["InternalServerError"];
-      501: components["responses"]["NotImplementedError"];
-    };
-  };
-  /** Returns a list of relative paths to the models in the package. */
-  "list-models": {
-    parameters: {
-      query?: {
-        /** @description Version ID */
-        versionId?: string;
+   };
+   /** Returns a list of relative paths to the databases embedded in the package. */
+   "list-databases": {
+      parameters: {
+         query?: {
+            /** @description Version ID */
+            versionId?: string;
+         };
+         path: {
+            /** @description Name of project */
+            projectName: string;
+            /** @description Name of package */
+            packageName: string;
+         };
       };
-      path: {
-        /** @description Name of project */
-        projectName: string;
-        /** @description Name of package */
-        packageName: string;
+      responses: {
+         /** @description A list of relative paths to the databases embedded in the package. */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Database"][];
+            };
+         };
+         401: components["responses"]["UnauthorizedError"];
+         404: components["responses"]["NotFoundError"];
+         500: components["responses"]["InternalServerError"];
+         501: components["responses"]["NotImplementedError"];
       };
-    };
-    responses: {
-      /** @description A list of relative paths to the models in the package. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Model"][];
-        };
+   };
+   /** Returns a list of running schedules. */
+   "list-schedules": {
+      parameters: {
+         query?: {
+            /** @description Version ID */
+            versionId?: string;
+         };
+         path: {
+            /** @description Name of project */
+            projectName: string;
+            /** @description Name of package */
+            packageName: string;
+         };
       };
-      401: components["responses"]["UnauthorizedError"];
-      404: components["responses"]["NotFoundError"];
-      500: components["responses"]["InternalServerError"];
-      501: components["responses"]["NotImplementedError"];
-    };
-  };
-  /** Returns a Malloy model. */
-  "get-model": {
-    parameters: {
-      query?: {
-        /** @description Version ID */
-        versionId?: string;
+      responses: {
+         /** @description A list of running schedules. */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Schedule"][];
+            };
+         };
+         401: components["responses"]["UnauthorizedError"];
+         404: components["responses"]["NotFoundError"];
+         500: components["responses"]["InternalServerError"];
+         501: components["responses"]["NotImplementedError"];
       };
-      path: {
-        /** @description Name of project */
-        projectName: string;
-        /** @description Name of package. */
-        packageName: string;
-        /** @description Path to model wihin the package. */
-        path: string;
-      };
-    };
-    responses: {
-      /** @description A Malloy model. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["CompiledModel"];
-        };
-      };
-      401: components["responses"]["UnauthorizedError"];
-      404: components["responses"]["NotFoundError"];
-      500: components["responses"]["InternalServerError"];
-      501: components["responses"]["NotImplementedError"];
-    };
-  };
-  /** Returns a query and its results. */
-  "execute-query": {
-    parameters: {
-      query?: {
-        /** @description Query string to execute on the model.  If the query is paramter is set, the queryName parameter must be empty. */
-        query?: string;
-        /** @description Name of the source in the model to use for queryName, search, and topValue requests. */
-        sourceName?: string;
-        /** @description Name of a query to execute on a source in the model.  Requires the sourceName parameter is set.  If the queryName is paramter is set, the query parameter must be empty. */
-        queryName?: string;
-        /** @description Version ID */
-        versionId?: string;
-      };
-      path: {
-        /** @description Name of project */
-        projectName: string;
-        /** @description Name of package */
-        packageName: string;
-        /** @description Path to model within the package. */
-        path: string;
-      };
-    };
-    responses: {
-      /** @description A query and its results. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["QueryResult"];
-        };
-      };
-      400: components["responses"]["BadRequestError"];
-      401: components["responses"]["UnauthorizedError"];
-      404: components["responses"]["NotFoundError"];
-      500: components["responses"]["InternalServerError"];
-      501: components["responses"]["NotImplementedError"];
-    };
-  };
-  /** Returns a list of relative paths to the databases embedded in the package. */
-  "list-databases": {
-    parameters: {
-      query?: {
-        /** @description Version ID */
-        versionId?: string;
-      };
-      path: {
-        /** @description Name of project */
-        projectName: string;
-        /** @description Name of package */
-        packageName: string;
-      };
-    };
-    responses: {
-      /** @description A list of relative paths to the databases embedded in the package. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Database"][];
-        };
-      };
-      401: components["responses"]["UnauthorizedError"];
-      404: components["responses"]["NotFoundError"];
-      500: components["responses"]["InternalServerError"];
-      501: components["responses"]["NotImplementedError"];
-    };
-  };
-  /** Returns a list of running schedules. */
-  "list-schedules": {
-    parameters: {
-      query?: {
-        /** @description Version ID */
-        versionId?: string;
-      };
-      path: {
-        /** @description Name of project */
-        projectName: string;
-        /** @description Name of package */
-        packageName: string;
-      };
-    };
-    responses: {
-      /** @description A list of running schedules. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Schedule"][];
-        };
-      };
-      401: components["responses"]["UnauthorizedError"];
-      404: components["responses"]["NotFoundError"];
-      500: components["responses"]["InternalServerError"];
-      501: components["responses"]["NotImplementedError"];
-    };
-  };
+   };
 }

--- a/packages/server/src/controller/query.controller.ts
+++ b/packages/server/src/controller/query.controller.ts
@@ -26,9 +26,15 @@ export class QueryController {
       if (!model) {
          throw new ModelNotFoundError(`${modelPath} does not exist`);
       } else {
-         await model.getQueryResults(sourceName, queryName, query);
+         const { queryResults, modelDef, dataStyles } =
+            await model.getQueryResults(sourceName, queryName, query);
 
-         return {};
+         // TODO: Remove this stringification once the frontend can handle it
+         return {
+            dataStyles: JSON.stringify(dataStyles),
+            modelDef: JSON.stringify(modelDef),
+            queryResult: JSON.stringify(queryResults?._queryResult),
+         } as ApiQuery;
       }
    }
 }

--- a/packages/server/src/dto/connection.dto.spec.ts
+++ b/packages/server/src/dto/connection.dto.spec.ts
@@ -26,7 +26,7 @@ describe("dto/connection", () => {
          );
 
          const errors = await validate(postgresConnection);
-         expect(errors).toBe.empty;
+         expect(errors).toHaveLength(0);
       });
 
       it("should return errors for invalid PostgresConnection object", async () => {

--- a/packages/server/src/dto/package.dto.spec.ts
+++ b/packages/server/src/dto/package.dto.spec.ts
@@ -14,7 +14,7 @@ describe("dto/package", () => {
          }),
       );
 
-      expect(errors).toBe.empty;
+      expect(errors).toHaveLength(0);
    });
 
    it("should throw when no name is specified", async () => {

--- a/packages/server/src/mcp/error_messages.ts
+++ b/packages/server/src/mcp/error_messages.ts
@@ -103,6 +103,9 @@ export function getMalloyErrorDetails(
       const fieldNotFoundMatch = error.message.match(
          /Field '([^']+)' not found in (source|query|view) '([^']+)'/i,
       );
+      const invalidRequestMatch = error.message.match(
+         /Invalid query request\\. Query OR queryName must be defined/i,
+      );
 
       if (viewNotFoundMatch) {
          refined = true;
@@ -150,6 +153,12 @@ export function getMalloyErrorDetails(
          );
          suggestions.push(
             "Ensure the database server is running and accessible from the publisher server.",
+         );
+      } else if (invalidRequestMatch) {
+         refined = true;
+         suggestions.unshift(
+            "Suggestion: This error can occur when specifying a view using 'sourceName' and 'queryName'. Try providing the full query string directly in the 'query' parameter instead (e.g., 'query': 'run: your_source_name->your_view_name').",
+            "Suggestion: Also verify you are providing either the 'query' parameter OR the correct combination of 'queryName' (and optionally 'sourceName' for views).",
          );
       }
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -4,7 +4,7 @@ import { AddressInfo } from "net";
 import * as path from "path";
 import morgan from "morgan";
 import * as bodyParser from "body-parser";
-import { createProxyMiddleware } from 'http-proxy-middleware';
+import { createProxyMiddleware } from "http-proxy-middleware";
 import cors from "cors";
 import { internalErrorToHttpError, NotImplementedError } from "./errors";
 import { ProjectStore } from "./service/project_store";
@@ -24,7 +24,7 @@ const MCP_ENDPOINT = "/mcp";
 const ROOT = path.join(__dirname, "../../app/dist/");
 const SERVER_ROOT = path.resolve(process.cwd(), process.env.SERVER_ROOT || ".");
 const API_PREFIX = "/api/v0";
-const isDevelopment = process.env.NODE_ENV === 'development';
+const isDevelopment = process.env.NODE_ENV === "development";
 
 const app = express();
 app.use(morgan("tiny"));
@@ -114,8 +114,8 @@ mcpApp.all(MCP_ENDPOINT, async (req, res) => {
             error: { code: -32603, message: "Internal server error" },
             id:
                typeof req.body === "object" &&
-                  req.body !== null &&
-                  "id" in req.body
+               req.body !== null &&
+               "id" in req.body
                   ? req.body.id
                   : null,
          });
@@ -128,26 +128,24 @@ mcpApp.all(MCP_ENDPOINT, async (req, res) => {
 if (!isDevelopment) {
    app.use("/", express.static(path.join(ROOT, "/")));
    app.use("/api-doc.html", express.static(path.join(ROOT, "/api-doc.html")));
- } else {
+} else {
    // In development mode, proxy requests to React dev server
    // Handle API routes first
    app.use(`${API_PREFIX}`, (req, res, next) => {
-     console.log(`[Express] Handling API request: ${req.method} ${req.url}`);
-     next();
+      console.log(`[Express] Handling API request: ${req.method} ${req.url}`);
+      next();
    });
- 
+
    // Proxy everything else to Vite
    app.use(
-     createProxyMiddleware({
-       target: 'http://localhost:5173',
-       changeOrigin: true,
-       ws: true,
-       pathFilter: (path) => !path.startsWith('/api'),
-       
-     })
+      createProxyMiddleware({
+         target: "http://localhost:5173",
+         changeOrigin: true,
+         ws: true,
+         pathFilter: (path) => !path.startsWith("/api"),
+      }),
    );
- }
- 
+}
 
 const setVersionIdError = (res: express.Response) => {
    const { json, status } = internalErrorToHttpError(
@@ -474,7 +472,7 @@ app.get(
 
 // Modify the catch-all route to only serve index.html in production
 if (!isDevelopment) {
-  app.get("*", (_req, res) => res.sendFile(path.resolve(ROOT, "index.html")));
+   app.get("*", (_req, res) => res.sendFile(path.resolve(ROOT, "index.html")));
 }
 
 app.use((err: Error, _req: express.Request, res: express.Response) => {
@@ -490,7 +488,9 @@ mainServer.listen(PUBLISHER_PORT, PUBLISHER_HOST, () => {
       `Publisher server listening at http://${address.address}:${address.port}`,
    );
    if (isDevelopment) {
-     console.log('Running in development mode - proxying to React dev server at http://localhost:5173');
+      console.log(
+         "Running in development mode - proxying to React dev server at http://localhost:5173",
+      );
    }
 });
 

--- a/packages/server/src/service/project.ts
+++ b/packages/server/src/service/project.ts
@@ -93,7 +93,9 @@ export class Project {
 
    public async listPackages(): Promise<ApiPackage[]> {
       try {
-         const files = await fs.readdir(this.projectPath, { withFileTypes: true });
+         const files = await fs.readdir(this.projectPath, {
+            withFileTypes: true,
+         });
          const packageMetadata = await Promise.all(
             files
                .filter((file) => file.isDirectory())
@@ -102,7 +104,10 @@ export class Project {
                      `[Project LOG] listPackages: Mapping directory: ${directory.name}`,
                   );
                   try {
-                     const _package = await this.getPackage(directory.name, false);
+                     const _package = await this.getPackage(
+                        directory.name,
+                        false,
+                     );
                      console.log(
                         `[Project LOG] listPackages: getPackage succeeded for ${directory.name}`,
                      );


### PR DESCRIPTION
This PR reverts a previous change to `QueryController.getQuery` that caused it to return an empty object instead of the actual query results. (see comment here: https://github.com/malloydata/publisher/pull/48#discussion_r2072640681)

- Reverted the logic in `packages/server/src/controller/query.controller.ts` to capture and return the data from `model.getQueryResults`.
- Ran `bun run format` and `bunx eslint --fix` on the `packages/server` directory to address numerous formatting inconsistencies and fix two `no-unused-expressions` errors in test files (`*.dto.spec.ts`).
- This restores the functionality of the `/api/v0/projects/:projectName/packages/:packageName/queryResults/*` endpoint.

----
This PR also fixes the `malloy/executeQuery` MCP tool, which failed to run nested views (e.g., `run: source->view`) when specified using the `sourceName` and `queryName` parameters, returning a misleading error.

-   Corrected the underlying call to the Malloy SDK's `model.getQueryResults` within `packages/server/src/mcp/tools/execute_query_tool.ts` to prevent an internal validation error. The tool now correctly handles executing nested views via these parameters.
-   Improved error handling in `packages/server/src/mcp/error_messages.ts` by adding specific suggestions for the misleading error message previously returned in this scenario.
