### PR TITLE
Add timeouts to package loading. init server

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -92,6 +92,7 @@ const scheduleController = new ScheduleController(projectStore);
 
 const mcpApp = express();
 
+initProjects();
 mcpApp.use(MCP_ENDPOINT, express.json());
 mcpApp.use(MCP_ENDPOINT, cors());
 
@@ -634,3 +635,14 @@ const mcpHttpServer = mcpApp.listen(MCP_PORT, PUBLISHER_HOST, () => {
 });
 
 export { app, mainServer as httpServer, mcpApp, mcpHttpServer };
+
+// Warm up the packages
+function initProjects() {
+   projectStore.listProjects().then((projects) => {
+      projects.forEach((project) => {
+         projectStore.getProject(project.name!, false).then((project) => {
+            project.listPackages();
+         });
+      });
+   });
+}

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -31,7 +31,7 @@ type ApiSchedule = components["schemas"]["Schedule"];
 type ApiColumn = components["schemas"]["Column"];
 type ApiTableDescription = components["schemas"]["TableDescription"];
 
-const ENABLE_LIST_MODEL_COMPILATION = false;
+const ENABLE_LIST_MODEL_COMPILATION = true;
 export class Package {
    private projectName: string;
    private packageName: string;

--- a/packages/server/src/service/project.ts
+++ b/packages/server/src/service/project.ts
@@ -10,6 +10,8 @@ import { Package } from "./package";
 type ApiPackage = components["schemas"]["Package"];
 type ApiProject = components["schemas"]["Project"];
 
+const MAX_PACKAGE_INIT_TIMEOUT = 20000;
+
 export class Project {
    private packages: Map<string, Package> = new Map();
    private malloyConnections: Map<string, BaseConnection>;
@@ -129,14 +131,26 @@ export class Project {
                .filter((file) => file.isDirectory())
                .map(async (directory) => {
                   try {
-                     const _package = await this.getPackage(
-                        directory.name,
-                        false,
+                     // Create a timeout promise that rejects after 6 seconds
+                     const timeoutPromise = new Promise<never>((_, reject) => {
+                        setTimeout(() => {
+                           reject(new Error(`Package loading timeout`));
+                        }, MAX_PACKAGE_INIT_TIMEOUT);
+                     });
+
+                     // Race between the actual package loading and the timeout
+                     const _package = await Promise.race([
+                        this.getPackage(directory.name, false),
+                        timeoutPromise,
+                     ]);
+
+                     return _package.getPackageMetadata();
+                  } catch (error) {
+                     console.log(
+                        `Failed to load package: ${directory.name} due to : ${error}`,
                      );
-                     const metadata = _package.getPackageMetadata();
-                     return metadata;
-                  } catch {
                      // Directory did not contain a valid package.json file -- therefore, it's not a package.
+                     // Or it timed out
                      return undefined;
                   }
                }),


### PR DESCRIPTION
Adds a 30s timeout to individual package loading.
As soon as server starts, it begins initializing packages. Hopefully this will resolve some startup waiting time issues in CI?