### PR TITLE
Add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 environment variable to GitHub…

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -116,8 +116,17 @@ jobs:
           else
             CURRENT_VERSION=$(cat packages/sdk/package.json | grep '"version"' | sed 's/.*"version": "\(.*\)".*/\1/')
           fi
-          echo "::notice title=Current Version::Publishing SDK version $CURRENT_VERSION"
+
+          # Pre-release versions (e.g. 0.0.189-dev, 1.0.0-rc.1) must not update the "latest" tag.
+          if [[ "$CURRENT_VERSION" == *-* ]]; then
+            IS_PRERELEASE=true
+          else
+            IS_PRERELEASE=false
+          fi
+
+          echo "::notice title=Current Version::Publishing SDK version $CURRENT_VERSION (prerelease=$IS_PRERELEASE)"
           echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "is_prerelease=$IS_PRERELEASE" >> $GITHUB_OUTPUT
 
       - name: Docker meta
         id: meta
@@ -126,7 +135,8 @@ jobs:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
             type=raw,value=${{ steps.version_step.outputs.current_version }}
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ steps.version_step.outputs.is_prerelease == 'false' }}
+            type=raw,value=next,enable=${{ steps.version_step.outputs.is_prerelease == 'true' }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
@@ -139,7 +149,12 @@ jobs:
 
           if [ -z "${{ steps.meta.outputs.tags }}" ]; then
             echo "No tags generated, using fallback tags"
-            TAGS="-t ${{ env.REGISTRY_IMAGE }}:${{ steps.version_step.outputs.current_version }} -t ${{ env.REGISTRY_IMAGE }}:latest"
+            TAGS="-t ${{ env.REGISTRY_IMAGE }}:${{ steps.version_step.outputs.current_version }}"
+            if [ "${{ steps.version_step.outputs.is_prerelease }}" = "false" ]; then
+              TAGS="$TAGS -t ${{ env.REGISTRY_IMAGE }}:latest"
+            else
+              TAGS="$TAGS -t ${{ env.REGISTRY_IMAGE }}:next"
+            fi
           else
             TAGS=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< '${{ steps.meta.outputs.json }}')
           fi

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   REGISTRY_IMAGE: ms2data/malloy-publisher
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build:

--- a/.github/workflows/npm-sdk.yml
+++ b/.github/workflows/npm-sdk.yml
@@ -39,8 +39,18 @@ jobs:
         id: version_step
         run: |
           CURRENT_VERSION=$(cat packages/sdk/package.json | grep '"version"' | sed 's/.*"version": "\(.*\)".*/\1/')
+
+          # Stable versions publish under "latest"; any pre-release (0.0.189-dev,
+          # 1.0.0-rc.1, 2.0.0-beta.2, etc.) publishes under "next".
+          if [[ "$CURRENT_VERSION" == *-* ]]; then
+            NPM_TAG="next"
+          else
+            NPM_TAG="latest"
+          fi
+
           echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-          echo "::notice title=Current Version::Publishing SDK version $CURRENT_VERSION"
+          echo "npm_tag=$NPM_TAG" >> $GITHUB_OUTPUT
+          echo "::notice title=Current Version::Publishing SDK version $CURRENT_VERSION under npm dist-tag '$NPM_TAG'"
 
       - name: Install dependencies
         run: bun install
@@ -64,10 +74,10 @@ jobs:
           NODE_AUTH_TOKEN: ""
         run: |
           cd packages/sdk
-          npm publish --access public --tag latest
+          npm publish --access public --tag ${{ steps.version_step.outputs.npm_tag }}
 
           cd ../app
-          npm publish --access public --tag latest
+          npm publish --access public --tag ${{ steps.version_step.outputs.npm_tag }}
 
       - name: Build & publish Server package
         env:
@@ -75,4 +85,4 @@ jobs:
         run: |
           cd packages/server
           NODE_ENV=production bun run build
-          npm publish --access public --tag latest
+          npm publish --access public --tag ${{ steps.version_step.outputs.npm_tag }}

--- a/.github/workflows/npm-sdk.yml
+++ b/.github/workflows/npm-sdk.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   BUN_VERSION: 1.3.13
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,37 +80,50 @@ jobs:
       current_version: ${{ needs.prepare.outputs.new_version }}
       ref: ${{ needs.prepare.outputs.branch_name }}
 
-  open-pr:
+  gh-release:
     needs: [prepare, publish-npm, publish-docker]
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: write
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.prepare.outputs.branch_name }}
           fetch-depth: 0
 
-      - name: Create pull request to main
+      - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.prepare.outputs.new_version }}
+          BRANCH: ${{ needs.prepare.outputs.branch_name }}
         run: |
-          BRANCH="${{ needs.prepare.outputs.branch_name }}"
-          VERSION="${{ needs.prepare.outputs.new_version }}"
+          TAG="v${VERSION}"
 
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "Release SDK/App v${VERSION}" \
-            --body "Automated release PR for version \`${VERSION}\`.
+          NOTES_FILE="$(mktemp)"
+          cat > "$NOTES_FILE" <<EOF
+          ## Release v${VERSION}
 
-          - NPM packages published: \`@malloy-publisher/sdk\`, \`@malloy-publisher/app\`, \`@malloy-publisher/server\`
-          - Docker image published: \`ms2data/malloy-publisher:${VERSION}\` (and \`latest\`)
+          ### 📦 NPM packages
+          - [\`@malloy-publisher/sdk@${VERSION}\`](https://www.npmjs.com/package/@malloy-publisher/sdk/v/${VERSION})
+          - [\`@malloy-publisher/app@${VERSION}\`](https://www.npmjs.com/package/@malloy-publisher/app/v/${VERSION})
+          - [\`@malloy-publisher/server@${VERSION}\`](https://www.npmjs.com/package/@malloy-publisher/server/v/${VERSION})
 
-          Triggered by @${{ github.actor }} via \`release.yml\`."
+          ### 🐳 Docker image
+          \`\`\`
+          docker pull ms2data/malloy-publisher:${VERSION}
+          docker pull ms2data/malloy-publisher:latest
+          \`\`\`
 
-          echo "## 🚀 Release ${VERSION}" >> $GITHUB_STEP_SUMMARY
-          echo "- Branch: \`${BRANCH}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- NPM + Docker published" >> $GITHUB_STEP_SUMMARY
-          echo "- PR opened against \`main\`" >> $GITHUB_STEP_SUMMARY
+          ### ℹ️ Details
+          - Release branch: \`${BRANCH}\`
+          - Triggered by: @${{ github.actor }}
+          EOF
+
+          gh release create "$TAG" \
+            --target "$BRANCH" \
+            --title "v${VERSION}" \
+            --notes-file "$NOTES_FILE" \
+            --generate-notes
+
+          echo "## 🏷️ GitHub Release" >> $GITHUB_STEP_SUMMARY
+          echo "Created release [\`${TAG}\`](https://github.com/${{ github.repository }}/releases/tag/${TAG})" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
         required: false
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   prepare:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Updated docker-image.yml and npm-sdk.yml to differentiate between stable and pre-release versions, adjusting the tags used for Docker and NPM publishing accordingly.
- Implemented logic to set the appropriate NPM dist-tag based on the version type, ensuring that pre-releases are published under 'next' and stable versions under 'latest'.
- Modified release.yml to create GitHub releases with detailed notes, improving the release process documentation.
- Introduced FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 variable in docker-image.yml, npm-sdk.yml, and release.yml to ensure compatibility with Node.js 24 for JavaScript actions.