### PR TITLE
Add support for Snowflake PKCS#1 and PKCS#8 private key normalization

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
     },
     "packages/app": {
       "name": "@malloy-publisher/app",
-      "version": "0.0.192",
+      "version": "0.0.193",
       "dependencies": {
         "@malloy-publisher/sdk": "workspace:*",
         "@mui/icons-material": "^7.0.2",
@@ -79,7 +79,7 @@
     },
     "packages/sdk": {
       "name": "@malloy-publisher/sdk",
-      "version": "0.0.192",
+      "version": "0.0.193",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
@@ -90,7 +90,7 @@
       },
       "devDependencies": {
         "@malloydata/malloy-explorer": "0.0.338-dev260215172810",
-        "@malloydata/malloy-query-builder": "0.0.383",
+        "@malloydata/malloy-query-builder": "^0.0.383",
         "@openapitools/openapi-generator-cli": "^2.20.2",
         "@shikijs/langs": "^1.16.3",
         "@shikijs/themes": "^1.16.3",
@@ -132,7 +132,7 @@
     },
     "packages/server": {
       "name": "@malloy-publisher/server",
-      "version": "0.0.192",
+      "version": "0.0.193",
       "bin": {
         "malloy-publisher": "dist/server.mjs",
       },
@@ -211,7 +211,7 @@
   "overrides": {
     "@malloydata/malloy-explorer": "0.0.338-dev260215172810",
     "@malloydata/malloy-interfaces": "^0.0.383",
-    "@malloydata/malloy-query-builder": "0.0.383",
+    "@malloydata/malloy-query-builder": "^0.0.383",
     "duckdb": "1.4.4",
     "esbuild": "0.25.9",
   },

--- a/packages/server/src/service/connection_config.spec.ts
+++ b/packages/server/src/service/connection_config.spec.ts
@@ -1,5 +1,9 @@
+import { generateKeyPairSync } from "crypto";
 import { describe, expect, it } from "bun:test";
-import { assembleProjectConnections } from "./connection_config";
+import {
+   assembleProjectConnections,
+   normalizeSnowflakePrivateKey,
+} from "./connection_config";
 import { components } from "../api";
 
 type ApiConnection = components["schemas"]["Connection"];
@@ -119,5 +123,46 @@ describe("assembleProjectConnections — databricks", () => {
       expect(() => assembleProjectConnections([conn])).toThrow(
          "Databricks requires",
       );
+   });
+});
+
+describe("normalizeSnowflakePrivateKey", () => {
+   const { privateKey: pkcs8Pem } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+      publicKeyEncoding: { type: "spki", format: "pem" },
+   });
+   const { privateKey: pkcs1Pem } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: "pkcs1", format: "pem" },
+      publicKeyEncoding: { type: "pkcs1", format: "pem" },
+   });
+
+   it("passes a multi-line PKCS#8 key through and adds a trailing newline", () => {
+      const trimmed = (pkcs8Pem as string).trimEnd();
+      const result = normalizeSnowflakePrivateKey(trimmed);
+      expect(result).toContain("-----BEGIN PRIVATE KEY-----");
+      expect(result.endsWith("\n")).toBe(true);
+   });
+
+   it("converts a multi-line PKCS#1 RSA key to PKCS#8", () => {
+      const result = normalizeSnowflakePrivateKey(pkcs1Pem as string);
+      expect(result).toContain("-----BEGIN PRIVATE KEY-----");
+      expect(result).not.toContain("BEGIN RSA PRIVATE KEY");
+      expect(result.endsWith("\n")).toBe(true);
+   });
+
+   it("converts a single-line PKCS#1 RSA key to PKCS#8", () => {
+      const singleLine = (pkcs1Pem as string).replace(/\n/g, "");
+      const result = normalizeSnowflakePrivateKey(singleLine);
+      expect(result).toContain("-----BEGIN PRIVATE KEY-----");
+      expect(result).not.toContain("BEGIN RSA PRIVATE KEY");
+   });
+
+   it("reconstructs a single-line PKCS#8 key without conversion", () => {
+      const singleLine = (pkcs8Pem as string).replace(/\n/g, "");
+      const result = normalizeSnowflakePrivateKey(singleLine);
+      expect(result.startsWith("-----BEGIN PRIVATE KEY-----\n")).toBe(true);
+      expect(result.endsWith("-----END PRIVATE KEY-----\n")).toBe(true);
    });
 });

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -1,3 +1,4 @@
+import { createPrivateKey } from "crypto";
 import path from "path";
 import { components } from "../api";
 
@@ -48,6 +49,12 @@ export function normalizeSnowflakePrivateKey(privateKey: string): string {
             beginMarker: "-----BEGIN PRIVATE KEY-----",
             endMarker: "-----END PRIVATE KEY-----",
          },
+         {
+            beginRegex: /-----BEGIN\s+RSA\s+PRIVATE\s+KEY-----/i,
+            endRegex: /-----END\s+RSA\s+PRIVATE\s+KEY-----/i,
+            beginMarker: "-----BEGIN RSA PRIVATE KEY-----",
+            endMarker: "-----END RSA PRIVATE KEY-----",
+         },
       ];
 
       for (const pattern of keyPatterns) {
@@ -71,6 +78,28 @@ export function normalizeSnowflakePrivateKey(privateKey: string): string {
       }
    } else if (!privateKeyContent.endsWith("\n")) {
       privateKeyContent += "\n";
+   }
+
+   // Snowflake's Node SDK requires PKCS#8 ("BEGIN PRIVATE KEY"). Convert
+   // PKCS#1 ("BEGIN RSA PRIVATE KEY") so users can paste either format.
+   if (/-----BEGIN\s+RSA\s+PRIVATE\s+KEY-----/i.test(privateKeyContent)) {
+      try {
+         privateKeyContent = createPrivateKey({
+            key: privateKeyContent,
+            format: "pem",
+         })
+            .export({ type: "pkcs8", format: "pem" })
+            .toString();
+      } catch (err) {
+         throw new Error(
+            `Failed to convert Snowflake RSA private key (PKCS#1) to PKCS#8: ${
+               err instanceof Error ? err.message : String(err)
+            }`,
+         );
+      }
+      if (!privateKeyContent.endsWith("\n")) {
+         privateKeyContent += "\n";
+      }
    }
 
    return privateKeyContent;


### PR DESCRIPTION
- Bump versions of `@malloy-publisher/app`, `@malloy-publisher/sdk`, and `@malloy-publisher/server` to 0.0.193 in `bun.lock`.
- Introduce `normalizeSnowflakePrivateKey` function in `connection_config.ts` to handle PKCS#1 and PKCS#8 formats, ensuring compatibility with Snowflake's Node SDK.
- Add unit tests for `normalizeSnowflakePrivateKey` to validate key normalization behavior.

This update improves dependency management and enhances the handling of Snowflake private keys.