### PR TITLE
fix module output

### DIFF
--- a/packages/sdk/vite.config.ts
+++ b/packages/sdk/vite.config.ts
@@ -79,21 +79,21 @@ export default ({ mode }) => {
                ...Object.keys(peerDependencies),
             ],
             output: [
-               // ES modules build with preserved modules for better tree-shaking
+               // ES modules build - bundled to avoid resolution issues with external dependencies
                {
                   format: "es",
-                  preserveModules: true,
-                  preserveModulesRoot: "src",
                   exports: "named",
                   entryFileNames: "[name].es.js",
-                  chunkFileNames: "[name].es.js",
+                  chunkFileNames: "[name]-[hash].es.js",
+                  // Don't preserve modules to avoid node_modules path issues
+                  preserveModules: false,
                },
                // CommonJS build bundled (not preserved) to avoid resolution issues
                {
                   format: "cjs",
                   exports: "named",
                   entryFileNames: "[name].cjs.js",
-                  chunkFileNames: "[name].cjs.js",
+                  chunkFileNames: "[name]-[hash].cjs.js",
                   // Don't preserve modules for CJS to avoid resolution issues
                   preserveModules: false,
                },


### PR DESCRIPTION
Previous fixes caused the SDK to be built with the wrong dependency references which crashed when building AdminApp