### PR TITLE
Fix SDK build

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import dts from "vite-plugin-dts";
 import path from "path";
+import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
 export default ({ mode }) => {
@@ -49,7 +49,7 @@ export default ({ mode }) => {
    return defineConfig({
       plugins: [react()],
       define: {
-         "process.env": JSON.stringify(mode),
+         "process.env.NODE_ENV": JSON.stringify(mode),
       },
       resolve,
    });

--- a/packages/sdk/vite.config.ts
+++ b/packages/sdk/vite.config.ts
@@ -7,7 +7,7 @@ import { peerDependencies } from "./package.json";
 export default ({ mode }) => {
    return defineConfig({
       define: {
-         "process.env": JSON.stringify(mode),
+         "process.env.NODE_ENV": JSON.stringify(mode),
       },
       build: {
          minify: mode === "production",

--- a/packages/sdk/vite.config.ts.timestamp-1732998513502-40117fb4923d1.mjs
+++ b/packages/sdk/vite.config.ts.timestamp-1732998513502-40117fb4923d1.mjs
@@ -1,6 +1,6 @@
 // vite.config.ts
-import { defineConfig } from "file:///home/kjnesbit/publisher/node_modules/vite/dist/node/index.js";
 import dts from "file:///home/kjnesbit/publisher/node_modules/vite-plugin-dts/dist/index.mjs";
+import { defineConfig } from "file:///home/kjnesbit/publisher/node_modules/vite/dist/node/index.js";
 
 // package.json
 var peerDependencies = {
@@ -11,12 +11,12 @@ var peerDependencies = {
 };
 
 // vite.config.ts
-import svgr from "file:///home/kjnesbit/publisher/node_modules/vite-plugin-svgr/dist/index.js";
 import react from "file:///home/kjnesbit/publisher/node_modules/@vitejs/plugin-react/dist/index.mjs";
+import svgr from "file:///home/kjnesbit/publisher/node_modules/vite-plugin-svgr/dist/index.js";
 var vite_config_default = ({ mode }) => {
    return defineConfig({
       define: {
-         "process.env": JSON.stringify(mode),
+         "process.env.NODE_ENV": JSON.stringify(mode),
       },
       build: {
          minify: mode === "production",


### PR DESCRIPTION
This PR fixes a bug where the malloy SDK would always bundle the `development` version of React 19, causing apps built with the `production` version of React 19 to crash by referencing undefined methods.