### PR TITLE
(WIP - Testing) Add query utility function for normalizing Express query parameters

### DIFF
--- a/packages/server/src/query_utils.ts
+++ b/packages/server/src/query_utils.ts
@@ -1,0 +1,6 @@
+/** Normalize an Express query param into a string[] or undefined. */
+export function normalizeQueryArray(value: unknown): string[] | undefined {
+   if (value === undefined || value === null) return undefined;
+   if (Array.isArray(value)) return value.map(String);
+   return [String(value)];
+}

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -36,16 +36,12 @@ import { logger, loggerMiddleware } from "./logger";
 import { ManifestController } from "./controller/manifest.controller";
 import { MaterializationController } from "./controller/materialization.controller";
 import { initializeMcpServer } from "./mcp/server";
+import { normalizeQueryArray } from "./query_utils";
 import { ManifestService } from "./service/manifest_service";
 import { MaterializationService } from "./service/materialization_service";
 import { ProjectStore } from "./service/project_store";
 
-/** Normalize an Express query param into a string[] or undefined. */
-export function normalizeQueryArray(value: unknown): string[] | undefined {
-   if (value === undefined || value === null) return undefined;
-   if (Array.isArray(value)) return value.map(String);
-   return [String(value)];
-}
+export { normalizeQueryArray };
 
 // Parse command line arguments
 function parseArgs() {

--- a/packages/server/tests/integration/mcp/mcp_resource.integration.spec.ts
+++ b/packages/server/tests/integration/mcp/mcp_resource.integration.spec.ts
@@ -77,13 +77,21 @@ describe("MCP Resource Handlers (E2E Integration)", () => {
             expect(result).toBeDefined();
             expect(result.resources).toBeDefined();
             expect(Array.isArray(result.resources)).toBe(true);
-            expect(result.resources.length).toBeGreaterThan(0);
+            if (result.resources.length === 0) {
+               throw new Error(
+                  "listResources returned no resources. For E2E, ensure packages (e.g. malloy-samples) are available under SERVER_ROOT and INITIALIZE_STORAGE has allowed them to download.",
+               );
+            }
 
             const faaPackageEntry = result.resources.find(
                (r) => r.uri === faaPackageUri,
             );
             expect(faaPackageEntry).toBeDefined();
             expect(faaPackageEntry?.name).toBe("faa");
+            // Server attaches package metadata for listed packages; assert on a known URI instead of
+            // resources[0] because MCP Resource.description is optional and ordering is not guaranteed.
+            expect(faaPackageEntry?.description).toBeDefined();
+            expect(typeof faaPackageEntry?.description).toBe("string");
 
             const firstResource = result.resources[0];
             expect(firstResource).toBeDefined();
@@ -92,8 +100,6 @@ describe("MCP Resource Handlers (E2E Integration)", () => {
             expect(firstResource.uri).toMatch(/^malloy:\/\//);
             expect(firstResource.name).toBeDefined();
             expect(typeof firstResource.name).toBe("string");
-            expect(firstResource.description).toBeDefined();
-            expect(typeof firstResource.description).toBe("string");
             if (firstResource.mimeType) {
                expect(typeof firstResource.mimeType).toBe("string");
             }
@@ -112,7 +118,11 @@ describe("MCP Resource Handlers (E2E Integration)", () => {
          expect(result).toBeDefined();
          expect(result.resources).toBeDefined();
          expect(Array.isArray(result.resources)).toBe(true);
-         expect(result.resources.length).toBeGreaterThan(0);
+         if (result.resources.length === 0) {
+            throw new Error(
+               "listResources (with extra params) returned no resources. For E2E, ensure packages (e.g. malloy-samples) are available under SERVER_ROOT and INITIALIZE_STORAGE has allowed them to download.",
+            );
+         }
       });
    });
 


### PR DESCRIPTION
Introduced a new utility function `normalizeQueryArray` in `query_utils.ts` to standardize the handling of query parameters as string arrays or undefined. Updated `server.ts` to export this function for use in other modules.