### PR TITLE
Fix vite bundling initialization order issues

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -29,30 +29,8 @@ export default ({ mode }) => {
       },
    };
 
-   const manualChunks = {
-      // React core
-      "react-vendor": [
-         "react",
-         "react-dom",
-         "react/jsx-runtime",
-         "react-dom/client",
-      ],
-
-      // MUI Ecosystem
-      "mui-core": ["@mui/material", "@mui/system"],
-      "mui-icons": ["@mui/icons-material"],
-      "mui-tree": ["@mui/x-tree-view"],
-
-      // Utilities
-      "emotion-vendor": ["@emotion/react", "@emotion/styled"],
-
-      // Editor
-      "editor-vendor": ["@uiw/react-md-editor", "markdown-to-jsx"],
-
-      // Other large libraries
-      "spring-vendor": ["@react-spring/web"],
-      "query-vendor": ["@tanstack/react-query"],
-   };
+   // Disable chunking entirely to avoid initialization order issues
+   const manualChunks = undefined;
 
    return defineConfig({
       server: isDev
@@ -112,9 +90,13 @@ export default ({ mode }) => {
          include: [
             "react",
             "react-dom",
+            "@emotion/react",
+            "@emotion/styled",
             "@mui/material",
             "@mui/icons-material",
+            "@mui/system",
          ],
+         exclude: [],
       },
    });
 };


### PR DESCRIPTION
Disable manual chunking to resolve circular dependency errors that were preventing the React app from loading. The previous chunking configuration was causing initialization order issues where variables were accessed before initialization in emotion/MUI dependencies.

This change bundles all dependencies together to ensure proper initialization order and resolves the blank page issue.

Fixes: "Cannot access 'z' before initialization" and similar errors