### PR TITLE
CRUD interface & `freezeConfig` option

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -29,6 +29,30 @@ paths:
           $ref: "#/components/responses/UnauthorizedError"
         "500":
           $ref: "#/components/responses/InternalServerError"
+    post:
+      tags:
+        - projects
+      operationId: create-project
+      summary: Creates a new project.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              items:
+                $ref: '#/components/schemas/Project'
+      responses:
+        "200":
+          description: Returns the project created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /projects/{projectName}:
     get:
@@ -52,6 +76,62 @@ paths:
       responses:
         "200":
           description: Metadata about the project.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    patch:
+      tags:
+        - projects
+      operationId: update-project
+      summary: Updates a project.
+      parameters:
+        - name: projectName
+          in: path
+          description: Name of project
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              items:
+                $ref: '#/components/schemas/Project'
+      responses:
+        "200":
+          description: Returns the project updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    delete:
+      tags:
+        - projects
+      operationId: delete-project
+      summary: Deletes a project.
+      parameters:
+        - name: projectName
+          in: path
+          description: Name of project
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Returns the project deleted
           content:
             application/json:
               schema:
@@ -424,6 +504,39 @@ paths:
           $ref: "#/components/responses/InternalServerError"
         "501":
           $ref: "#/components/responses/NotImplementedError"
+    post:
+      tags:
+        - packages
+      operationId: create-package
+      summary: Creates a new package.
+      parameters:
+        - name: projectName
+          in: path
+          description: Name of project
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              items:
+                $ref: '#/components/schemas/Package'
+      responses:
+        "200":
+          description: Returns the package created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Package"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "501":
+          $ref: "#/components/responses/NotImplementedError"
 
   /projects/{projectName}/packages/{packageName}:
     get:
@@ -459,6 +572,80 @@ paths:
       responses:
         "200":
           description: Package metadata.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Package"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "501":
+          $ref: "#/components/responses/NotImplementedError"
+    patch:
+      tags:
+        - packages
+      operationId: update-package
+      summary: Updates a package.
+      parameters:
+        - name: projectName
+          in: path
+          description: Name of project
+          required: true
+          schema:
+            type: string
+        - name: packageName
+          in: path
+          description: Name of package
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              items:
+                $ref: '#/components/schemas/Package'
+      responses:
+        "200":
+          description: Returns the package updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Package"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "501":
+          $ref: "#/components/responses/NotImplementedError"
+    delete:
+      tags:
+        - packages
+      operationId: delete-package
+      summary: Deletes a package.
+      parameters:
+        - name: projectName
+          in: path
+          description: Name of project
+          required: true
+          schema:
+            type: string
+        - name: packageName
+          in: path
+          description: Name of package
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Returns the package deleted
           content:
             application/json:
               schema:

--- a/packages/server/publisher.config.json
+++ b/packages/server/publisher.config.json
@@ -1,4 +1,5 @@
 {
+   "frozenConfig": false,
    "projects": {
       "malloy-samples": "./malloy-samples"
    }

--- a/packages/server/src/controller/package.controller.ts
+++ b/packages/server/src/controller/package.controller.ts
@@ -1,4 +1,5 @@
 import { components } from "../api";
+import { BadRequestError } from "../errors";
 import { ProjectStore } from "../service/project_store";
 
 type ApiPackage = components["schemas"]["Package"];
@@ -23,5 +24,27 @@ export class PackageController {
       const project = await this.projectStore.getProject(projectName, false);
       const p = await project.getPackage(packageName, reload);
       return p.getPackageMetadata();
+   }
+
+   async addPackage(projectName: string, body: ApiPackage) {
+      if (!body.name) {
+         throw new BadRequestError("Package name is required");
+      }
+      const project = await this.projectStore.getProject(projectName, false);
+      return project.addPackage(body.name);
+   }
+
+   public async deletePackage(projectName: string, packageName: string) {
+      const project = await this.projectStore.getProject(projectName, false);
+      return project.deletePackage(packageName);
+   }
+
+   public async updatePackage(
+      projectName: string,
+      packageName: string,
+      body: ApiPackage,
+   ) {
+      const project = await this.projectStore.getProject(projectName, false);
+      return project.updatePackage(packageName, body);
    }
 }

--- a/packages/server/src/controller/package.controller.ts
+++ b/packages/server/src/controller/package.controller.ts
@@ -1,5 +1,5 @@
 import { components } from "../api";
-import { BadRequestError } from "../errors";
+import { BadRequestError, FrozenConfigError } from "../errors";
 import { ProjectStore } from "../service/project_store";
 
 type ApiPackage = components["schemas"]["Package"];
@@ -27,6 +27,9 @@ export class PackageController {
    }
 
    async addPackage(projectName: string, body: ApiPackage) {
+      if (this.projectStore.publisherConfigIsFrozen) {
+         throw new FrozenConfigError();
+      }
       if (!body.name) {
          throw new BadRequestError("Package name is required");
       }
@@ -35,6 +38,9 @@ export class PackageController {
    }
 
    public async deletePackage(projectName: string, packageName: string) {
+      if (this.projectStore.publisherConfigIsFrozen) {
+         throw new FrozenConfigError();
+      }
       const project = await this.projectStore.getProject(projectName, false);
       return project.deletePackage(packageName);
    }
@@ -44,6 +50,9 @@ export class PackageController {
       packageName: string,
       body: ApiPackage,
    ) {
+      if (this.projectStore.publisherConfigIsFrozen) {
+         throw new FrozenConfigError();
+      }
       const project = await this.projectStore.getProject(projectName, false);
       return project.updatePackage(packageName, body);
    }

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -77,3 +77,11 @@ export class ModelCompilationError extends Error {
       super(error.message);
    }
 }
+
+export class FrozenConfigError extends Error {
+   constructor(
+      message = "Publisher config can't be updated when publisher.config.json has `frozenConfig: true`",
+   ) {
+      super(message);
+   }
+}

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -3,6 +3,8 @@ import { MalloyError } from "@malloydata/malloy";
 export function internalErrorToHttpError(error: Error) {
    if (error instanceof BadRequestError) {
       return httpError(400, error.message);
+   } else if (error instanceof ProjectNotFoundError) {
+      return httpError(404, error.message);
    } else if (error instanceof PackageNotFoundError) {
       return httpError(404, error.message);
    } else if (error instanceof ModelNotFoundError) {

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -3,6 +3,8 @@ import { MalloyError } from "@malloydata/malloy";
 export function internalErrorToHttpError(error: Error) {
    if (error instanceof BadRequestError) {
       return httpError(400, error.message);
+   } else if (error instanceof FrozenConfigError) {
+      return httpError(403, error.message);
    } else if (error instanceof ProjectNotFoundError) {
       return httpError(404, error.message);
    } else if (error instanceof PackageNotFoundError) {

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -2,12 +2,19 @@ import { AxiosError } from "axios";
 import { RequestHandler } from "express";
 import winston from "winston";
 
+const isTelemetryEnabled = Boolean(process.env.OTEL_EXPORTER_OTLP_ENDPOINT);
+
 export const logger = winston.createLogger({
-   format: winston.format.combine(
-      winston.format.uncolorize(),
-      winston.format.timestamp(),
-      winston.format.json(),
-   ),
+   format: isTelemetryEnabled
+      ? winston.format.combine(
+           winston.format.uncolorize(),
+           winston.format.timestamp(),
+           winston.format.json(),
+        )
+      : winston.format.combine(
+           winston.format.colorize(),
+           winston.format.simple(),
+        ),
    transports: [new winston.transports.Console()],
 });
 

--- a/packages/server/src/mcp/tools/discovery_tools.ts
+++ b/packages/server/src/mcp/tools/discovery_tools.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 import { ProjectStore } from "../../service/project_store";
 import { buildMalloyUri } from "../handler_utils";
-import { z } from "zod";
 
 const listPackagesShape = {
    // projectName is required; other fields mirror SDK expectations
@@ -78,7 +78,7 @@ export function registerTools(
             allProjects.map(async (project) => {
                const name = project.name;
                const projectInstance = await project.project;
-               const metadata = await projectInstance.getProjectMetadata();
+               const metadata = await projectInstance.reloadProjectMetadata();
                const readme = metadata.readme;
                return {
                   name,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -12,15 +12,10 @@ import { ModelController } from "./controller/model.controller";
 import { PackageController } from "./controller/package.controller";
 import { QueryController } from "./controller/query.controller";
 import { ScheduleController } from "./controller/schedule.controller";
-import {
-   FrozenConfigError,
-   internalErrorToHttpError,
-   NotImplementedError,
-} from "./errors";
+import { internalErrorToHttpError, NotImplementedError } from "./errors";
 import { logger, loggerMiddleware } from "./logger";
 import { initializeMcpServer } from "./mcp/server";
 import { ProjectStore } from "./service/project_store";
-import { isPublisherConfigFrozen } from "./utils";
 
 // Parse command line arguments
 function parseArgs() {
@@ -82,7 +77,6 @@ if (require.main) {
 const SERVER_ROOT = path.resolve(process.cwd(), process.env.SERVER_ROOT || ".");
 const API_PREFIX = "/api/v0";
 const isDevelopment = process.env["NODE_ENV"] === "development";
-const publisherConfigIsFrozen = isPublisherConfigFrozen(SERVER_ROOT);
 
 const app = express();
 app.use(loggerMiddleware);
@@ -225,9 +219,6 @@ app.get(`${API_PREFIX}/projects`, async (_req, res) => {
 
 app.post(`${API_PREFIX}/projects`, async (req, res) => {
    try {
-      if (publisherConfigIsFrozen) {
-         throw new FrozenConfigError();
-      }
       res.status(200).json(await projectStore.addProject(req.body));
    } catch (error) {
       logger.error(error);
@@ -252,9 +243,6 @@ app.get(`${API_PREFIX}/projects/:projectName`, async (req, res) => {
 
 app.patch(`${API_PREFIX}/projects/:projectName`, async (req, res) => {
    try {
-      if (publisherConfigIsFrozen) {
-         throw new FrozenConfigError();
-      }
       await projectStore.deleteProject(req.params.projectName);
       const overwrittenProject = await projectStore.addProject(req.body);
       res.status(200).json(overwrittenProject);
@@ -267,9 +255,6 @@ app.patch(`${API_PREFIX}/projects/:projectName`, async (req, res) => {
 
 app.delete(`${API_PREFIX}/projects/:projectName`, async (req, res) => {
    try {
-      if (publisherConfigIsFrozen) {
-         throw new FrozenConfigError();
-      }
       res.status(200).json(
          await projectStore.deleteProject(req.params.projectName),
       );
@@ -463,9 +448,6 @@ app.get(`${API_PREFIX}/projects/:projectName/packages`, async (req, res) => {
 
 app.post(`${API_PREFIX}/projects/:projectName/packages`, async (req, res) => {
    try {
-      if (publisherConfigIsFrozen) {
-         throw new FrozenConfigError();
-      }
       res.status(200).json(
          await packageController.addPackage(req.params.projectName, req.body),
       );
@@ -504,9 +486,6 @@ app.patch(
    `${API_PREFIX}/projects/:projectName/packages/:packageName`,
    async (req, res) => {
       try {
-         if (publisherConfigIsFrozen) {
-            throw new FrozenConfigError();
-         }
          res.status(200).json(
             await packageController.updatePackage(
                req.params.projectName,
@@ -526,9 +505,6 @@ app.delete(
    `${API_PREFIX}/projects/:projectName/packages/:packageName`,
    async (req, res) => {
       try {
-         if (publisherConfigIsFrozen) {
-            throw new FrozenConfigError();
-         }
          res.status(200).json(
             await packageController.deletePackage(
                req.params.projectName,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -446,6 +446,18 @@ app.get(`${API_PREFIX}/projects/:projectName/packages`, async (req, res) => {
    }
 });
 
+app.post(`${API_PREFIX}/projects/:projectName/packages`, async (req, res) => {
+   try {
+      res.status(200).json(
+         await packageController.addPackage(req.params.projectName, req.body),
+      );
+   } catch (error) {
+      logger.error(error);
+      const { json, status } = internalErrorToHttpError(error as Error);
+      res.status(status).json(json);
+   }
+});
+
 app.get(
    `${API_PREFIX}/projects/:projectName/packages/:packageName`,
    async (req, res) => {
@@ -460,6 +472,43 @@ app.get(
                req.params.projectName,
                req.params.packageName,
                req.query.reload === "true",
+            ),
+         );
+      } catch (error) {
+         logger.error(error);
+         const { json, status } = internalErrorToHttpError(error as Error);
+         res.status(status).json(json);
+      }
+   },
+);
+
+app.patch(
+   `${API_PREFIX}/projects/:projectName/packages/:packageName`,
+   async (req, res) => {
+      try {
+         res.status(200).json(
+            await packageController.updatePackage(
+               req.params.projectName,
+               req.params.packageName,
+               req.body,
+            ),
+         );
+      } catch (error) {
+         logger.error(error);
+         const { json, status } = internalErrorToHttpError(error as Error);
+         res.status(status).json(json);
+      }
+   },
+);
+
+app.delete(
+   `${API_PREFIX}/projects/:projectName/packages/:packageName`,
+   async (req, res) => {
+      try {
+         res.status(200).json(
+            await packageController.deletePackage(
+               req.params.projectName,
+               req.params.packageName,
             ),
          );
       } catch (error) {

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -374,6 +374,14 @@ export class Package {
       return { name: databasePath, rowCount, columns: schema };
    }
 
+   public setName(name: string) {
+      this.packageName = name;
+   }
+
+   public setProjectName(projectName: string) {
+      this.projectName = projectName;
+   }
+
    public setPackageMetadata(packageMetadata: ApiPackage) {
       this.packageMetadata = packageMetadata;
    }

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -373,4 +373,8 @@ export class Package {
       const rowCount = result.data.value[0].row_count?.valueOf() as number;
       return { name: databasePath, rowCount, columns: schema };
    }
+
+   public setPackageMetadata(packageMetadata: ApiPackage) {
+      this.packageMetadata = packageMetadata;
+   }
 }

--- a/packages/server/src/service/project.ts
+++ b/packages/server/src/service/project.ts
@@ -212,7 +212,10 @@ export class Project {
 
    public async addPackage(packageName: string) {
       const packagePath = path.join(this.projectPath, packageName);
-      if (!(await fs.stat(packagePath)).isDirectory()) {
+      if (
+         !(await fs.exists(packagePath)) ||
+         !(await fs.stat(packagePath)).isDirectory()
+      ) {
          throw new PackageNotFoundError(`Package ${packageName} not found`);
       }
       this.packages.set(

--- a/packages/server/src/service/project.ts
+++ b/packages/server/src/service/project.ts
@@ -42,6 +42,9 @@ export class Project {
    public async update(payload: ApiProject) {
       if (payload.name) {
          this.projectName = payload.name;
+         this.packages.forEach((_package) => {
+            _package.setProjectName(this.projectName);
+         });
       }
       if (payload.resource) {
          this.projectPath = payload.resource.replace(
@@ -237,6 +240,9 @@ export class Project {
       const _package = this.packages.get(packageName);
       if (!_package) {
          throw new PackageNotFoundError(`Package ${packageName} not found`);
+      }
+      if (body.name) {
+         _package.setName(body.name);
       }
       _package.setPackageMetadata({
          name: body.name,

--- a/packages/server/src/service/project.ts
+++ b/packages/server/src/service/project.ts
@@ -38,6 +38,10 @@ export class Project {
       // InternalConnections have full connection details for doing schema inspection
       this.internalConnections = internalConnections;
       this.apiConnections = apiConnections;
+      this.metadata = {
+         resource: `${API_PREFIX}/projects/${this.projectName}`,
+         name: this.projectName,
+      };
       void this.reloadProjectMetadata();
    }
 

--- a/packages/server/src/service/project.ts
+++ b/packages/server/src/service/project.ts
@@ -35,6 +35,24 @@ export class Project {
       this.apiConnections = apiConnections;
    }
 
+   public async update(payload: ApiProject) {
+      if (payload.name) {
+         this.projectName = payload.name;
+      }
+      if (payload.resource) {
+         this.projectPath = payload.resource.replace(
+            `${API_PREFIX}/projects/`,
+            "",
+         );
+         if (!(await fs.stat(this.projectPath)).isDirectory()) {
+            throw new ProjectNotFoundError(
+               `Project path ${this.projectPath} not found`,
+            );
+         }
+      }
+      return this;
+   }
+
    static async create(
       projectName: string,
       projectPath: string,

--- a/packages/server/src/service/project_store.spec.ts
+++ b/packages/server/src/service/project_store.spec.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, mock, spyOn } from "bun:test";
+import * as fs from "fs/promises";
+import path from "path";
+import { FrozenConfigError, ProjectNotFoundError } from "../errors";
+import { isPublisherConfigFrozen } from "../utils";
+import { ProjectStore } from "./project_store";
+
+describe("ProjectStore", () => {
+   const serverRoot = path.resolve(
+      process.cwd(),
+      process.env.SERVER_ROOT || ".",
+   );
+
+   async function waitForInitialization(projectStore: ProjectStore) {
+      const maxRetries = 100;
+      let retries = 0;
+      do {
+         await new Promise((resolve) => setTimeout(resolve, 10));
+         retries++;
+      } while (projectStore.listProjects().length === 0 && retries < maxRetries);
+      if (projectStore.listProjects().length === 0) {
+         throw new Error("Timed out initializing ProjectStore");
+      }
+   }
+
+   it("should load all projects from publisher.config.json within a second on initialization", async () => {
+      mock(isPublisherConfigFrozen).mockReturnValue(true);
+      const projectStore = new ProjectStore(serverRoot);
+      await waitForInitialization(projectStore);
+      expect(projectStore.listProjects()).toEqual([
+         {
+            name: "malloy-samples",
+            readme: expect.stringContaining("# Malloy Analysis Examples"),
+            resource: "/api/v0/projects/malloy-samples",
+         },
+      ]);
+   });
+
+   it("should list projects from memory by default", async () => {
+      mock(isPublisherConfigFrozen).mockReturnValue(true);
+      const projectStore = new ProjectStore(serverRoot);
+      // Mock fs.readFile & fs.readdir to track calls
+      const readFileSpy = spyOn(fs, "readFile");
+      const readdirSpy = spyOn(fs, "readdir");
+      // Call listProjects, which should use memory and not call fs.readFile
+      projectStore.listProjects();
+
+      expect(readFileSpy).not.toHaveBeenCalled();
+      expect(readdirSpy).not.toHaveBeenCalled();
+   });
+
+   it("should list projects from disk if reload is true", async () => {
+      // Mock fs.readFile to track calls
+      const fs = await import("fs/promises");
+      const readFileSpy = spyOn(fs, "readFile");
+      mock(isPublisherConfigFrozen).mockReturnValue(true);
+      const projectStore = new ProjectStore(serverRoot);
+
+      // Call getProject with reload=true
+      await projectStore.getProject("malloy-samples", true);
+
+      expect(readFileSpy).toHaveBeenCalled();
+   });
+
+   it("should allow modifying the in-memory hashmap if config is not frozen", async () => {
+      mock.module("../utils", () => ({
+         isPublisherConfigFrozen: () => false,
+      }));
+      const projectStore = new ProjectStore(serverRoot);
+      await waitForInitialization(projectStore);
+      await projectStore.updateProject({
+         name: "malloy-samples",
+         readme: "Updated README",
+      });
+      expect(projectStore.listProjects()).toEqual([
+         {
+            name: "malloy-samples",
+            readme: "Updated README",
+            resource: "/api/v0/projects/malloy-samples",
+         },
+      ]);
+      await projectStore.deleteProject("malloy-samples");
+      expect(projectStore.listProjects()).toEqual([]);
+      await projectStore.addProject({
+         name: "malloy-samples",
+      });
+
+      expect(
+         await projectStore.getProject("malloy-samples", false),
+      ).toHaveProperty("metadata", {
+         name: "malloy-samples",
+         resource: "/api/v0/projects/malloy-samples",
+      });
+
+      // After a while, it'll resolve the async promise where the readme gets loaded in memory
+      await waitForInitialization(projectStore);
+      expect(projectStore.listProjects()).toEqual([
+         {
+            name: "malloy-samples",
+            readme: expect.stringContaining("# Malloy Analysis Examples"),
+            resource: "/api/v0/projects/malloy-samples",
+         },
+      ]);
+   });
+
+   it("should not allow modifying the in-memory hashmap if config is frozen", async () => {
+      mock.module("../utils", () => ({
+         isPublisherConfigFrozen: () => true,
+      }));
+      const projectStore = new ProjectStore(serverRoot);
+      // Initialization should succeed
+      await waitForInitialization(projectStore);
+      expect(projectStore.listProjects()).toEqual([
+         {
+            name: "malloy-samples",
+            readme: expect.stringContaining("# Malloy Analysis Examples"),
+            resource: "/api/v0/projects/malloy-samples",
+         },
+      ]);
+      // Adding a project should fail
+      expect(
+         projectStore.addProject({
+            name: "malloy-samples",
+         }),
+      ).rejects.toThrow(FrozenConfigError);
+
+      // Updating a project should fail
+      expect(
+         projectStore.updateProject({
+            name: "malloy-samples",
+            readme: "Updated README",
+         }),
+      ).rejects.toThrow(FrozenConfigError);
+
+      // Deleting a project should fail
+      expect(projectStore.deleteProject("malloy-samples")).rejects.toThrow(
+         FrozenConfigError,
+      );
+
+      // Failed methods should not modify the in-memory hashmap
+      expect(projectStore.listProjects()).toEqual([
+         {
+            name: "malloy-samples",
+            readme: expect.stringContaining("# Malloy Analysis Examples"),
+            resource: "/api/v0/projects/malloy-samples",
+         },
+      ]);
+   });
+
+   it("should always try to reload a project if it's not in the hashmap", async () => {
+      mock.module("../utils", () => ({
+         isPublisherConfigFrozen: () => false,
+      }));
+      const projectStore = new ProjectStore(serverRoot);
+      await waitForInitialization(projectStore);
+      await projectStore.deleteProject("malloy-samples");
+      expect(projectStore.listProjects()).toEqual([]);
+      const readFileSpy = spyOn(fs, "readFile");
+      await projectStore.getProject("malloy-samples", true);
+      expect(readFileSpy).toHaveBeenCalled();
+   });
+
+   it("should throw a NotFound error when reloading a project that is not in disk", async () => {
+      mock.module("../utils", () => ({
+         isPublisherConfigFrozen: () => false,
+      }));
+      const projectStore = new ProjectStore(serverRoot);
+      await waitForInitialization(projectStore);
+      expect(projectStore.getProject("this-one-does-not-exist", true)).rejects.toThrow(
+         ProjectNotFoundError,
+      );
+   });
+});

--- a/packages/server/src/service/project_store.ts
+++ b/packages/server/src/service/project_store.ts
@@ -79,6 +79,7 @@ export class ProjectStore {
       return newProject;
    }
 
+   // TODO: Return name and readme from memory instead of reading from disk
    public async updateProject(project: ApiProject) {
       const projectName = project.name;
       if (!projectName) {

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -1,5 +1,6 @@
 import { URLReader } from "@malloydata/malloy";
-import { promises as fs } from "fs";
+import * as fs from "fs";
+import path from "path";
 import { fileURLToPath } from "url";
 
 export const PACKAGE_MANIFEST_NAME = "publisher.json";
@@ -15,6 +16,17 @@ export const URL_READER: URLReader = {
       if (url.protocol == "file:") {
          path = fileURLToPath(url);
       }
-      return fs.readFile(path, "utf8");
+      return fs.promises.readFile(path, "utf8");
    },
+};
+
+export const isPublisherConfigFrozen = (serverRoot: string) => {
+   const publisherConfigPath = path.join(serverRoot, "publisher.config.json");
+   if (!fs.existsSync(publisherConfigPath)) {
+      return false;
+   }
+   const publisherConfig = JSON.parse(
+      fs.readFileSync(publisherConfigPath, "utf8"),
+   );
+   return Boolean(publisherConfig.frozenConfig);
 };


### PR DESCRIPTION
- This PR adds methods to create and delete projects and packages.
- It also uses the publisher.config.json as a startup configuration file. At start up, the server reads the configuration and loads the package, connections, etc. into the Publisher in-memory data structures. After startup, the Publisher's configurations are mutable through the CRUD API.
- It also features a `frozenConfig` boolean flag to the Publisher's configuration file that makes the publisher read-only. That is, if `frozenConfig` is true, the API methods to create & delete packages & projects return errors and have no effect on the Publisher's state.