### PR TITLE
Adds NotebookStorage API, Notebook ListUI

### DIFF
--- a/packages/app/src/components/ScatchNotebookPageList.tsx
+++ b/packages/app/src/components/ScatchNotebookPageList.tsx
@@ -1,15 +1,17 @@
 import { useParams } from "react-router-dom";
 import {
    BrowserNotebookStorage,
-   MutableNotebook,
+   MutableNotebookList,
    NotebookStorageProvider,
+   PublisherPackageProvider,
 } from "@malloy-publisher/sdk";
-import { PublisherPackageProvider } from "@malloy-publisher/sdk";
-interface ScratchNotebookPageProps {
+interface ScratchNotebookPageListProps {
    server?: string;
 }
 
-export function ScratchNotebookPage({ server }: ScratchNotebookPageProps) {
+export function ScratchNotebookPageList({
+   server,
+}: ScratchNotebookPageListProps) {
    const { projectName, packageName } = useParams();
    if (!projectName) {
       return (
@@ -34,7 +36,7 @@ export function ScratchNotebookPage({ server }: ScratchNotebookPageProps) {
                notebookStorage={new BrowserNotebookStorage()}
                userContext={{ project: projectName, package: packageName }}
             >
-               <MutableNotebook inputNotebookPath={undefined} />
+               <MutableNotebookList />
             </NotebookStorageProvider>
          </PublisherPackageProvider>
       );

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -12,6 +12,7 @@ import { ModelPage } from "./components/ModelPage";
 import { ConnectionsPage } from "./components/ConnectionsPage";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { ScratchNotebookPage } from "./components/ScratchNotebookPage";
+import { ScratchNotebookPageList } from "./components/ScatchNotebookPageList";
 
 const server = `${window.location.protocol}//${window.location.host}/api/v0`;
 const router = createBrowserRouter([
@@ -41,6 +42,10 @@ const router = createBrowserRouter([
          {
             path: ":projectName/:packageName/scratch_notebook",
             element: <ScratchNotebookPage server={server} />,
+         },
+         {
+            path: ":projectName/:packageName/list_scratch_notebook",
+            element: <ScratchNotebookPageList server={server} />,
          },
          {
             path: ":projectName/:packageName/*",

--- a/packages/sdk/src/components/Model/SourcesExplorer.tsx
+++ b/packages/sdk/src/components/Model/SourcesExplorer.tsx
@@ -188,7 +188,6 @@ export function SourceExplorerComponent({
          onChange(qer);
       }
    }, [onChange, qer]);
-   console.log("qer", qer);
    const { server, projectName, packageName, versionId, accessToken } =
       usePublisherPackage();
    const mutation = useMutation(

--- a/packages/sdk/src/components/MutableNotebook/BrowserNotebookStorage.ts
+++ b/packages/sdk/src/components/MutableNotebook/BrowserNotebookStorage.ts
@@ -1,0 +1,58 @@
+import type { NotebookStorage, UserContext } from "./NotebookStorage";
+
+export class BrowserNotebookStorage implements NotebookStorage {
+   private makeKey(context: UserContext, path?: string): string {
+      let key = `BROWSER_NOTEBOOK_STORAGE__${context.project}/${context.package}`;
+      if (path) {
+         key += `/${path}`;
+      }
+      return key;
+   }
+
+   listNotebooks(context: UserContext): string[] {
+      const prefix = this.makeKey(context);
+      const keys: string[] = [];
+      for (let i = 0; i < localStorage.length; i++) {
+         const key = localStorage.key(i);
+         if (key && key.startsWith(prefix + "/")) {
+            // Extract the notebook path after the prefix
+            const notebookPath = key.substring(prefix.length + 1);
+            keys.push(notebookPath);
+         }
+      }
+      return keys;
+   }
+
+   getNotebook(context: UserContext, path: string): string {
+      const key = this.makeKey(context, path);
+      const notebook = localStorage.getItem(key);
+      if (notebook === null) {
+         throw new Error(`Notebook not found at path: ${path}`);
+      }
+      return notebook;
+   }
+
+   deleteNotebook(context: UserContext, path: string): void {
+      const key = this.makeKey(context, path);
+      if (localStorage.getItem(key) === null) {
+         throw new Error(`Notebook not found at path: ${path}`);
+      }
+      localStorage.removeItem(key);
+   }
+
+   saveNotebook(context: UserContext, path: string, notebook: string): void {
+      const key = this.makeKey(context, path);
+      localStorage.setItem(key, notebook);
+   }
+
+   moveNotebook(context: UserContext, from: string, to: string): void {
+      const fromKey = this.makeKey(context, from);
+      const toKey = this.makeKey(context, to);
+      const notebook = localStorage.getItem(fromKey);
+      if (notebook === null) {
+         throw new Error(`Notebook not found at path: ${from}`);
+      }
+      localStorage.setItem(toKey, notebook);
+      localStorage.removeItem(fromKey);
+   }
+}

--- a/packages/sdk/src/components/MutableNotebook/MutableCell.tsx
+++ b/packages/sdk/src/components/MutableNotebook/MutableCell.tsx
@@ -83,6 +83,7 @@ export function MutableCell({
       onDelete();
       setDeleteDialogOpen(false);
    };
+   const noSources = sourceAndPaths.length === 0;
 
    const deleteButton = (
       <Tooltip title="Delete Cell">
@@ -278,14 +279,19 @@ export function MutableCell({
                         />
                      </Stack>
                   </Collapse>
-                  {editingMalloy && (
-                     <EditableMalloyCell
-                        sourceAndPaths={sourceAndPaths}
-                        onCellChange={onCellChange}
-                        onClose={onClose}
-                        cell={cell}
-                     />
-                  )}
+                  {editingMalloy &&
+                     (noSources ? (
+                        <Typography>
+                           No Model Imports. Please add a model import above.
+                        </Typography>
+                     ) : (
+                        <EditableMalloyCell
+                           sourceAndPaths={sourceAndPaths}
+                           onCellChange={onCellChange}
+                           onClose={onClose}
+                           cell={cell}
+                        />
+                     ))}
                   {!editingMalloy && cell.result && (
                      <>
                         <CardContent

--- a/packages/sdk/src/components/MutableNotebook/MutableNotebook.tsx
+++ b/packages/sdk/src/components/MutableNotebook/MutableNotebook.tsx
@@ -19,6 +19,7 @@ import { ModelPicker } from "./ModelPicker";
 import { usePublisherPackage } from "../Package";
 import { NotebookManager } from "../NotebookManager";
 import { SourceAndPath } from "../Model/SourcesExplorer";
+import { useNotebookStorage } from "./NotebookStorageProvider";
 
 import * as Malloy from "@malloydata/malloy-interfaces";
 
@@ -46,6 +47,17 @@ export default function MutableNotebook({
 }: MutableNotebookProps) {
    const { server, projectName, packageName, versionId, accessToken } =
       usePublisherPackage();
+   if (!projectName || !packageName) {
+      throw new Error(
+         "Project and package must be provided via PubliserPackageProvider",
+      );
+   }
+   const { notebookStorage, userContext } = useNotebookStorage();
+   if (!notebookStorage || !userContext) {
+      throw new Error(
+         "Notebook storage and user context must be provided via NotebookStorageProvider",
+      );
+   }
    const [notebookData, setNotebookData] = React.useState<
       NotebookManager | undefined
    >();
@@ -146,14 +158,14 @@ export default function MutableNotebook({
       if (!notebookData) {
          setNotebookData(
             NotebookManager.loadNotebook(
-               projectName,
-               packageName,
+               notebookStorage,
+               userContext,
                getNotebookPath(),
             ),
          );
          setNotebookPath(getNotebookPath());
       }
-   }, [notebookData, packageName, projectName]);
+   }, [notebookData, packageName, projectName, notebookStorage, userContext]);
 
    if (!notebookData) {
       return <div>Loading...</div>;
@@ -200,8 +212,14 @@ export default function MutableNotebook({
                   justifyContent: "space-between",
                }}
             >
-               <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                  <Typography sx={{ fontSize: "150%", fontWeight: "bold" }}>
+               <Box sx={{ display: "flex", alignItems: "top", gap: 1 }}>
+                  <Typography
+                     sx={{
+                        fontSize: "150%",
+                        minHeight: "56px",
+                        fontWeight: "bold",
+                     }}
+                  >
                      Notebook :
                   </Typography>
                   <TextField
@@ -217,6 +235,12 @@ export default function MutableNotebook({
                      }}
                      size="medium"
                      variant="standard"
+                     error={!notebookPath}
+                     helperText={
+                        !notebookPath
+                           ? "Please enter a notebook name"
+                           : undefined
+                     }
                      sx={{ flex: 1 }}
                   />
                </Box>

--- a/packages/sdk/src/components/MutableNotebook/MutableNotebookList.tsx
+++ b/packages/sdk/src/components/MutableNotebook/MutableNotebookList.tsx
@@ -1,0 +1,138 @@
+import React from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+   List,
+   ListItem,
+   ListItemText,
+   IconButton,
+   Dialog,
+   DialogTitle,
+   DialogContent,
+   DialogContentText,
+   DialogActions,
+   Button,
+   Typography,
+   Box,
+   ListItemButton,
+} from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
+import { useNotebookStorage } from "./NotebookStorageProvider";
+
+export function MutableNotebookList() {
+   const { projectName, packageName } = useParams();
+   const navigate = useNavigate();
+   const { notebookStorage, userContext } = useNotebookStorage();
+   const [notebooks, setNotebooks] = React.useState<string[]>([]);
+   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
+   const [notebookToDelete, setNotebookToDelete] = React.useState<
+      string | null
+   >(null);
+
+   React.useEffect(() => {
+      if (notebookStorage && userContext) {
+         setNotebooks(notebookStorage.listNotebooks(userContext));
+      }
+   }, [notebookStorage, userContext]);
+
+   const handleDeleteClick = (notebook: string) => {
+      setNotebookToDelete(notebook);
+      setDeleteDialogOpen(true);
+   };
+
+   const handleDeleteConfirm = () => {
+      if (notebookToDelete && notebookStorage && userContext) {
+         notebookStorage.deleteNotebook(userContext, notebookToDelete);
+         setNotebooks(notebookStorage.listNotebooks(userContext));
+      }
+      setDeleteDialogOpen(false);
+      setNotebookToDelete(null);
+   };
+
+   const handleDeleteCancel = () => {
+      setDeleteDialogOpen(false);
+      setNotebookToDelete(null);
+   };
+
+   const handleNotebookClick = (notebook: string) => {
+      if (projectName && packageName) {
+         // Navigate to the ScratchNotebookPage with anchor text for notebookPath
+         navigate(
+            `/${projectName}/${packageName}/scratch_notebook#notebookPath=${encodeURIComponent(notebook)}`,
+         );
+      }
+   };
+
+   return (
+      <Box>
+         <Typography variant="h5" sx={{ mb: 2 }}>
+            Notebooks
+         </Typography>
+         <Button
+            variant="contained"
+            onClick={() => handleNotebookClick("")}
+            sx={{ mb: 2 }}
+         >
+            New Notebook
+         </Button>
+
+         <List>
+            {notebooks.length === 0 && (
+               <ListItem>
+                  <ListItemText primary="No notebooks found." />
+               </ListItem>
+            )}
+            {notebooks.map((notebook) => (
+               <ListItem
+                  key={notebook}
+                  secondaryAction={
+                     <IconButton
+                        edge="end"
+                        aria-label="delete"
+                        onClick={(e) => {
+                           e.stopPropagation();
+                           handleDeleteClick(notebook);
+                        }}
+                     >
+                        <DeleteIcon />
+                     </IconButton>
+                  }
+                  disablePadding
+               >
+                  <ListItemButton onClick={() => handleNotebookClick(notebook)}>
+                     <ListItemText
+                        primary={
+                           <Typography
+                              component="span"
+                              sx={{
+                                 color: "primary.main",
+                                 textDecoration: "underline",
+                              }}
+                           >
+                              {notebook}
+                           </Typography>
+                        }
+                     />
+                  </ListItemButton>
+               </ListItem>
+            ))}
+         </List>
+         <Dialog open={deleteDialogOpen} onClose={handleDeleteCancel}>
+            <DialogTitle>Delete Notebook</DialogTitle>
+            <DialogContent>
+               <DialogContentText>
+                  Are you sure you want to delete the notebook &quot;
+                  {notebookToDelete}&quot;? This action cannot be undone.
+               </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+               <Button onClick={handleDeleteCancel} color="primary">
+                  Cancel
+               </Button>
+               <Button onClick={handleDeleteConfirm} color="error" autoFocus>
+                  Delete
+               </Button>
+            </DialogActions>
+         </Dialog>
+      </Box>
+   );
+}

--- a/packages/sdk/src/components/MutableNotebook/NotebookStorage.ts
+++ b/packages/sdk/src/components/MutableNotebook/NotebookStorage.ts
@@ -1,0 +1,27 @@
+export interface UserContext {
+   // UserContext holds the project & package associated with
+   // the notebook. PublisherStorage interfaces will
+   // implement this and add data representing configuration,
+   // user permissions, and access tokens.
+   project: string;
+   package: string;
+}
+
+export interface NotebookStorage {
+   // Lists all available notebooks for the context.
+   // Notebooks names are like S3 paths- / denote hierarchical
+   // folders, but otherwise folders are not "real" objects
+   listNotebooks(context: UserContext): string[];
+
+   // Returns the notebook at the specific path, throws an exception if no such notebook exists (or cannot be accessed)
+   getNotebook(context: UserContext, path: string): string;
+
+   // Deletes the notebook at the specified path, or throws an
+   // Exception on failure
+   deleteNotebook(context: UserContext, path: string): void;
+
+   saveNotebook(context: UserContext, path: string, notebook: string): void;
+
+   // Moves notebook from the "from" path to the "to" path
+   moveNotebook(context: UserContext, from: string, to: string): void;
+}

--- a/packages/sdk/src/components/MutableNotebook/NotebookStorageProvider.tsx
+++ b/packages/sdk/src/components/MutableNotebook/NotebookStorageProvider.tsx
@@ -1,0 +1,43 @@
+import React, { createContext, useContext, useMemo } from "react";
+import type { NotebookStorage, UserContext } from "./NotebookStorage";
+
+interface NotebookStorageProviderProps {
+   children: React.ReactNode;
+   userContext: UserContext;
+   notebookStorage: NotebookStorage;
+}
+
+interface NotebookStorageContextValue {
+   notebookStorage: NotebookStorage;
+   userContext: UserContext;
+}
+
+const NotebookStorageContext = createContext<
+   NotebookStorageContextValue | undefined
+>(undefined);
+
+export default function NotebookStorageProvider({
+   children,
+   userContext,
+   notebookStorage,
+}: NotebookStorageProviderProps) {
+   const value = useMemo(
+      () => ({ notebookStorage, userContext }),
+      [notebookStorage, userContext],
+   );
+   return (
+      <NotebookStorageContext.Provider value={value}>
+         {children}
+      </NotebookStorageContext.Provider>
+   );
+}
+
+export function useNotebookStorage() {
+   const context = useContext(NotebookStorageContext);
+   if (!context) {
+      throw new Error(
+         "useNotebookStorage must be used within a NotebookStorageProvider",
+      );
+   }
+   return context;
+}

--- a/packages/sdk/src/components/MutableNotebook/index.ts
+++ b/packages/sdk/src/components/MutableNotebook/index.ts
@@ -1,1 +1,5 @@
 export { default as MutableNotebook } from "./MutableNotebook";
+export { default as NotebookStorageProvider } from "./NotebookStorageProvider";
+export { BrowserNotebookStorage } from "./BrowserNotebookStorage";
+export type { UserContext, NotebookStorage } from "./NotebookStorage";
+export { MutableNotebookList } from "./MutableNotebookList";

--- a/packages/sdk/src/components/Package/Package.tsx
+++ b/packages/sdk/src/components/Package/Package.tsx
@@ -86,10 +86,10 @@ export default function Package({
          <Grid size={{ xs: 12, md: 12 }}>
             <Button
                variant="contained"
-               onClick={() => navigate(`scratch_notebook`)}
+               onClick={() => navigate(`list_scratch_notebook`)}
                sx={{ mb: 2 }}
             >
-               New Scratch Notebook
+               Scratch Notebooks
             </Button>
          </Grid>
          <Grid size={{ xs: 12, md: 12 }}>


### PR DESCRIPTION
Alternate UI would be to just show the Notebook list in the package page directly. Saves space and clicks, but might be more limiting if the UI expands (folders, sharing, etc..)
Also worth noting that "MutableNotebookList" is entirely Cursor-written, with only 1 minor edit


https://github.com/user-attachments/assets/fbe69807-4719-4a2d-83a1-e37059fcaf2f

