### PR TITLE
Adds database schema to package UI

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -877,9 +877,8 @@ components:
         path:
           type: string
           description: Database's relative path in its package directory.
-        size:
-          type: integer
-          description: Size of the embedded database in bytes.
+        info:
+          $ref: "#/components/schemas/TableDescription"
         type:
           type: string
           enum: ["embedded", "materialized"]
@@ -1047,4 +1046,24 @@ components:
           type: string
         message:
           type: string
+    
+    Column:
+      type: object
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+
+    TableDescription:
+      type: object
+      properties:
+        name:
+          type: string
+        rowCount:
+          type: integer
+        columns:
+          type: array
+          items:
+            $ref: "#/components/schemas/Column"
       

--- a/packages/sdk/src/client/api.ts
+++ b/packages/sdk/src/client/api.ts
@@ -80,6 +80,25 @@ export interface BigqueryConnection {
     'queryTimeoutMilliseconds'?: string;
 }
 /**
+ * 
+ * @export
+ * @interface Column
+ */
+export interface Column {
+    /**
+     * 
+     * @type {string}
+     * @memberof Column
+     */
+    'name'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Column
+     */
+    'type'?: string;
+}
+/**
  * Malloy model def and result data.  Malloy model def and result data is Malloy version depdendent.
  * @export
  * @interface CompiledModel
@@ -239,11 +258,11 @@ export interface Database {
      */
     'path'?: string;
     /**
-     * Size of the embedded database in bytes.
-     * @type {number}
+     * 
+     * @type {TableDescription}
      * @memberof Database
      */
-    'size'?: number;
+    'info'?: TableDescription;
     /**
      * Type of database.
      * @type {string}
@@ -635,6 +654,31 @@ export interface SqlSource {
      * @memberof SqlSource
      */
     'source'?: string;
+}
+/**
+ * 
+ * @export
+ * @interface TableDescription
+ */
+export interface TableDescription {
+    /**
+     * 
+     * @type {string}
+     * @memberof TableDescription
+     */
+    'name'?: string;
+    /**
+     * 
+     * @type {number}
+     * @memberof TableDescription
+     */
+    'rowCount'?: number;
+    /**
+     * 
+     * @type {Array<Column>}
+     * @memberof TableDescription
+     */
+    'columns'?: Array<Column>;
 }
 /**
  * 

--- a/packages/sdk/src/components/Package/Databases.tsx
+++ b/packages/sdk/src/components/Package/Databases.tsx
@@ -1,6 +1,10 @@
 import {
    Box,
+   Dialog,
+   DialogContent,
+   DialogTitle,
    Divider,
+   IconButton,
    Table,
    TableBody,
    TableCell,
@@ -11,8 +15,9 @@ import {
    Typography,
 } from "@mui/material";
 import { QueryClient, useQuery } from "@tanstack/react-query";
-import { Configuration, DatabasesApi } from "../../client";
+import { Configuration, Database, DatabasesApi } from "../../client";
 import { StyledCard, StyledCardContent } from "../styles";
+import React from "react";
 
 const databasesApi = new DatabasesApi(new Configuration());
 const queryClient = new QueryClient();
@@ -25,7 +30,7 @@ interface DatabaseProps {
    accessToken: string;
 }
 
-export default function Database({
+export default function DatabaseView({
    server,
    projectName,
    packageName,
@@ -47,15 +52,15 @@ export default function Database({
       },
       queryClient,
    );
-   const formatFileSize = (size: number) => {
+   const formatRowSize = (size: number) => {
       if (size >= 1024 * 1024 * 1024 * 1024) {
-         return `${(size / (1024 * 1024 * 1024)).toFixed(2)} TB`;
+         return `${(size / (1024 * 1024 * 1024)).toFixed(2)} T`;
       } else if (size >= 1024 * 1024 * 1024) {
-         return `${(size / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+         return `${(size / (1024 * 1024 * 1024)).toFixed(2)} G`;
       } else if (size >= 1024 * 1024) {
-         return `${(size / (1024 * 1024)).toFixed(2)} MB`;
+         return `${(size / (1024 * 1024)).toFixed(2)} M`;
       } else {
-         return `${(size / 1024).toFixed(2)} KB`;
+         return `${(size / 1024).toFixed(2)} K`;
       }
    };
    return (
@@ -86,33 +91,18 @@ export default function Database({
                         <TableHead>
                            <TableRow>
                               <TableCell>Database Name</TableCell>
-                              <TableCell align="right">Size</TableCell>
+                              <TableCell align="right">rows</TableCell>
                            </TableRow>
                         </TableHead>
                         <TableBody>
                            {data.data.map((database) => (
                               <TableRow key={database.path}>
                                  <TableCell>
-                                    <Tooltip
-                                       title={database.path}
-                                       placement="top"
-                                    >
-                                       <Typography
-                                          variant="body2"
-                                          sx={{
-                                             maxWidth: "200px",
-                                             overflow: "hidden",
-                                             textOverflow: "ellipsis",
-                                             whiteSpace: "nowrap",
-                                          }}
-                                       >
-                                          {database.path}
-                                       </Typography>
-                                    </Tooltip>
+                                    <NameAndSchema database={database} />
                                  </TableCell>
                                  <TableCell align="right">
                                     <Typography variant="body2">
-                                       {formatFileSize(database.size)}
+                                       {formatRowSize(database.info.rowCount)}
                                     </Typography>
                                  </TableCell>
                               </TableRow>
@@ -133,4 +123,83 @@ export default function Database({
          </StyledCardContent>
       </StyledCard>
    );
+}
+
+function NameAndSchema({ database }: { database: Database }) {
+   const [open, setOpen] = React.useState(false);
+   return <Box
+      sx={{ display: 'flex', alignItems: 'center' }}
+      onClick={() => setOpen(!open)}
+   style={{ cursor: 'pointer' }}
+   >
+   
+   <Typography
+      variant="body2"
+      color="primary"
+      sx={{
+         maxWidth: "200px",
+         overflow: "hidden",
+         textOverflow: "ellipsis",
+         whiteSpace: "nowrap",
+      }}
+   >
+      {database.path}
+   </Typography>
+   &nbsp;
+   <Box sx={{ display: 'flex', alignItems: 'center' }}>
+      <Box sx={{ mr: 1, display: 'flex', alignItems: 'center' }}>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M11 7H6C5.46957 7 4.96086 7.21071 4.58579 7.58579C4.21071 7.96086 4 8.46957 4 9V18C4 18.5304 4.21071 19.0391 4.58579 19.4142C4.96086 19.7893 5.46957 20 6 20H15C15.5304 20 16.0391 19.7893 16.4142 19.4142C16.7893 19.0391 17 18.5304 17 18V13" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+          <path d="M9 15L20 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+          <path d="M15 4H20V9" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+      </Box>
+   </Box>
+ <SchemaButton database={database} open={open} setClose={() => setOpen(false)} />
+</Box>
+}
+
+function SchemaButton({ database, open, setClose }: { open: boolean, setClose: () => void, database: Database }) {
+  return (
+      <Dialog
+         open={open}
+         onClose={setClose}
+         maxWidth="sm"
+         fullWidth
+      >
+      <DialogTitle>
+         Schema: <Typography fontSize="large" variant="body2" fontFamily="monospace" component="span">{database.path}</Typography>
+         <IconButton
+            aria-label="close"
+            onClick={setClose}
+            sx={{ position: 'absolute', right: 8, top: 8 }}
+         >
+            <Box sx={{ width: 24, height: 24, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+               X
+            </Box>
+         </IconButton>
+      </DialogTitle>
+      <DialogContent>
+         <TableContainer>
+         <Table size="small"
+               sx={{ "& .MuiTableCell-root": { padding: "10px" } }}>
+               <TableHead>
+                  <TableRow>
+                     <TableCell>NAME</TableCell>
+                     <TableCell>TYPE</TableCell>
+                  </TableRow>
+               </TableHead>
+               <TableBody>
+                  {database.info.columns.map((row) => (
+                     <TableRow key={row.name}>
+                        <TableCell>{row.name}</TableCell>
+                        <TableCell>{row.type}</TableCell>
+                     </TableRow>
+                  ))}
+               </TableBody>
+            </Table>
+         </TableContainer>
+      </DialogContent>
+      </Dialog>
+   )
 }

--- a/packages/sdk/src/components/Package/Databases.tsx
+++ b/packages/sdk/src/components/Package/Databases.tsx
@@ -91,7 +91,7 @@ export default function DatabaseView({
                         <TableHead>
                            <TableRow>
                               <TableCell>Database Name</TableCell>
-                              <TableCell align="right">rows</TableCell>
+                              <TableCell align="right">Table Rows</TableCell>
                            </TableRow>
                         </TableHead>
                         <TableBody>

--- a/packages/sdk/src/components/Package/Package.tsx
+++ b/packages/sdk/src/components/Package/Package.tsx
@@ -35,7 +35,7 @@ export default function Package({
       <Grid
          container
          spacing={2}
-         columns={12}
+         columns={10}
          sx={{ mb: (theme) => theme.spacing(2) }}
       >
          <Grid size={{ xs: 12, md: 12, lg: 4 }}>

--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -180,8 +180,7 @@ export interface components {
       resource?: string;
       /** @description Database's relative path in its package directory. */
       path?: string;
-      /** @description Size of the embedded database in bytes. */
-      size?: number;
+      info?: components["schemas"]["TableDescription"];
       /**
        * @description Type of database.
        * @enum {string}
@@ -273,6 +272,15 @@ export interface components {
     Error: {
       code?: string;
       message?: string;
+    };
+    Column: {
+      name?: string;
+      type?: string;
+    };
+    TableDescription: {
+      name?: string;
+      rowCount?: number;
+      columns?: components["schemas"]["Column"][];
     };
   };
   responses: {

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -253,7 +253,10 @@ export class Package {
          .map((fullPath: string) => {
             return path.relative(packagePath, fullPath).replace(/\\/g, "/");
          })
-         .filter((modelPath: string) => modelPath.endsWith(".parquet"));
+         .filter(
+            (modelPath: string) =>
+               modelPath.endsWith(".parquet") || modelPath.endsWith(".csv"),
+         );
    }
 
    private static async getDatabaseInfo(

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -262,6 +262,9 @@ export class Package {
    ): Promise<ApiTableDescription> {
       const fullPath = path.join(packagePath, databasePath);
 
+      // Create a DuckDB source then:
+      // 1. Load the model and get the table schema from model
+      // 2. Run a query to get the row count from the table
       const runtime = new ConnectionRuntime({
          urlReader: new EmptyURLReader(),
          connections: [new DuckDBConnection("duckdb")],
@@ -274,13 +277,10 @@ export class Package {
       const schema = fields.map((field): ApiColumn => {
          return { type: field.type, name: field.name };
       });
-      console.log("schema", schema);
-
       const runner = model.loadQuery(
          "run: temp->{aggregate: row_count is count()}",
       );
       const result = await runner.run();
-      console.log("results", result.data.value);
       const rowCount = result.data.value[0].row_count?.valueOf() as number;
       return { name: databasePath, rowCount, columns: schema };
    }


### PR DESCRIPTION
* Embedded DBs are now clickable -> Table schema.
* Size -> Rows (seems more relevant?)
* Width fixed so only 2 cards/row
* Adds support for `.csv` as package embedded DBs

https://github.com/user-attachments/assets/f2d31361-1757-4e66-8d9e-4334e74ab6db

