### PR TITLE
Update ServerProvider to not prepend 'Bearer'

### DIFF
--- a/packages/sdk/src/components/ServerProvider.tsx
+++ b/packages/sdk/src/components/ServerProvider.tsx
@@ -56,7 +56,7 @@ const getApiClients = (
 
    axiosInstance.interceptors.request.use(async (config) => {
       const token = await accessToken?.();
-      config.headers.Authorization = token ? `Bearer ${token}` : "";
+      config.headers.Authorization = token || "";
       return config;
    });
 


### PR DESCRIPTION
This is part 1 of fixing: https://github.com/ms2data/service/issues/2328

Once this change is pushed, when we update the service to use the new SDK, we will update the service code to pass `Bearer $TOKEN` into ServerProvider.