### PR TITLE
Export malloy-explorer.css

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,55 +1,67 @@
 {
-  "name": "@malloy-publisher/sdk",
-  "description": "Malloy Publisher SDK",
-  "version": "0.0.13",
-  "type": "module",
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.es.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "bun generate-api-types && bunx vite build",
-    "test": "",
-    "lint": "bunx eslint ./src --ext .ts,.tsx --ignore-path .gitignore --fix",
-    "format": "bunx prettier --write --parser typescript '**/*.{ts,tsx}'",
-    "analyze": "bunx vite-bundle-visualizer",
-    "generate-api-types": "bunx openapi-generator-cli generate -i ../../api-doc.yaml -g typescript-axios -o src/client/"
-  },
-  "peerDependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.0"
-  },
-  "dependencies": {
-    "@emotion/react": "^11.14.0",
-    "@emotion/styled": "^11.14.0",
-    "@malloydata/malloy-explorer": "^0.0.275-dev250512182350",
-    "@malloydata/render": "^0.0.275",
-    "@mui/icons-material": "^7.0.2",
-    "@mui/material": "^7.0.2",
-    "@mui/system": "^7.0.2",
-    "@mui/x-tree-view": "^7.16.0",
-    "@react-spring/web": "^9.7.5",
-    "@tanstack/react-query": "^5.59.16",
-    "axios": "^1.7.7",
-    "markdown-to-jsx": "^7.5.0",
-    "react-router-dom": "^6.26.1"
-  },
-  "devDependencies": {
-    "@openapitools/openapi-generator-cli": "^2.13.5",
-    "@types/k6": "^1.0.2",
-    "@types/react": "^18.3.1",
-    "@typescript-eslint/eslint-plugin": "8.16.0",
-    "@typescript-eslint/parser": "8.16.0",
-    "@vitejs/plugin-react": "^4.4.1",
-    "archiver": "^7.0.1",
-    "eslint-config-prettier": "9.1.0",
-    "eslint-plugin-prettier": "5.2.1",
-    "eslint-plugin-react": "7.37.2",
-    "eslint-plugin-react-hooks": "5.0.0",
-    "eslint-plugin-storybook": "^0.11.4",
-    "shiki": "^1.16.3",
-    "vite": "^6.3.2",
-    "vite-plugin-dts": "^4.5.3",
-    "vite-plugin-svgr": "^4.3.0",
-    "ajv": "^8.12.0"
-  }
+   "name": "@malloy-publisher/sdk",
+   "description": "Malloy Publisher SDK",
+   "version": "0.0.13",
+   "type": "module",
+   "main": "dist/index.cjs.js",
+   "module": "dist/index.es.js",
+   "types": "dist/index.d.ts",
+   "exports": {
+      ".": {
+         "import": "./dist/index.es.js",
+         "require": "./dist/index.cjs.js",
+         "types": "./dist/index.d.ts"
+      },
+      "./malloy-explorer.css": {
+         "default": "./dist/malloy-explorer.css"
+      }
+   },
+   "style": "./dist/malloy-explorer.css",
+   "scripts": {
+      "build": "bun generate-api-types && bunx vite build",
+      "postbuild": "cp ./node_modules/@malloydata/malloy-explorer/dist/malloy-explorer.css ./dist/malloy-explorer.css",
+      "test": "",
+      "lint": "bunx eslint ./src --ext .ts,.tsx --ignore-path .gitignore --fix",
+      "format": "bunx prettier --write --parser typescript '**/*.{ts,tsx}'",
+      "analyze": "bunx vite-bundle-visualizer",
+      "generate-api-types": "bunx openapi-generator-cli generate -i ../../api-doc.yaml -g typescript-axios -o src/client/"
+   },
+   "peerDependencies": {
+      "react": "^18.3.1",
+      "react-dom": "^18.3.0"
+   },
+   "dependencies": {
+      "@emotion/react": "^11.14.0",
+      "@emotion/styled": "^11.14.0",
+      "@malloydata/malloy-explorer": "^0.0.278-dev250516210719",
+      "@malloydata/render": "^0.0.275",
+      "@mui/icons-material": "^7.0.2",
+      "@mui/material": "^7.0.2",
+      "@mui/system": "^7.0.2",
+      "@mui/x-tree-view": "^7.16.0",
+      "@react-spring/web": "^9.7.5",
+      "@tanstack/react-query": "^5.59.16",
+      "axios": "^1.7.7",
+      "markdown-to-jsx": "^7.5.0",
+      "react-router-dom": "^6.26.1"
+   },
+   "devDependencies": {
+      "@openapitools/openapi-generator-cli": "^2.13.5",
+      "@types/k6": "^1.0.2",
+      "@types/react": "^18.3.1",
+      "@typescript-eslint/eslint-plugin": "8.16.0",
+      "@typescript-eslint/parser": "8.16.0",
+      "@vitejs/plugin-react": "^4.4.1",
+      "archiver": "^7.0.1",
+      "eslint-config-prettier": "9.1.0",
+      "eslint-plugin-prettier": "5.2.1",
+      "eslint-plugin-react": "7.37.2",
+      "eslint-plugin-react-hooks": "5.0.0",
+      "eslint-plugin-storybook": "^0.11.4",
+      "shiki": "^1.16.3",
+      "vite": "^6.3.2",
+      "vite-plugin-dts": "^4.5.3",
+      "vite-plugin-svgr": "^4.3.0",
+      "ajv": "^8.12.0"
+   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/sdk",
    "description": "Malloy Publisher SDK",
-   "version": "0.0.13",
+   "version": "0.0.14",
    "type": "module",
    "main": "dist/index.cjs.js",
    "module": "dist/index.es.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -19,7 +19,7 @@
    "style": "./dist/malloy-explorer.css",
    "scripts": {
       "build": "bun generate-api-types && bunx vite build",
-      "postbuild": "cp ./node_modules/@malloydata/malloy-explorer/dist/malloy-explorer.css ./dist/malloy-explorer.css",
+      "postbuild": "cp ../../node_modules/@malloydata/malloy-explorer/dist/malloy-explorer.css ./dist/malloy-explorer.css",
       "test": "",
       "lint": "bunx eslint ./src --ext .ts,.tsx --ignore-path .gitignore --fix",
       "format": "bunx prettier --write --parser typescript '**/*.{ts,tsx}'",

--- a/packages/sdk/src/components/Model/Model.tsx
+++ b/packages/sdk/src/components/Model/Model.tsx
@@ -54,6 +54,10 @@ interface ModelProps {
    accessToken?: string;
 }
 
+// Note: For this to properly render outside of publisher,
+// you must explicitly import the styles from the package:
+// import "@malloy-publisher/sdk/malloy-explorer.css";
+
 export default function Model({
    server,
    projectName,


### PR DESCRIPTION
Explicitly export the malloy-explorer CSS (from styleX) so it can be imported by AdminApp (or other SDK consumers).
I think there's a way to configure JS bundlers to automatically find the CSS and use it, but I'm not sure how.