### PR TITLE
Update API documentation and server timeout settings

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -1085,7 +1085,7 @@ paths:
           description: Name of the package
           required: true
           schema:
-            $ref: "#/components/schemas/IdentifierPattern"
+            $ref: "#/components/schemas/VersionIdPattern"
         - name: path
           in: path
           description: Path to the model within the package

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -788,6 +788,10 @@ app.use(
 
 const mainServer = http.createServer(app);
 
+mainServer.timeout = 600000;
+mainServer.keepAliveTimeout = 600000;
+mainServer.headersTimeout = 600000;
+
 mainServer.listen(PUBLISHER_PORT, PUBLISHER_HOST, () => {
    const address = mainServer.address() as AddressInfo;
    logger.info(
@@ -799,6 +803,10 @@ mainServer.listen(PUBLISHER_PORT, PUBLISHER_HOST, () => {
       );
    }
 });
-mcpApp.listen(MCP_PORT, PUBLISHER_HOST, () => {
+const mcpServer = mcpApp.listen(MCP_PORT, PUBLISHER_HOST, () => {
    logger.info(`MCP server listening at http://${PUBLISHER_HOST}:${MCP_PORT}`);
 });
+
+mcpServer.timeout = 600000;
+mcpServer.keepAliveTimeout = 600000;
+mcpServer.headersTimeout = 600000;


### PR DESCRIPTION
* Changed reference in api-doc.yaml from IdentifierPattern to VersionIdPattern.
* Increased timeout settings for main server and MCP server to 600000 milliseconds (10 mins).