### PR TITLE
Ctrl-click and other normal click options work in the UI

### DIFF
--- a/packages/app/src/components/HomePage.tsx
+++ b/packages/app/src/components/HomePage.tsx
@@ -1,10 +1,10 @@
 import { Home } from "@malloy-publisher/sdk";
-import { useNavigate } from "react-router-dom";
+import { useRouterClickHandler } from "@malloy-publisher/sdk";
 interface HomePageProps {
    server?: string;
 }
 
 export function HomePage({ server }: HomePageProps) {
-   const navigate = useNavigate();
+   const navigate = useRouterClickHandler();
    return <Home server={server} navigate={navigate} />;
 }

--- a/packages/app/src/components/MainPage.tsx
+++ b/packages/app/src/components/MainPage.tsx
@@ -19,13 +19,14 @@ import {
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
 import React from "react";
-import { Outlet, useNavigate, useParams } from "react-router-dom";
+import { Outlet, useParams } from "react-router-dom";
 import BreadcrumbNav from "./BreadcrumbNav";
 import { MutableNotebookList } from "./MutableNotebookList";
+import { useRouterClickHandler } from "@malloy-publisher/sdk";
 
 export default function MainPage() {
    const { projectName, packageName } = useParams();
-   const navigate = useNavigate();
+   const navigate = useRouterClickHandler();
 
    const [analysisName, setAnalysisName] = React.useState("");
    const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
@@ -45,19 +46,21 @@ export default function MainPage() {
       setNewDialogOpen(false);
    };
 
-   const handleNotebookClick = (notebook: string) => {
+   const handleNotebookClick = (notebook: string, event: React.MouseEvent) => {
       setOpenDialogOpen(false);
       // Navigate to the ScratchNotebookPage with anchor text for notebookPath
       navigate(
          `/${projectName}/${packageName}/scratchNotebook/${encodeURIComponent(notebook)}`,
+         event,
       );
    };
 
-   const createNotebookClick = () => {
+   const createNotebookClick = (event?: React.MouseEvent) => {
       setNewDialogOpen(false);
       // Navigate to the ScratchNotebookPage with anchor text for notebookPath
       navigate(
          `/${projectName}/${packageName}/scratchNotebook/${encodeURIComponent(analysisName)}`,
+         event,
       );
       setAnalysisName("");
    };
@@ -159,7 +162,9 @@ export default function MainPage() {
                                     setAnalysisName(e.target.value)
                                  }
                               />
-                              <Button onClick={createNotebookClick}>
+                              <Button
+                                 onClick={(event) => createNotebookClick(event)}
+                              >
                                  Create
                               </Button>
                            </FormControl>

--- a/packages/app/src/components/MutableNotebookList.tsx
+++ b/packages/app/src/components/MutableNotebookList.tsx
@@ -3,7 +3,7 @@ import { Divider, Table, TableBody, TableCell, TableRow } from "@mui/material";
 import React from "react";
 
 interface MutableNotebookListProps {
-   onNotebookClick: (notebook: string) => void;
+   onNotebookClick: (notebook: string, event: React.MouseEvent) => void;
 }
 
 export function MutableNotebookList({
@@ -32,7 +32,9 @@ export function MutableNotebookList({
                {notebooks.map((notebook) => (
                   <TableRow key={notebook}>
                      <TableCell
-                        onClick={() => onNotebookClick(notebook)}
+                        onClick={(event: React.MouseEvent) =>
+                           onNotebookClick(notebook, event)
+                        }
                         sx={{ width: "200px", cursor: "pointer" }}
                      >
                         {notebook}

--- a/packages/app/src/components/PackagePage.tsx
+++ b/packages/app/src/components/PackagePage.tsx
@@ -1,5 +1,6 @@
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { Package } from "@malloy-publisher/sdk";
+import { useRouterClickHandler } from "@malloy-publisher/sdk";
 
 interface PackagePageProps {
    server?: string;
@@ -7,7 +8,7 @@ interface PackagePageProps {
 
 export function PackagePage({ server }: PackagePageProps) {
    const { projectName, packageName } = useParams();
-   const navigate = useNavigate();
+   const navigate = useRouterClickHandler();
    if (!projectName) {
       return (
          <div>

--- a/packages/app/src/components/ProjectPage.tsx
+++ b/packages/app/src/components/ProjectPage.tsx
@@ -1,12 +1,13 @@
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { Project } from "@malloy-publisher/sdk";
+import { useRouterClickHandler } from "@malloy-publisher/sdk";
 
 interface ProjectPageProps {
    server?: string;
 }
 
 export function ProjectPage({ server }: ProjectPageProps) {
-   const navigate = useNavigate();
+   const navigate = useRouterClickHandler();
    const { projectName } = useParams();
    if (!projectName) {
       return (

--- a/packages/sdk/src/components/Home/Home.tsx
+++ b/packages/sdk/src/components/Home/Home.tsx
@@ -9,7 +9,7 @@ const queryClient = new QueryClient();
 
 interface HomeProps {
    server?: string;
-   navigate?: (to: string) => void;
+   navigate?: (to: string, event?: React.MouseEvent) => void;
 }
 
 export default function Home({ server, navigate }: HomeProps) {
@@ -44,7 +44,9 @@ export default function Home({ server, navigate }: HomeProps) {
                   <Grid key={project.name}>
                      <Typography
                         variant="h1"
-                        onClick={() => navigate(`/${project.name}/`)}
+                        onClick={(event) =>
+                           navigate(`/${project.name}/`, event)
+                        }
                      >
                         {project.name}
                      </Typography>

--- a/packages/sdk/src/components/MutableNotebook/MutableNotebook.tsx
+++ b/packages/sdk/src/components/MutableNotebook/MutableNotebook.tsx
@@ -16,7 +16,7 @@ import {
 } from "@mui/material";
 import Stack from "@mui/material/Stack";
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { useRouterClickHandler } from "../click_helper";
 import { Configuration, ModelsApi } from "../../client";
 import { SourceAndPath } from "../Model/SourcesExplorer";
 import { NotebookManager } from "../NotebookManager";
@@ -46,7 +46,7 @@ export default function MutableNotebook({
    expandCodeCells,
    expandEmbeddings,
 }: MutableNotebookProps) {
-   const navigate = useNavigate();
+   const navigate = useRouterClickHandler();
    const { server, projectName, packageName, versionId, accessToken } =
       usePublisherPackage();
    if (!projectName || !packageName) {
@@ -107,12 +107,12 @@ export default function MutableNotebook({
       setDeleteDialogOpen(true);
    };
 
-   const handleDeleteConfirm = () => {
+   const handleDeleteConfirm = (event?: React.MouseEvent) => {
       if (notebookPath && notebookStorage && userContext) {
          notebookStorage.deleteNotebook(userContext, notebookPath);
       }
       setDeleteDialogOpen(false);
-      navigate(`/${projectName}/${packageName}`);
+      navigate(`/${projectName}/${packageName}`, event);
    };
 
    const handleDeleteCancel = () => {
@@ -286,7 +286,7 @@ export default function MutableNotebook({
                               Cancel
                            </Button>
                            <Button
-                              onClick={handleDeleteConfirm}
+                              onClick={(event) => handleDeleteConfirm(event)}
                               color="error"
                               autoFocus
                            >

--- a/packages/sdk/src/components/Package/Connections.tsx
+++ b/packages/sdk/src/components/Package/Connections.tsx
@@ -19,7 +19,7 @@ interface ConnectionsProps {
    server?: string;
    projectName: string;
    accessToken: string;
-   navigate: (to: string) => void;
+   navigate: (to: string, event?: React.MouseEvent) => void;
 }
 
 // TODO(jjs) - Move this UI to the ConnectionExplorer component

--- a/packages/sdk/src/components/Package/FileTreeView.tsx
+++ b/packages/sdk/src/components/Package/FileTreeView.tsx
@@ -27,7 +27,7 @@ import { Typography } from "@mui/material";
 interface FiieTreeViewProps {
    items: Model[] | Database[];
    defaultExpandedItems: string[];
-   navigate?: (to: string) => void;
+   navigate?: (to: string, event?: React.MouseEvent) => void;
 }
 
 export function FileTreeView({
@@ -64,7 +64,7 @@ type ExtendedTreeItemProps = {
    label: string;
    fileType: FileType;
    selectable: boolean;
-   link: () => void | undefined;
+   link: ((event?: React.MouseEvent) => void) | undefined;
 };
 
 interface CustomLabelProps {
@@ -135,7 +135,7 @@ const CustomTreeItem = React.forwardRef(function CustomTreeItem(
             <TreeItem2Content
                {...getContentProps()}
                {...(item.link && {
-                  onClick: () => item.link(),
+                  onClick: (event) => item.link(event),
                })}
                sx={{
                   // If the item is not selectable, disable pointer events.
@@ -159,7 +159,7 @@ const CustomTreeItem = React.forwardRef(function CustomTreeItem(
 
 function getTreeView(
    metadataEntries: Model[] | Database[],
-   navigate: (to: string) => void,
+   navigate: (to: string, event?: React.MouseEvent) => void,
 ): TreeViewBaseItem<ExtendedTreeItemProps>[] {
    const tree = new Map<string, unknown>();
    metadataEntries.map((entry: Model | Database) => {
@@ -182,7 +182,7 @@ function getTreeView(
 function getTreeViewRecursive(
    node: Map<string, unknown>,
    path: string,
-   navigate: (to: string) => void,
+   navigate: (to: string, event?: React.MouseEvent) => void,
 ): TreeViewBaseItem<ExtendedTreeItemProps>[] {
    const treeViewItems: TreeViewBaseItem<ExtendedTreeItemProps>[] = [];
    node.forEach((value, key) => {
@@ -199,7 +199,7 @@ function getTreeViewRecursive(
             fileType: fileType,
             link:
                fileType === "model" || fileType === "notebook"
-                  ? navigate.bind(null, path + key)
+                  ? (event) => navigate(path + key, event)
                   : undefined,
             selectable: fileType === "model" || fileType === "notebook",
          });

--- a/packages/sdk/src/components/Package/Models.tsx
+++ b/packages/sdk/src/components/Package/Models.tsx
@@ -16,7 +16,7 @@ interface ModelsProps {
    projectName: string;
    packageName: string;
    versionId?: string;
-   navigate: (to: string) => void;
+   navigate: (to: string, event?: React.MouseEvent) => void;
    accessToken?: string;
 }
 

--- a/packages/sdk/src/components/Package/Notebooks.tsx
+++ b/packages/sdk/src/components/Package/Notebooks.tsx
@@ -14,7 +14,7 @@ interface ModelsProps {
    projectName: string;
    packageName: string;
    versionId?: string;
-   navigate: (to: string) => void;
+   navigate: (to: string, event?: React.MouseEvent) => void;
    accessToken?: string;
 }
 

--- a/packages/sdk/src/components/Package/Package.tsx
+++ b/packages/sdk/src/components/Package/Package.tsx
@@ -15,7 +15,7 @@ interface PackageProps {
    projectName: string;
    packageName: string;
    versionId?: string;
-   navigate?: (to: string) => void;
+   navigate?: (to: string, event?: React.MouseEvent) => void;
    accessToken?: string;
 }
 

--- a/packages/sdk/src/components/Project/Packages.tsx
+++ b/packages/sdk/src/components/Project/Packages.tsx
@@ -9,7 +9,7 @@ const queryClient = new QueryClient();
 interface ProjectProps {
    server?: string;
    projectName: string;
-   navigate?: (to: string, event?: React.MouseEvent) => void;
+   navigate: (to: string, event?: React.MouseEvent) => void;
    accessToken?: string;
 }
 
@@ -33,12 +33,6 @@ export default function Project({
       },
       queryClient,
    );
-
-   if (!navigate) {
-      navigate = (to: string) => {
-         window.location.href = to;
-      };
-   }
 
    return (
       <>

--- a/packages/sdk/src/components/Project/Packages.tsx
+++ b/packages/sdk/src/components/Project/Packages.tsx
@@ -9,7 +9,7 @@ const queryClient = new QueryClient();
 interface ProjectProps {
    server?: string;
    projectName: string;
-   navigate?: (to: string) => void;
+   navigate?: (to: string, event?: React.MouseEvent) => void;
    accessToken?: string;
 }
 
@@ -74,7 +74,9 @@ export default function Project({
                               <StyledCard
                                  variant="outlined"
                                  sx={{ padding: "10px", cursor: "pointer" }}
-                                 onClick={() => navigate(p.name + "/")}
+                                 onClick={(event) =>
+                                    navigate(p.name + "/", event)
+                                 }
                               >
                                  <StyledCardContent>
                                     <Typography

--- a/packages/sdk/src/components/Project/Project.tsx
+++ b/packages/sdk/src/components/Project/Project.tsx
@@ -5,7 +5,7 @@ import Packages from "./Packages";
 interface ProjectProps {
    server?: string;
    projectName: string;
-   navigate?: (to: string) => void;
+   navigate: (to: string, event?: React.MouseEvent) => void;
    accessToken?: string;
 }
 

--- a/packages/sdk/src/components/RenderedResult/ResultContainer.tsx
+++ b/packages/sdk/src/components/RenderedResult/ResultContainer.tsx
@@ -65,12 +65,6 @@ export default function ResultContainer({
       if (contentHeight < availableHeight) {
          setExplicitHeight(contentHeight + 20);
       }
-      console.log("Height comparison:", {
-         contentHeight,
-         minHeight,
-         availableHeight,
-         exceedsHeight,
-      });
       setShouldShowToggle(exceedsHeight);
    }, [contentHeight, minHeight]);
 
@@ -92,8 +86,8 @@ export default function ResultContainer({
                position: "relative",
                minHeight: `${minHeight}px`,
                maxHeight: `${isExpanded ? maxHeight : minHeight}px`,
-               border: "1px solid #e0e0e0",
-               borderRadius: 1,
+               border: "0px",
+               borderRadius: 0,
                overflow: "hidden",
                display: "flex",
                flexDirection: "column",

--- a/packages/sdk/src/components/click_helper.ts
+++ b/packages/sdk/src/components/click_helper.ts
@@ -24,7 +24,7 @@ export function useRouterClickHandler() {
       }
 
       // For modifier keys or middle mouse, let browser handle it by opening URL
-      const href = window.location.origin + to;
+      const href = new URL(to, window.location.href).href;
 
       if (event.metaKey || event.ctrlKey || event.button === 1) {
          // CMD/Ctrl click or middle mouse - open in new tab

--- a/packages/sdk/src/components/click_helper.ts
+++ b/packages/sdk/src/components/click_helper.ts
@@ -1,0 +1,37 @@
+import { useNavigate } from "react-router-dom";
+import { MouseEvent } from "react";
+
+/**
+ * Custom hook that returns a function for handling clicks with proper modifier key support.
+ * The returned function handles CMD/Ctrl clicks to open in new tabs, regular clicks for navigation.
+ *
+ * @returns A function that takes a relative URL and either navigates or opens in new tab
+ */
+export function useRouterClickHandler() {
+   const navigate = useNavigate();
+
+   return (to: string, event?: MouseEvent) => {
+      // If no event or no modifier keys, use normal navigation
+      if (
+         !event ||
+         (!event.metaKey &&
+            !event.ctrlKey &&
+            !event.shiftKey &&
+            event.button !== 1)
+      ) {
+         navigate(to);
+         return;
+      }
+
+      // For modifier keys or middle mouse, let browser handle it by opening URL
+      const href = window.location.origin + to;
+
+      if (event.metaKey || event.ctrlKey || event.button === 1) {
+         // CMD/Ctrl click or middle mouse - open in new tab
+         window.open(href, "_blank");
+      } else if (event.shiftKey) {
+         // Shift click - open in new window
+         window.open(href, "_blank");
+      }
+   };
+}

--- a/packages/sdk/src/components/index.ts
+++ b/packages/sdk/src/components/index.ts
@@ -5,3 +5,4 @@ export * from "./Package";
 export * from "./Project";
 export * from "./QueryResult";
 export * from "./Home";
+export { useRouterClickHandler } from "./click_helper";


### PR DESCRIPTION
Navigation should be replaced by a provider, so it does not need to be part of the prop render tree.