### PR TITLE
Enhance error handling for Trino connection in getConnectionTableSource Function

### DIFF
--- a/packages/server/src/service/db_utils.ts
+++ b/packages/server/src/service/db_utils.ts
@@ -437,6 +437,13 @@ export async function getConnectionTableSource(
          );
       }
 
+      //This is for the Trino connection. The connection will not throw an error if the table is not found.
+      // Instead it will return an empty fields array. So we need to check for that.
+      // But it is fine to have it for all other connections as well.
+      if (malloyFields.length === 0) {
+         throw new ConnectionError(`Table ${tablePath} not found`);
+      }
+
       const fields = malloyFields.map((field) => {
          return {
             name: field.name,


### PR DESCRIPTION
Added check to throw ConnectionError if no fields are found for the specified table.