### PR TITLE
Update main server configuration to set maxHeaderSize to 256kb

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -827,7 +827,7 @@ app.use(
    },
 );
 
-const mainServer = http.createServer(app);
+const mainServer = http.createServer({ maxHeaderSize: 262144 }, app);
 
 mainServer.timeout = 600000;
 mainServer.keepAliveTimeout = 600000;


### PR DESCRIPTION
+ Quick Fix for QueryData API 431 Error