### PR TITLE
Fix notebook rerender, add in MUI styling overrides

### DIFF
--- a/packages/app/src/theme.tsx
+++ b/packages/app/src/theme.tsx
@@ -1,5 +1,6 @@
 import { createTheme } from "@mui/material/styles";
 import { red } from "@mui/material/colors";
+import { surfacesCustomizations } from "./theme/customizations";
 
 // A custom theme for this app
 const theme = createTheme({
@@ -13,6 +14,9 @@ const theme = createTheme({
       error: {
          main: red.A400,
       },
+   },
+   components: {
+      ...surfacesCustomizations,
    },
 });
 

--- a/packages/app/src/theme/customizations/surfaces.ts
+++ b/packages/app/src/theme/customizations/surfaces.ts
@@ -9,7 +9,7 @@ export const surfacesCustomizations: Components<Theme> = {
       },
       styleOverrides: {
          root: ({ theme }) => ({
-            padding: 4,
+            padding: 2,
             overflow: "clip",
             backgroundColor: theme.palette.background.default,
             border: "1px solid",
@@ -46,7 +46,7 @@ export const surfacesCustomizations: Components<Theme> = {
    },
    MuiAccordionDetails: {
       styleOverrides: {
-         root: { mb: 20, border: "none" },
+         root: { mb: 4, border: "none" },
       },
    },
    MuiPaper: {
@@ -58,8 +58,8 @@ export const surfacesCustomizations: Components<Theme> = {
       styleOverrides: {
          root: ({ theme }) => {
             return {
-               padding: 16,
-               gap: 16,
+               padding: 2,
+               gap: 2,
                transition: "all 100ms ease",
                backgroundColor: gray[50],
                borderRadius: theme.shape.borderRadius,
@@ -84,6 +84,13 @@ export const surfacesCustomizations: Components<Theme> = {
                   },
                ],
             };
+         },
+      },
+   },
+   MuiIconButton: {
+      styleOverrides: {
+         root: {
+            padding: 0,
          },
       },
    },

--- a/packages/sdk/src/components/Notebook/NotebookCell.tsx
+++ b/packages/sdk/src/components/Notebook/NotebookCell.tsx
@@ -213,7 +213,13 @@ export function NotebookCell({
             {cell.result && !sourcesExpanded && (
                <>
                   <Divider sx={{ mb: "10px" }} />
-                  <CardContent sx={{ maxHeight: "800px", overflow: "auto" }}>
+                  <CardContent
+                     sx={{
+                        minHeight: "100px",
+                        maxHeight: "800px",
+                        overflow: "auto",
+                     }}
+                  >
                      <Suspense fallback="Loading malloy...">
                         <RenderedResult result={cell.result} />
                      </Suspense>


### PR DESCRIPTION
* Fixes https://github.com/ms2data/service/issues/726#issue-3107785790 -
  Adds a miniumum height to the notebookCell
* Applies MUI styling to compactify Cards & icons 
<img width="1074" alt="Screenshot 2025-06-09 at 3 29 42 PM" src="https://github.com/user-attachments/assets/0d924d29-92ad-411f-a438-bf404553142b" />
