### PR TITLE
Dockerfile: run server with node instead of bun run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,4 +80,4 @@ ENV PATH="/root/.duckdb/cli/latest:$PATH"
 RUN mkdir -p /etc/publisher
 EXPOSE 4000
 
-CMD ["bun", "run", "./packages/server/dist/server.js"]
+CMD ["node", "./packages/server/dist/server.js"]


### PR DESCRIPTION
## Summary

Switch the production `CMD` from `bun run ./packages/server/dist/server.js` to `node ./packages/server/dist/server.js`.

## Why

The server bundle is already a Node target:

- `packages/server/build.ts` builds with `target: "node"`, `format: "cjs"`, writes a `#!/usr/bin/env node` shebang, and `chmod +x`'s the output.
- `packages/server/package.json`'s `scripts.start` is `NODE_ENV=production node ./dist/server.js`.
- The publisher itself uses `http.createServer` + Express on port 4000 — it is not a `Bun.serve` server.

Running it under `bun run` was incidental, and after the 1.2.23 → 1.3.13 Bun upgrade in #693 it is actively broken in production.

## Symptom

Every pod crashes on startup with:

```
TypeError: Bun.serve() needs either:
  - A routes object: ...
  - Or a fetch handler: ...
 code: "ERR_INVALID_ARG_TYPE"
      at bun:main:15:28
      at loadAndEvaluateModule (2:1)

Bun v1.3.13 (Linux x64 baseline)
```

In Bun 1.3.x, `bun run <file>` sends the module through an auto-serve wrapper (`bun:main`) that calls `Bun.serve(entryNamespace.default)`. When the default export is not a valid server config (publisher isn't one), it throws `ERR_INVALID_ARG_TYPE` and the container exits. The downstream effect is that every Deployment using `ms2data/malloy-publisher:0.0.190` (worker, api, etc.) fails its rollout with `Deployment exceeded its progress deadline`.

## Fix

Change `CMD` to invoke `node` directly — matches `scripts.start`, matches the bundle's build target, and sidesteps Bun's auto-serve wrapper entirely.

Node is already installed in `base-deps` (via the `curl -fsSL https://deb.nodesource.com/setup_20.x | bash -` + `apt-get install -y nodejs` step), so no other changes are needed.