### PR TITLE
Refactor ModelExplorer

### DIFF
--- a/examples/data-app/src/components/AddChartDialog.tsx
+++ b/examples/data-app/src/components/AddChartDialog.tsx
@@ -20,6 +20,7 @@ import {
   Packages,
   Model,
   createEmbeddedQueryResult,
+  ModelExplorer,
 } from "@malloy-publisher/sdk";
 import { QueryExplorerResult } from "@malloy-publisher/sdk/dist/components/Model/SourcesExplorer";
 import "@malloydata/malloy-explorer/styles.css";
@@ -227,7 +228,7 @@ export default function AddChartDialog({
                     overflow: "auto",
                   }}
                 >
-                  <Model
+                  <ModelExplorer
                     modelPath={selectedModel}
                     expandResults={false}
                     hideResultIcons={true}

--- a/packages/sdk/src/components/Model/ModelExplorer.tsx
+++ b/packages/sdk/src/components/Model/ModelExplorer.tsx
@@ -1,0 +1,138 @@
+import React from "react";
+import { Box, Stack, Typography, Tabs, Tab } from "@mui/material";
+import { StyledCard, StyledCardContent } from "../styles";
+import { ModelCell } from "./ModelCell";
+import {
+   QueryExplorerResult,
+   SourceExplorerComponent,
+} from "./SourcesExplorer";
+import { ApiErrorDisplay } from "../ApiErrorDisplay";
+import { Loading } from "../Loading";
+import { useModelData } from "./useModelData";
+
+export interface ModelExplorerProps {
+   modelPath: string;
+   versionId?: string;
+   /** Display options forwarded to ModelCell */
+   expandResults?: boolean;
+   hideResultIcons?: boolean;
+   expandEmbeddings?: boolean;
+   hideEmbeddingIcons?: boolean;
+   /** Callback when the explorer changes (e.g. when a query is selected). */
+   onChange?: (query: QueryExplorerResult) => void;
+}
+
+/**
+ * ModelExplorer renders the main explorer UI for a Malloy model. It shows the
+ * selected source (via `SourceExplorerComponent`) along with the list of named
+ * queries for that model. This logic was originally embedded inside `Model.tsx`
+ * but has been extracted for easier reuse.
+ */
+export function ModelExplorer({
+   modelPath,
+   versionId,
+   expandResults,
+   hideResultIcons,
+   expandEmbeddings,
+   hideEmbeddingIcons,
+   onChange,
+}: ModelExplorerProps) {
+   const [selectedTab, setSelectedTab] = React.useState(0);
+
+   const { data, isError, isLoading, error } = useModelData(
+      modelPath,
+      versionId,
+   );
+
+   if (isLoading) {
+      return <Loading text="Fetching Model..." />;
+   }
+
+   if (isError) {
+      console.log("error", error);
+      return (
+         <ApiErrorDisplay
+            error={error}
+            context={`ModelExplorer > ${modelPath}`}
+         />
+      );
+   }
+
+   return (
+      <Stack spacing={2} component="section">
+         {/* Render the tabs for source selection */}
+         {Array.isArray(data.sourceInfos) && data.sourceInfos.length > 0 && (
+            <Stack sx={{ flexDirection: "row", justifyContent: "flex-start" }}>
+               <Tabs
+                  value={selectedTab}
+                  onChange={(_, newValue) => setSelectedTab(newValue)}
+                  variant="scrollable"
+                  scrollButtons="auto"
+                  sx={{
+                     borderBottom: 1,
+                     borderColor: "divider",
+                     minHeight: 36,
+                  }}
+               >
+                  {data.sourceInfos.map((source, idx) => {
+                     let sourceInfo;
+                     try {
+                        sourceInfo = JSON.parse(source);
+                     } catch {
+                        sourceInfo = { name: String(idx) };
+                     }
+                     return (
+                        <Tab
+                           key={sourceInfo.name || idx}
+                           label={sourceInfo.name || `Source ${idx + 1}`}
+                           sx={{ minHeight: 36 }}
+                        />
+                     );
+                  })}
+               </Tabs>
+            </Stack>
+         )}
+
+         {/* Render the selected source info */}
+         {Array.isArray(data.sourceInfos) && data.sourceInfos.length > 0 && (
+            <SourceExplorerComponent
+               sourceAndPath={{
+                  modelPath,
+                  sourceInfo: JSON.parse(data.sourceInfos[selectedTab]),
+               }}
+               onChange={onChange}
+            />
+         )}
+
+         {/* Render the named queries */}
+         {data.queries?.length > 0 && (
+            <StyledCard
+               variant="outlined"
+               sx={{ padding: "0px 10px 0px 10px" }}
+            >
+               <StyledCardContent sx={{ p: "10px" }}>
+                  <Typography variant="subtitle1">Named Queries</Typography>
+               </StyledCardContent>
+
+               <Stack spacing={1} component="section">
+                  {data.queries.map((query) => (
+                     <ModelCell
+                        key={query.name}
+                        modelPath={modelPath}
+                        queryName={query.name}
+                        expandResult={expandResults}
+                        hideResultIcon={hideResultIcons}
+                        expandEmbedding={expandEmbeddings}
+                        hideEmbeddingIcon={hideEmbeddingIcons}
+                        noView={true}
+                        annotations={query.annotations}
+                     />
+                  ))}
+               </Stack>
+               <Box height="10px" />
+            </StyledCard>
+         )}
+         <Box height="5px" />
+      </Stack>
+   );
+}

--- a/packages/sdk/src/components/Model/SourcesExplorer.tsx
+++ b/packages/sdk/src/components/Model/SourcesExplorer.tsx
@@ -235,7 +235,7 @@ function SourceExplorerComponentInner({
 
    const onQueryChange = React.useCallback(
       (malloyQuery: Malloy.Query) => {
-         setQuery({ ...query, malloyQuery });
+         setQuery({ ...query, malloyQuery, malloyResult: undefined });
       },
       [query],
    );
@@ -243,88 +243,75 @@ function SourceExplorerComponentInner({
    if (oldSourceInfo !== sourceAndPath.sourceInfo.name) {
       return <div>Loading...</div>;
    }
-
    return (
-      <StyledExplorerPage key={sourceAndPath.sourceInfo.name}>
-         <StyledExplorerContent>
-            <MalloyExplorerProvider
-               source={sourceAndPath.sourceInfo}
-               query={query?.malloyQuery}
-               onQueryChange={onQueryChange}
-               focusedNestViewPath={focusedNestViewPath}
-               onFocusedNestViewPathChange={setFocusedNestViewPath}
-               onDrill={(params) => {
-                  console.info(params);
+      <StyledExplorerContent key={sourceAndPath.sourceInfo.name}>
+         <MalloyExplorerProvider
+            source={sourceAndPath.sourceInfo}
+            query={query?.malloyQuery}
+            onQueryChange={onQueryChange}
+            focusedNestViewPath={focusedNestViewPath}
+            onFocusedNestViewPathChange={setFocusedNestViewPath}
+            onDrill={(params) => {
+               console.info(params);
+            }}
+         >
+            <div
+               style={{
+                  display: "flex",
+                  height: "100%",
+                  overflowY: "auto",
                }}
             >
-               <div
-                  style={{
-                     display: "flex",
-                     flexDirection: "column",
-                     height: "100%",
-                  }}
+               <ResizableCollapsiblePanel
+                  isInitiallyExpanded={true}
+                  initialWidth={180}
+                  minWidth={180}
+                  icon="database"
+                  title={sourceAndPath.sourceInfo.name}
                >
-                  <div
-                     style={{
-                        display: "flex",
-                        height: "100%",
-                        overflowY: "auto",
+                  <SourcePanel
+                     onRefresh={() => setQuery(emptyQueryExplorerResult())}
+                  />
+               </ResizableCollapsiblePanel>
+               <ResizableCollapsiblePanel
+                  isInitiallyExpanded={true}
+                  initialWidth={280}
+                  minWidth={280}
+                  icon="filterSliders"
+                  title="Query"
+               >
+                  <QueryPanel
+                     runQuery={() => {
+                        mutation.mutate();
                      }}
-                  >
-                     <ResizableCollapsiblePanel
-                        isInitiallyExpanded={true}
-                        initialWidth={180}
-                        minWidth={180}
-                        icon="database"
-                        title={sourceAndPath.sourceInfo.name}
-                     >
-                        <SourcePanel
-                           onRefresh={() =>
-                              setQuery(emptyQueryExplorerResult())
-                           }
-                        />
-                     </ResizableCollapsiblePanel>
-                     <ResizableCollapsiblePanel
-                        isInitiallyExpanded={true}
-                        initialWidth={280}
-                        minWidth={280}
-                        icon="filterSliders"
-                        title="Query"
-                     >
-                        <QueryPanel
-                           runQuery={() => {
-                              mutation.mutate();
-                           }}
-                        />
-                     </ResizableCollapsiblePanel>
-                     <ResultPanel
-                        source={sourceAndPath.sourceInfo}
-                        draftQuery={query?.malloyQuery}
-                        setDraftQuery={(malloyQuery) =>
-                           setQuery({ ...query, malloyQuery: malloyQuery })
-                        }
-                        submittedQuery={
-                           query?.malloyQuery
-                              ? {
-                                   executionState: mutation.isPending
-                                      ? "running"
-                                      : "finished",
-                                   response: {
-                                      result: query.malloyResult,
-                                   },
-                                   query: query.malloyQuery,
-                                   queryResolutionStartMillis: Date.now(),
-                                   onCancel: mutation.reset,
-                                }
-                              : undefined
-                        }
-                        options={{ showRawQuery: true }}
-                     />
-                  </div>
-               </div>
-            </MalloyExplorerProvider>
-         </StyledExplorerContent>
-      </StyledExplorerPage>
+                  />
+               </ResizableCollapsiblePanel>
+               <ResultPanel
+                  source={sourceAndPath.sourceInfo}
+                  draftQuery={query?.malloyQuery}
+                  setDraftQuery={(malloyQuery) =>
+                     setQuery({ ...query, malloyQuery: malloyQuery })
+                  }
+                  submittedQuery={
+                     query?.malloyQuery
+                        ? {
+                             executionState: mutation.isPending
+                                ? "running"
+                                : "finished",
+                             response: {
+                                result: query.malloyResult,
+                             },
+                             query: query.malloyQuery,
+                             queryResolutionStartMillis: Date.now(),
+                             onCancel: mutation.reset,
+                          }
+                        : undefined
+                  }
+                  options={{ showRawQuery: true }}
+               />
+            </div>
+         </MalloyExplorerProvider>
+      </StyledExplorerContent>
    );
 }
 
@@ -366,7 +353,6 @@ export function SourceExplorerComponent(props: SourceExplorerComponentProps) {
             <StyledExplorerContent>
                <div
                   style={{
-                     display: "flex",
                      alignItems: "center",
                      justifyContent: "center",
                      height: "200px",

--- a/packages/sdk/src/components/Model/index.ts
+++ b/packages/sdk/src/components/Model/index.ts
@@ -1,4 +1,7 @@
 export { default as Model } from "./Model";
+export { ModelExplorer } from "./ModelExplorer";
 export { SourcesExplorer } from "./SourcesExplorer";
 export { SourceExplorerComponent } from "./SourcesExplorer";
 export type { SourceAndPath } from "./SourcesExplorer";
+export { useModelData } from "./useModelData";
+export type { ModelExplorerProps } from "./ModelExplorer";

--- a/packages/sdk/src/components/Model/useModelData.ts
+++ b/packages/sdk/src/components/Model/useModelData.ts
@@ -1,0 +1,38 @@
+import { Configuration, ModelsApi, CompiledModel } from "../../client";
+import { usePackage } from "../Package/PackageProvider";
+import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
+
+const modelsApi = new ModelsApi(new Configuration());
+
+/**
+ * Custom hook for fetching model data. Combines usePackage context with
+ * useQueryWithApiError to fetch a compiled model.
+ */
+export function useModelData(modelPath: string, versionId?: string) {
+   const {
+      projectName,
+      packageName,
+      versionId: packageVersionId,
+   } = usePackage();
+   const effectiveVersionId = versionId || packageVersionId;
+
+   return useQueryWithApiError<CompiledModel>({
+      queryKey: [
+         "package",
+         projectName,
+         packageName,
+         modelPath,
+         effectiveVersionId,
+      ],
+      queryFn: async (config) => {
+         const response = await modelsApi.getModel(
+            projectName,
+            packageName,
+            modelPath,
+            effectiveVersionId,
+            config,
+         );
+         return response.data;
+      },
+   });
+}

--- a/packages/sdk/src/components/styles.ts
+++ b/packages/sdk/src/components/styles.ts
@@ -18,8 +18,6 @@ export const StyledCardMedia = styled(CardMedia)({
 });
 
 export const StyledExplorerPage = styled("div")({
-   display: "flex",
-   flexDirection: "column",
    height: "100%",
 });
 
@@ -32,7 +30,6 @@ export const StyledExplorerBanner = styled("div")({
 });
 
 export const StyledExplorerContent = styled("div")({
-   display: "flex",
    height: "75vh",
    width: "100%",
    overflowY: "auto",


### PR DESCRIPTION
Pulls out Explorer display from Model Page.
Fixes Flex issues causing squished line graphs
Fixes "clear" -> new_query  causing old result display