### PR TITLE
Fix SingleEmbedDashboard embedded query string handling

### DIFF
--- a/examples/data-app/src/components/SingleEmbedDashboard.tsx
+++ b/examples/data-app/src/components/SingleEmbedDashboard.tsx
@@ -1,30 +1,82 @@
-import { Stack, Typography, Box } from "@mui/material";
+import { Stack, Typography, Box, Alert } from "@mui/material";
 import Header from "./Header";
-import { QueryResult } from "@malloy-publisher/sdk";
+import { EmbeddedQueryResult } from "@malloy-publisher/sdk";
+import { useState, useEffect } from "react";
 
 export default function SingleEmbedDashboard({
   selectedView,
 }: {
   selectedView: "malloySamples" | "singleEmbed" | "dynamicDashboard";
 }) {
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  
+  // TODO: Replace this embedded query with your own!
+  // Copy the embedded query string from your dashboard or notebook
+  // and paste it here. Make sure to keep the backticks and quotes intact.
+  // Example format: {"modelPath":"your-model.malloynb","query":"your query here","optionalPackageName":"your-package","optionalProjectName":"your-project"}
+  const rawEmbeddedQuery = `{"modelPath":"README.malloynb","query":"# dashboard\nrun: stories -> term_dashboard + {\n  where: title ~ r'BigQuery'\n}","optionalPackageName":"bigquery-hackernews","optionalProjectName":"malloy-samples"}`;
+  
+  // Process the query string the same way the UI does
+  const embeddedQuery = rawEmbeddedQuery.replace(/\\n/g, '\n').replace(/\n/g, '\\n');
+ 
+  useEffect(() => {
+    // Validate the embedded query
+    try {
+      JSON.parse(embeddedQuery);
+    } catch (parseError) {
+      setError(`Failed to parse embedded query: ${parseError}`);
+    }
+    
+    // Set loading to false after a short delay
+    const timer = setTimeout(() => setIsLoading(false), 1000);
+    return () => clearTimeout(timer);
+  }, [embeddedQuery, rawEmbeddedQuery]);
+
   return (
     <Stack spacing={2} sx={{ mt: { xs: 8, md: 0 }, mb: 8 }}>
       <Header selectedView={selectedView} />
-      <Box
-        sx={{
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-          minHeight: "50vh",
-          textAlign: "center",
-          px: 2,
-        }}
-      >
-        <Typography variant="h6" color="text.secondary">
-          Open 'src/components/SingleEmbedDashboard.tsx' and replace this text
-          with a embedding json obtained from a notebook cell in the MS2 admin
-          app.
+      
+      <Box sx={{ p: 2 }}>
+        <Typography variant="h5" sx={{ mb: 2, fontWeight: 'bold' }}>
+          Single Embedded Query Result
         </Typography>
+        <Typography variant="body1" sx={{ mb: 3, color: 'text.secondary' }}>
+          Paste your embedded query string in the SingleEmbedDashboard.tsx file as the rawEmbeddedQuery variable above. Copy the query from your dashboard or notebook and replace the example below.
+          <strong>Important:</strong> Keep the backticks (`) and quotes intact when pasting your query string. 
+        </Typography>
+        
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+        
+        {isLoading && (
+          <Alert severity="info" sx={{ mb: 2 }}>
+            Loading embedded query result...
+          </Alert>
+        )}
+        
+        <Box sx={{ 
+          border: '1px solid #e0e0e0', 
+          borderRadius: 2, 
+          p: 2,
+          minHeight: 400,
+          backgroundColor: '#fafafa'
+        }}>
+          <Box
+            sx={{
+              width: "90%",
+              height: "396px",
+              overflow: "visible",
+            }}
+          >
+            <EmbeddedQueryResult 
+              embeddedQueryResult={embeddedQuery}
+            />
+          </Box>
+        </Box>
       </Box>
     </Stack>
   );


### PR DESCRIPTION
## Problem
The SingleEmbedDashboard component wasn't rendering embedded query results properly, while the same query strings worked fine in DynamicDashboard.

## Root Cause
- Container styling was different from DynamicDashboard
- String processing for newlines wasn't consistent with UI behavior
- Users had to manually escape newlines when pasting from UI

## Solution
- Updated container styling to match DynamicDashboard (width: 90%, height: 396px, overflow: visible)
- Added automatic string processing: `rawEmbeddedQuery.replace(/\\n/g, '\n').replace(/\n/g, '\\n')`
- Users can now paste query strings directly from UI without manual escaping
- Cleaned up debug code and console logs

## Testing
- Verified that query strings copied from DynamicDashboard UI work directly in SingleEmbedDashboard
- Confirmed that both escaped and unescaped newlines are handled correctly
- Tested with bigquery-hackernews package query

## User Experience
- Clear instructions for pasting embedded query strings
- No manual escaping required
- Consistent behavior with other dashboard components