### PR TITLE
Notebook requests are per-cell

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -1163,18 +1163,15 @@ paths:
         "501":
           $ref: "#/components/responses/NotImplemented"
 
-  # TODO: Notebooks should return the notebook file content, not the compiled notebook.  The front end shoould
-  # run the individual notebook cells against the backend.
   /projects/{projectName}/packages/{packageName}/notebooks/{path}:
     get:
       tags:
         - notebooks
       operationId: get-notebook
-      summary: Get compiled Malloy notebook
+      summary: Get Malloy notebook cells
       description: |
-        Retrieves a compiled Malloy notebook with its cells, results, and metadata. The notebook
-        is compiled using the specified version of the Malloy compiler. This endpoint provides
-        access to the notebook's structure, cells, and execution results for use in applications.
+        Retrieves a Malloy notebook with its raw cell contents (markdown and code).
+        Cell execution should be done separately via the execute-notebook-cell endpoint.
       parameters:
         - name: projectName
           in: path
@@ -1202,11 +1199,70 @@ paths:
             $ref: "#/components/schemas/VersionIdPattern"
       responses:
         "200":
-          description: A Malloy notebook.
+          description: A Malloy notebook with raw cell contents.
           content:
             "application/json":
               schema:
-                $ref: "#/components/schemas/CompiledNotebook"
+                $ref: "#/components/schemas/RawNotebook"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "501":
+          $ref: "#/components/responses/NotImplemented"
+
+  /projects/{projectName}/packages/{packageName}/notebooks/{path}/cells/{cellIndex}:
+    get:
+      tags:
+        - notebooks
+      operationId: execute-notebook-cell
+      summary: Execute a specific notebook cell
+      description: |
+        Executes a specific cell in a Malloy notebook by index. For code cells, this compiles
+        and runs the Malloy code, returning query results and any new sources defined.
+        For markdown cells, this simply returns the cell content.
+      parameters:
+        - name: projectName
+          in: path
+          description: Name of the project
+          required: true
+          schema:
+            $ref: "#/components/schemas/IdentifierPattern"
+        - name: packageName
+          in: path
+          description: Name of the package
+          required: true
+          schema:
+            type: string
+        - name: path
+          in: path
+          description: Path to notebook within the package
+          required: true
+          schema:
+            type: string
+        - name: cellIndex
+          in: path
+          description: Index of the cell to execute (0-based)
+          required: true
+          schema:
+            type: integer
+        - name: versionId
+          in: query
+          description: Version identifier for the package
+          required: false
+          schema:
+            $ref: "#/components/schemas/VersionIdPattern"
+      responses:
+        "200":
+          description: Cell execution result
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/NotebookCellResult"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -1515,9 +1571,9 @@ components:
           type: string
           description: Error message if the notebook failed to compile or load
 
-    CompiledNotebook:
+    RawNotebook:
       type: object
-      description: Compiled Malloy notebook with cells, results, and execution data
+      description: Raw Malloy notebook with unexecuted cell contents
       properties:
         resource:
           type: string
@@ -1533,7 +1589,7 @@ components:
           description: Version of the Malloy compiler used to generate the notebook data
         notebookCells:
           type: array
-          description: Array of notebook cells containing code, markdown, and execution results
+          description: Array of notebook cells containing raw markdown and code content
           items:
             $ref: "#/components/schemas/NotebookCell"
 
@@ -1616,6 +1672,18 @@ components:
     NotebookCell:
       type: object
       description: Individual cell within a Malloy notebook
+      properties:
+        type:
+          type: string
+          enum: ["markdown", "code"]
+          description: Type of notebook cell
+        text:
+          type: string
+          description: Text contents of the notebook cell (either markdown or Malloy code)
+
+    NotebookCellResult:
+      type: object
+      description: Result of executing a notebook cell
       properties:
         type:
           type: string

--- a/packages/sdk/src/components/Notebook/Notebook.tsx
+++ b/packages/sdk/src/components/Notebook/Notebook.tsx
@@ -1,6 +1,7 @@
 import "@malloydata/malloy-explorer/styles.css";
 import { Stack, Typography } from "@mui/material";
-import { CompiledNotebook } from "../../client";
+import { useEffect, useState } from "react";
+import { RawNotebook } from "../../client";
 import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 
@@ -9,6 +10,7 @@ import { Loading } from "../Loading";
 import { useServer } from "../ServerProvider";
 import { CleanNotebookContainer, CleanNotebookSection } from "../styles";
 import { NotebookCell } from "./NotebookCell";
+import { EnhancedNotebookCell } from "./types";
 
 interface NotebookProps {
    resourceUri: string;
@@ -27,12 +29,14 @@ export default function Notebook({
       versionId,
       modelPath: notebookPath,
    } = parseResourceUri(resourceUri);
+
+   // Fetch the raw notebook cells
    const {
       data: notebook,
       isSuccess,
       isError,
       error,
-   } = useQueryWithApiError<CompiledNotebook>({
+   } = useQueryWithApiError<RawNotebook>({
       queryKey: [resourceUri],
       queryFn: async () => {
          const response = await apiClients.notebooks.getNotebook(
@@ -45,15 +49,101 @@ export default function Notebook({
       },
    });
 
+   // State to store executed cells with results
+   const [enhancedCells, setEnhancedCells] = useState<EnhancedNotebookCell[]>(
+      [],
+   );
+   const [isExecuting, setIsExecuting] = useState(false);
+   const [executionError, setExecutionError] = useState<Error | null>(null);
+
+   // Execute cells sequentially when notebook is loaded
+   useEffect(() => {
+      if (!isSuccess || !notebook.notebookCells) return;
+
+      const executeCells = async () => {
+         setIsExecuting(true);
+         setExecutionError(null);
+         const cells: EnhancedNotebookCell[] = [];
+
+         try {
+            // Execute cells sequentially
+            for (let i = 0; i < notebook.notebookCells.length; i++) {
+               const rawCell = notebook.notebookCells[i];
+
+               // Markdown cells don't need execution - use raw content directly
+               if (rawCell.type === "markdown") {
+                  cells.push({
+                     type: rawCell.type,
+                     text: rawCell.text,
+                  });
+                  continue;
+               }
+
+               // Execute code cells
+               try {
+                  // Call the executeNotebookCell API
+                  const response = await fetch(
+                     `/api/v0/projects/${projectName}/packages/${packageName}/notebooks/${notebookPath}/cells/${i}${versionId ? `?versionId=${versionId}` : ""}`,
+                     {
+                        method: "GET",
+                        credentials: "include",
+                     },
+                  );
+
+                  if (!response.ok) {
+                     throw new Error(
+                        `Failed to execute cell ${i}: ${response.statusText}`,
+                     );
+                  }
+
+                  const executedCell = await response.json();
+
+                  // Combine raw cell with execution results
+                  cells.push({
+                     type: rawCell.type,
+                     text: rawCell.text,
+                     queryName: executedCell.queryName,
+                     result: executedCell.result,
+                     newSources: executedCell.newSources,
+                  });
+               } catch (cellError) {
+                  // If a cell fails, add it without execution results
+                  console.error(`Error executing cell ${i}:`, cellError);
+                  cells.push({
+                     type: rawCell.type,
+                     text: rawCell.text,
+                  });
+               }
+            }
+
+            setEnhancedCells(cells);
+         } catch (error) {
+            console.error("Error executing notebook cells:", error);
+            setExecutionError(error as Error);
+         } finally {
+            setIsExecuting(false);
+         }
+      };
+
+      executeCells();
+   }, [isSuccess, notebook, projectName, packageName, notebookPath, versionId]);
+
    return (
       <CleanNotebookContainer>
          <CleanNotebookSection>
             <Stack spacing={3} component="section">
-               {!isSuccess && !isError && (
-                  <Loading text="Fetching Notebook..." />
+               {(!isSuccess || isExecuting) && !isError && (
+                  <Loading
+                     text={
+                        isExecuting
+                           ? "Executing Notebook..."
+                           : "Fetching Notebook..."
+                     }
+                  />
                )}
                {isSuccess &&
-                  notebook.notebookCells?.map((cell, index) => (
+                  !isExecuting &&
+                  enhancedCells.map((cell, index) => (
                      <NotebookCell
                         cell={cell}
                         key={index}
@@ -73,6 +163,17 @@ export default function Notebook({
                   <ApiErrorDisplay
                      error={error}
                      context={`${projectName} > ${packageName} > ${notebookPath}`}
+                  />
+               )}
+
+               {executionError && (
+                  <ApiErrorDisplay
+                     error={{
+                        message: executionError.message,
+                        status: 500,
+                        name: "ExecutionError",
+                     }}
+                     context="Notebook Execution"
                   />
                )}
             </Stack>

--- a/packages/sdk/src/components/Notebook/NotebookCell.tsx
+++ b/packages/sdk/src/components/Notebook/NotebookCell.tsx
@@ -16,16 +16,16 @@ import {
 } from "@mui/material";
 import Markdown from "markdown-to-jsx";
 import React, { useEffect, useState } from "react";
-import { NotebookCell as ClientNotebookCell } from "../../client";
 import { highlight } from "../highlighter";
 import { ModelExplorerDialog } from "../Model/ModelExplorerDialog";
 import { createEmbeddedQueryResult } from "../QueryResult/QueryResult";
 import ResultContainer from "../RenderedResult/ResultContainer";
 import ResultsDialog from "../ResultsDialog";
 import { CleanMetricCard, CleanNotebookCell } from "../styles";
+import { EnhancedNotebookCell } from "./types";
 
 interface NotebookCellProps {
-   cell: ClientNotebookCell;
+   cell: EnhancedNotebookCell;
    expandCodeCell?: boolean;
    hideCodeCellIcon?: boolean;
    expandEmbedding?: boolean;

--- a/packages/sdk/src/components/Notebook/types.ts
+++ b/packages/sdk/src/components/Notebook/types.ts
@@ -1,0 +1,24 @@
+import { NotebookCell as ClientNotebookCell } from "../../client";
+
+/**
+ * Enhanced notebook cell that extends the base API cell with execution results.
+ * The base ClientNotebookCell only contains type and text (raw content).
+ * This interface adds the runtime execution data.
+ */
+export interface EnhancedNotebookCell extends ClientNotebookCell {
+   /**
+    * Name of the query that was executed (for code cells that run queries)
+    */
+   queryName?: string;
+
+   /**
+    * JSON string containing the query execution results
+    */
+   result?: string;
+
+   /**
+    * Array of JSON strings containing SourceInfo objects for data sources
+    * that become available in this cell (e.g., from imports or source definitions)
+    */
+   newSources?: string[];
+}

--- a/packages/server/src/mcp/resources/notebook_resource.ts
+++ b/packages/server/src/mcp/resources/notebook_resource.ts
@@ -82,9 +82,9 @@ export function registerNotebookResource(
                      throw new McpGetResourceError(errorDetails);
                   }
 
-                  // Now try to compile/get the actual notebook content
-                  const notebookContent: components["schemas"]["CompiledNotebook"] =
-                     await modelInstance.getNotebook(); // This can throw ModelCompilationError
+                  // Now try to get the actual notebook content
+                  const notebookContent: components["schemas"]["RawNotebook"] =
+                     await modelInstance.getNotebook();
                   return notebookContent;
                } catch (error) {
                   if (error instanceof McpGetResourceError) {


### PR DESCRIPTION
Notebook query now returns raw text for each cell.
SDK Notebook component then calls "executeCell" for each non-Markdown cell and plots the results.
Cells are executed in sequence (so it doesn't bog down server/DB)