### PR TITLE
Fix Postgres schema/table listing crash

### DIFF
--- a/packages/server/src/service/db_utils.spec.ts
+++ b/packages/server/src/service/db_utils.spec.ts
@@ -167,10 +167,11 @@ describe("listTablesForSchema", () => {
          },
       };
 
-      it("queries information_schema.columns with correct schema", async () => {
+      it("queries information_schema.columns wrapped in row_to_json", async () => {
          const m = mockConnection(columnRows);
          const tables = await listTablesForSchema(conn, "public", m.conn);
 
+         expect(m.lastSQL).toContain("row_to_json");
          expect(m.lastSQL).toContain("information_schema.columns");
          expect(m.lastSQL).toContain("table_schema = 'public'");
          expect(tables).toHaveLength(2);
@@ -470,7 +471,7 @@ describe("getSchemasForConnection", () => {
          },
       };
 
-      it("queries information_schema.schemata", async () => {
+      it("queries information_schema.schemata wrapped in row_to_json", async () => {
          const rows = [
             { schema_name: "public" },
             { schema_name: "information_schema" },
@@ -480,6 +481,7 @@ describe("getSchemasForConnection", () => {
          const m = mockConnection(rows);
          const schemas = await getSchemasForConnection(conn, m.conn);
 
+         expect(m.lastSQL).toContain("row_to_json");
          expect(m.lastSQL).toContain("information_schema.schemata");
          expect(schemas).toHaveLength(4);
          expect(schemas.find((s) => s.name === "public")?.isDefault).toBe(true);

--- a/packages/server/src/service/db_utils.spec.ts
+++ b/packages/server/src/service/db_utils.spec.ts
@@ -208,31 +208,6 @@ describe("listTablesForSchema", () => {
          expect(tables[0].resource).toBe("MY_DB.PUBLIC.orders");
       });
 
-      it("normalizes Snowflake types to Malloy types", async () => {
-         const snowflakeRows = [
-            { TABLE_NAME: "t", COLUMN_NAME: "a", DATA_TYPE: "TEXT" },
-            { TABLE_NAME: "t", COLUMN_NAME: "b", DATA_TYPE: "NUMBER" },
-            { TABLE_NAME: "t", COLUMN_NAME: "c", DATA_TYPE: "FLOAT" },
-            { TABLE_NAME: "t", COLUMN_NAME: "d", DATA_TYPE: "BOOLEAN" },
-            { TABLE_NAME: "t", COLUMN_NAME: "e", DATA_TYPE: "DATE" },
-            { TABLE_NAME: "t", COLUMN_NAME: "f", DATA_TYPE: "TIMESTAMP_NTZ" },
-            { TABLE_NAME: "t", COLUMN_NAME: "g", DATA_TYPE: "TIMESTAMP_TZ" },
-            { TABLE_NAME: "t", COLUMN_NAME: "h", DATA_TYPE: "VARIANT" },
-         ];
-         const m = mockConnection(snowflakeRows);
-         const tables = await listTablesForSchema(conn, "MY_DB.PUBLIC", m.conn);
-
-         const cols = tables[0].columns!;
-         expect(cols.find((c) => c.name === "a")?.type).toBe("string");
-         expect(cols.find((c) => c.name === "b")?.type).toBe("number");
-         expect(cols.find((c) => c.name === "c")?.type).toBe("number");
-         expect(cols.find((c) => c.name === "d")?.type).toBe("boolean");
-         expect(cols.find((c) => c.name === "e")?.type).toBe("date");
-         expect(cols.find((c) => c.name === "f")?.type).toBe("timestamp");
-         expect(cols.find((c) => c.name === "g")?.type).toBe("timestamptz");
-         expect(cols.find((c) => c.name === "h")?.type).toBe("variant");
-      });
-
       it("falls back to connection database when schema is unqualified", async () => {
          const m = mockConnection(columnRows);
          const tables = await listTablesForSchema(conn, "PUBLIC", m.conn);

--- a/packages/server/src/service/db_utils.spec.ts
+++ b/packages/server/src/service/db_utils.spec.ts
@@ -208,6 +208,31 @@ describe("listTablesForSchema", () => {
          expect(tables[0].resource).toBe("MY_DB.PUBLIC.orders");
       });
 
+      it("normalizes Snowflake types to Malloy types", async () => {
+         const snowflakeRows = [
+            { TABLE_NAME: "t", COLUMN_NAME: "a", DATA_TYPE: "TEXT" },
+            { TABLE_NAME: "t", COLUMN_NAME: "b", DATA_TYPE: "NUMBER" },
+            { TABLE_NAME: "t", COLUMN_NAME: "c", DATA_TYPE: "FLOAT" },
+            { TABLE_NAME: "t", COLUMN_NAME: "d", DATA_TYPE: "BOOLEAN" },
+            { TABLE_NAME: "t", COLUMN_NAME: "e", DATA_TYPE: "DATE" },
+            { TABLE_NAME: "t", COLUMN_NAME: "f", DATA_TYPE: "TIMESTAMP_NTZ" },
+            { TABLE_NAME: "t", COLUMN_NAME: "g", DATA_TYPE: "TIMESTAMP_TZ" },
+            { TABLE_NAME: "t", COLUMN_NAME: "h", DATA_TYPE: "VARIANT" },
+         ];
+         const m = mockConnection(snowflakeRows);
+         const tables = await listTablesForSchema(conn, "MY_DB.PUBLIC", m.conn);
+
+         const cols = tables[0].columns!;
+         expect(cols.find((c) => c.name === "a")?.type).toBe("string");
+         expect(cols.find((c) => c.name === "b")?.type).toBe("number");
+         expect(cols.find((c) => c.name === "c")?.type).toBe("number");
+         expect(cols.find((c) => c.name === "d")?.type).toBe("boolean");
+         expect(cols.find((c) => c.name === "e")?.type).toBe("date");
+         expect(cols.find((c) => c.name === "f")?.type).toBe("timestamp");
+         expect(cols.find((c) => c.name === "g")?.type).toBe("timestamptz");
+         expect(cols.find((c) => c.name === "h")?.type).toBe("variant");
+      });
+
       it("falls back to connection database when schema is unqualified", async () => {
          const m = mockConnection(columnRows);
          const tables = await listTablesForSchema(conn, "PUBLIC", m.conn);

--- a/packages/server/src/service/db_utils.ts
+++ b/packages/server/src/service/db_utils.ts
@@ -36,13 +36,15 @@ export function sqlInFilter(columnName: string, values?: string[]): string {
 function groupColumnRowsIntoTables(
    rows: unknown[],
    buildResource: (tableName: string) => string,
+   normalizeType?: (rawType: string) => string,
 ): ApiTable[] {
    const tableMap = new Map<string, { name: string; type: string }[]>();
    for (const row of rows) {
       const r = row as Record<string, unknown>;
       const tableName = String(r.TABLE_NAME ?? r.table_name ?? "");
       const columnName = String(r.COLUMN_NAME ?? r.column_name ?? "");
-      const dataType = String(r.DATA_TYPE ?? r.data_type ?? "").toLowerCase();
+      const rawType = String(r.DATA_TYPE ?? r.data_type ?? "").toLowerCase();
+      const dataType = normalizeType ? normalizeType(rawType) : rawType;
       if (!tableName) continue;
       if (!tableMap.has(tableName)) tableMap.set(tableName, []);
       tableMap.get(tableName)!.push({ name: columnName, type: dataType });
@@ -966,6 +968,57 @@ async function listTablesForPostgres(
    }
 }
 
+/**
+ * Map raw Snowflake SQL types to Malloy type names so that column types
+ * returned by listTables match those returned by Malloy's fetchTableSchema.
+ * Mirrors the snowflakeToMalloyTypes map in @malloydata/malloy's Snowflake dialect.
+ */
+const snowflakeTypeToMalloy: Record<string, string> = {
+   // string
+   varchar: "string",
+   text: "string",
+   string: "string",
+   char: "string",
+   character: "string",
+   nvarchar: "string",
+   nvarchar2: "string",
+   "char varying": "string",
+   "nchar varying": "string",
+   // integer
+   integer: "number",
+   int: "number",
+   bigint: "number",
+   smallint: "number",
+   tinyint: "number",
+   byteint: "number",
+   number: "number",
+   numeric: "number",
+   decimal: "number",
+   dec: "number",
+   // float
+   float: "number",
+   float4: "number",
+   float8: "number",
+   double: "number",
+   "double precision": "number",
+   real: "number",
+   // boolean
+   boolean: "boolean",
+   // date/time
+   date: "date",
+   timestamp: "timestamp",
+   timestampntz: "timestamp",
+   timestamp_ntz: "timestamp",
+   "timestamp without time zone": "timestamp",
+   timestamptz: "timestamptz",
+   timestamp_tz: "timestamptz",
+   "timestamp with time zone": "timestamptz",
+};
+
+function normalizeSnowflakeType(rawType: string): string {
+   return snowflakeTypeToMalloy[rawType] ?? rawType;
+}
+
 async function listTablesForSnowflake(
    connection: ApiConnection,
    schemaName: string,
@@ -999,7 +1052,11 @@ async function listTablesForSnowflake(
          `SELECT TABLE_NAME, COLUMN_NAME, DATA_TYPE FROM ${databaseName}.INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '${schemaOnly}' ${sqlInFilter("TABLE_NAME", tableNames)} ORDER BY TABLE_NAME, ORDINAL_POSITION`,
       );
       const rows = standardizeRunSQLResult(result);
-      return groupColumnRowsIntoTables(rows, (t) => `${qualifiedSchema}.${t}`);
+      return groupColumnRowsIntoTables(
+         rows,
+         (t) => `${qualifiedSchema}.${t}`,
+         normalizeSnowflakeType,
+      );
    } catch (error) {
       logger.error(
          `Error getting tables for Snowflake schema ${schemaName} in connection ${connection.name}`,

--- a/packages/server/src/service/db_utils.ts
+++ b/packages/server/src/service/db_utils.ts
@@ -36,15 +36,13 @@ export function sqlInFilter(columnName: string, values?: string[]): string {
 function groupColumnRowsIntoTables(
    rows: unknown[],
    buildResource: (tableName: string) => string,
-   normalizeType?: (rawType: string) => string,
 ): ApiTable[] {
    const tableMap = new Map<string, { name: string; type: string }[]>();
    for (const row of rows) {
       const r = row as Record<string, unknown>;
       const tableName = String(r.TABLE_NAME ?? r.table_name ?? "");
       const columnName = String(r.COLUMN_NAME ?? r.column_name ?? "");
-      const rawType = String(r.DATA_TYPE ?? r.data_type ?? "").toLowerCase();
-      const dataType = normalizeType ? normalizeType(rawType) : rawType;
+      const dataType = String(r.DATA_TYPE ?? r.data_type ?? "").toLowerCase();
       if (!tableName) continue;
       if (!tableMap.has(tableName)) tableMap.set(tableName, []);
       tableMap.get(tableName)!.push({ name: columnName, type: dataType });
@@ -968,57 +966,6 @@ async function listTablesForPostgres(
    }
 }
 
-/**
- * Map raw Snowflake SQL types to Malloy type names so that column types
- * returned by listTables match those returned by Malloy's fetchTableSchema.
- * Mirrors the snowflakeToMalloyTypes map in @malloydata/malloy's Snowflake dialect.
- */
-const snowflakeTypeToMalloy: Record<string, string> = {
-   // string
-   varchar: "string",
-   text: "string",
-   string: "string",
-   char: "string",
-   character: "string",
-   nvarchar: "string",
-   nvarchar2: "string",
-   "char varying": "string",
-   "nchar varying": "string",
-   // integer
-   integer: "number",
-   int: "number",
-   bigint: "number",
-   smallint: "number",
-   tinyint: "number",
-   byteint: "number",
-   number: "number",
-   numeric: "number",
-   decimal: "number",
-   dec: "number",
-   // float
-   float: "number",
-   float4: "number",
-   float8: "number",
-   double: "number",
-   "double precision": "number",
-   real: "number",
-   // boolean
-   boolean: "boolean",
-   // date/time
-   date: "date",
-   timestamp: "timestamp",
-   timestampntz: "timestamp",
-   timestamp_ntz: "timestamp",
-   "timestamp without time zone": "timestamp",
-   timestamptz: "timestamptz",
-   timestamp_tz: "timestamptz",
-   "timestamp with time zone": "timestamptz",
-};
-
-function normalizeSnowflakeType(rawType: string): string {
-   return snowflakeTypeToMalloy[rawType] ?? rawType;
-}
-
 async function listTablesForSnowflake(
    connection: ApiConnection,
    schemaName: string,
@@ -1052,11 +999,7 @@ async function listTablesForSnowflake(
          `SELECT TABLE_NAME, COLUMN_NAME, DATA_TYPE FROM ${databaseName}.INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '${schemaOnly}' ${sqlInFilter("TABLE_NAME", tableNames)} ORDER BY TABLE_NAME, ORDINAL_POSITION`,
       );
       const rows = standardizeRunSQLResult(result);
-      return groupColumnRowsIntoTables(
-         rows,
-         (t) => `${qualifiedSchema}.${t}`,
-         normalizeSnowflakeType,
-      );
+      return groupColumnRowsIntoTables(rows, (t) => `${qualifiedSchema}.${t}`);
    } catch (error) {
       logger.error(
          `Error getting tables for Snowflake schema ${schemaName} in connection ${connection.name}`,

--- a/packages/server/src/service/db_utils.ts
+++ b/packages/server/src/service/db_utils.ts
@@ -175,8 +175,10 @@ async function getSchemasForPostgres(
       throw new Error("Postgres connection is required");
    }
    try {
+      // Wrap in row_to_json because the Malloy Postgres driver's runSQL
+      // de-JSONs each row via row.row (matching Malloy-generated queries).
       const result = await malloyConnection.runSQL(
-         "SELECT schema_name FROM information_schema.schemata ORDER BY schema_name",
+         "SELECT row_to_json(t) as row FROM (SELECT schema_name FROM information_schema.schemata ORDER BY schema_name) t",
       );
       const rows = standardizeRunSQLResult(result);
       return rows.map((row: unknown) => {
@@ -946,8 +948,10 @@ async function listTablesForPostgres(
       throw new Error("Postgres connection is required");
    }
    try {
+      // Wrap in row_to_json because the Malloy Postgres driver's runSQL
+      // de-JSONs each row via row.row (matching Malloy-generated queries).
       const result = await malloyConnection.runSQL(
-         `SELECT table_name, column_name, data_type FROM information_schema.columns WHERE table_schema = '${schemaName}' ${sqlInFilter("table_name", tableNames)} ORDER BY table_name, ordinal_position`,
+         `SELECT row_to_json(t) as row FROM (SELECT table_name, column_name, data_type FROM information_schema.columns WHERE table_schema = '${schemaName}' ${sqlInFilter("table_name", tableNames)} ORDER BY table_name, ordinal_position) t`,
       );
       const rows = standardizeRunSQLResult(result);
       return groupColumnRowsIntoTables(rows, (t) => `${schemaName}.${t}`);


### PR DESCRIPTION
## Summary
- Fix `undefined is not an object (evaluating 'typedRow.schema_name')` error when listing schemas/tables for Postgres connections
- The Malloy Postgres driver's `runSQL` internally de-JSONs each row via `row.row`, expecting queries to use `row_to_json` wrapping (matching Malloy-generated SQL). Our plain SQL queries returned `undefined` for every row, causing the crash.
- Wrap both `getSchemasForPostgres` and `listTablesForPostgres` SQL queries in `row_to_json(t) as row` to match the driver's expected format

## Test plan
- [x] Unit tests updated and passing (43/43)
- [ ] Verify schema listing works against a live Postgres connection
- [ ] Verify table listing works against a live Postgres connection

Made with [Cursor](https://cursor.com)