### PR TITLE
Package Name Not Matching Bug Fix + listPackages logic to match with listProjects (similar to earlier Sidecar)

### DIFF
--- a/packages/server/src/service/project.ts
+++ b/packages/server/src/service/project.ts
@@ -186,7 +186,7 @@ export class Project {
          const packageMetadata = await Promise.all(
             this.packageStatuses.keys().map(async (packageName) => {
                try {
-                  let packageMetadata = (
+                  const packageMetadata = (
                      this.packageStatuses.get(packageName)?.status ===
                      PackageStatus.LOADING
                         ? undefined

--- a/packages/server/src/service/project.ts
+++ b/packages/server/src/service/project.ts
@@ -3,7 +3,7 @@ import { Mutex } from "async-mutex";
 import * as fs from "fs";
 import * as path from "path";
 import { components } from "../api";
-import { API_PREFIX, PACKAGE_MANIFEST_NAME, README_NAME } from "../constants";
+import { API_PREFIX, README_NAME } from "../constants";
 import {
    ConnectionNotFoundError,
    PackageNotFoundError,
@@ -14,7 +14,7 @@ import { createConnections, InternalConnection } from "./connection";
 import { ApiConnection } from "./model";
 import { Package } from "./package";
 
-enum PackageStatus {
+export enum PackageStatus {
    LOADING = "loading",
    SERVING = "serving",
    UNLOADING = "unloading",
@@ -183,28 +183,22 @@ export class Project {
    public async listPackages(): Promise<ApiPackage[]> {
       logger.info("Listing packages", { projectPath: this.projectPath });
       try {
-         const files = await fs.promises.readdir(this.projectPath, {
-            withFileTypes: true,
-         });
-         const packageDirectories = files.filter(
-            (file) =>
-               file.isDirectory() &&
-               fs.existsSync(
-                  path.join(this.projectPath, file.name, PACKAGE_MANIFEST_NAME),
-               ),
-         );
          const packageMetadata = await Promise.all(
-            packageDirectories.map(async (directory) => {
+            this.packageStatuses.keys().map(async (packageName) => {
                try {
-                  return (
-                     this.packageStatuses.get(directory.name)?.status ===
+                  let packageMetadata = (
+                     this.packageStatuses.get(packageName)?.status ===
                      PackageStatus.LOADING
                         ? undefined
-                        : await this.getPackage(directory.name, false)
+                        : await this.getPackage(packageName, false)
                   )?.getPackageMetadata();
+                  if (packageMetadata) {
+                     packageMetadata.name = packageName;
+                  }
+                  return packageMetadata;
                } catch (error) {
                   logger.error(
-                     `Failed to load package: ${directory.name} due to : ${error}`,
+                     `Failed to load package: ${packageName} due to : ${error}`,
                   );
                   // Directory did not contain a valid package.json file -- therefore, it's not a package.
                   // Or it timed out

--- a/packages/server/src/service/project.ts
+++ b/packages/server/src/service/project.ts
@@ -184,7 +184,7 @@ export class Project {
       logger.info("Listing packages", { projectPath: this.projectPath });
       try {
          const packageMetadata = await Promise.all(
-            this.packageStatuses.keys().map(async (packageName) => {
+            Array.from(this.packageStatuses.keys()).map(async (packageName) => {
                try {
                   const packageMetadata = (
                      this.packageStatuses.get(packageName)?.status ===

--- a/packages/server/src/service/project_store.ts
+++ b/packages/server/src/service/project_store.ts
@@ -81,8 +81,10 @@ export class ProjectStore {
       try {
          await fs.promises.rm(publisherPath, { recursive: true, force: true });
       } catch (error) {
-         if ((error as NodeJS.ErrnoException).code === 'EACCES') {
-            logger.warn(`Permission denied, skipping cleanup of publisher path ${publisherPath}`);
+         if ((error as NodeJS.ErrnoException).code === "EACCES") {
+            logger.warn(
+               `Permission denied, skipping cleanup of publisher path ${publisherPath}`,
+            );
          } else {
             throw error;
          }

--- a/packages/server/src/service/project_store.ts
+++ b/packages/server/src/service/project_store.ts
@@ -78,7 +78,15 @@ export class ProjectStore {
 
    private async cleanupAndCreatePublisherPath() {
       logger.info(`Cleaning up publisher path ${publisherPath}`);
-      await fs.promises.rm(publisherPath, { recursive: true, force: true });
+      try {
+         await fs.promises.rm(publisherPath, { recursive: true, force: true });
+      } catch (error) {
+         if ((error as NodeJS.ErrnoException).code === 'EACCES') {
+            logger.warn(`Permission denied, skipping cleanup of publisher path ${publisherPath}`);
+         } else {
+            throw error;
+         }
+      }
       await fs.promises.mkdir(publisherPath, { recursive: true });
    }
 

--- a/packages/server/src/service/project_store.ts
+++ b/packages/server/src/service/project_store.ts
@@ -19,7 +19,7 @@ import {
    ProjectNotFoundError,
 } from "../errors";
 import { logger } from "../logger";
-import { Project } from "./project";
+import { PackageStatus, Project } from "./project";
 type ApiProject = components["schemas"]["Project"];
 
 export class ProjectStore {
@@ -218,6 +218,9 @@ export class ProjectStore {
          this.serverRootPath,
       );
       this.projects.set(projectName, newProject);
+      projectConfig?.packages.forEach((_package) => {
+         newProject.setPackageStatus(_package.name, PackageStatus.SERVING);
+      });
       return newProject;
    }
 

--- a/packages/server/src/service/project_store.ts
+++ b/packages/server/src/service/project_store.ts
@@ -49,6 +49,7 @@ export class ProjectStore {
          const projectManifest = await ProjectStore.reloadProjectManifest(
             this.serverRootPath,
          );
+         await this.cleanupAndCreatePublisherPath();
          logger.info(`Initializing project store.`);
          await Promise.all(
             projectManifest.projects.map(async (project) => {
@@ -73,6 +74,12 @@ export class ProjectStore {
          console.error(error);
          process.exit(1);
       }
+   }
+
+   private async cleanupAndCreatePublisherPath() {
+      logger.info(`Cleaning up publisher path ${publisherPath}`);
+      await fs.promises.rm(publisherPath, { recursive: true, force: true });
+      await fs.promises.mkdir(publisherPath, { recursive: true });
    }
 
    public async listProjects(skipInitializationCheck: boolean = false) {


### PR DESCRIPTION
+ Package Name Not Matching Bug Fix
+ Updated listPackages logic to match with listProjects (similar to earlier Sidecar). This approach will only focus on listing packages that were loaded via Publisher during the current runtime
+ Added marking packages to SERVING during the inital project load from publisher.config.json (Earlier packageStatus was used for tracking package statuses for the packages added after the initial loading from the config file)