### PR TITLE
Update cross-platform test job naming in GitHub Actions workflow

### DIFF
--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   cross_platform_test:
     name: >-
-      Platform: (${{ matrix.os }})${{ github.event.pull_request && format(' - PR: {0}', github.event.pull_request.title) || '' }}
+      Platform: (${{ matrix.os }})
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]


### PR DESCRIPTION
- Removed the pull request title from the job name for cross-platform tests to simplify the naming format.
- This change enhances clarity in CI logs by focusing solely on the operating system being tested.

This update improves the readability of CI job names, facilitating better tracking of test results across different platforms.