### PR TITLE
Fix memory management during sdk build

### DIFF
--- a/packages/sdk/vite.config.ts
+++ b/packages/sdk/vite.config.ts
@@ -1,8 +1,8 @@
+import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
-import { peerDependencies } from "./package.json";
 import svgr from "vite-plugin-svgr";
-import react from "@vitejs/plugin-react";
+import { peerDependencies } from "./package.json";
 
 export default ({ mode }) => {
    return defineConfig({
@@ -19,18 +19,38 @@ export default ({ mode }) => {
          },
          rollupOptions: {
             onwarn(warning, warn) {
-               if (warning.code === "MODULE_LEVEL_DIRECTIVE") {
-                  return;
-               }
-               if (warning.code === "SOURCEMAP_ERROR") {
+               if (
+                  warning.code === "MODULE_LEVEL_DIRECTIVE" ||
+                  warning.code === "SOURCEMAP_ERROR"
+               ) {
                   return;
                }
                warn(warning);
             },
             external: [...Object.keys(peerDependencies)], // Defines external dependencies for Rollup bundling.
+            output: {
+               manualChunks: {
+                  vendor: [
+                     "@emotion/react",
+                     "@emotion/styled",
+                     "@mui/material",
+                     "@mui/icons-material",
+                     "@mui/system",
+                     "@mui/x-tree-view",
+                     "@react-spring/web",
+                     "@tanstack/react-query",
+                     "@uiw/react-md-editor",
+                     "axios",
+                     "markdown-to-jsx",
+                     "react-router-dom",
+                  ],
+               },
+            },
          },
-         sourcemap: true, // Generates source maps for debugging.
+         sourcemap: mode !== "production",
          emptyOutDir: true, // Clears the output directory before building.
+         chunkSizeWarningLimit: 1000,
+         target: "es2020",
       },
       plugins: [dts(), svgr(), react()],
    });


### PR DESCRIPTION
This PR fixes an issue where the sdk needed over 4GB ram to build and it would crash when building with constrained resources