### PR TITLE
Fix ConnectionExplorer and BigQuery client configuration

### DIFF
--- a/packages/sdk/src/components/Project/ConnectionExplorer.tsx
+++ b/packages/sdk/src/components/Project/ConnectionExplorer.tsx
@@ -115,9 +115,10 @@ export default function ConnectionExplorer({
                                     <ListItemButton
                                        key={schemaName}
                                        selected={isSelected}
-                                       onClick={() =>
-                                          setSelectedSchema(schemaName)
-                                       }
+                                       onClick={() => {
+                                          setSelectedSchema(schemaName);
+                                          setSelectedTable(undefined);
+                                       }}
                                     >
                                        <ListItemText primary={schemaName} />
                                     </ListItemButton>


### PR DESCRIPTION
- Updated ConnectionExplorer to reset the selected table when a schema is selected.
- Improved BigQuery client configuration to handle missing project IDs more gracefully, allowing for project ID inference from service account credentials or environment variables. Added error handling for required connection parameters.