### PR TITLE
Refactor accessToken to be a method

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -57,20 +57,20 @@ export const createMalloyRouter = (
 
 export interface MalloyPublisherAppProps {
    server?: string;
-   accessToken?: string;
+   getAccessToken?: () => Promise<string>;
    basePath?: string;
    headerProps: HeaderProps;
 }
 
 export const MalloyPublisherApp: React.FC<MalloyPublisherAppProps> = ({
    server,
-   accessToken,
+   getAccessToken,
    basePath = "/",
    headerProps,
 }) => {
    const router = createMalloyRouter(basePath, headerProps);
    return (
-      <ServerProvider server={server} accessToken={accessToken}>
+      <ServerProvider server={server} getAccessToken={getAccessToken}>
          <RouterProvider router={router} />
       </ServerProvider>
    );

--- a/packages/sdk/src/components/ServerProvider.tsx
+++ b/packages/sdk/src/components/ServerProvider.tsx
@@ -2,25 +2,25 @@ import React, { createContext, useContext, ReactNode } from "react";
 
 export interface ServerContextValue {
    server: string;
-   accessToken?: string;
+   getAccessToken?: () => Promise<string>;
 }
 
 const ServerContext = createContext<ServerContextValue | undefined>(undefined);
 
 export interface ServerProviderProps {
    server?: string;
-   accessToken?: string;
+   getAccessToken?: () => Promise<string>;
    children: ReactNode;
 }
 
 export const ServerProvider: React.FC<ServerProviderProps> = ({
    server = `${window.location.protocol}//${window.location.host}/api/v0`,
-   accessToken,
+   getAccessToken,
    children,
 }) => {
    const value: ServerContextValue = {
       server,
-      accessToken,
+      getAccessToken,
    };
 
    return (

--- a/packages/sdk/src/hooks/index.ts
+++ b/packages/sdk/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { getAxiosConfig } from "./useQueryWithApiError";


### PR DESCRIPTION
Instead of providing a static authToken to publisher, ServerProvider now provides an async method.
This is inline with how Auth0 works. Auth0 checks to see if token is valid/non-expired and only returns if it is. Otherwise user is redirected to logout page.

* Refactored useQueryWithApiError to consolidate config/AccessToken handling
* Exported method so can be used in MutableNotebook

Will follow up with Service update for this.