### PR TITLE
Added deprecated options query parameter in api-doc.yaml for backward compatibility.

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -738,6 +738,7 @@ paths:
         - name: options
           in: query
           description: Options (deprecated; pass in body instead)
+          deprecated: true
           required: false
           schema:
             type: string

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -735,6 +735,12 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/IdentifierPattern"
+        - name: options
+          in: query
+          description: Options (deprecated; pass in body instead)
+          required: false
+          schema:
+            type: string
       requestBody:
         description: SQL statement to execute
         required: true
@@ -2259,7 +2265,8 @@ components:
         filterParams:
           type: object
           description: Filter parameter values keyed by filter name. Used with sources
-            that declare \#(filter) annotations. Each value is either a string or an array of strings.
+            that declare \#(filter) annotations. Each value is either a string
+            or an array of strings.
           additionalProperties: true
         bypassFilters:
           type: boolean

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,10 +1,4 @@
 // Pre-load the instrumentation module; the instrumentation module must be loaded before the other imports.
-import "./instrumentation";
-import {
-   getPrometheusMetricsHandler,
-   httpMetricsMiddleware,
-} from "./instrumentation";
-
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import bodyParser from "body-parser";
 import cors from "cors";
@@ -13,6 +7,7 @@ import * as http from "http";
 import { createProxyMiddleware } from "http-proxy-middleware";
 import { AddressInfo } from "net";
 import * as path from "path";
+import { ParsedQs } from "qs";
 import { fileURLToPath } from "url";
 import { CompileController } from "./controller/compile.controller";
 import { ConnectionController } from "./controller/connection.controller";
@@ -31,6 +26,11 @@ import {
    registerHealthEndpoints,
    registerSignalHandlers,
 } from "./health";
+import "./instrumentation";
+import {
+   getPrometheusMetricsHandler,
+   httpMetricsMiddleware,
+} from "./instrumentation";
 import { logger, loggerMiddleware } from "./logger";
 
 import { ManifestController } from "./controller/manifest.controller";
@@ -592,12 +592,21 @@ app.post(
    `${API_PREFIX}/projects/:projectName/connections/:connectionName/sqlQuery`,
    async (req, res) => {
       try {
+         let options: string | ParsedQs | (string | ParsedQs)[] | undefined;
+
+         // Support both body and query parameters for options for backwards compatibility
+         // TODO: To be removed in the future
+         if (req.body?.options) {
+            options = req.body.options;
+         } else {
+            options = req.query.options;
+         }
          res.status(200).json(
             await connectionController.getConnectionQueryData(
                req.params.projectName,
                req.params.connectionName,
                req.body.sqlStatement as string,
-               req.body.options as string,
+               options as string,
             ),
          );
       } catch (error) {


### PR DESCRIPTION
 Updated server.ts to support options from both body and query parameters, improving usability while maintaining legacy support.