### PR TITLE
Update build.yml to Node v20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,8 @@ jobs:
           bun-version: 1.2.23
       - name: build server
         run: bun install && bun run build
+        env:
+          BUN_CONFIG_SKIP_POSTINSTALL_SCRIPTS: "1"
       - name: Link local package
         run: |
           cd packages/server && npm link


### PR DESCRIPTION
Without Node v20, the DuckDB install takes 20+ minutes b/c it has to build (since the pre-built binaries don't work with Node <v20).
Now build.yml takes 2 minutes instead of 15-30.