### PR TITLE
Refactor ReactQuery usage for error handling

### DIFF
--- a/packages/sdk/src/components/ApiErrorDisplay.tsx
+++ b/packages/sdk/src/components/ApiErrorDisplay.tsx
@@ -14,6 +14,7 @@ interface ApiErrorDisplayProps {
 }
 
 export function ApiErrorDisplay({ error, context }: ApiErrorDisplayProps) {
+   const errorMessage = error.data?.message || "Unknown Error";
    return (
       <>
          {context && (
@@ -21,18 +22,17 @@ export function ApiErrorDisplay({ error, context }: ApiErrorDisplayProps) {
                {context}
             </Typography>
          )}
-         {error.data && (
-            <pre
-               style={{
-                  whiteSpace: "pre-wrap",
-                  color: "red",
-                  padding: "10px",
-                  margin: "auto",
-               }}
-            >
-               {error.data.message}
-            </pre>
-         )}
+
+         <pre
+            style={{
+               whiteSpace: "pre-wrap",
+               color: "red",
+               padding: "10px",
+               margin: "auto",
+            }}
+         >
+            {errorMessage}
+         </pre>
       </>
    );
 }

--- a/packages/sdk/src/components/Home/Home.tsx
+++ b/packages/sdk/src/components/Home/Home.tsx
@@ -1,11 +1,10 @@
 import { Grid, Typography } from "@mui/material";
-import { QueryClient, useQuery } from "@tanstack/react-query";
 import { ProjectsApi, Configuration } from "../../client";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
+import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 
 const projectsApi = new ProjectsApi(new Configuration());
-const queryClient = new QueryClient();
 
 interface HomeProps {
    server?: string;
@@ -13,18 +12,14 @@ interface HomeProps {
 }
 
 export default function Home({ server, navigate }: HomeProps) {
-   const { data, isSuccess, isError, error } = useQuery(
-      {
-         queryKey: ["projects", server],
-         queryFn: () =>
-            projectsApi.listProjects({
-               baseURL: server,
-            }),
-         retry: false,
-         throwOnError: false,
-      },
-      queryClient,
-   );
+   const { data, isSuccess, isError, error } = useQueryWithApiError({
+      queryKey: ["projects", server],
+      queryFn: () =>
+         projectsApi.listProjects({
+            baseURL: server,
+            withCredentials: true,
+         }),
+   });
 
    console.log(JSON.stringify(data?.data, null, 2));
 

--- a/packages/sdk/src/components/MutableNotebook/ModelPicker.tsx
+++ b/packages/sdk/src/components/MutableNotebook/ModelPicker.tsx
@@ -10,14 +10,13 @@ import {
    Stack,
    Typography,
 } from "@mui/material";
-import { QueryClient, useQuery } from "@tanstack/react-query";
 import React from "react";
 import { Configuration, ModelsApi } from "../../client";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { usePackage } from "../Package/PackageProvider";
+import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 
 const modelsApi = new ModelsApi(new Configuration());
-const queryClient = new QueryClient();
 
 interface ModelPickerProps {
    initialSelectedModels: string[];
@@ -34,22 +33,17 @@ export function ModelPicker({
 }: ModelPickerProps) {
    const { server, projectName, packageName, versionId, accessToken } =
       usePackage();
-   const { data, isLoading, isSuccess, isError, error } = useQuery(
-      {
-         queryKey: ["models", server, projectName, packageName, versionId],
-         queryFn: () =>
-            modelsApi.listModels(projectName, packageName, versionId, {
-               baseURL: server,
-               withCredentials: !accessToken,
-               headers: {
-                  Authorization: accessToken && `Bearer ${accessToken}`,
-               },
-            }),
-         retry: false,
-         throwOnError: false,
-      },
-      queryClient,
-   );
+   const { data, isLoading, isSuccess, isError, error } = useQueryWithApiError({
+      queryKey: ["models", server, projectName, packageName, versionId],
+      queryFn: () =>
+         modelsApi.listModels(projectName, packageName, versionId, {
+            baseURL: server,
+            withCredentials: !accessToken,
+            headers: {
+               Authorization: accessToken && `Bearer ${accessToken}`,
+            },
+         }),
+   });
    const [selectedModels, setSelectedModels] = React.useState<string[]>(
       initialSelectedModels || [],
    );

--- a/packages/sdk/src/components/Package/Config.tsx
+++ b/packages/sdk/src/components/Package/Config.tsx
@@ -7,36 +7,30 @@ import {
    ListItemText,
    Typography,
 } from "@mui/material";
-import { QueryClient, useQuery } from "@tanstack/react-query";
 import { Configuration, PackagesApi } from "../../client";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
 import { StyledCard, StyledCardContent } from "../styles";
 import { usePackage } from "./PackageProvider";
+import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 
 const packagesApi = new PackagesApi(new Configuration());
-const queryClient = new QueryClient();
 
 export default function Config() {
    const { server, projectName, packageName, versionId, accessToken } =
       usePackage();
 
-   const { data, isSuccess, isError, error } = useQuery(
-      {
-         queryKey: ["package", server, projectName, packageName, versionId],
-         queryFn: () =>
-            packagesApi.getPackage(projectName, packageName, versionId, false, {
-               baseURL: server,
-               withCredentials: !accessToken,
-               headers: {
-                  Authorization: accessToken && `Bearer ${accessToken}`,
-               },
-            }),
-         retry: false,
-         throwOnError: false,
-      },
-      queryClient,
-   );
+   const { data, isSuccess, isError, error } = useQueryWithApiError({
+      queryKey: ["package", server, projectName, packageName, versionId],
+      queryFn: () =>
+         packagesApi.getPackage(projectName, packageName, versionId, false, {
+            baseURL: server,
+            withCredentials: !accessToken,
+            headers: {
+               Authorization: accessToken && `Bearer ${accessToken}`,
+            },
+         }),
+   });
 
    return (
       <StyledCard variant="outlined" sx={{ padding: "10px", width: "100%" }}>
@@ -70,20 +64,20 @@ export default function Config() {
                            />
                         </ListItem>
                      )) || (
-                           <ListItem
-                              disablePadding={true}
-                              dense={true}
-                              sx={{ mt: "20px" }}
-                           >
-                              <ErrorIcon
-                                 sx={{
-                                    color: "grey.600",
-                                    mr: "10px",
-                                 }}
-                              />
-                              <ListItemText primary={"No package manifest"} />
-                           </ListItem>
-                        ))}
+                        <ListItem
+                           disablePadding={true}
+                           dense={true}
+                           sx={{ mt: "20px" }}
+                        >
+                           <ErrorIcon
+                              sx={{
+                                 color: "grey.600",
+                                 mr: "10px",
+                              }}
+                           />
+                           <ListItemText primary={"No package manifest"} />
+                        </ListItem>
+                     ))}
                   {isError && (
                      <ApiErrorDisplay
                         error={error}

--- a/packages/sdk/src/components/Package/Connections.tsx
+++ b/packages/sdk/src/components/Package/Connections.tsx
@@ -7,15 +7,14 @@ import {
    TableRow,
    Typography,
 } from "@mui/material";
-import { QueryClient, useQuery } from "@tanstack/react-query";
 import { Configuration, ConnectionsApi } from "../../client";
 import { Connection as ApiConnection } from "../../client/api";
 import { StyledCard, StyledCardContent } from "../styles";
 import { usePackage } from "./PackageProvider";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
+import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 
 const connectionsApi = new ConnectionsApi(new Configuration());
-const queryClient = new QueryClient();
 
 // TODO(jjs) - Move this UI to the ConnectionExplorer component
 function Connection({ connection }: { connection: ApiConnection }) {
@@ -34,22 +33,17 @@ function Connection({ connection }: { connection: ApiConnection }) {
 export default function Connections() {
    const { server, projectName, accessToken } = usePackage();
 
-   const { data, isSuccess, isError, error } = useQuery(
-      {
-         queryKey: ["connections", server, projectName],
-         queryFn: () =>
-            connectionsApi.listConnections(projectName, {
-               baseURL: server,
-               withCredentials: !accessToken,
-               headers: {
-                  Authorization: accessToken && `Bearer ${accessToken}`,
-               },
-            }),
-         retry: false,
-         throwOnError: false,
-      },
-      queryClient,
-   );
+   const { data, isSuccess, isError, error } = useQueryWithApiError({
+      queryKey: ["connections", server, projectName],
+      queryFn: () =>
+         connectionsApi.listConnections(projectName, {
+            baseURL: server,
+            withCredentials: !accessToken,
+            headers: {
+               Authorization: accessToken && `Bearer ${accessToken}`,
+            },
+         }),
+   });
 
    return (
       <StyledCard variant="outlined" sx={{ padding: "10px", width: "100%" }}>

--- a/packages/sdk/src/components/Package/Databases.tsx
+++ b/packages/sdk/src/components/Package/Databases.tsx
@@ -12,16 +12,15 @@ import {
    TableRow,
    Typography,
 } from "@mui/material";
-import { QueryClient, useQuery } from "@tanstack/react-query";
 import React from "react";
 import { Configuration, Database, DatabasesApi } from "../../client";
 import { StyledCard, StyledCardContent } from "../styles";
 import { usePackage } from "./PackageProvider";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
+import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 
 const databasesApi = new DatabasesApi(new Configuration());
-const queryClient = new QueryClient();
 
 export default function Databases() {
    const { server, projectName, packageName, versionId, accessToken } =
@@ -41,22 +40,17 @@ export default function Databases() {
       setSelectedDatabase(null);
    };
 
-   const { data, isError, error, isSuccess } = useQuery(
-      {
-         queryKey: ["databases", server, projectName, packageName, versionId],
-         queryFn: () =>
-            databasesApi.listDatabases(projectName, packageName, versionId, {
-               baseURL: server,
-               withCredentials: !accessToken,
-               headers: {
-                  Authorization: accessToken && `Bearer ${accessToken}`,
-               },
-            }),
-         retry: false,
-         throwOnError: false,
-      },
-      queryClient,
-   );
+   const { data, isError, error, isSuccess } = useQueryWithApiError({
+      queryKey: ["databases", server, projectName, packageName, versionId],
+      queryFn: () =>
+         databasesApi.listDatabases(projectName, packageName, versionId, {
+            baseURL: server,
+            withCredentials: !accessToken,
+            headers: {
+               Authorization: accessToken && `Bearer ${accessToken}`,
+            },
+         }),
+   });
    const formatRowSize = (size: number) => {
       if (size >= 1024 * 1024 * 1024 * 1024) {
          return `${(size / (1024 * 1024 * 1024)).toFixed(2)} T`;

--- a/packages/sdk/src/components/Package/Models.tsx
+++ b/packages/sdk/src/components/Package/Models.tsx
@@ -1,16 +1,13 @@
 import { Box, Divider, Typography } from "@mui/material";
-import { QueryClient, useQuery } from "@tanstack/react-query";
-import axios from "axios";
 import { Configuration, ModelsApi } from "../../client";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
 import { StyledCard, StyledCardContent } from "../styles";
 import { FileTreeView } from "./FileTreeView";
 import { usePackage } from "./PackageProvider";
+import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 
-axios.defaults.baseURL = "http://localhost:4000";
 const modelsApi = new ModelsApi(new Configuration());
-const queryClient = new QueryClient();
 
 const DEFAULT_EXPANDED_FOLDERS = ["notebooks/", "models/"];
 
@@ -22,22 +19,17 @@ export default function Models({ navigate }: ModelsProps) {
    const { server, projectName, packageName, versionId, accessToken } =
       usePackage();
 
-   const { data, isError, error, isSuccess } = useQuery(
-      {
-         queryKey: ["models", server, projectName, packageName, versionId],
-         queryFn: () =>
-            modelsApi.listModels(projectName, packageName, versionId, {
-               baseURL: server,
-               withCredentials: !accessToken,
-               headers: {
-                  Authorization: accessToken && `Bearer ${accessToken}`,
-               },
-            }),
-         throwOnError: false,
-         retry: false,
-      },
-      queryClient,
-   );
+   const { data, isError, error, isSuccess } = useQueryWithApiError({
+      queryKey: ["models", server, projectName, packageName, versionId],
+      queryFn: () =>
+         modelsApi.listModels(projectName, packageName, versionId, {
+            baseURL: server,
+            withCredentials: !accessToken,
+            headers: {
+               Authorization: accessToken && `Bearer ${accessToken}`,
+            },
+         }),
+   });
 
    return (
       <StyledCard variant="outlined" sx={{ padding: "10px", width: "100%" }}>

--- a/packages/sdk/src/components/Package/Notebooks.tsx
+++ b/packages/sdk/src/components/Package/Notebooks.tsx
@@ -1,14 +1,13 @@
 import { Box, Divider, Typography } from "@mui/material";
-import { QueryClient, useQuery } from "@tanstack/react-query";
 import { Configuration, NotebooksApi } from "../../client";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
 import { StyledCard, StyledCardContent } from "../styles";
 import { FileTreeView } from "./FileTreeView";
 import { usePackage } from "./PackageProvider";
+import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 
 const notebooksApi = new NotebooksApi(new Configuration());
-const queryClient = new QueryClient();
 
 const DEFAULT_EXPANDED_FOLDERS = ["notebooks/"];
 
@@ -20,22 +19,24 @@ export default function Notebooks({ navigate }: NotebooksProps) {
    const { server, projectName, packageName, versionId, accessToken } =
       usePackage();
 
-   const { data, isError, error, isSuccess } = useQuery(
-      {
-         queryKey: ["notebooks", server, projectName, packageName, versionId],
-         queryFn: () =>
-            notebooksApi.listNotebooks(projectName, packageName, versionId, {
+   const { data, isError, error, isSuccess } = useQueryWithApiError({
+      queryKey: ["notebooks", server, projectName, packageName, versionId],
+      queryFn: async () => {
+         const response = await notebooksApi.listNotebooks(
+            projectName,
+            packageName,
+            versionId,
+            {
                baseURL: server,
                withCredentials: !accessToken,
                headers: {
                   Authorization: accessToken && `Bearer ${accessToken}`,
                },
-            }),
-         throwOnError: false,
-         retry: false,
+            },
+         );
+         return response;
       },
-      queryClient,
-   );
+   });
 
    return (
       <StyledCard variant="outlined" sx={{ padding: "10px", width: "100%" }}>

--- a/packages/sdk/src/components/Package/Schedules.tsx
+++ b/packages/sdk/src/components/Package/Schedules.tsx
@@ -10,36 +10,30 @@ import {
    TableRow,
    Typography,
 } from "@mui/material";
-import { QueryClient, useQuery } from "@tanstack/react-query";
 import { Configuration, SchedulesApi } from "../../client";
 import { StyledCard, StyledCardContent } from "../styles";
 import { usePackage } from "./PackageProvider";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
+import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 
 const schedulesApi = new SchedulesApi(new Configuration());
-const queryClient = new QueryClient();
 
 export default function Schedules() {
    const { server, projectName, packageName, versionId, accessToken } =
       usePackage();
 
-   const { data, isError, isLoading, error } = useQuery(
-      {
-         queryKey: ["schedules", server, projectName, packageName, versionId],
-         queryFn: () =>
-            schedulesApi.listSchedules(projectName, packageName, versionId, {
-               baseURL: server,
-               withCredentials: !accessToken,
-               headers: {
-                  Authorization: accessToken && `Bearer ${accessToken}`,
-               },
-            }),
-         retry: false,
-         throwOnError: false,
-      },
-      queryClient,
-   );
+   const { data, isError, isLoading, error } = useQueryWithApiError({
+      queryKey: ["schedules", server, projectName, packageName, versionId],
+      queryFn: () =>
+         schedulesApi.listSchedules(projectName, packageName, versionId, {
+            baseURL: server,
+            withCredentials: !accessToken,
+            headers: {
+               Authorization: accessToken && `Bearer ${accessToken}`,
+            },
+         }),
+   });
 
    if (isLoading) {
       return <Loading text="Fetching Schedules..." />;

--- a/packages/sdk/src/components/Project/About.tsx
+++ b/packages/sdk/src/components/Project/About.tsx
@@ -2,33 +2,27 @@ import { Divider, Typography } from "@mui/material";
 import { Configuration, ProjectsApi } from "../../client";
 import Markdown from "markdown-to-jsx";
 import { StyledCard, StyledCardContent, StyledCardMedia } from "../styles";
-import { QueryClient, useQuery } from "@tanstack/react-query";
 import { useProject } from "./Project";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
+import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 
 const projectsApi = new ProjectsApi(new Configuration());
-const queryClient = new QueryClient();
 
 export default function About() {
    const { server, projectName, accessToken } = useProject();
 
-   const { data, isSuccess, isError, error } = useQuery(
-      {
-         queryKey: ["about", server, projectName],
-         queryFn: () =>
-            projectsApi.getProject(projectName, false, {
-               baseURL: server,
-               withCredentials: true,
-               headers: {
-                  Authorization: accessToken && `Bearer ${accessToken}`,
-               },
-            }),
-         retry: false,
-         throwOnError: false,
-      },
-      queryClient,
-   );
+   const { data, isSuccess, isError, error } = useQueryWithApiError({
+      queryKey: ["about", server, projectName],
+      queryFn: () =>
+         projectsApi.getProject(projectName, false, {
+            baseURL: server,
+            withCredentials: true,
+            headers: {
+               Authorization: accessToken && `Bearer ${accessToken}`,
+            },
+         }),
+   });
 
    return (
       <>

--- a/packages/sdk/src/components/Project/ConnectionExplorer.tsx
+++ b/packages/sdk/src/components/Project/ConnectionExplorer.tsx
@@ -21,15 +21,14 @@ import {
    TableHead,
    TableRow,
 } from "@mui/material";
-import { QueryClient, useQuery } from "@tanstack/react-query";
 import { ConnectionsApi } from "../../client/api";
 import { Configuration } from "../../client/configuration";
 import { useProject } from "./Project";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
+import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 
 const connectionsApi = new ConnectionsApi(new Configuration());
-const queryClient = new QueryClient();
 
 interface ConnectionExplorerProps {
    connectionName: string;
@@ -47,22 +46,17 @@ export default function ConnectionExplorer({
       null,
    );
    const [showHiddenSchemas, setShowHiddenSchemas] = React.useState(false);
-   const { data, isSuccess, isError, error, isLoading } = useQuery(
-      {
-         queryKey: ["tablePath", server, projectName, connectionName],
-         queryFn: () =>
-            connectionsApi.listSchemas(projectName, connectionName, {
-               baseURL: server,
-               withCredentials: !accessToken,
-               headers: {
-                  Authorization: accessToken && `Bearer ${accessToken}`,
-               },
-            }),
-         retry: false,
-         throwOnError: false,
-      },
-      queryClient,
-   );
+   const { data, isSuccess, isError, error, isLoading } = useQueryWithApiError({
+      queryKey: ["tablePath", server, projectName, connectionName],
+      queryFn: () =>
+         connectionsApi.listSchemas(projectName, connectionName, {
+            baseURL: server,
+            withCredentials: !accessToken,
+            headers: {
+               Authorization: accessToken && `Bearer ${accessToken}`,
+            },
+         }),
+   });
 
    return (
       <Grid container spacing={2}>
@@ -174,35 +168,30 @@ function TableViewer({
 }: TableViewerProps) {
    const { server, projectName, accessToken } = useProject();
 
-   const { data, isSuccess, isError, error, isLoading } = useQuery(
-      {
-         queryKey: [
-            "tablePathSchema",
-            server,
+   const { data, isSuccess, isError, error, isLoading } = useQueryWithApiError({
+      queryKey: [
+         "tablePathSchema",
+         server,
+         projectName,
+         connectionName,
+         schemaName,
+         tableName,
+      ],
+      queryFn: () =>
+         connectionsApi.getTablesource(
             projectName,
             connectionName,
-            schemaName,
             tableName,
-         ],
-         queryFn: () =>
-            connectionsApi.getTablesource(
-               projectName,
-               connectionName,
-               tableName,
-               `${schemaName}.${tableName}`,
-               {
-                  baseURL: server,
-                  withCredentials: !accessToken,
-                  headers: {
-                     Authorization: accessToken && `Bearer ${accessToken}`,
-                  },
+            `${schemaName}.${tableName}`,
+            {
+               baseURL: server,
+               withCredentials: !accessToken,
+               headers: {
+                  Authorization: accessToken && `Bearer ${accessToken}`,
                },
-            ),
-         retry: false,
-         throwOnError: false,
-      },
-      queryClient,
-   );
+            },
+         ),
+   });
 
    if (isSuccess && data) {
       console.log(data);
@@ -289,28 +278,23 @@ function TablesInSchema({
 }: TablesInSchemaProps) {
    const { server, projectName, accessToken } = useProject();
 
-   const { data, isSuccess, isError, error, isLoading } = useQuery(
-      {
-         queryKey: [
-            "tablesInSchema",
-            server,
-            projectName,
-            connectionName,
-            schemaName,
-         ],
-         queryFn: () =>
-            connectionsApi.listTables(projectName, connectionName, schemaName, {
-               baseURL: server,
-               withCredentials: !accessToken,
-               headers: {
-                  Authorization: accessToken && `Bearer ${accessToken}`,
-               },
-            }),
-         retry: false,
-         throwOnError: false,
-      },
-      queryClient,
-   );
+   const { data, isSuccess, isError, error, isLoading } = useQueryWithApiError({
+      queryKey: [
+         "tablesInSchema",
+         server,
+         projectName,
+         connectionName,
+         schemaName,
+      ],
+      queryFn: () =>
+         connectionsApi.listTables(projectName, connectionName, schemaName, {
+            baseURL: server,
+            withCredentials: !accessToken,
+            headers: {
+               Authorization: accessToken && `Bearer ${accessToken}`,
+            },
+         }),
+   });
 
    return (
       <>

--- a/packages/sdk/src/components/Project/Packages.tsx
+++ b/packages/sdk/src/components/Project/Packages.tsx
@@ -1,13 +1,12 @@
 import { Box, Divider, Grid, Typography } from "@mui/material";
 import { Configuration, PackagesApi } from "../../client";
 import { StyledCard, StyledCardContent, StyledCardMedia } from "../styles";
-import { QueryClient, useQuery } from "@tanstack/react-query";
 import { useProject } from "./Project";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
+import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 
 const packagesApi = new PackagesApi(new Configuration());
-const queryClient = new QueryClient();
 
 interface PackagesProps {
    navigate: (to: string, event?: React.MouseEvent) => void;
@@ -16,22 +15,17 @@ interface PackagesProps {
 export default function Packages({ navigate }: PackagesProps) {
    const { server, projectName, accessToken } = useProject();
 
-   const { data, isSuccess, isError, error } = useQuery(
-      {
-         queryKey: ["packages", server, projectName],
-         queryFn: () =>
-            packagesApi.listPackages(projectName, {
-               baseURL: server,
-               withCredentials: !accessToken,
-               headers: {
-                  Authorization: accessToken && `Bearer ${accessToken}`,
-               },
-            }),
-         retry: false,
-         throwOnError: false,
-      },
-      queryClient,
-   );
+   const { data, isSuccess, isError, error } = useQueryWithApiError({
+      queryKey: ["packages", server, projectName],
+      queryFn: () =>
+         packagesApi.listPackages(projectName, {
+            baseURL: server,
+            withCredentials: !accessToken,
+            headers: {
+               Authorization: accessToken && `Bearer ${accessToken}`,
+            },
+         }),
+   });
 
    return (
       <>

--- a/packages/sdk/src/components/QueryResult/QueryResult.tsx
+++ b/packages/sdk/src/components/QueryResult/QueryResult.tsx
@@ -1,14 +1,13 @@
 import { Suspense, lazy } from "react";
 import { Configuration, QueryresultsApi } from "../../client";
-import { QueryClient, useQuery } from "@tanstack/react-query";
 import { usePackage } from "../Package/PackageProvider";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
+import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 
 const RenderedResult = lazy(() => import("../RenderedResult/RenderedResult"));
 
 const queryResultsApi = new QueryresultsApi(new Configuration());
-const queryClient = new QueryClient();
 
 interface QueryResultProps {
    modelPath: string;
@@ -26,41 +25,36 @@ export default function QueryResult({
    const { server, projectName, packageName, versionId, accessToken } =
       usePackage();
 
-   const { data, isSuccess, isError, error } = useQuery(
-      {
-         queryKey: [
-            "queryResult",
-            server,
+   const { data, isSuccess, isError, error } = useQueryWithApiError({
+      queryKey: [
+         "queryResult",
+         server,
+         projectName,
+         packageName,
+         modelPath,
+         versionId,
+         query,
+         sourceName,
+         queryName,
+      ],
+      queryFn: () =>
+         queryResultsApi.executeQuery(
             projectName,
             packageName,
             modelPath,
-            versionId,
             query,
             sourceName,
             queryName,
-         ],
-         queryFn: () =>
-            queryResultsApi.executeQuery(
-               projectName,
-               packageName,
-               modelPath,
-               query,
-               sourceName,
-               queryName,
-               versionId,
-               {
-                  baseURL: server,
-                  withCredentials: !accessToken,
-                  headers: {
-                     Authorization: accessToken && `Bearer ${accessToken}`,
-                  },
+            versionId,
+            {
+               baseURL: server,
+               withCredentials: !accessToken,
+               headers: {
+                  Authorization: accessToken && `Bearer ${accessToken}`,
                },
-            ),
-         retry: false,
-         throwOnError: false,
-      },
-      queryClient,
-   );
+            },
+         ),
+   });
 
    return (
       <>

--- a/packages/sdk/src/hooks/useQueryWithApiError.ts
+++ b/packages/sdk/src/hooks/useQueryWithApiError.ts
@@ -1,0 +1,114 @@
+import {
+   useQuery,
+   useMutation,
+   QueryClient,
+   UseQueryOptions,
+   UseQueryResult,
+   UseMutationOptions,
+   UseMutationResult,
+} from "@tanstack/react-query";
+import { ApiError } from "../components/ApiErrorDisplay";
+
+// Global QueryClient instance
+const globalQueryClient = new QueryClient({
+   defaultOptions: {
+      queries: {
+         retry: false,
+         throwOnError: false,
+      },
+      mutations: {
+         retry: false,
+         throwOnError: false,
+      },
+   },
+});
+
+export function useQueryWithApiError<TData = unknown, TError = ApiError>(
+   options: Omit<UseQueryOptions<TData, TError>, "throwOnError" | "retry"> & {
+      queryFn: () => Promise<TData>;
+   },
+): UseQueryResult<TData, TError> {
+   const enhancedOptions: UseQueryOptions<TData, TError> = {
+      ...options,
+      queryFn: async () => {
+         try {
+            return await options.queryFn();
+         } catch (err) {
+            // Standardized error handling for axios errors
+            if (err && typeof err === "object" && "response" in err) {
+               const axiosError = err as {
+                  response?: {
+                     status: number;
+                     data: { code: number; message: string };
+                  };
+                  message: string;
+               };
+               if (axiosError.response?.data) {
+                  const apiError: ApiError = new Error(
+                     axiosError.response.data.message || axiosError.message,
+                  );
+                  apiError.status = axiosError.response.status;
+                  apiError.data = axiosError.response.data;
+                  throw apiError;
+               }
+            }
+            // For other errors, throw as is
+            throw err;
+         }
+      },
+      retry: false,
+      throwOnError: false,
+   };
+
+   return useQuery(enhancedOptions, globalQueryClient);
+}
+
+export function useMutationWithApiError<
+   TData = unknown,
+   TError = ApiError,
+   TVariables = void,
+>(
+   options: Omit<
+      UseMutationOptions<TData, TError, TVariables>,
+      "throwOnError" | "retry"
+   > & {
+      mutationFn: (variables: TVariables) => Promise<TData>;
+   },
+): UseMutationResult<TData, TError, TVariables> {
+   const enhancedOptions: UseMutationOptions<TData, TError, TVariables> = {
+      ...options,
+      mutationFn: async (variables: TVariables) => {
+         try {
+            return await options.mutationFn(variables);
+         } catch (err) {
+            // Standardized error handling for axios errors
+            if (err && typeof err === "object" && "response" in err) {
+               const axiosError = err as {
+                  response?: {
+                     status: number;
+                     data: { code: number; message: string };
+                  };
+                  message: string;
+               };
+               if (axiosError.response?.data) {
+                  const apiError: ApiError = new Error(
+                     axiosError.response.data.message || axiosError.message,
+                  );
+                  apiError.status = axiosError.response.status;
+                  apiError.data = axiosError.response.data;
+                  throw apiError;
+               }
+            }
+            // For other errors, throw as is
+            throw err;
+         }
+      },
+      retry: false,
+      throwOnError: false,
+   };
+
+   return useMutation(enhancedOptions, globalQueryClient);
+}
+
+// Export the global query client for direct access if needed
+export { globalQueryClient };


### PR DESCRIPTION
Cursor Refactoring:
Replaces direct use of useQuery/useMutation with consolidated utility.
Utility does error handing (extracting error payload from the thrown AxiosError
Utilty uses a Centralized QueryClient (so it can actually cache things reliably across components.
