### PR TITLE
Fix DuckDB bundling issue causing crashes with bun/bunx

### DIFF
--- a/packages/server/build.ts
+++ b/packages/server/build.ts
@@ -11,6 +11,7 @@ await build({
    format: "cjs",
    external: [
       "@malloydata/db-duckdb",
+      "duckdb",
       "@malloydata/malloy",
       "@malloydata/malloy-sql",
       "@malloydata/render",


### PR DESCRIPTION
## Summary

- Add `duckdb` to the external array in `build.ts` to prevent the native module from being bundled

## Problem

When running Publisher via `bunx @malloy-publisher/server`, users encounter this error:

```
Error: /home/runner/work/publisher/publisher/node_modules/duckdb/package.json does not exist
at exports2.find (/tmp/bunx-1000-@malloy-publisher/server@0.0.150/node_modules/@malloy-...
```

The bundled code contains hardcoded paths from the CI build environment (`/home/runner/work/...`).

This issue was introduced in v0.0.146 when DuckDB was added for CRUD state persistence (#503).

## Root Cause

The `duckdb` native module was being bundled by Bun's bundler, which captures absolute paths from the build environment and breaks native binary loading at runtime.

## Solution

Mark `duckdb` as external in `build.ts` so it's loaded from `node_modules` at runtime rather than bundled.

## Testing

Verified the fix works across all deployment methods:
- ✅ `bunx` (was failing, now works)
- ✅ `npx`/`node` 
- ✅ Docker