### PR TITLE
Fix app bug where packageName was used instead of resource

### DIFF
--- a/packages/sdk/src/components/Project/Packages.tsx
+++ b/packages/sdk/src/components/Project/Packages.tsx
@@ -33,44 +33,50 @@ export default function Packages({ navigate }: PackagesProps) {
                      .sort((a, b) => {
                         return a.name.localeCompare(b.name);
                      })
-                     .map((p) => (
-                        <Grid
-                           size={{ xs: 12, sm: 12, md: 12, lg: 4 }}
-                           key={p.name}
-                        >
-                           <StyledCard
-                              variant="outlined"
-                              sx={{
-                                 cursor: "pointer",
-                                 transition: "all 0.2s ease-in-out",
-                                 "&:hover": {
-                                    boxShadow: "0 4px 12px rgba(0, 0, 0, 0.1)",
-                                    transform: "translateY(-2px)",
-                                 },
-                              }}
-                              onClick={(event) => navigate(p.name + "/", event)}
+                     .map((p) => {
+                        const href = p.resource
+                           .replace("/api/v0/projects", "")
+                           .replace("/packages", "");
+                        return (
+                           <Grid
+                              size={{ xs: 12, sm: 12, md: 12, lg: 4 }}
+                              key={p.name}
                            >
-                              <StyledCardContent>
-                                 <Typography
-                                    variant="overline"
-                                    color="primary.main"
-                                 >
-                                    {p.name}
-                                 </Typography>
-                                 <Box
-                                    sx={{
-                                       maxHeight: "120px",
-                                       overflowY: "auto",
-                                    }}
-                                 >
-                                    <Typography variant="body2">
-                                       {p.description}
+                              <StyledCard
+                                 variant="outlined"
+                                 sx={{
+                                    cursor: "pointer",
+                                    transition: "all 0.2s ease-in-out",
+                                    "&:hover": {
+                                       boxShadow:
+                                          "0 4px 12px rgba(0, 0, 0, 0.1)",
+                                       transform: "translateY(-2px)",
+                                    },
+                                 }}
+                                 onClick={(event) => navigate(href, event)}
+                              >
+                                 <StyledCardContent>
+                                    <Typography
+                                       variant="overline"
+                                       color="primary.main"
+                                    >
+                                       {p.name}
                                     </Typography>
-                                 </Box>
-                              </StyledCardContent>
-                           </StyledCard>
-                        </Grid>
-                     ))}
+                                    <Box
+                                       sx={{
+                                          maxHeight: "120px",
+                                          overflowY: "auto",
+                                       }}
+                                    >
+                                       <Typography variant="body2">
+                                          {p.description}
+                                       </Typography>
+                                    </Box>
+                                 </StyledCardContent>
+                              </StyledCard>
+                           </Grid>
+                        );
+                     })}
                </Grid>
             </StyledCard>
          )}


### PR DESCRIPTION
This PR fixes a bug where the frontend tried to read packages by their name instead of their assigned resource url, creating links in the front page that led to broken pages.

This is what happened before and after this PR when creating a malloy sample called `dirName` containing a publisher.json file such as 
```json
{
    "name": "packageName",
    "version": "1.0.0",
    "description": "This should break" 
}
```
| Before | After |
| --- | --- |
| <img width="1236" height="968" alt="localhost_4000_malloy-samples_packageName_" src="https://github.com/user-attachments/assets/24d91785-2400-4436-9539-ffdc301cdb51" /> | <img width="1236" height="968" alt="localhost_4000_malloy-samples_" src="https://github.com/user-attachments/assets/fc02462b-9cd3-4cdf-ab21-a25dab6aea3b" /> |