### PR TITLE
Fix lockfile

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3,9 +3,6 @@
   "workspaces": {
     "": {
       "name": "malloy-publisher",
-      "dependencies": {
-        "handlebars": "^4.7.8",
-      },
       "devDependencies": {
         "eslint": "^8.50.0",
         "prettier": "^3.0.0",
@@ -83,14 +80,14 @@
         "publisher": "dist/server.js",
       },
       "dependencies": {
-        "@malloydata/db-bigquery": "^0.0.275",
-        "@malloydata/db-duckdb": "^0.0.275",
-        "@malloydata/db-postgres": "^0.0.275",
-        "@malloydata/db-snowflake": "^0.0.275",
-        "@malloydata/db-trino": "^0.0.275",
-        "@malloydata/malloy": "^0.0.275",
-        "@malloydata/malloy-sql": "^0.0.275",
-        "@malloydata/render": "^0.0.275",
+        "@malloydata/db-bigquery": "^0.0.270",
+        "@malloydata/db-duckdb": "^0.0.270",
+        "@malloydata/db-postgres": "^0.0.270",
+        "@malloydata/db-snowflake": "^0.0.270",
+        "@malloydata/db-trino": "^0.0.270",
+        "@malloydata/malloy": "^0.0.270",
+        "@malloydata/malloy-sql": "^0.0.270",
+        "@malloydata/render": "^0.0.270",
         "@modelcontextprotocol/sdk": "^1.10.2",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.57.0",
@@ -103,6 +100,7 @@
         "cors": "^2.8.5",
         "express": "^4.21.0",
         "globals": "^15.9.0",
+        "handlebars": "^4.7.8",
         "http-proxy-middleware": "^3.0.5",
         "morgan": "^1.10.0",
         "node-cron": "^3.0.3",
@@ -306,7 +304,7 @@
 
     "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
-    "@duckdb/duckdb-wasm": ["@duckdb/duckdb-wasm@1.29.1-dev132.0", "", { "dependencies": { "apache-arrow": "^17.0.0" } }, "sha512-OUkJuH9564GQ/OgggdgJ/Yxmlk5PYnWiJe0rrNkEs0Sfsi00nK6WZgJmWGGAtCK6le2KJxFWZ4Z2MjUKGBzLuQ=="],
+    "@duckdb/duckdb-wasm": ["@duckdb/duckdb-wasm@1.29.0", "", { "dependencies": { "apache-arrow": "^17.0.0" } }, "sha512-8Zq7vafQuIz9gklC/9375KE38UlkaS2n8+yvG+/JK7irm3DjwYNJHL4xfplIj0bSHFIg6we5XhWYFqtE/vO3+Q=="],
 
     "@emotion/babel-plugin": ["@emotion/babel-plugin@11.13.5", "", { "dependencies": { "@babel/helper-module-imports": "^7.16.7", "@babel/runtime": "^7.18.3", "@emotion/hash": "^0.9.2", "@emotion/memoize": "^0.9.0", "@emotion/serialize": "^1.3.3", "babel-plugin-macros": "^3.1.0", "convert-source-map": "^1.5.0", "escape-string-regexp": "^4.0.0", "find-root": "^1.1.0", "source-map": "^0.5.7", "stylis": "4.2.0" } }, "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ=="],
 
@@ -460,17 +458,17 @@
 
     "@malloy-publisher/server": ["@malloy-publisher/server@workspace:packages/server"],
 
-    "@malloydata/db-bigquery": ["@malloydata/db-bigquery@0.0.275", "", { "dependencies": { "@google-cloud/bigquery": "^7.3.0", "@google-cloud/common": "^5.0.1", "@google-cloud/paginator": "^5.0.0", "@malloydata/malloy": "0.0.275", "gaxios": "^4.2.0" } }, "sha512-9j/4mX0izlosGWOWFAmr8W7e5illO6R5V+M3R3TlaR1pLuk16cxczmu8c4dgylej0EmQzTV/bxvB0so+l2TFKg=="],
+    "@malloydata/db-bigquery": ["@malloydata/db-bigquery@0.0.270", "", { "dependencies": { "@google-cloud/bigquery": "^7.3.0", "@google-cloud/common": "^5.0.1", "@google-cloud/paginator": "^5.0.0", "@malloydata/malloy": "^0.0.270", "gaxios": "^4.2.0" } }, "sha512-CsS/s5BKKDVThDoPVW330AcvoCGZx58N2mBZ91a6JqORokTHoYu9W60tq3jEyhQ1e7mX1/7C0j7NW87ko0+n6A=="],
 
-    "@malloydata/db-duckdb": ["@malloydata/db-duckdb@0.0.275", "", { "dependencies": { "@duckdb/duckdb-wasm": "1.29.1-dev132.0", "@malloydata/malloy": "0.0.275", "@motherduck/wasm-client": "^0.6.6", "apache-arrow": "^17.0.0", "duckdb": "1.2.1", "web-worker": "^1.3.0" } }, "sha512-8T+hh9AASv8TuIQdAZgRctk4ZuOeLMHmYhrrw6ybmnX0+zxVTiAcMVlnp/WhXtp24eC1OaJAslqbgyHu/IsiSg=="],
+    "@malloydata/db-duckdb": ["@malloydata/db-duckdb@0.0.270", "", { "dependencies": { "@duckdb/duckdb-wasm": "1.29.0", "@malloydata/malloy": "^0.0.270", "@motherduck/wasm-client": "^0.6.6", "apache-arrow": "^17.0.0", "duckdb": "1.2.1", "web-worker": "^1.3.0" } }, "sha512-8u18ch4g9hNe1Wm16OLpd+vbocYC+Zfll35o8oHl8R3N32xONhm0SKXx/S0u1HwpsEp2F8GORWEMrxncUfNOIw=="],
 
-    "@malloydata/db-postgres": ["@malloydata/db-postgres@0.0.275", "", { "dependencies": { "@malloydata/malloy": "0.0.275", "@types/pg": "^8.6.1", "pg": "^8.7.1", "pg-query-stream": "4.2.3" } }, "sha512-1TSl88yH+IQmLqD33nyYtrKlv8ILnhUMdnO5Q1laY/JGzksyjtOaVckYgsahfk6HInZ6s2jNiX13VKPk1yKHfw=="],
+    "@malloydata/db-postgres": ["@malloydata/db-postgres@0.0.270", "", { "dependencies": { "@malloydata/malloy": "^0.0.270", "@types/pg": "^8.6.1", "pg": "^8.7.1", "pg-query-stream": "4.2.3" } }, "sha512-k5FoXIPh116o3qpbG7CyNlDAHPH60J6/DfNKiJ09ZHz6plH45Hw1MFSjLpc6nrkGrMXpM2THx3wI1dvN1/hU5g=="],
 
-    "@malloydata/db-snowflake": ["@malloydata/db-snowflake@0.0.275", "", { "dependencies": { "@malloydata/malloy": "0.0.275", "generic-pool": "^3.9.0", "snowflake-sdk": "2.0.2", "toml": "^3.0.0" } }, "sha512-5rOQTSz08qTl8SAFeCwv6pmMGcxZ8KSH2XFgzb9v2wsWsV4GFGNyuttd00eTjFZPaZsaKbM41GBzrB8VlwazOw=="],
+    "@malloydata/db-snowflake": ["@malloydata/db-snowflake@0.0.270", "", { "dependencies": { "@malloydata/malloy": "^0.0.270", "generic-pool": "^3.9.0", "snowflake-sdk": "2.0.2", "toml": "^3.0.0" } }, "sha512-zQgcpEjGPeTlUzWX2Sq0wbYywP4iNoZ5VNlVQWReXuE+s7VfOUEIbpeDAhsVMaaeC20KVSoWpeTxYzed84NTdw=="],
 
-    "@malloydata/db-trino": ["@malloydata/db-trino@0.0.275", "", { "dependencies": { "@malloydata/malloy": "0.0.275", "@prestodb/presto-js-client": "^1.0.0", "gaxios": "^4.2.0", "trino-client": "^0.2.2" } }, "sha512-2LLZ1Kr13SIiQ1IVEBFHutiz1hbcQSDe4OfY5CXaovTXJTdXeCSC1cIY5aCshpOAN5rkEsbDueEI1IgiCAjzfA=="],
+    "@malloydata/db-trino": ["@malloydata/db-trino@0.0.270", "", { "dependencies": { "@malloydata/malloy": "^0.0.270", "@prestodb/presto-js-client": "^1.0.0", "gaxios": "^4.2.0", "trino-client": "^0.2.2" } }, "sha512-eF8Lqc78L+t7SO5NG1PoLRssYh7y8Qe65jfRCLf5+ukPQju87K9cILLStCL7Yx8W5QR20ETJsRnJFQwW4miuhQ=="],
 
-    "@malloydata/malloy": ["@malloydata/malloy@0.0.275", "", { "dependencies": { "@malloydata/malloy-filter": "0.0.275", "@malloydata/malloy-interfaces": "0.0.275", "@malloydata/malloy-tag": "0.0.275", "antlr4ts": "^0.5.0-alpha.4", "assert": "^2.0.0", "jaro-winkler": "^0.2.8", "jest-diff": "^29.6.2", "lodash": "^4.17.20", "luxon": "^2.4.0", "uuid": "^8.3.2" } }, "sha512-BsOU/lh9W0CiMp/h2XH8psC4TwgPmjaGOl1G6dNL5LHMewjslTqv6/RIO9PqLY+LoOffyoJ0QXiW42D3x8ltRQ=="],
+    "@malloydata/malloy": ["@malloydata/malloy@0.0.270", "", { "dependencies": { "@malloydata/malloy-filter": "^0.0.270", "@malloydata/malloy-interfaces": "^0.0.270", "@malloydata/malloy-tag": "^0.0.270", "antlr4ts": "^0.5.0-alpha.4", "assert": "^2.0.0", "jaro-winkler": "^0.2.8", "jest-diff": "^29.6.2", "lodash": "^4.17.20", "luxon": "^2.4.0", "uuid": "^8.3.2" } }, "sha512-He62OCS8Ccq/dESFH/lIwhu02bonBFfSsUmZO0peUjYjr0QmADIpy+CTDzftRBBxVNsIEkdzXZu2Pfag2FQd/w=="],
 
     "@malloydata/malloy-explorer": ["@malloydata/malloy-explorer@0.0.278-dev250516210719", "", { "dependencies": { "@dnd-kit/core": "^6.3.1", "@dnd-kit/sortable": "^10.0.0", "@dnd-kit/utilities": "^3.2.2", "@floating-ui/react-dom": "2.1.2", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-dropdown-menu": "^2.1.6", "@radix-ui/react-icons": "^1.3.2", "@radix-ui/react-popover": "^1.1.6", "@radix-ui/react-scroll-area": "^1.2.3", "@radix-ui/react-select": "^2.1.6", "@radix-ui/react-tabs": "^1.1.3", "@radix-ui/react-tooltip": "^1.1.8", "@shikijs/core": "^3.2.1", "@shikijs/engine-javascript": "^3.2.1", "@shikijs/langs": "^3.2.1", "@shikijs/themes": "^3.2.1", "@shikijs/types": "^3.2.1", "@stylexjs/stylex": "^0.10.1", "assert": "^2.1.0", "moment": "^2.30.1", "react": ">= 19.0.0", "react-dom": ">= 19.0.0" }, "peerDependencies": { "@malloydata/malloy-filter": ">= 0.0.278", "@malloydata/malloy-interfaces": ">= 0.0.278", "@malloydata/malloy-query-builder": ">= 0.0.278", "@malloydata/malloy-tag": ">= 0.0.278", "@malloydata/render": ">= 0.0.278" }, "bin": { "malloy-packages": "scripts/malloy-packages.ts" } }, "sha512-Ut6OTRJnoZrxNDZK2dT3L4UfhRWs1EaDTrUKZIOa7ARBuWC95k46OXM3G4sUOxzfyx+j4Z9DumxY/X8J25awTw=="],
 
@@ -480,7 +478,7 @@
 
     "@malloydata/malloy-query-builder": ["@malloydata/malloy-query-builder@0.0.275", "", { "dependencies": { "@malloydata/malloy-filter": "0.0.275", "@malloydata/malloy-interfaces": "0.0.275", "@malloydata/malloy-tag": "0.0.275" } }, "sha512-kFYfIDFcZuUVEbu+MP8xqiWpwXsU0LCt/zDh0+TQ/kNTHxFvWIUoXwDAY2CI0AU0xV4jwTvoa0Q5e1rMfkqy0Q=="],
 
-    "@malloydata/malloy-sql": ["@malloydata/malloy-sql@0.0.275", "", { "dependencies": { "@malloydata/malloy": "0.0.275" } }, "sha512-g5YYnLNeQNbn5n/4H1uAlwbVaDZgVSbqleAK0YzrRpUGy5R8n6N3TWU8Crzhi8hg3G5CqJoAQjLNyCjdOT2wrg=="],
+    "@malloydata/malloy-sql": ["@malloydata/malloy-sql@0.0.270", "", { "dependencies": { "@malloydata/malloy": "^0.0.270" } }, "sha512-sBeD1eCJrzA2me07F3IryEqlewmlhHKvngx1jfbPyv0LMY9hY6prFwrn+3WmCIqlHGjwrv8ZLBY79ytIkw3SdA=="],
 
     "@malloydata/malloy-tag": ["@malloydata/malloy-tag@0.0.275", "", { "dependencies": { "antlr4ts": "^0.5.0-alpha.4", "assert": "^2.0.0", "uuid": "^8.3.2" } }, "sha512-2yKo7gaiA8ElvmkO+8oPCP05Nay4nE2xBIduZr/eEYQNgK5oKfUuEvpz1FKcpFLJDtJxGDMLM9clAQqGOJ0j4g=="],
 
@@ -3324,6 +3322,14 @@
 
     "@malloy-publisher/sdk/@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.16.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.16.0", "@typescript-eslint/type-utils": "8.16.0", "@typescript-eslint/utils": "8.16.0", "@typescript-eslint/visitor-keys": "8.16.0", "graphemer": "^1.4.0", "ignore": "^5.3.1", "natural-compare": "^1.4.0", "ts-api-utils": "^1.3.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0", "eslint": "^8.57.0 || ^9.0.0" } }, "sha512-5YTHKV8MYlyMI6BaEG7crQ9BhSc8RxzshOReKwZwRWN0+XvvTOm+L/UYLCYxFpfwYuAAqhxiq4yae0CMFwbL7Q=="],
 
+    "@malloy-publisher/server/@malloydata/render": ["@malloydata/render@0.0.270", "", { "dependencies": { "@malloydata/malloy": "^0.0.270", "@malloydata/malloy-interfaces": "^0.0.270", "@malloydata/malloy-tag": "^0.0.270", "@tanstack/solid-virtual": "^3.10.4", "component-register": "^0.8.6", "lodash": "^4.17.20", "luxon": "^2.4.0", "solid-element": "^1.8.0", "solid-js": "^1.8.15", "ssf": "^0.11.2", "us-atlas": "^3.0.0", "vega": "^5.21.0", "vega-lite": "^5.2.0" } }, "sha512-Zjqr943RF//cUM3vdBAqCgmfIR0Yza5t0E896BNFqaP6rQleIpXR9xKT4DlwtftzXnSVP3JNJb0TlUT8D8ntSA=="],
+
+    "@malloydata/malloy/@malloydata/malloy-filter": ["@malloydata/malloy-filter@0.0.270", "", { "dependencies": { "jest-diff": "^29.6.2", "luxon": "^3.5.0", "moo": "^0.5.2", "nearley": "^2.20.1" } }, "sha512-wt3UDoNT/1eeK1N2uD0ZwAoPWog7THQsetd8pjuuWzE1D8GAZzIs+rmey65QtKiz2oVfXSWTNbummyzVCQ3TuA=="],
+
+    "@malloydata/malloy/@malloydata/malloy-interfaces": ["@malloydata/malloy-interfaces@0.0.270", "", { "dependencies": { "@creditkarma/thrift-server-core": "^1.0.4" } }, "sha512-XCqtIh0/2CZxcCiKcGLE6YUODbRdlNhffvUsysnw2YYBVGgtxOh/OYBYS2UB1wydwkYenN5GaBUDrG/I0so8Zw=="],
+
+    "@malloydata/malloy/@malloydata/malloy-tag": ["@malloydata/malloy-tag@0.0.270", "", { "dependencies": { "antlr4ts": "^0.5.0-alpha.4", "assert": "^2.0.0", "uuid": "^8.3.2" } }, "sha512-b96ntXdN3hlHZvGaNJtg9u57CKVNoDfmPu+cYPQWyHUN6WRVUGevhY+CJ+olm/I+fJvRqQ71uxXKVtB0Mv35EQ=="],
+
     "@malloydata/malloy/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
     "@malloydata/malloy-explorer/@shikijs/core": ["@shikijs/core@3.4.0", "", { "dependencies": { "@shikijs/types": "3.4.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-0YOzTSRDn/IAfQWtK791gs1u8v87HNGToU6IwcA3K7nPoVOrS2Dh6X6A6YfXgPTSkTwR5y6myk0MnI0htjnwrA=="],
@@ -3343,6 +3349,8 @@
     "@malloydata/malloy-filter/luxon": ["luxon@3.6.1", "", {}, "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ=="],
 
     "@malloydata/malloy-tag/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
+
+    "@malloydata/render/@malloydata/malloy": ["@malloydata/malloy@0.0.275", "", { "dependencies": { "@malloydata/malloy-filter": "0.0.275", "@malloydata/malloy-interfaces": "0.0.275", "@malloydata/malloy-tag": "0.0.275", "antlr4ts": "^0.5.0-alpha.4", "assert": "^2.0.0", "jaro-winkler": "^0.2.8", "jest-diff": "^29.6.2", "lodash": "^4.17.20", "luxon": "^2.4.0", "uuid": "^8.3.2" } }, "sha512-BsOU/lh9W0CiMp/h2XH8psC4TwgPmjaGOl1G6dNL5LHMewjslTqv6/RIO9PqLY+LoOffyoJ0QXiW42D3x8ltRQ=="],
 
     "@mapbox/node-pre-gyp/consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
@@ -3774,9 +3782,17 @@
 
     "@malloy-publisher/sdk/@typescript-eslint/eslint-plugin/ts-api-utils": ["ts-api-utils@1.4.3", "", { "peerDependencies": { "typescript": ">=4.2.0" } }, "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw=="],
 
+    "@malloy-publisher/server/@malloydata/render/@malloydata/malloy-interfaces": ["@malloydata/malloy-interfaces@0.0.270", "", { "dependencies": { "@creditkarma/thrift-server-core": "^1.0.4" } }, "sha512-XCqtIh0/2CZxcCiKcGLE6YUODbRdlNhffvUsysnw2YYBVGgtxOh/OYBYS2UB1wydwkYenN5GaBUDrG/I0so8Zw=="],
+
+    "@malloy-publisher/server/@malloydata/render/@malloydata/malloy-tag": ["@malloydata/malloy-tag@0.0.270", "", { "dependencies": { "antlr4ts": "^0.5.0-alpha.4", "assert": "^2.0.0", "uuid": "^8.3.2" } }, "sha512-b96ntXdN3hlHZvGaNJtg9u57CKVNoDfmPu+cYPQWyHUN6WRVUGevhY+CJ+olm/I+fJvRqQ71uxXKVtB0Mv35EQ=="],
+
     "@malloydata/malloy-explorer/@shikijs/engine-javascript/oniguruma-to-es": ["oniguruma-to-es@4.3.3", "", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg=="],
 
     "@malloydata/malloy-explorer/react-dom/scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
+
+    "@malloydata/malloy/@malloydata/malloy-filter/luxon": ["luxon@3.6.1", "", {}, "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ=="],
+
+    "@malloydata/render/@malloydata/malloy/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
     "@microsoft/api-extractor/semver/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
@@ -4029,6 +4045,8 @@
     "@grpc/proto-loader/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "@malloy-publisher/sdk/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@4.2.0", "", {}, "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw=="],
+
+    "@malloy-publisher/server/@malloydata/render/@malloydata/malloy-tag/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
     "@malloydata/malloy-explorer/@shikijs/engine-javascript/oniguruma-to-es/regex": ["regex@6.0.1", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA=="],
 


### PR DESCRIPTION
This PR allows installing dependencies with a frozen lockfile

```sh
❯ bun i --frozen-lockfile
bun install v1.2.10 (db2e7d7f)
error: lockfile had changes, but lockfile is frozen
note: try re-running without --frozen-lockfile and commit the updated lockfile
❯ bun i
bun install v1.2.10 (db2e7d7f)
❯ bun i --frozen-lockfile
bun install v1.2.10 (db2e7d7f)

Checked 1960 installs across 1801 packages (no changes) [457.00ms]
```