### PR TITLE
Move Axios Client into ServerProvider

### DIFF
--- a/examples/data-app/src/main.tsx
+++ b/examples/data-app/src/main.tsx
@@ -8,16 +8,11 @@ import { ServerProvider } from "@malloy-publisher/sdk";
 // Import required CSS
 import "@malloy-publisher/sdk/styles.css";
 
-const apiUrl = import.meta.env.VITE_PUBLISHER_API;
-const getAccessToken = async (): Promise<string> => {
-  return ""; // would replace with real auth logic when needed
-};
-
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <ServerProvider server={apiUrl} getAccessToken={getAccessToken}>
+      <ServerProvider>
         <AppShell />
       </ServerProvider>
     </ThemeProvider>

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -24,14 +24,12 @@ export const createMalloyRouter = (
    basePath: string = "/",
    workbookStorage: WorkbookStorage,
    headerProps?: HeaderProps,
-   server?: string,
-   getAccessToken?: () => Promise<string>,
 ) => {
    return createBrowserRouter([
       {
          path: basePath,
          element: (
-            <ServerProvider server={server} getAccessToken={getAccessToken}>
+            <ServerProvider>
                <WorkbookStorageProvider workbookStorage={workbookStorage}>
                   <ThemeProvider theme={theme}>
                      <CssBaseline />
@@ -68,26 +66,16 @@ export const createMalloyRouter = (
 };
 
 export interface MalloyPublisherAppProps {
-   server?: string;
-   getAccessToken?: () => Promise<string>;
    basePath?: string;
    headerProps: HeaderProps;
    workbookStorage: WorkbookStorage;
 }
 
 export const MalloyPublisherApp: React.FC<MalloyPublisherAppProps> = ({
-   server,
-   getAccessToken,
    workbookStorage,
    basePath = "/",
    headerProps,
 }) => {
-   const router = createMalloyRouter(
-      basePath,
-      workbookStorage,
-      headerProps,
-      server,
-      getAccessToken,
-   );
+   const router = createMalloyRouter(basePath, workbookStorage, headerProps);
    return <RouterProvider router={router} />;
 };

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -6,13 +6,7 @@ import { BrowserWorkbookStorage } from "@malloy-publisher/sdk";
 
 // Main.tsx is used to run the app locally. This is not used when the app is
 // embedded in another project.
-const server = `${window.location.protocol}//${window.location.host}/api/v0`;
-const router = createMalloyRouter(
-   "/",
-   new BrowserWorkbookStorage(),
-   undefined,
-   server,
-);
+const router = createMalloyRouter("/", new BrowserWorkbookStorage(), undefined);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
    <React.StrictMode>

--- a/packages/sdk/src/components/Home/Home.tsx
+++ b/packages/sdk/src/components/Home/Home.tsx
@@ -20,7 +20,7 @@ import {
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
-import { useApiClients } from "../ServerProvider";
+import { useServer } from "../ServerProvider";
 
 interface HomeProps {
    navigate?: (to: string, event?: React.MouseEvent) => void;
@@ -57,11 +57,11 @@ const getProjectDescription = (readme: string | undefined): string => {
 };
 
 export default function Home({ navigate }: HomeProps) {
-   const { projects } = useApiClients();
+   const { apiClients } = useServer();
 
    const { data, isSuccess, isError, error } = useQueryWithApiError({
       queryKey: ["projects"],
-      queryFn: () => projects.listProjects(),
+      queryFn: () => apiClients.projects.listProjects(),
    });
 
    if (isError) {

--- a/packages/sdk/src/components/Home/Home.tsx
+++ b/packages/sdk/src/components/Home/Home.tsx
@@ -17,12 +17,10 @@ import {
    Stack,
    Typography,
 } from "@mui/material";
-import { Configuration, ProjectsApi } from "../../client";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
-
-const projectsApi = new ProjectsApi(new Configuration());
+import { useApiClients } from "../ServerProvider";
 
 interface HomeProps {
    navigate?: (to: string, event?: React.MouseEvent) => void;
@@ -59,9 +57,11 @@ const getProjectDescription = (readme: string | undefined): string => {
 };
 
 export default function Home({ navigate }: HomeProps) {
+   const { projects } = useApiClients();
+
    const { data, isSuccess, isError, error } = useQueryWithApiError({
       queryKey: ["projects"],
-      queryFn: (config) => projectsApi.listProjects(config),
+      queryFn: () => projects.listProjects(),
    });
 
    if (isError) {

--- a/packages/sdk/src/components/Model/ModelCell.tsx
+++ b/packages/sdk/src/components/Model/ModelCell.tsx
@@ -7,7 +7,7 @@ import ResultContainer from "../RenderedResult/ResultContainer";
 import ResultsDialog from "../ResultsDialog";
 import { CleanMetricCard, CleanNotebookCell } from "../styles";
 import { parseResourceUri } from "../../utils/formatting";
-import { useApiClients } from "../ServerProvider";
+import { useServer } from "../ServerProvider";
 
 interface ModelCellProps {
    sourceName?: string;
@@ -28,7 +28,7 @@ export function ModelCell({
 
    const { packageName, projectName, versionId, modelPath } =
       parseResourceUri(resourceUri);
-   const { queryResults } = useApiClients();
+   const { apiClients } = useServer();
 
    const {
       data: queryData,
@@ -37,7 +37,7 @@ export function ModelCell({
    } = useQueryWithApiError({
       queryKey: ["namedQueryResult", resourceUri, queryName],
       queryFn: () =>
-         queryResults.executeQuery(
+         apiClients.queryResults.executeQuery(
             projectName,
             packageName,
             modelPath,

--- a/packages/sdk/src/components/Model/ModelCell.tsx
+++ b/packages/sdk/src/components/Model/ModelCell.tsx
@@ -1,13 +1,13 @@
 import { Box, Typography, IconButton } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import React, { useEffect } from "react";
-import { Configuration, QueryresultsApi } from "../../client";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { highlight } from "../highlighter";
 import ResultContainer from "../RenderedResult/ResultContainer";
 import ResultsDialog from "../ResultsDialog";
 import { CleanMetricCard, CleanNotebookCell } from "../styles";
 import { parseResourceUri } from "../../utils/formatting";
+import { useApiClients } from "../ServerProvider";
 
 interface ModelCellProps {
    sourceName?: string;
@@ -28,8 +28,7 @@ export function ModelCell({
 
    const { packageName, projectName, versionId, modelPath } =
       parseResourceUri(resourceUri);
-
-   const queryResultsApi = new QueryresultsApi(new Configuration());
+   const { queryResults } = useApiClients();
 
    const {
       data: queryData,
@@ -37,8 +36,8 @@ export function ModelCell({
       isLoading,
    } = useQueryWithApiError({
       queryKey: ["namedQueryResult", resourceUri, queryName],
-      queryFn: (config) =>
-         queryResultsApi.executeQuery(
+      queryFn: () =>
+         queryResults.executeQuery(
             projectName,
             packageName,
             modelPath,
@@ -46,7 +45,6 @@ export function ModelCell({
             undefined, // sourceName
             queryName, // queryName
             versionId, // versionId
-            config,
          ),
       enabled: true, // Always execute
    });

--- a/packages/sdk/src/components/Model/SourcesExplorer.tsx
+++ b/packages/sdk/src/components/Model/SourcesExplorer.tsx
@@ -9,7 +9,7 @@ import {
 import React, { useState, useEffect } from "react";
 import { useMutationWithApiError } from "../../hooks/useQueryWithApiError";
 import { parseResourceUri } from "../../utils/formatting";
-import { useApiClients } from "../ServerProvider";
+import { useServer } from "../ServerProvider";
 
 type ExplorerComponents = typeof import("@malloydata/malloy-explorer");
 type QueryBuilder = typeof import("@malloydata/malloy-query-builder");
@@ -133,7 +133,7 @@ function SourceExplorerComponentInner({
       packageName: packageName,
       versionId: versionId,
    } = parseResourceUri(resourceUri);
-   const { queryResults } = useApiClients();
+   const { apiClients } = useServer();
 
    const mutation = useMutationWithApiError({
       mutationFn: () => {
@@ -145,7 +145,7 @@ function SourceExplorerComponentInner({
             ...query,
             query: malloy,
          });
-         return queryResults.executeQuery(
+         return apiClients.queryResults.executeQuery(
             projectName,
             packageName,
             sourceAndPath.modelPath,

--- a/packages/sdk/src/components/Model/SourcesExplorer.tsx
+++ b/packages/sdk/src/components/Model/SourcesExplorer.tsx
@@ -7,14 +7,12 @@ import {
 } from "../styles";
 
 import React, { useState, useEffect } from "react";
-import { Configuration, QueryresultsApi } from "../../client";
 import { useMutationWithApiError } from "../../hooks/useQueryWithApiError";
 import { parseResourceUri } from "../../utils/formatting";
+import { useApiClients } from "../ServerProvider";
 
 type ExplorerComponents = typeof import("@malloydata/malloy-explorer");
 type QueryBuilder = typeof import("@malloydata/malloy-query-builder");
-
-const queryResultsApi = new QueryresultsApi(new Configuration());
 
 export interface SourceAndPath {
    modelPath: string;
@@ -135,8 +133,10 @@ function SourceExplorerComponentInner({
       packageName: packageName,
       versionId: versionId,
    } = parseResourceUri(resourceUri);
+   const { queryResults } = useApiClients();
+
    const mutation = useMutationWithApiError({
-      mutationFn: (_, config) => {
+      mutationFn: () => {
          const malloy = new QueryBuilder.ASTQuery({
             source: sourceAndPath.sourceInfo,
             query: query?.malloyQuery,
@@ -145,7 +145,7 @@ function SourceExplorerComponentInner({
             ...query,
             query: malloy,
          });
-         return queryResultsApi.executeQuery(
+         return queryResults.executeQuery(
             projectName,
             packageName,
             sourceAndPath.modelPath,
@@ -154,7 +154,6 @@ function SourceExplorerComponentInner({
             // sourceInfo.name,
             undefined,
             versionId,
-            config,
          );
       },
       onSuccess: (data) => {

--- a/packages/sdk/src/components/Model/useModelData.ts
+++ b/packages/sdk/src/components/Model/useModelData.ts
@@ -1,8 +1,7 @@
-import { Configuration, ModelsApi, CompiledModel } from "../../client";
+import { CompiledModel } from "../../client";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { parseResourceUri } from "../../utils/formatting";
-
-const modelsApi = new ModelsApi(new Configuration());
+import { useApiClients } from "../ServerProvider";
 
 /**
  * Custom hook for fetching model data. Combines usePackage context with
@@ -11,15 +10,16 @@ const modelsApi = new ModelsApi(new Configuration());
 export function useModelData(resourceUri: string) {
    const { modelPath, projectName, packageName, versionId } =
       parseResourceUri(resourceUri);
+   const { models } = useApiClients();
+
    return useQueryWithApiError<CompiledModel>({
       queryKey: ["package", projectName, packageName, modelPath, versionId],
-      queryFn: async (config) => {
-         const response = await modelsApi.getModel(
+      queryFn: async () => {
+         const response = await models.getModel(
             projectName,
             packageName,
             modelPath,
             versionId,
-            config,
          );
          return response.data;
       },

--- a/packages/sdk/src/components/Model/useModelData.ts
+++ b/packages/sdk/src/components/Model/useModelData.ts
@@ -1,7 +1,7 @@
 import { CompiledModel } from "../../client";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { parseResourceUri } from "../../utils/formatting";
-import { useApiClients } from "../ServerProvider";
+import { useServer } from "../ServerProvider";
 
 /**
  * Custom hook for fetching model data. Combines usePackage context with
@@ -10,12 +10,12 @@ import { useApiClients } from "../ServerProvider";
 export function useModelData(resourceUri: string) {
    const { modelPath, projectName, packageName, versionId } =
       parseResourceUri(resourceUri);
-   const { models } = useApiClients();
+   const { apiClients } = useServer();
 
    return useQueryWithApiError<CompiledModel>({
       queryKey: ["package", projectName, packageName, modelPath, versionId],
       queryFn: async () => {
-         const response = await models.getModel(
+         const response = await apiClients.models.getModel(
             projectName,
             packageName,
             modelPath,

--- a/packages/sdk/src/components/Notebook/Notebook.tsx
+++ b/packages/sdk/src/components/Notebook/Notebook.tsx
@@ -8,7 +8,7 @@ import { Loading } from "../Loading";
 import { CleanNotebookContainer, CleanNotebookSection } from "../styles";
 import { NotebookCell } from "./NotebookCell";
 import { parseResourceUri } from "../../utils/formatting";
-import { useApiClients } from "../ServerProvider";
+import { useServer } from "../ServerProvider";
 
 interface NotebookProps {
    resourceUri: string;
@@ -16,7 +16,7 @@ interface NotebookProps {
 
 // Requires PackageProvider
 export default function Notebook({ resourceUri }: NotebookProps) {
-   const { notebooks } = useApiClients();
+   const { apiClients } = useServer();
    const {
       projectName,
       packageName,
@@ -31,7 +31,7 @@ export default function Notebook({ resourceUri }: NotebookProps) {
    } = useQueryWithApiError<CompiledNotebook>({
       queryKey: [resourceUri],
       queryFn: async () => {
-         const response = await notebooks.getNotebook(
+         const response = await apiClients.notebooks.getNotebook(
             projectName,
             packageName,
             notebookPath,

--- a/packages/sdk/src/components/Notebook/Notebook.tsx
+++ b/packages/sdk/src/components/Notebook/Notebook.tsx
@@ -1,6 +1,6 @@
 import "@malloydata/malloy-explorer/styles.css";
 import { Stack, Typography } from "@mui/material";
-import { CompiledNotebook, Configuration, NotebooksApi } from "../../client";
+import { CompiledNotebook } from "../../client";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 
@@ -8,8 +8,7 @@ import { Loading } from "../Loading";
 import { CleanNotebookContainer, CleanNotebookSection } from "../styles";
 import { NotebookCell } from "./NotebookCell";
 import { parseResourceUri } from "../../utils/formatting";
-
-const notebooksApi = new NotebooksApi(new Configuration());
+import { useApiClients } from "../ServerProvider";
 
 interface NotebookProps {
    resourceUri: string;
@@ -17,6 +16,7 @@ interface NotebookProps {
 
 // Requires PackageProvider
 export default function Notebook({ resourceUri }: NotebookProps) {
+   const { notebooks } = useApiClients();
    const {
       projectName,
       packageName,
@@ -30,13 +30,12 @@ export default function Notebook({ resourceUri }: NotebookProps) {
       error,
    } = useQueryWithApiError<CompiledNotebook>({
       queryKey: [resourceUri],
-      queryFn: async (config) => {
-         const response = await notebooksApi.getNotebook(
+      queryFn: async () => {
+         const response = await notebooks.getNotebook(
             projectName,
             packageName,
             notebookPath,
             versionId,
-            config,
          );
          return response.data;
       },

--- a/packages/sdk/src/components/Package/Config.tsx
+++ b/packages/sdk/src/components/Package/Config.tsx
@@ -9,14 +9,14 @@ import {
    PackageSectionTitle,
 } from "../styles";
 import { parseResourceUri } from "../../utils/formatting";
-import { useApiClients } from "../ServerProvider";
+import { useServer } from "../ServerProvider";
 
 type Props = {
    resourceUri: string;
 };
 
 export default function Config({ resourceUri }: Props) {
-   const { packages } = useApiClients();
+   const { apiClients } = useServer();
    const {
       projectName: projectName,
       packageName: packageName,
@@ -26,7 +26,12 @@ export default function Config({ resourceUri }: Props) {
    const { data, isSuccess, isError, error } = useQueryWithApiError({
       queryKey: ["package", projectName, packageName, versionId],
       queryFn: () =>
-         packages.getPackage(projectName, packageName, versionId, false),
+         apiClients.packages.getPackage(
+            projectName,
+            packageName,
+            versionId,
+            false,
+         ),
    });
 
    return (

--- a/packages/sdk/src/components/Package/Config.tsx
+++ b/packages/sdk/src/components/Package/Config.tsx
@@ -1,6 +1,5 @@
 import ErrorIcon from "@mui/icons-material/ErrorOutlined";
 import { Box, List, ListItem, ListItemText } from "@mui/material";
-import { Configuration, PackagesApi } from "../../client";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
@@ -10,14 +9,14 @@ import {
    PackageSectionTitle,
 } from "../styles";
 import { parseResourceUri } from "../../utils/formatting";
-
-const packagesApi = new PackagesApi(new Configuration());
+import { useApiClients } from "../ServerProvider";
 
 type Props = {
    resourceUri: string;
 };
 
 export default function Config({ resourceUri }: Props) {
+   const { packages } = useApiClients();
    const {
       projectName: projectName,
       packageName: packageName,
@@ -26,14 +25,8 @@ export default function Config({ resourceUri }: Props) {
 
    const { data, isSuccess, isError, error } = useQueryWithApiError({
       queryKey: ["package", projectName, packageName, versionId],
-      queryFn: (config) =>
-         packagesApi.getPackage(
-            projectName,
-            packageName,
-            versionId,
-            false,
-            config,
-         ),
+      queryFn: () =>
+         packages.getPackage(projectName, packageName, versionId, false),
    });
 
    return (

--- a/packages/sdk/src/components/Package/Connections.tsx
+++ b/packages/sdk/src/components/Package/Connections.tsx
@@ -22,7 +22,7 @@ import {
 import ConnectionExplorer from "../Project/ConnectionExplorer";
 import { useState } from "react";
 import { encodeResourceUri, parseResourceUri } from "../../utils/formatting";
-import { useApiClients } from "../ServerProvider";
+import { useServer } from "../ServerProvider";
 
 type ConnectionProps = {
    connection: ApiConnection;
@@ -66,7 +66,7 @@ type ConnectionsProps = {
 };
 
 export default function Connections({ resourceUri }: ConnectionsProps) {
-   const { connections } = useApiClients();
+   const { apiClients } = useServer();
    const { projectName: projectName } = parseResourceUri(resourceUri);
    const [selectedConnection, setSelectedConnection] = useState<string | null>(
       null,
@@ -77,7 +77,7 @@ export default function Connections({ resourceUri }: ConnectionsProps) {
    });
    const { data, isSuccess, isError, error } = useQueryWithApiError({
       queryKey: ["connections", projectName],
-      queryFn: () => connections.listConnections(projectName),
+      queryFn: () => apiClients.connections.listConnections(projectName),
    });
 
    const handleConnectionClick = (connectionName: string) => {

--- a/packages/sdk/src/components/Package/Connections.tsx
+++ b/packages/sdk/src/components/Package/Connections.tsx
@@ -11,7 +11,6 @@ import {
    IconButton,
 } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
-import { Configuration, ConnectionsApi } from "../../client";
 import { Connection as ApiConnection } from "../../client/api";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
@@ -23,8 +22,7 @@ import {
 import ConnectionExplorer from "../Project/ConnectionExplorer";
 import { useState } from "react";
 import { encodeResourceUri, parseResourceUri } from "../../utils/formatting";
-
-const connectionsApi = new ConnectionsApi(new Configuration());
+import { useApiClients } from "../ServerProvider";
 
 type ConnectionProps = {
    connection: ApiConnection;
@@ -68,6 +66,7 @@ type ConnectionsProps = {
 };
 
 export default function Connections({ resourceUri }: ConnectionsProps) {
+   const { connections } = useApiClients();
    const { projectName: projectName } = parseResourceUri(resourceUri);
    const [selectedConnection, setSelectedConnection] = useState<string | null>(
       null,
@@ -78,7 +77,7 @@ export default function Connections({ resourceUri }: ConnectionsProps) {
    });
    const { data, isSuccess, isError, error } = useQueryWithApiError({
       queryKey: ["connections", projectName],
-      queryFn: (config) => connectionsApi.listConnections(projectName, config),
+      queryFn: () => connections.listConnections(projectName),
    });
 
    const handleConnectionClick = (connectionName: string) => {

--- a/packages/sdk/src/components/Package/Databases.tsx
+++ b/packages/sdk/src/components/Package/Databases.tsx
@@ -14,7 +14,7 @@ import {
 } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import React from "react";
-import { Configuration, Database, DatabasesApi } from "../../client";
+import { Database } from "../../client";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
@@ -24,14 +24,14 @@ import {
    PackageSectionTitle,
 } from "../styles";
 import { parseResourceUri } from "../../utils/formatting";
-
-const databasesApi = new DatabasesApi(new Configuration());
+import { useApiClients } from "../ServerProvider";
 
 type Props = {
    resourceUri: string;
 };
 
 export default function Databases({ resourceUri }: Props) {
+   const { databases } = useApiClients();
    const {
       projectName: projectName,
       packageName: packageName,
@@ -54,13 +54,8 @@ export default function Databases({ resourceUri }: Props) {
 
    const { data, isError, error, isSuccess } = useQueryWithApiError({
       queryKey: ["databases", projectName, packageName, versionId],
-      queryFn: (config) =>
-         databasesApi.listDatabases(
-            projectName,
-            packageName,
-            versionId,
-            config,
-         ),
+      queryFn: () =>
+         databases.listDatabases(projectName, packageName, versionId),
    });
    const formatRowSize = (size: number) => {
       if (size >= 1024 * 1024 * 1024 * 1024) {

--- a/packages/sdk/src/components/Package/Databases.tsx
+++ b/packages/sdk/src/components/Package/Databases.tsx
@@ -24,14 +24,14 @@ import {
    PackageSectionTitle,
 } from "../styles";
 import { parseResourceUri } from "../../utils/formatting";
-import { useApiClients } from "../ServerProvider";
+import { useServer } from "../ServerProvider";
 
 type Props = {
    resourceUri: string;
 };
 
 export default function Databases({ resourceUri }: Props) {
-   const { databases } = useApiClients();
+   const { apiClients } = useServer();
    const {
       projectName: projectName,
       packageName: packageName,
@@ -55,7 +55,11 @@ export default function Databases({ resourceUri }: Props) {
    const { data, isError, error, isSuccess } = useQueryWithApiError({
       queryKey: ["databases", projectName, packageName, versionId],
       queryFn: () =>
-         databases.listDatabases(projectName, packageName, versionId),
+         apiClients.databases.listDatabases(
+            projectName,
+            packageName,
+            versionId,
+         ),
    });
    const formatRowSize = (size: number) => {
       if (size >= 1024 * 1024 * 1024 * 1024) {

--- a/packages/sdk/src/components/Package/Models.tsx
+++ b/packages/sdk/src/components/Package/Models.tsx
@@ -9,7 +9,7 @@ import {
 } from "../styles";
 import { FileTreeView } from "./FileTreeView";
 import { parseResourceUri } from "../../utils/formatting";
-import { useApiClients } from "../ServerProvider";
+import { useServer } from "../ServerProvider";
 
 const DEFAULT_EXPANDED_FOLDERS = ["notebooks/", "models/"];
 
@@ -24,11 +24,12 @@ export default function Models({ navigate, resourceUri }: ModelsProps) {
       packageName: packageName,
       versionId: versionId,
    } = parseResourceUri(resourceUri);
-   const { models } = useApiClients();
+   const { apiClients } = useServer();
 
    const { data, isError, error, isSuccess } = useQueryWithApiError({
       queryKey: ["models", projectName, packageName, versionId],
-      queryFn: () => models.listModels(projectName, packageName, versionId),
+      queryFn: () =>
+         apiClients.models.listModels(projectName, packageName, versionId),
    });
 
    return (

--- a/packages/sdk/src/components/Package/Models.tsx
+++ b/packages/sdk/src/components/Package/Models.tsx
@@ -1,5 +1,4 @@
 import { Box, Typography } from "@mui/material";
-import { Configuration, ModelsApi } from "../../client";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
@@ -10,8 +9,7 @@ import {
 } from "../styles";
 import { FileTreeView } from "./FileTreeView";
 import { parseResourceUri } from "../../utils/formatting";
-
-const modelsApi = new ModelsApi(new Configuration());
+import { useApiClients } from "../ServerProvider";
 
 const DEFAULT_EXPANDED_FOLDERS = ["notebooks/", "models/"];
 
@@ -26,10 +24,11 @@ export default function Models({ navigate, resourceUri }: ModelsProps) {
       packageName: packageName,
       versionId: versionId,
    } = parseResourceUri(resourceUri);
+   const { models } = useApiClients();
+
    const { data, isError, error, isSuccess } = useQueryWithApiError({
       queryKey: ["models", projectName, packageName, versionId],
-      queryFn: (config) =>
-         modelsApi.listModels(projectName, packageName, versionId, config),
+      queryFn: () => models.listModels(projectName, packageName, versionId),
    });
 
    return (

--- a/packages/sdk/src/components/Package/Notebooks.tsx
+++ b/packages/sdk/src/components/Package/Notebooks.tsx
@@ -1,5 +1,4 @@
 import { Box, Typography } from "@mui/material";
-import { Configuration, NotebooksApi } from "../../client";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
@@ -10,8 +9,7 @@ import {
 } from "../styles";
 import { FileTreeView } from "./FileTreeView";
 import { parseResourceUri } from "../../utils/formatting";
-
-const notebooksApi = new NotebooksApi(new Configuration());
+import { useApiClients } from "../ServerProvider";
 
 const DEFAULT_EXPANDED_FOLDERS = ["notebooks/"];
 
@@ -21,6 +19,7 @@ interface NotebooksProps {
 }
 
 export default function Notebooks({ navigate, resourceUri }: NotebooksProps) {
+   const { notebooks } = useApiClients();
    const {
       projectName: projectName,
       packageName: packageName,
@@ -29,13 +28,8 @@ export default function Notebooks({ navigate, resourceUri }: NotebooksProps) {
 
    const { data, isError, error, isSuccess } = useQueryWithApiError({
       queryKey: ["notebooks", projectName, packageName, versionId],
-      queryFn: (config) =>
-         notebooksApi.listNotebooks(
-            projectName,
-            packageName,
-            versionId,
-            config,
-         ),
+      queryFn: () =>
+         notebooks.listNotebooks(projectName, packageName, versionId),
    });
 
    return (

--- a/packages/sdk/src/components/Package/Notebooks.tsx
+++ b/packages/sdk/src/components/Package/Notebooks.tsx
@@ -9,7 +9,7 @@ import {
 } from "../styles";
 import { FileTreeView } from "./FileTreeView";
 import { parseResourceUri } from "../../utils/formatting";
-import { useApiClients } from "../ServerProvider";
+import { useServer } from "../ServerProvider";
 
 const DEFAULT_EXPANDED_FOLDERS = ["notebooks/"];
 
@@ -19,7 +19,7 @@ interface NotebooksProps {
 }
 
 export default function Notebooks({ navigate, resourceUri }: NotebooksProps) {
-   const { notebooks } = useApiClients();
+   const { apiClients } = useServer();
    const {
       projectName: projectName,
       packageName: packageName,
@@ -29,7 +29,11 @@ export default function Notebooks({ navigate, resourceUri }: NotebooksProps) {
    const { data, isError, error, isSuccess } = useQueryWithApiError({
       queryKey: ["notebooks", projectName, packageName, versionId],
       queryFn: () =>
-         notebooks.listNotebooks(projectName, packageName, versionId),
+         apiClients.notebooks.listNotebooks(
+            projectName,
+            packageName,
+            versionId,
+         ),
    });
 
    return (

--- a/packages/sdk/src/components/Package/Schedules.tsx
+++ b/packages/sdk/src/components/Package/Schedules.tsx
@@ -17,14 +17,14 @@ import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { parseResourceUri } from "../../utils/formatting";
-import { useApiClients } from "../ServerProvider";
+import { useServer } from "../ServerProvider";
 
 type Props = {
    resourceUri: string;
 };
 
 export default function Schedules({ resourceUri }: Props) {
-   const { schedules } = useApiClients();
+   const { apiClients } = useServer();
    const {
       projectName: projectName,
       packageName: packageName,
@@ -34,7 +34,11 @@ export default function Schedules({ resourceUri }: Props) {
    const { data, isError, isLoading, error } = useQueryWithApiError({
       queryKey: ["schedules", projectName, packageName, versionId],
       queryFn: () =>
-         schedules.listSchedules(projectName, packageName, versionId),
+         apiClients.schedules.listSchedules(
+            projectName,
+            packageName,
+            versionId,
+         ),
    });
 
    if (isLoading) {

--- a/packages/sdk/src/components/Package/Schedules.tsx
+++ b/packages/sdk/src/components/Package/Schedules.tsx
@@ -8,7 +8,6 @@ import {
    TableHead,
    TableRow,
 } from "@mui/material";
-import { Configuration, SchedulesApi } from "../../client";
 import {
    PackageCard,
    PackageCardContent,
@@ -18,14 +17,14 @@ import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { parseResourceUri } from "../../utils/formatting";
-
-const schedulesApi = new SchedulesApi(new Configuration());
+import { useApiClients } from "../ServerProvider";
 
 type Props = {
    resourceUri: string;
 };
 
 export default function Schedules({ resourceUri }: Props) {
+   const { schedules } = useApiClients();
    const {
       projectName: projectName,
       packageName: packageName,
@@ -34,13 +33,8 @@ export default function Schedules({ resourceUri }: Props) {
 
    const { data, isError, isLoading, error } = useQueryWithApiError({
       queryKey: ["schedules", projectName, packageName, versionId],
-      queryFn: (config) =>
-         schedulesApi.listSchedules(
-            projectName,
-            packageName,
-            versionId,
-            config,
-         ),
+      queryFn: () =>
+         schedules.listSchedules(projectName, packageName, versionId),
    });
 
    if (isLoading) {

--- a/packages/sdk/src/components/Project/About.tsx
+++ b/packages/sdk/src/components/Project/About.tsx
@@ -1,6 +1,5 @@
 import { Box } from "@mui/material";
 import Markdown from "markdown-to-jsx";
-import { Configuration, ProjectsApi } from "../../client";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
@@ -10,8 +9,7 @@ import {
    PackageSectionTitle,
 } from "../styles";
 import { parseResourceUri } from "../../utils/formatting";
-
-const projectsApi = new ProjectsApi(new Configuration());
+import { useApiClients } from "../ServerProvider";
 
 interface AboutProps {
    resourceUri: string;
@@ -19,10 +17,11 @@ interface AboutProps {
 
 export default function About({ resourceUri }: AboutProps) {
    const { projectName: projectName } = parseResourceUri(resourceUri);
+   const { projects } = useApiClients();
 
    const { data, isSuccess, isError, error } = useQueryWithApiError({
       queryKey: ["about", projectName],
-      queryFn: (config) => projectsApi.getProject(projectName, false, config),
+      queryFn: () => projects.getProject(projectName, false),
    });
 
    return (

--- a/packages/sdk/src/components/Project/About.tsx
+++ b/packages/sdk/src/components/Project/About.tsx
@@ -9,7 +9,7 @@ import {
    PackageSectionTitle,
 } from "../styles";
 import { parseResourceUri } from "../../utils/formatting";
-import { useApiClients } from "../ServerProvider";
+import { useServer } from "../ServerProvider";
 
 interface AboutProps {
    resourceUri: string;
@@ -17,11 +17,11 @@ interface AboutProps {
 
 export default function About({ resourceUri }: AboutProps) {
    const { projectName: projectName } = parseResourceUri(resourceUri);
-   const { projects } = useApiClients();
+   const { apiClients } = useServer();
 
    const { data, isSuccess, isError, error } = useQueryWithApiError({
       queryKey: ["about", projectName],
-      queryFn: () => projects.getProject(projectName, false),
+      queryFn: () => apiClients.projects.getProject(projectName, false),
    });
 
    return (

--- a/packages/sdk/src/components/Project/ConnectionExplorer.tsx
+++ b/packages/sdk/src/components/Project/ConnectionExplorer.tsx
@@ -24,8 +24,7 @@ import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { parseResourceUri } from "../../utils/formatting";
-
-const connectionsApi = new ConnectionsApi(new Configuration());
+import { useApiClients } from "../ServerProvider";
 
 interface ConnectionExplorerProps {
    connectionName: string;
@@ -38,6 +37,7 @@ export default function ConnectionExplorer({
    resourceUri,
    schema,
 }: ConnectionExplorerProps) {
+   const { connections } = useApiClients();
    const { projectName: projectName } = parseResourceUri(resourceUri);
    const [selectedTable, setSelectedTable] = React.useState<string | undefined>(
       undefined,
@@ -48,8 +48,7 @@ export default function ConnectionExplorer({
    const [showHiddenSchemas, setShowHiddenSchemas] = React.useState(false);
    const { data, isSuccess, isError, error, isLoading } = useQueryWithApiError({
       queryKey: ["tablePath", projectName, connectionName],
-      queryFn: (config) =>
-         connectionsApi.listSchemas(projectName, connectionName, config),
+      queryFn: () => connections.listSchemas(projectName, connectionName),
    });
 
    return (
@@ -199,8 +198,8 @@ function TableSchemaViewer({
    tableName,
    resourceUri,
 }: TableSchemaViewerProps) {
+   const { connections } = useApiClients();
    const { projectName: projectName } = parseResourceUri(resourceUri);
-
    const { data, isSuccess, isError, error, isLoading } = useQueryWithApiError({
       queryKey: [
          "tablePathSchema",
@@ -209,13 +208,12 @@ function TableSchemaViewer({
          schemaName,
          tableName,
       ],
-      queryFn: (config) =>
-         connectionsApi.getTablesource(
+      queryFn: () =>
+         connections.getTablesource(
             projectName,
             connectionName,
             tableName,
             `${schemaName}.${tableName}`,
-            config,
          ),
    });
 
@@ -277,16 +275,11 @@ function TablesInSchema({
    resourceUri,
 }: TablesInSchemaProps) {
    const { projectName: projectName } = parseResourceUri(resourceUri);
-
+   const { connections } = useApiClients();
    const { data, isSuccess, isError, error, isLoading } = useQueryWithApiError({
       queryKey: ["tablesInSchema", projectName, connectionName, schemaName],
-      queryFn: (config) =>
-         connectionsApi.listTables(
-            projectName,
-            connectionName,
-            schemaName,
-            config,
-         ),
+      queryFn: () =>
+         connections.listTables(projectName, connectionName, schemaName),
    });
 
    return (

--- a/packages/sdk/src/components/Project/ConnectionExplorer.tsx
+++ b/packages/sdk/src/components/Project/ConnectionExplorer.tsx
@@ -22,7 +22,7 @@ import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { parseResourceUri } from "../../utils/formatting";
-import { useApiClients } from "../ServerProvider";
+import { useServer } from "../ServerProvider";
 
 interface ConnectionExplorerProps {
    connectionName: string;
@@ -35,7 +35,7 @@ export default function ConnectionExplorer({
    resourceUri,
    schema,
 }: ConnectionExplorerProps) {
-   const { connections } = useApiClients();
+   const { apiClients } = useServer();
    const { projectName: projectName } = parseResourceUri(resourceUri);
    const [selectedTable, setSelectedTable] = React.useState<string | undefined>(
       undefined,
@@ -46,7 +46,8 @@ export default function ConnectionExplorer({
    const [showHiddenSchemas, setShowHiddenSchemas] = React.useState(false);
    const { data, isSuccess, isError, error, isLoading } = useQueryWithApiError({
       queryKey: ["tablePath", projectName, connectionName],
-      queryFn: () => connections.listSchemas(projectName, connectionName),
+      queryFn: () =>
+         apiClients.connections.listSchemas(projectName, connectionName),
    });
 
    return (
@@ -196,7 +197,7 @@ function TableSchemaViewer({
    tableName,
    resourceUri,
 }: TableSchemaViewerProps) {
-   const { connections } = useApiClients();
+   const { apiClients } = useServer();
    const { projectName: projectName } = parseResourceUri(resourceUri);
    const { data, isSuccess, isError, error, isLoading } = useQueryWithApiError({
       queryKey: [
@@ -207,7 +208,7 @@ function TableSchemaViewer({
          tableName,
       ],
       queryFn: () =>
-         connections.getTablesource(
+         apiClients.connections.getTablesource(
             projectName,
             connectionName,
             tableName,
@@ -273,11 +274,15 @@ function TablesInSchema({
    resourceUri,
 }: TablesInSchemaProps) {
    const { projectName: projectName } = parseResourceUri(resourceUri);
-   const { connections } = useApiClients();
+   const { apiClients } = useServer();
    const { data, isSuccess, isError, error, isLoading } = useQueryWithApiError({
       queryKey: ["tablesInSchema", projectName, connectionName, schemaName],
       queryFn: () =>
-         connections.listTables(projectName, connectionName, schemaName),
+         apiClients.connections.listTables(
+            projectName,
+            connectionName,
+            schemaName,
+         ),
    });
 
    return (

--- a/packages/sdk/src/components/Project/ConnectionExplorer.tsx
+++ b/packages/sdk/src/components/Project/ConnectionExplorer.tsx
@@ -18,8 +18,6 @@ import {
    TableRow,
    Tooltip,
 } from "@mui/material";
-import { ConnectionsApi } from "../../client/api";
-import { Configuration } from "../../client/configuration";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";

--- a/packages/sdk/src/components/Project/Packages.tsx
+++ b/packages/sdk/src/components/Project/Packages.tsx
@@ -4,7 +4,7 @@ import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
 import { PackageCard, PackageCardContent } from "../styles";
 import { parseResourceUri } from "../../utils/formatting";
-import { useApiClients } from "../ServerProvider";
+import { useServer } from "../ServerProvider";
 
 interface PackagesProps {
    navigate: (to: string, event?: React.MouseEvent) => void;
@@ -12,11 +12,11 @@ interface PackagesProps {
 }
 
 export default function Packages({ navigate, resourceUri }: PackagesProps) {
-   const { packages } = useApiClients();
+   const { apiClients } = useServer();
    const { projectName: projectName } = parseResourceUri(resourceUri);
    const { data, isSuccess, isError, error } = useQueryWithApiError({
       queryKey: ["packages", projectName],
-      queryFn: () => packages.listPackages(projectName),
+      queryFn: () => apiClients.packages.listPackages(projectName),
    });
 
    return (

--- a/packages/sdk/src/components/Project/Packages.tsx
+++ b/packages/sdk/src/components/Project/Packages.tsx
@@ -1,12 +1,10 @@
 import { Box, Grid, Typography, Divider } from "@mui/material";
-import { Configuration, PackagesApi } from "../../client";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
 import { PackageCard, PackageCardContent } from "../styles";
 import { parseResourceUri } from "../../utils/formatting";
-
-const packagesApi = new PackagesApi(new Configuration());
+import { useApiClients } from "../ServerProvider";
 
 interface PackagesProps {
    navigate: (to: string, event?: React.MouseEvent) => void;
@@ -14,10 +12,11 @@ interface PackagesProps {
 }
 
 export default function Packages({ navigate, resourceUri }: PackagesProps) {
+   const { packages } = useApiClients();
    const { projectName: projectName } = parseResourceUri(resourceUri);
    const { data, isSuccess, isError, error } = useQueryWithApiError({
       queryKey: ["packages", projectName],
-      queryFn: (config) => packagesApi.listPackages(projectName, config),
+      queryFn: () => packages.listPackages(projectName),
    });
 
    return (

--- a/packages/sdk/src/components/QueryResult/QueryResult.tsx
+++ b/packages/sdk/src/components/QueryResult/QueryResult.tsx
@@ -3,7 +3,7 @@ import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { parseResourceUri } from "../../utils/formatting";
-import { useApiClients } from "../ServerProvider";
+import { useServer } from "../ServerProvider";
 
 const RenderedResult = lazy(() => import("../RenderedResult/RenderedResult"));
 
@@ -66,7 +66,7 @@ export default function QueryResult({
 }: QueryResultProps) {
    const { modelPath, projectName, packageName, versionId } =
       parseResourceUri(resourceUri);
-   const { queryResults } = useApiClients();
+   const { apiClients } = useServer();
 
    if (!projectName || !packageName) {
       throw new Error(
@@ -77,7 +77,7 @@ export default function QueryResult({
    const { data, isSuccess, isError, error } = useQueryWithApiError({
       queryKey: [resourceUri, query, sourceName, queryName],
       queryFn: () =>
-         queryResults.executeQuery(
+         apiClients.queryResults.executeQuery(
             projectName,
             packageName,
             modelPath,

--- a/packages/sdk/src/components/QueryResult/QueryResult.tsx
+++ b/packages/sdk/src/components/QueryResult/QueryResult.tsx
@@ -1,13 +1,11 @@
 import { Suspense, lazy } from "react";
-import { Configuration, QueryresultsApi } from "../../client";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { Loading } from "../Loading";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { parseResourceUri } from "../../utils/formatting";
+import { useApiClients } from "../ServerProvider";
 
 const RenderedResult = lazy(() => import("../RenderedResult/RenderedResult"));
-
-const queryResultsApi = new QueryresultsApi(new Configuration());
 
 interface QueryResultProps {
    query?: string;
@@ -68,6 +66,7 @@ export default function QueryResult({
 }: QueryResultProps) {
    const { modelPath, projectName, packageName, versionId } =
       parseResourceUri(resourceUri);
+   const { queryResults } = useApiClients();
 
    if (!projectName || !packageName) {
       throw new Error(
@@ -77,8 +76,8 @@ export default function QueryResult({
 
    const { data, isSuccess, isError, error } = useQueryWithApiError({
       queryKey: [resourceUri, query, sourceName, queryName],
-      queryFn: (config) =>
-         queryResultsApi.executeQuery(
+      queryFn: () =>
+         queryResults.executeQuery(
             projectName,
             packageName,
             modelPath,
@@ -86,7 +85,6 @@ export default function QueryResult({
             sourceName,
             queryName,
             versionId,
-            config,
          ),
    });
 

--- a/packages/sdk/src/components/ServerProvider.tsx
+++ b/packages/sdk/src/components/ServerProvider.tsx
@@ -1,26 +1,66 @@
-import React, { createContext, useContext, ReactNode } from "react";
+import React, { createContext, useContext, ReactNode, useMemo } from "react";
+import { Configuration } from "../client/configuration";
+import {
+   QueryresultsApi,
+   ModelsApi,
+   ProjectsApi,
+   PackagesApi,
+   NotebooksApi,
+   ConnectionsApi,
+   DatabasesApi,
+   SchedulesApi,
+   WatchModeApi,
+} from "../client";
+import axios from "axios";
 
 export interface ServerContextValue {
    server: string;
    getAccessToken?: () => Promise<string>;
+   apiClients: ApiClients;
 }
 
 const ServerContext = createContext<ServerContextValue | undefined>(undefined);
 
 export interface ServerProviderProps {
-   server?: string;
-   getAccessToken?: () => Promise<string>;
    children: ReactNode;
 }
 
-export const ServerProvider: React.FC<ServerProviderProps> = ({
-   server = `${window.location.protocol}//${window.location.host}/api/v0`,
-   getAccessToken,
-   children,
-}) => {
+const getApiClients = () => {
+   const basePath = `${window.location.protocol}//${window.location.host}/api/v0`;
+
+   // Create a custom axios instance with proper configuration
+   const axiosInstance = axios.create({
+      baseURL: basePath,
+      withCredentials: true,
+   });
+
+   const config = new Configuration({
+      basePath,
+      accessToken: () => "",
+   });
+
+   return {
+      queryResults: new QueryresultsApi(config, basePath, axiosInstance),
+      models: new ModelsApi(config, basePath, axiosInstance),
+      projects: new ProjectsApi(config, basePath, axiosInstance),
+      packages: new PackagesApi(config, basePath, axiosInstance),
+      notebooks: new NotebooksApi(config, basePath, axiosInstance),
+      connections: new ConnectionsApi(config, basePath, axiosInstance),
+      databases: new DatabasesApi(config, basePath, axiosInstance),
+      schedules: new SchedulesApi(config, basePath, axiosInstance),
+      watchMode: new WatchModeApi(config, basePath, axiosInstance),
+   };
+};
+
+export type ApiClients = ReturnType<typeof getApiClients>;
+
+export const ServerProvider: React.FC<ServerProviderProps> = ({ children }) => {
+   const apiClients = useMemo(getApiClients, []);
+
    const value: ServerContextValue = {
-      server,
-      getAccessToken,
+      server: `${window.location.protocol}//${window.location.host}/api/v0`,
+      getAccessToken: () => Promise.resolve(""),
+      apiClients,
    };
 
    return (
@@ -34,4 +74,9 @@ export const useServer = (): ServerContextValue => {
       throw new Error("useServer must be used within a ServerProvider");
    }
    return context;
+};
+
+export const useApiClients = (): ApiClients => {
+   const { apiClients } = useServer();
+   return apiClients;
 };

--- a/packages/sdk/src/components/Workbook/ModelPicker.tsx
+++ b/packages/sdk/src/components/Workbook/ModelPicker.tsx
@@ -14,7 +14,7 @@ import React from "react";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { parseResourceUri } from "../../utils/formatting";
-import { useApiClients } from "../ServerProvider";
+import { useServer } from "../ServerProvider";
 
 interface ModelPickerProps {
    initialSelectedModels: string[];
@@ -36,11 +36,12 @@ export function ModelPicker({
       packageName: packageName,
       versionId: versionId,
    } = parseResourceUri(resourceUri);
-   const { models } = useApiClients();
+   const { apiClients } = useServer();
 
    const { data, isLoading, isSuccess, isError, error } = useQueryWithApiError({
       queryKey: ["models", projectName, packageName, versionId],
-      queryFn: () => models.listModels(projectName, packageName, versionId),
+      queryFn: () =>
+         apiClients.models.listModels(projectName, packageName, versionId),
    });
    const [selectedModels, setSelectedModels] = React.useState<string[]>(
       initialSelectedModels || [],

--- a/packages/sdk/src/components/Workbook/ModelPicker.tsx
+++ b/packages/sdk/src/components/Workbook/ModelPicker.tsx
@@ -11,12 +11,10 @@ import {
    Typography,
 } from "@mui/material";
 import React from "react";
-import { Configuration, ModelsApi } from "../../client";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { parseResourceUri } from "../../utils/formatting";
-
-const modelsApi = new ModelsApi(new Configuration());
+import { useApiClients } from "../ServerProvider";
 
 interface ModelPickerProps {
    initialSelectedModels: string[];
@@ -38,10 +36,11 @@ export function ModelPicker({
       packageName: packageName,
       versionId: versionId,
    } = parseResourceUri(resourceUri);
+   const { models } = useApiClients();
+
    const { data, isLoading, isSuccess, isError, error } = useQueryWithApiError({
       queryKey: ["models", projectName, packageName, versionId],
-      queryFn: (config) =>
-         modelsApi.listModels(projectName, packageName, versionId, config),
+      queryFn: () => models.listModels(projectName, packageName, versionId),
    });
    const [selectedModels, setSelectedModels] = React.useState<string[]>(
       initialSelectedModels || [],

--- a/packages/sdk/src/components/Workbook/Workbook.tsx
+++ b/packages/sdk/src/components/Workbook/Workbook.tsx
@@ -19,7 +19,7 @@ import Stack from "@mui/material/Stack";
 import React from "react";
 import { SourceAndPath } from "../Model/SourcesExplorer";
 import { WorkbookManager } from "./WorkbookManager";
-import { useServer, useApiClients } from "../ServerProvider";
+import { useServer } from "../ServerProvider";
 import { StyledCard, StyledCardContent, StyledCardMedia } from "../styles";
 import { MutableCell } from "./MutableCell";
 import { useWorkbookStorage } from "./WorkbookStorageProvider";
@@ -43,7 +43,7 @@ interface PathToSources {
 export default function Workbook({ workbookPath, resourceUri }: WorkbookProps) {
    const navigate = useRouterClickHandler();
    const { server, getAccessToken } = useServer();
-   const { models } = useApiClients();
+   const { apiClients } = useServer();
    const { workbookStorage } = useWorkbookStorage();
    const { projectName, packageName } = parseResourceUri(resourceUri);
    const [success, setSuccess] = React.useState<string | undefined>(undefined);
@@ -154,7 +154,7 @@ export default function Workbook({ workbookPath, resourceUri }: WorkbookProps) {
             if (!modelPathToSourceInfo.has(model)) {
                console.log("Fetching model from Publisher", model);
                promises.push(
-                  models
+                  apiClients.models
                      .getModel(projectName, packageName, model, undefined)
                      .then((data) => ({
                         modelPath: model,

--- a/packages/sdk/src/components/Workbook/Workbook.tsx
+++ b/packages/sdk/src/components/Workbook/Workbook.tsx
@@ -17,22 +17,18 @@ import {
 } from "@mui/material";
 import Stack from "@mui/material/Stack";
 import React from "react";
-import { Configuration, ModelsApi } from "../../client";
 import { SourceAndPath } from "../Model/SourcesExplorer";
 import { WorkbookManager } from "./WorkbookManager";
-import { useServer } from "../ServerProvider";
+import { useServer, useApiClients } from "../ServerProvider";
 import { StyledCard, StyledCardContent, StyledCardMedia } from "../styles";
 import { MutableCell } from "./MutableCell";
 import { useWorkbookStorage } from "./WorkbookStorageProvider";
 
 import * as Malloy from "@malloydata/malloy-interfaces";
 import { ModelPicker } from "./ModelPicker";
-import { getAxiosConfig } from "../../hooks";
 import { WorkbookLocator } from "./WorkbookStorage";
 import { useRouterClickHandler } from "../click_helper";
 import { parseResourceUri } from "../../utils/formatting";
-
-const modelsApi = new ModelsApi(new Configuration());
 
 interface WorkbookProps {
    workbookPath?: WorkbookLocator;
@@ -47,6 +43,7 @@ interface PathToSources {
 export default function Workbook({ workbookPath, resourceUri }: WorkbookProps) {
    const navigate = useRouterClickHandler();
    const { server, getAccessToken } = useServer();
+   const { models } = useApiClients();
    const { workbookStorage } = useWorkbookStorage();
    const { projectName, packageName } = parseResourceUri(resourceUri);
    const [success, setSuccess] = React.useState<string | undefined>(undefined);
@@ -157,14 +154,8 @@ export default function Workbook({ workbookPath, resourceUri }: WorkbookProps) {
             if (!modelPathToSourceInfo.has(model)) {
                console.log("Fetching model from Publisher", model);
                promises.push(
-                  modelsApi
-                     .getModel(
-                        projectName,
-                        packageName,
-                        model,
-                        undefined,
-                        await getAxiosConfig(server, getAccessToken),
-                     )
+                  models
+                     .getModel(projectName, packageName, model, undefined)
                      .then((data) => ({
                         modelPath: model,
                         sourceInfos: data.data.sourceInfos.map((source) =>

--- a/packages/sdk/src/hooks/index.ts
+++ b/packages/sdk/src/hooks/index.ts
@@ -1,1 +1,0 @@
-export { getAxiosConfig } from "./useQueryWithApiError";

--- a/packages/sdk/src/hooks/useQueryWithApiError.ts
+++ b/packages/sdk/src/hooks/useQueryWithApiError.ts
@@ -9,7 +9,6 @@ import {
 } from "@tanstack/react-query";
 import { ApiError } from "../components/ApiErrorDisplay";
 import { useServer } from "../components";
-import { RawAxiosRequestConfig } from "axios";
 
 // Global QueryClient instance
 const globalQueryClient = new QueryClient({
@@ -24,37 +23,19 @@ const globalQueryClient = new QueryClient({
       },
    },
 });
-
-export const getAxiosConfig = async (
-   server: string,
-   getAccessToken: () => Promise<string>,
-): Promise<RawAxiosRequestConfig> => {
-   const accessToken = getAccessToken ? await getAccessToken() : undefined;
-   const headers = accessToken
-      ? {
-           Authorization: `Bearer ${accessToken}`,
-        }
-      : {};
-   return {
-      baseURL: server,
-      withCredentials: !!accessToken,
-      headers,
-   } as RawAxiosRequestConfig;
-};
 export function useQueryWithApiError<TData = unknown, TError = ApiError>(
    options: Omit<UseQueryOptions<TData, TError>, "throwOnError" | "retry"> & {
-      queryFn: (config: RawAxiosRequestConfig) => Promise<TData>;
+      queryFn: () => Promise<TData>;
    },
 ): UseQueryResult<TData, TError> {
-   const { server, getAccessToken } = useServer();
+   const { server } = useServer();
    const enhancedOptions: UseQueryOptions<TData, TError> = {
       ...options,
       // Add in the server to the query key so that we can have a per-server caches.
       queryKey: [...options.queryKey, server],
       queryFn: async () => {
          try {
-            const config = await getAxiosConfig(server, getAccessToken);
-            return await options.queryFn(config);
+            return await options.queryFn();
          } catch (err) {
             // Standardized error handling for axios errors
             if (err && typeof err === "object" && "response" in err) {
@@ -94,19 +75,15 @@ export function useMutationWithApiError<
       UseMutationOptions<TData, TError, TVariables>,
       "throwOnError" | "retry" | "mutationFn"
    > & {
-      mutationFn: (
-         variables: TVariables,
-         config: RawAxiosRequestConfig,
-      ) => Promise<TData>;
+      mutationFn: (variables: TVariables) => Promise<TData>;
    },
 ): UseMutationResult<TData, TError, TVariables> {
-   const { server, getAccessToken } = useServer();
+   const { server } = useServer();
    const enhancedOptions: UseMutationOptions<TData, TError, TVariables> = {
       ...options,
       mutationFn: async (variables: TVariables) => {
          try {
-            const config = await getAxiosConfig(server, getAccessToken);
-            return await options.mutationFn(variables, config);
+            return await options.mutationFn(variables);
          } catch (err) {
             // Standardized error handling for axios errors
             if (err && typeof err === "object" && "response" in err) {

--- a/packages/sdk/src/hooks/useQueryWithApiError.ts
+++ b/packages/sdk/src/hooks/useQueryWithApiError.ts
@@ -78,7 +78,6 @@ export function useMutationWithApiError<
       mutationFn: (variables: TVariables) => Promise<TData>;
    },
 ): UseMutationResult<TData, TError, TVariables> {
-   const { server } = useServer();
    const enhancedOptions: UseMutationOptions<TData, TError, TVariables> = {
       ...options,
       mutationFn: async (variables: TVariables) => {

--- a/packages/sdk/src/hooks/useRawQueryData.ts
+++ b/packages/sdk/src/hooks/useRawQueryData.ts
@@ -1,8 +1,6 @@
-import { Configuration, QueryresultsApi } from "../client";
 import { parseResourceUri } from "../utils/formatting";
 import { useQueryWithApiError } from "./useQueryWithApiError";
-
-const queryResultsApi = new QueryresultsApi(new Configuration());
+import { useApiClients } from "../components/ServerProvider";
 
 interface UseRawQueryDataProps {
    modelPath: string;
@@ -23,6 +21,7 @@ export function useRawQueryData({
 }: UseRawQueryDataProps) {
    const { projectName, packageName, versionId } =
       parseResourceUri(resourceUri);
+   const { queryResults } = useApiClients();
 
    const { data, isSuccess, isError, error, isLoading } = useQueryWithApiError({
       queryKey: [
@@ -35,8 +34,8 @@ export function useRawQueryData({
          sourceName,
          queryName,
       ],
-      queryFn: (config) =>
-         queryResultsApi.executeQuery(
+      queryFn: () =>
+         queryResults.executeQuery(
             projectName,
             packageName,
             modelPath,
@@ -44,7 +43,6 @@ export function useRawQueryData({
             sourceName,
             queryName,
             versionId,
-            config,
          ),
       enabled,
    });

--- a/packages/sdk/src/hooks/useRawQueryData.ts
+++ b/packages/sdk/src/hooks/useRawQueryData.ts
@@ -1,6 +1,6 @@
 import { parseResourceUri } from "../utils/formatting";
 import { useQueryWithApiError } from "./useQueryWithApiError";
-import { useApiClients } from "../components/ServerProvider";
+import { useServer } from "../components/ServerProvider";
 
 interface UseRawQueryDataProps {
    modelPath: string;
@@ -21,7 +21,7 @@ export function useRawQueryData({
 }: UseRawQueryDataProps) {
    const { projectName, packageName, versionId } =
       parseResourceUri(resourceUri);
-   const { queryResults } = useApiClients();
+   const { apiClients } = useServer();
 
    const { data, isSuccess, isError, error, isLoading } = useQueryWithApiError({
       queryKey: [
@@ -35,7 +35,7 @@ export function useRawQueryData({
          queryName,
       ],
       queryFn: () =>
-         queryResults.executeQuery(
+         apiClients.queryResults.executeQuery(
             projectName,
             packageName,
             modelPath,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,7 +2,7 @@ export * from "./components";
 export * from "./utils/formatting";
 export { default as ConnectionExplorer } from "./components/Project/ConnectionExplorer";
 export { useRawQueryData } from "./hooks/useRawQueryData";
-export { useApiClients } from "./components/ServerProvider";
+export { useServer } from "./components/ServerProvider";
 import axios from "axios";
 
 // There's a bug in the OpenAPI generator that causes it to ignore baseURL in the

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,6 +2,7 @@ export * from "./components";
 export * from "./utils/formatting";
 export { default as ConnectionExplorer } from "./components/Project/ConnectionExplorer";
 export { useRawQueryData } from "./hooks/useRawQueryData";
+export { useApiClients } from "./components/ServerProvider";
 import axios from "axios";
 
 // There's a bug in the OpenAPI generator that causes it to ignore baseURL in the

--- a/packages/sdk/src/utils/formatting.ts
+++ b/packages/sdk/src/utils/formatting.ts
@@ -8,7 +8,7 @@ export type ParsedResource = {
 
 export const parseResourceUri = (resourceUri: string) => {
    const parsedUri = new URL(resourceUri);
-   let parsedResource = {} as ParsedResource;
+   const parsedResource = {} as ParsedResource;
    if (parsedUri.protocol !== "publisher:") {
       throw new Error(`Failed to parse resource URI: ${resourceUri}`);
    }


### PR DESCRIPTION
This pr replaces direct API client instantiation with a new `useApiClients` hook from the ServerProvider across all components, it centralizes API client management and removes `config` imports.