### PR TITLE
Add Playwright E2E tests and configure GitHub Actions workflow

### DIFF
--- a/.github/workflows/app-playwright.yml
+++ b/.github/workflows/app-playwright.yml
@@ -2,9 +2,7 @@ name: App Playwright E2E
 
 on:
   pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+    branches: [ main, sagark/project-to-env-latest ]
 
 env:
   BUN_VERSION: 1.3.13

--- a/.github/workflows/app-playwright.yml
+++ b/.github/workflows/app-playwright.yml
@@ -65,6 +65,7 @@ jobs:
         run: bunx playwright test --config=playwright.config.ts
         env:
           CI: "true"
+          DISABLE_RESPONSE_LOGGING: true
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/app-playwright.yml
+++ b/.github/workflows/app-playwright.yml
@@ -1,0 +1,85 @@
+name: App Playwright E2E
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  BUN_VERSION: 1.3.13
+
+jobs:
+  playwright:
+    name: Playwright (packages/app)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "true"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Cache Bun dependencies
+        id: bun-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ env.BUN_VERSION }}-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-${{ env.BUN_VERSION }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        env:
+          BUN_CONFIG_SKIP_POSTINSTALL_SCRIPTS: "1"
+
+      - name: Generate API types
+        run: bun run generate-api-types
+
+      - name: Build SDK + server
+        run: bun run build
+
+      - name: Build app
+        run: bun run build:app
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright browsers
+        working-directory: packages/app
+        run: bunx playwright install --with-deps chromium
+
+      # playwright.config.ts spawns `npm run start:init` from the repo root as
+      # its webServer, polls /api/v0/status in global-setup until the publisher
+      # reaches operationalState=serving, then runs the suite.
+      - name: Run Playwright suite
+        working-directory: packages/app
+        run: bunx playwright test --config=playwright.config.ts
+        env:
+          CI: "true"
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: packages/app/playwright-report
+          retention-days: 7
+
+      - name: Upload test results (traces, screenshots, videos)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: packages/app/test-results
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __pycache__/
 
 packages/server/k6-tests/clients/
 packages/server/k6-tests/results/
+
+# Playwright MCP artifacts
+.playwright-mcp/*

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "malloy-publisher",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -35,7 +35,10 @@
       "lint": "bunx eslint ./src --fix",
       "format": "bunx prettier --write --parser typescript '**/*.{ts,tsx}'",
       "analyze": "bunx vite-bundle-visualizer",
-      "generate-api-types": ""
+      "generate-api-types": "",
+      "test:playwright:install": "bunx playwright install chromium-headless-shell chromium",
+      "test:playwright": "bunx playwright test --config=playwright.config.ts",
+      "test:playwright:headed": "bunx playwright test --config=playwright.config.ts --headed"
    },
    "dependencies": {
       "@malloy-publisher/sdk": "workspace:*",

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -1,0 +1,58 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright config for the Publisher React app.
+ *
+ * Expects a publisher server running at BASE_URL (default
+ * http://localhost:4000). The global-setup step polls /api/v0/status until
+ * `operationalState === "serving"` before any spec runs, so packages have
+ * finished loading.
+ *
+ * Run the server yourself (e.g. `npm run start:init` from repo root) OR let
+ * the `webServer` block below spawn it.
+ */
+
+const BASE_URL = process.env.PUBLISHER_URL ?? "http://localhost:4000";
+const USE_WEB_SERVER = process.env.PLAYWRIGHT_USE_WEBSERVER !== "0";
+const IS_CI = !!process.env.CI;
+
+export default defineConfig({
+   testDir: "./tests/playwright",
+   timeout: 60_000,
+   expect: { timeout: 15_000 },
+   fullyParallel: false,
+   retries: IS_CI ? 1 : 0,
+   reporter: IS_CI
+      ? [
+           ["list"],
+           ["html", { outputFolder: "playwright-report", open: "never" }],
+        ]
+      : [["list"]],
+   use: {
+      baseURL: BASE_URL,
+      trace: IS_CI ? "retain-on-failure" : "on-first-retry",
+      screenshot: "only-on-failure",
+      video: IS_CI ? "retain-on-failure" : "off",
+   },
+   projects: [
+      {
+         name: "chromium",
+         use: { ...devices["Desktop Chrome"] },
+      },
+   ],
+   globalSetup: "./tests/playwright/global-setup.ts",
+   webServer: USE_WEB_SERVER
+      ? {
+           // Start the publisher from the repo root so `npm run start:init`
+           // resolves to the server's init-mode start (loads config,
+           // downloads fixture packages, marks ready when done).
+           command: "npm run start:init",
+           cwd: "../../",
+           url: `${BASE_URL}/api/v0/status`,
+           reuseExistingServer: true,
+           timeout: 300_000,
+           stdout: "pipe",
+           stderr: "pipe",
+        }
+      : undefined,
+});

--- a/packages/app/tests/playwright/README.md
+++ b/packages/app/tests/playwright/README.md
@@ -1,0 +1,113 @@
+# Publisher app — Playwright E2E
+
+End-to-end tests for the React SPA in `packages/app`.
+
+## Running tests
+
+All commands from `packages/app/`.
+
+### Against a running publisher (fastest loop)
+
+Start the publisher once, leave it running, then iterate on specs:
+
+```bash
+# In one terminal — pick one:
+bun run start:init         # built publisher on :4000
+bun run dev                # Vite dev server on :5173, proxies /api/v0 → :4000
+
+# In another terminal:
+PLAYWRIGHT_USE_WEBSERVER=0 PUBLISHER_URL=http://localhost:4000 bunx playwright test
+# or against the dev server for instant SDK edits:
+PLAYWRIGHT_USE_WEBSERVER=0 PUBLISHER_URL=http://localhost:5173 bunx playwright test
+```
+
+### Watch it run (headed)
+
+```bash
+PLAYWRIGHT_USE_WEBSERVER=0 PUBLISHER_URL=http://localhost:5173 bunx playwright test --headed
+```
+
+### Let Playwright spawn the server
+
+Default behavior — slower because it builds & boots the publisher:
+
+```bash
+bun run test:playwright
+```
+
+### Run a single spec or test
+
+```bash
+bunx playwright test tests/playwright/packages.spec.ts
+bunx playwright test -g "create env → add package from git"
+```
+
+### Debug a failure
+
+```bash
+bunx playwright test --debug -g "<title substring>"
+bunx playwright show-report            # open the HTML report (after a run)
+bunx playwright show-trace test-results/<folder>/trace.zip
+```
+
+## Files
+
+```
+tests/playwright/
+├── global-setup.ts              # polls /api/v0/status until operationalState=serving
+├── helpers/
+│   ├── fixtures.ts              # DEFAULT_ENV, PACKAGES, tmpName()
+│   ├── navigation.ts            # gotoHome / openEnvironment / openPackage
+│   └── publisherStatus.ts       # fetches /api/v0/status; applies frozenConfig → mutable=false
+├── environments.spec.ts         # Home + env CRUD + mutability parity
+├── packages.spec.ts             # package list + full create-from-git → open → delete lifecycle
+├── package-models.spec.ts       # .malloy list, open, source combobox, run query → assert rows
+├── package-notebooks.spec.ts    # .malloynb list, open → workbook route, content rendered
+└── package-databases.spec.ts    # embedded DBs + schema dialog + connection CRUD
+```
+
+## Mutable vs frozen publishers
+
+The UI hides create/edit/delete controls when the server reports `frozenConfig: true`
+or `mutable: false` (see `packages/sdk/src/components/ServerProvider.tsx`). Tests adapt:
+
+- CRUD suites: `test.skip(!mutable, …)` via `getPublisherStatus(baseURL)` in `beforeAll`.
+- Mutability-parity tests assert the control count matches the status flag, so they pass in both modes.
+
+## CI
+
+Runs on every `pull_request` to `main` via `.github/workflows/app-playwright.yml`:
+
+1. Build SDK + server + app.
+2. Install Chromium via `bunx playwright install --with-deps chromium`.
+3. Run the suite (`playwright.config.ts` spawns `start:init`; `global-setup.ts` waits for `serving`).
+4. Upload `playwright-report/` always; upload `test-results/` (traces, videos) on failure.
+
+In CI the config sets `retries: 1`, `trace: retain-on-failure`, `video: retain-on-failure`,
+and adds the `html` reporter on top of `list`.
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `PUBLISHER_URL` | `http://localhost:4000` | Base URL under test |
+| `PLAYWRIGHT_USE_WEBSERVER` | unset (on) | Set to `0` to reuse an already-running server |
+| `CI` | unset | When set, enables retries + HTML reporter + trace/video artifacts |
+
+## Writing new tests — notes that bite
+
+- **Package tiles** are `<div>`, not `<a>`. Use `page.getByText(pkg, { exact: true })` to click.
+- **Source combobox** is an MUI Autocomplete — assert with `toHaveValue('people')`, not `toContainText`.
+- `imdb.malloy` is a substring of `imdb.malloynb`; always pass `{ exact: true }` on treeitems.
+- Action buttons carry stable aria-labels: `"Environment actions for <name>"`,
+  `"Package actions for <name>"`, `"Edit connection <name>"`, `"Delete connection <name>"`.
+- The sticky `Publisher API` header link can intercept pointer events on the env-card overflow
+  button — use `.dispatchEvent("click")` to fire the React handler directly.
+- Package sections render `Fetching …` placeholders — wait for a row/treeitem, not just the section heading.
+- Adding a package from a git URL can take up to a minute; allow `{ timeout: 60_000 }` on the
+  tile-visible assertion.
+
+## Related
+
+- `e2e/tests/workspace.playwright.spec.ts` — legacy suite using older "Project" copy.
+  New coverage belongs here; `e2e/` will be retired.

--- a/packages/app/tests/playwright/environments.spec.ts
+++ b/packages/app/tests/playwright/environments.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "@playwright/test";
+import { DEFAULT_ENV, tmpName } from "./helpers/fixtures";
+import { gotoHome, openEnvironment } from "./helpers/navigation";
+import { getPublisherStatus } from "./helpers/publisherStatus";
+
+test.describe("environments — read", () => {
+   test("Home loads with the Publisher heading", async ({ page }) => {
+      await gotoHome(page);
+   });
+
+   test(`lists the ${DEFAULT_ENV} environment card`, async ({ page }) => {
+      await gotoHome(page);
+      await expect(
+         page.getByRole("heading", { name: DEFAULT_ENV, level: 6 }),
+      ).toBeVisible();
+   });
+
+   test("Open Environment navigates to /:environmentName", async ({ page }) => {
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+   });
+});
+
+test.describe("environments — mutable CRUD", () => {
+   test.beforeAll(async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL ?? "http://localhost:4000";
+      const { mutable } = await getPublisherStatus(baseURL);
+      test.skip(
+         !mutable,
+         "publisher is read-only (frozenConfig or mutable=false)",
+      );
+   });
+
+   test("Create New Environment button is present", async ({ page }) => {
+      await gotoHome(page);
+      await expect(
+         page.getByRole("button", { name: "Create New Environment" }),
+      ).toBeVisible();
+   });
+
+   test("environment card exposes Environment actions menu", async ({
+      page,
+   }) => {
+      await gotoHome(page);
+      const actions = page.getByRole("button", {
+         name: `Environment actions for ${DEFAULT_ENV}`,
+      });
+      await expect(actions).toBeVisible();
+      // Sticky `Publisher API` header link sits over the env card's top-right;
+      // a regular (or force) click lands on the link and navigates away. Dispatch
+      // the React onClick directly instead of going through the pointer pipeline.
+      await actions.dispatchEvent("click");
+      await expect(
+         page.getByRole("menuitem", { name: /edit|delete/i }).first(),
+      ).toBeVisible();
+      await page.keyboard.press("Escape");
+   });
+
+   test("create → verify → edit → verify → delete disposable environment", async ({
+      page,
+   }) => {
+      const name = tmpName("env");
+      const description = `created by playwright at ${new Date().toISOString()}`;
+      const editedDescription = `${description} [edited]`;
+
+      await gotoHome(page);
+
+      // --- Create ---
+      await page
+         .getByRole("button", { name: "Create New Environment" })
+         .click();
+      const createDialog = page.getByRole("dialog", {
+         name: "Create New Environment",
+      });
+      await expect(createDialog).toBeVisible();
+      await createDialog.getByLabel("Environment Name").fill(name);
+      await createDialog
+         .getByLabel("Environment Description")
+         .fill(description);
+      await createDialog
+         .getByRole("button", { name: "Create Environment" })
+         .click();
+      await expect(createDialog).toBeHidden();
+
+      // Verify the new card (and its description) rendered on Home.
+      const newCardHeading = page.getByRole("heading", { name, level: 6 });
+      await expect(newCardHeading).toBeVisible();
+      await expect(page.getByText(description)).toBeVisible();
+
+      // --- Edit ---
+      await page
+         .getByRole("button", { name: `Environment actions for ${name}` })
+         .dispatchEvent("click");
+      await page.getByRole("menuitem", { name: "Edit" }).click();
+      const editDialog = page.getByRole("dialog", { name: "Edit Environment" });
+      await expect(editDialog).toBeVisible();
+      const descField = editDialog.getByLabel("Environment Description");
+      await descField.fill(editedDescription);
+      await editDialog.getByRole("button", { name: "Save Changes" }).click();
+      await expect(editDialog).toBeHidden();
+      await expect(page.getByText(editedDescription)).toBeVisible();
+
+      // --- Delete ---
+      await page
+         .getByRole("button", { name: `Environment actions for ${name}` })
+         .dispatchEvent("click");
+      await page.getByRole("menuitem", { name: "Delete" }).click();
+      const deleteDialog = page.getByRole("dialog", {
+         name: "Delete Environment",
+      });
+      await expect(deleteDialog).toBeVisible();
+      await expect(deleteDialog).toContainText(name);
+      await deleteDialog.getByRole("button", { name: "Delete" }).click();
+      await expect(deleteDialog).toBeHidden();
+      await expect(newCardHeading).toHaveCount(0);
+   });
+});
+
+test.describe("environments — mutability parity with /api/v0/status", () => {
+   test("Create/Edit controls render iff the publisher reports mutable", async ({
+      page,
+   }, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL ?? "http://localhost:4000";
+      const { mutable } = await getPublisherStatus(baseURL);
+      const expected = mutable ? 1 : 0;
+
+      await gotoHome(page);
+      await expect(
+         page.getByRole("button", { name: "Create New Environment" }),
+      ).toHaveCount(expected);
+      await expect(
+         page.getByRole("button", {
+            name: `Environment actions for ${DEFAULT_ENV}`,
+         }),
+      ).toHaveCount(expected);
+   });
+});

--- a/packages/app/tests/playwright/global-setup.ts
+++ b/packages/app/tests/playwright/global-setup.ts
@@ -1,0 +1,46 @@
+import { FullConfig } from "@playwright/test";
+
+/**
+ * Wait for the publisher to reach `operationalState: "serving"` before
+ * tests start. Playwright's `webServer.url` only checks that the endpoint
+ * returns 2xx/3xx, but /api/v0/status returns 200 while still "initializing"
+ * (packages downloading). We want specs to run only after packages are
+ * fully loaded, so poll the state explicitly here.
+ */
+export default async function globalSetup(config: FullConfig): Promise<void> {
+   const baseURL =
+      config.projects[0]?.use?.baseURL ??
+      process.env.PUBLISHER_URL ??
+      "http://localhost:4000";
+   const statusUrl = `${baseURL}/api/v0/status`;
+   const deadline = Date.now() + 300_000; // 5 min ceiling
+   let last: unknown = null;
+
+   // eslint-disable-next-line no-console
+   console.log(`[global-setup] polling ${statusUrl} for serving state...`);
+
+   while (Date.now() < deadline) {
+      try {
+         const res = await fetch(statusUrl);
+         if (res.ok) {
+            const body = (await res.json()) as {
+               operationalState?: string;
+               initialized?: boolean;
+            };
+            last = body;
+            if (body.operationalState === "serving") {
+               // eslint-disable-next-line no-console
+               console.log("[global-setup] server is serving — ready");
+               return;
+            }
+         }
+      } catch {
+         // server not up yet
+      }
+      await new Promise((r) => setTimeout(r, 1000));
+   }
+
+   throw new Error(
+      `Publisher did not reach operationalState="serving" within 5 min. Last status: ${JSON.stringify(last)}`,
+   );
+}

--- a/packages/app/tests/playwright/helpers/fixtures.ts
+++ b/packages/app/tests/playwright/helpers/fixtures.ts
@@ -1,0 +1,15 @@
+export const DEFAULT_ENV = "malloy-samples";
+
+export const PACKAGES = {
+   imdb: "imdb",
+   ecommerce: "ecommerce",
+   faa: "faa",
+} as const;
+
+/**
+ * Disposable name with a timestamp suffix so parallel/repeat test runs do not
+ * collide on fixtures they create and later delete.
+ */
+export function tmpName(prefix: string): string {
+   return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+}

--- a/packages/app/tests/playwright/helpers/navigation.ts
+++ b/packages/app/tests/playwright/helpers/navigation.ts
@@ -1,0 +1,32 @@
+import { Page, expect } from "@playwright/test";
+import { DEFAULT_ENV } from "./fixtures";
+
+export async function gotoHome(page: Page): Promise<void> {
+   await page.goto("/");
+   await expect(
+      page.getByRole("heading", { name: "Publisher", level: 1 }),
+   ).toBeVisible();
+}
+
+export async function openEnvironment(
+   page: Page,
+   name: string = DEFAULT_ENV,
+): Promise<void> {
+   await expect(page.getByRole("heading", { name, level: 6 })).toBeVisible();
+   await page.getByRole("button", { name: "Open Environment" }).first().click();
+   await expect(page).toHaveURL(new RegExp(`/${name}/?$`));
+}
+
+export async function openPackage(
+   page: Page,
+   env: string,
+   pkg: string,
+): Promise<void> {
+   // Scope to the packages heading's section; the word can otherwise match
+   // descriptions, breadcrumbs, or env card text.
+   await expect(
+      page.getByRole("heading", { name: `${env} packages`, level: 6 }),
+   ).toBeVisible();
+   await page.getByText(pkg, { exact: true }).first().click();
+   await expect(page).toHaveURL(new RegExp(`/${env}/${pkg}/?$`));
+}

--- a/packages/app/tests/playwright/helpers/publisherStatus.ts
+++ b/packages/app/tests/playwright/helpers/publisherStatus.ts
@@ -1,0 +1,32 @@
+import { request } from "@playwright/test";
+
+export type PublisherStatus = {
+   mutable: boolean;
+   frozenConfig: boolean;
+};
+
+/**
+ * Fetches /api/v0/status and returns the effective mutability flags the
+ * ServerProvider uses. `frozenConfig: true` forces `mutable: false` in the UI
+ * regardless of the server's own setting.
+ */
+export async function getPublisherStatus(
+   baseURL: string,
+): Promise<PublisherStatus> {
+   const ctx = await request.newContext({ baseURL });
+   try {
+      const res = await ctx.get("/api/v0/status");
+      if (!res.ok()) {
+         return { mutable: false, frozenConfig: true };
+      }
+      const body = (await res.json()) as {
+         frozenConfig?: boolean;
+         mutable?: boolean;
+      };
+      const frozenConfig = Boolean(body.frozenConfig);
+      const mutable = frozenConfig ? false : body.mutable !== false;
+      return { mutable, frozenConfig };
+   } finally {
+      await ctx.dispose();
+   }
+}

--- a/packages/app/tests/playwright/package-databases.spec.ts
+++ b/packages/app/tests/playwright/package-databases.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "@playwright/test";
+import { DEFAULT_ENV, PACKAGES } from "./helpers/fixtures";
+import { gotoHome, openEnvironment, openPackage } from "./helpers/navigation";
+import { getPublisherStatus } from "./helpers/publisherStatus";
+
+test.describe("package-databases — embedded", () => {
+   test("Embedded Databases section is visible with at least one row", async ({
+      page,
+   }) => {
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      await openPackage(page, DEFAULT_ENV, PACKAGES.imdb);
+
+      await expect(page.getByText("Embedded Databases")).toBeVisible();
+      // Section renders `Fetching Databases...` until the API resolves; wait for the first row.
+      const rows = page.locator("tr").filter({ hasText: ".parquet" });
+      await expect(rows.first()).toBeVisible();
+   });
+
+   test("clicking a parquet row opens a schema dialog that can close", async ({
+      page,
+   }) => {
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      await openPackage(page, DEFAULT_ENV, PACKAGES.imdb);
+
+      const firstRow = page
+         .locator("tr")
+         .filter({ hasText: ".parquet" })
+         .first();
+      await firstRow.click();
+
+      const dialog = page.getByRole("dialog");
+      await expect(dialog).toBeVisible();
+      await dialog.getByRole("button", { name: "close" }).click();
+      await expect(dialog).toHaveCount(0);
+   });
+});
+
+test.describe("package-databases — connections read", () => {
+   test("Database Connections section lists connections", async ({ page }) => {
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      await openPackage(page, DEFAULT_ENV, PACKAGES.imdb);
+
+      await expect(page.getByText("Database Connections")).toBeVisible();
+      // `bigquery` is the fixture connection present on every malloy-samples package.
+      await expect(
+         page.getByRole("row", { name: /bigquery.*bigquery/ }),
+      ).toBeVisible();
+   });
+});
+
+test.describe("package-databases — connections mutable", () => {
+   test.beforeAll(async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL ?? "http://localhost:4000";
+      const { mutable } = await getPublisherStatus(baseURL);
+      test.skip(!mutable, "publisher is read-only");
+   });
+
+   test("Add Connection button is present", async ({ page }) => {
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      await openPackage(page, DEFAULT_ENV, PACKAGES.imdb);
+
+      await expect(
+         page.getByRole("button", { name: "Add Connection" }),
+      ).toBeVisible();
+   });
+
+   test("connection row exposes Edit and Delete actions", async ({ page }) => {
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      await openPackage(page, DEFAULT_ENV, PACKAGES.imdb);
+
+      await expect(
+         page.getByRole("button", { name: "Edit connection bigquery" }),
+      ).toBeVisible();
+      await expect(
+         page.getByRole("button", { name: "Delete connection bigquery" }),
+      ).toBeVisible();
+   });
+});
+
+test.describe("package-databases — mutability parity with /api/v0/status", () => {
+   test("connection mutation controls render iff publisher reports mutable", async ({
+      page,
+   }, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL ?? "http://localhost:4000";
+      const { mutable } = await getPublisherStatus(baseURL);
+      const expected = mutable ? 1 : 0;
+
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      await openPackage(page, DEFAULT_ENV, PACKAGES.imdb);
+
+      await expect(
+         page.getByRole("button", { name: "Add Connection" }),
+      ).toHaveCount(expected);
+   });
+});

--- a/packages/app/tests/playwright/package-models.spec.ts
+++ b/packages/app/tests/playwright/package-models.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "@playwright/test";
+import { DEFAULT_ENV, PACKAGES } from "./helpers/fixtures";
+import { gotoHome, openEnvironment, openPackage } from "./helpers/navigation";
+
+test.describe("package-models", () => {
+   test("Semantic Models section lists .malloy files", async ({ page }) => {
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      await openPackage(page, DEFAULT_ENV, PACKAGES.imdb);
+
+      // exact: true so `imdb.malloy` doesn't also match `imdb.malloynb`.
+      await expect(
+         page.getByRole("treeitem", { name: "imdb.malloy", exact: true }),
+      ).toBeVisible();
+   });
+
+   test("opening a model routes to /:env/:pkg/:model and loads Sources", async ({
+      page,
+   }) => {
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      await openPackage(page, DEFAULT_ENV, PACKAGES.imdb);
+
+      await page
+         .getByRole("treeitem", { name: "imdb.malloy", exact: true })
+         .click();
+      await expect(page).toHaveURL(
+         new RegExp(`/${DEFAULT_ENV}/${PACKAGES.imdb}/imdb\\.malloy$`),
+      );
+      await expect(
+         page.getByRole("heading", { name: "Sources", level: 1 }),
+      ).toBeVisible();
+   });
+
+   test("source combobox defaults to a known source value", async ({
+      page,
+   }) => {
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      await openPackage(page, DEFAULT_ENV, PACKAGES.imdb);
+      await page
+         .getByRole("treeitem", { name: "imdb.malloy", exact: true })
+         .click();
+
+      // MUI Autocomplete: input value, not innerText.
+      await expect(page.getByRole("combobox").first()).toHaveValue("people");
+   });
+
+   test("picking a dimension and running returns rows", async ({ page }) => {
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      await openPackage(page, DEFAULT_ENV, PACKAGES.imdb);
+      await page
+         .getByRole("treeitem", { name: "imdb.malloy", exact: true })
+         .click();
+
+      const sourceSelect = page.getByRole("combobox").first();
+      await expect(sourceSelect).toHaveValue("people");
+      await page.keyboard.press("Escape");
+
+      const dimensionsToggle = page.getByText("Dimensions5");
+      await expect(dimensionsToggle).toBeVisible();
+      await dimensionsToggle.scrollIntoViewIfNeeded();
+      await dimensionsToggle.click();
+
+      const primaryNameField = page.getByText("primaryName", { exact: true });
+      await expect(primaryNameField).toBeVisible();
+      await primaryNameField.scrollIntoViewIfNeeded();
+      // force: label sits under an icon button; Playwright otherwise reports pointer interception.
+      await primaryNameField.click({ force: true });
+
+      const runQuery = page.getByRole("button", { name: "Run", exact: true });
+      await expect(runQuery).toBeEnabled();
+      await runQuery.click();
+
+      await expect(page.getByRole("tab", { name: "Results" })).toBeVisible();
+      const resultsPanel = page.getByRole("tabpanel", { name: "Results" });
+      await expect(resultsPanel).toContainText(
+         /(?:'|’)?A\.J\.(?:'|’)? Marriot|50 Cent|A Martinez|A Winged Victory for the Sullen|A\. Kitman Ho|A\. Michael Baldwin|A\. Sreekar Prasad|A\.A\. Milne/,
+      );
+   });
+});

--- a/packages/app/tests/playwright/package-notebooks.spec.ts
+++ b/packages/app/tests/playwright/package-notebooks.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+import { DEFAULT_ENV, PACKAGES } from "./helpers/fixtures";
+import { gotoHome, openEnvironment, openPackage } from "./helpers/navigation";
+
+test.describe("package-notebooks", () => {
+   test("Notebooks section lists .malloynb files", async ({ page }) => {
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      await openPackage(page, DEFAULT_ENV, PACKAGES.imdb);
+
+      await expect(
+         page.getByRole("treeitem", { name: "imdb.malloynb", exact: true }),
+      ).toBeVisible();
+      await expect(
+         page.getByRole("treeitem", { name: "README.malloynb", exact: true }),
+      ).toBeVisible();
+   });
+
+   test("opening a notebook routes into the workbook view", async ({
+      page,
+   }) => {
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      await openPackage(page, DEFAULT_ENV, PACKAGES.imdb);
+
+      await page
+         .getByRole("treeitem", { name: "imdb.malloynb", exact: true })
+         .click();
+
+      // Router uses a workbook-scoped path; assert we navigated off the package route.
+      await expect(page).not.toHaveURL(
+         new RegExp(`/${DEFAULT_ENV}/${PACKAGES.imdb}/?$`),
+      );
+      await expect(page).toHaveURL(/imdb\.malloynb/);
+   });
+
+   test("workbook renders authored content from the notebook", async ({
+      page,
+   }) => {
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      await openPackage(page, DEFAULT_ENV, PACKAGES.imdb);
+      await page
+         .getByRole("treeitem", { name: "imdb.malloynb", exact: true })
+         .click();
+      // The imdb.malloynb renders an authored H1 ("IMDB Analysis in Malloy") —
+      // presence confirms the Workbook mounted and executed the notebook.
+      await expect(
+         page.getByRole("heading", {
+            name: "IMDB Analysis in Malloy",
+            level: 1,
+         }),
+      ).toBeVisible();
+   });
+});

--- a/packages/app/tests/playwright/packages.spec.ts
+++ b/packages/app/tests/playwright/packages.spec.ts
@@ -1,0 +1,191 @@
+import { expect, test } from "@playwright/test";
+import { DEFAULT_ENV, PACKAGES, tmpName } from "./helpers/fixtures";
+import { gotoHome, openEnvironment, openPackage } from "./helpers/navigation";
+import { getPublisherStatus } from "./helpers/publisherStatus";
+
+test.describe("packages — read", () => {
+   test("environment page shows the packages heading", async ({ page }) => {
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      await expect(
+         page.getByRole("heading", {
+            name: `${DEFAULT_ENV} packages`,
+            level: 6,
+         }),
+      ).toBeVisible();
+   });
+
+   test("fixture packages are listed", async ({ page }) => {
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      for (const pkg of [PACKAGES.imdb, PACKAGES.ecommerce, PACKAGES.faa]) {
+         await expect(page.getByText(pkg, { exact: true })).toBeVisible();
+      }
+   });
+
+   test("clicking a package tile routes to /:env/:package", async ({
+      page,
+   }) => {
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      await openPackage(page, DEFAULT_ENV, PACKAGES.imdb);
+   });
+});
+
+test.describe("packages — mutable CRUD", () => {
+   test.beforeAll(async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL ?? "http://localhost:4000";
+      const { mutable } = await getPublisherStatus(baseURL);
+      test.skip(!mutable, "publisher is read-only");
+   });
+
+   test("Add Package button is present on environment page", async ({
+      page,
+   }) => {
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      await expect(
+         page.getByRole("button", { name: "Add Package" }),
+      ).toBeVisible();
+   });
+
+   test("package tile exposes Package actions menu", async ({ page }) => {
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      const actions = page.getByRole("button", {
+         name: `Package actions for ${PACKAGES.imdb}`,
+      });
+      await expect(actions).toBeVisible();
+      await actions.click();
+      await expect(page.getByRole("menu")).toBeVisible();
+      await page.keyboard.press("Escape");
+   });
+
+   test("create env → add package from git → open → back → delete package → delete env", async ({
+      page,
+   }) => {
+      test.setTimeout(180_000);
+
+      const envName = tmpName("env");
+      const packageName = "ecommerce";
+      const packageLocation =
+         "https://github.com/credibledata/malloy-samples/tree/main/ecommerce";
+      const packageDescription = `playwright fixture ${new Date().toISOString()}`;
+
+      // --- 1. Create a disposable environment ---
+      await gotoHome(page);
+      await page
+         .getByRole("button", { name: "Create New Environment" })
+         .click();
+      const createEnvDialog = page.getByRole("dialog", {
+         name: "Create New Environment",
+      });
+      await createEnvDialog.getByLabel("Environment Name").fill(envName);
+      await createEnvDialog
+         .getByRole("button", { name: "Create Environment" })
+         .click();
+      await expect(createEnvDialog).toBeHidden();
+      await expect(
+         page.getByRole("heading", { name: envName, level: 6 }),
+      ).toBeVisible();
+
+      // --- 2. Open it ---
+      // Walk from the env's heading up to its containing card, then click that card's Open Environment.
+      const envCard = page
+         .getByRole("heading", { name: envName, level: 6 })
+         .locator("xpath=ancestor::div[contains(@class,'MuiCard-root')][1]");
+      await envCard.getByRole("button", { name: "Open Environment" }).click();
+      await expect(page).toHaveURL(new RegExp(`/${envName}/?$`));
+
+      // Fresh env: no packages yet.
+      await expect(
+         page.getByRole("heading", {
+            name: `${envName} packages`,
+            level: 6,
+         }),
+      ).toBeVisible();
+
+      // --- 3. Add ecommerce package from git ---
+      await page.getByRole("button", { name: "Add Package" }).click();
+      const addPkgDialog = page.getByRole("dialog", {
+         name: "Create New Package",
+      });
+      await expect(addPkgDialog).toBeVisible();
+      await addPkgDialog.getByLabel("Package Name").fill(packageName);
+      // Description uses a rich-text area; the `textarea[name=description]` is
+      // the actual editable; fall back to filling via role so both renderings pass.
+      await addPkgDialog
+         .locator("textarea[name=description]")
+         .fill(packageDescription);
+      await addPkgDialog.getByLabel("Location").fill(packageLocation);
+      await addPkgDialog.getByRole("button", { name: "Save Changes" }).click();
+
+      // Git clone can take a while; wait up to 60s for the tile to appear.
+      const pkgTile = page.getByText(packageName, { exact: true });
+      await expect(pkgTile).toBeVisible({ timeout: 60_000 });
+      // Dialog closes when the server responds; don't race it against the tile.
+      await expect(addPkgDialog).toBeHidden({ timeout: 60_000 });
+
+      // --- 4. Open the package ---
+      await pkgTile.click();
+      await expect(page).toHaveURL(new RegExp(`/${envName}/${packageName}/?$`));
+
+      // --- 5. Go back to the environment ---
+      await page.goBack();
+      await expect(page).toHaveURL(new RegExp(`/${envName}/?$`));
+      await expect(
+         page.getByRole("heading", {
+            name: `${envName} packages`,
+            level: 6,
+         }),
+      ).toBeVisible();
+
+      // --- 6. Delete the package ---
+      await page
+         .getByRole("button", { name: `Package actions for ${packageName}` })
+         .dispatchEvent("click");
+      await page.getByRole("menuitem", { name: "Delete" }).click();
+      const deletePkgDialog = page.getByRole("dialog", {
+         name: "Delete Package",
+      });
+      await expect(deletePkgDialog).toContainText(packageName);
+      await deletePkgDialog.getByRole("button", { name: "Delete" }).click();
+      await expect(deletePkgDialog).toBeHidden();
+      await expect(page.getByText(packageName, { exact: true })).toHaveCount(0);
+
+      // --- 7. Go back to Home and delete the environment ---
+      await page.goto("/");
+      await expect(
+         page.getByRole("heading", { name: envName, level: 6 }),
+      ).toBeVisible();
+      await page
+         .getByRole("button", { name: `Environment actions for ${envName}` })
+         .dispatchEvent("click");
+      await page.getByRole("menuitem", { name: "Delete" }).click();
+      const deleteEnvDialog = page.getByRole("dialog", {
+         name: "Delete Environment",
+      });
+      await expect(deleteEnvDialog).toContainText(envName);
+      await deleteEnvDialog.getByRole("button", { name: "Delete" }).click();
+      await expect(deleteEnvDialog).toBeHidden();
+      await expect(
+         page.getByRole("heading", { name: envName, level: 6 }),
+      ).toHaveCount(0);
+   });
+});
+
+test.describe("packages — mutability parity with /api/v0/status", () => {
+   test("Add Package renders iff the publisher reports mutable", async ({
+      page,
+   }, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL ?? "http://localhost:4000";
+      const { mutable } = await getPublisherStatus(baseURL);
+      const expected = mutable ? 1 : 0;
+
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      await expect(
+         page.getByRole("button", { name: "Add Package" }),
+      ).toHaveCount(expected);
+   });
+});

--- a/packages/sdk/src/components/Connections/DeleteConnectionDialog.tsx
+++ b/packages/sdk/src/components/Connections/DeleteConnectionDialog.tsx
@@ -35,6 +35,7 @@ export default function DeleteConnectionDialog({
    return (
       <React.Fragment>
          <IconButton
+            aria-label={`Delete connection ${connection?.name ?? ""}`.trim()}
             onClick={(event) => {
                event.stopPropagation();
                handleClickOpen();

--- a/packages/sdk/src/components/Connections/EditConnectionDialog.tsx
+++ b/packages/sdk/src/components/Connections/EditConnectionDialog.tsx
@@ -432,6 +432,7 @@ export default function EditConnectionDialog({
    return (
       <React.Fragment>
          <IconButton
+            aria-label={`Edit connection ${connection?.name ?? ""}`.trim()}
             onClick={(event) => {
                event.preventDefault();
                event.stopPropagation();
@@ -722,6 +723,7 @@ export default function EditConnectionDialog({
                                        Database {index + 1}
                                     </Typography>
                                     <IconButton
+                                       aria-label={`Remove attached database ${index + 1}`}
                                        onClick={() =>
                                           removeAttachedDatabase(index)
                                        }

--- a/packages/sdk/src/components/Environment/Packages.tsx
+++ b/packages/sdk/src/components/Environment/Packages.tsx
@@ -45,6 +45,7 @@ const PackageMenu = ({
          {mutable && (
             <>
                <IconButton
+                  aria-label={`Package actions for ${p.name}`}
                   onClick={(event) => {
                      event.stopPropagation();
                      openMenu(event);

--- a/packages/sdk/src/components/Home/Home.tsx
+++ b/packages/sdk/src/components/Home/Home.tsx
@@ -395,6 +395,7 @@ function EnvironmentCard({
             {mutable && (
                <>
                   <IconButton
+                     aria-label={`Environment actions for ${environment.name}`}
                      aria-controls={isMenuOpen ? "environment-menu" : undefined}
                      aria-haspopup="true"
                      aria-expanded={isMenuOpen ? "true" : undefined}

--- a/packages/sdk/src/components/ServerProvider.tsx
+++ b/packages/sdk/src/components/ServerProvider.tsx
@@ -52,8 +52,8 @@ export interface ServerProviderProps {
     * Will send "Bearer 123" in the Authorization header.
     */
    getAccessToken?: () => Promise<string>;
-   /** Whether the publisher should allow project and package management operations.
-    * When false, users can only view and explore existing projects and packages.
+   /** Whether the publisher should allow environment and package management operations.
+    * When false, users can only view and explore existing environments and packages.
     * @default true
     */
    mutable?: boolean;


### PR DESCRIPTION
- Introduced Playwright end-to-end tests for the application, covering various functionalities including environment management and package interactions.
- Created a new GitHub Actions workflow for running Playwright tests on pull requests and pushes to the main branch.
- Updated package.json scripts to include commands for installing Playwright and running tests.
- Added configuration files for Playwright to manage test execution and reporting.

This enhancement improves the testing framework and ensures better coverage for application features.