### PR TITLE
Propagate materializationStorage from project payload to internal Project metadata

### DIFF
--- a/packages/server/src/service/project.ts
+++ b/packages/server/src/service/project.ts
@@ -99,6 +99,10 @@ export class Project {
          await this.writeProjectReadme(payload.readme);
       }
 
+      if (payload.materializationStorage !== undefined) {
+         this.metadata.materializationStorage = payload.materializationStorage;
+      }
+
       // Handle connections update
       // TODO: Update project connections should have its own API endpoint
       if (payload.connections) {

--- a/packages/server/src/service/project_store.spec.ts
+++ b/packages/server/src/service/project_store.spec.ts
@@ -10,11 +10,23 @@ import { ProjectStore } from "./project_store";
 
 type MockData = Record<string, unknown>;
 
+const initializeDuckLakeCalls: Array<{
+   projectId: string;
+   config: { catalogUrl: string; dataPath: string };
+}> = [];
+
 mock.module("../storage/StorageManager", () => {
    return {
       StorageManager: class MockStorageManager {
          async initialize(_reInit?: boolean): Promise<void> {
             return;
+         }
+
+         async initializeDuckLakeForProject(
+            projectId: string,
+            config: { catalogUrl: string; dataPath: string },
+         ): Promise<void> {
+            initializeDuckLakeCalls.push({ projectId, config });
          }
 
          getRepository() {
@@ -465,6 +477,69 @@ describe("ProjectStore Service", () => {
       expect(existsSync(readmePath)).toBe(true);
       const readmeContent = readFileSync(readmePath, "utf-8");
       expect(readmeContent).toBe("Updated README content");
+   });
+
+   it("should propagate materializationStorage on addProject for new project", async () => {
+      writeFileSync(
+         path.join(serverRootPath, "publisher.config.json"),
+         JSON.stringify({ frozenConfig: false, projects: [] }),
+      );
+
+      await projectStore.finishedInitialization;
+
+      const materializationStorage = {
+         catalogUrl:
+            "postgres:host=localhost port=5432 dbname=ducklake user=u password=p",
+         dataPath: "gs://test-bucket",
+      };
+
+      initializeDuckLakeCalls.length = 0;
+      const project = await projectStore.addProject({
+         name: projectName,
+         materializationStorage,
+      });
+
+      expect(project.metadata.materializationStorage).toEqual(
+         materializationStorage,
+      );
+      expect(initializeDuckLakeCalls).toHaveLength(1);
+      expect(initializeDuckLakeCalls[0].config).toEqual(materializationStorage);
+   });
+
+   it("should propagate materializationStorage on update", async () => {
+      const projectPath = path.join(serverRootPath, projectName);
+      mkdirSync(projectPath, { recursive: true });
+      writeFileSync(
+         path.join(projectPath, "publisher.json"),
+         JSON.stringify({ name: projectName, description: "Test package" }),
+      );
+      writeFileSync(
+         path.join(serverRootPath, "publisher.config.json"),
+         JSON.stringify({
+            frozenConfig: false,
+            projects: [
+               {
+                  name: projectName,
+                  packages: [{ name: projectName, location: projectPath }],
+               },
+            ],
+         }),
+      );
+
+      await projectStore.finishedInitialization;
+      const project = await projectStore.getProject(projectName);
+
+      const materializationStorage = {
+         catalogUrl:
+            "postgres:host=localhost port=5432 dbname=ducklake user=u password=p",
+         dataPath: "gs://test-bucket",
+      };
+
+      await project.update({ name: projectName, materializationStorage });
+
+      expect(project.metadata.materializationStorage).toEqual(
+         materializationStorage,
+      );
    });
 
    it(

--- a/packages/server/src/service/project_store.ts
+++ b/packages/server/src/service/project_store.ts
@@ -808,7 +808,8 @@ export class ProjectStore {
       if (!newProject.metadata) newProject.metadata = {};
       newProject.metadata.location = absoluteProjectPath;
       if (project.materializationStorage !== undefined) {
-         newProject.metadata.materializationStorage = project.materializationStorage;
+         newProject.metadata.materializationStorage =
+            project.materializationStorage;
       }
 
       this.projects.set(projectName, newProject);

--- a/packages/server/src/service/project_store.ts
+++ b/packages/server/src/service/project_store.ts
@@ -807,6 +807,9 @@ export class ProjectStore {
 
       if (!newProject.metadata) newProject.metadata = {};
       newProject.metadata.location = absoluteProjectPath;
+      if (project.materializationStorage !== undefined) {
+         newProject.metadata.materializationStorage = project.materializationStorage;
+      }
 
       this.projects.set(projectName, newProject);
 


### PR DESCRIPTION
## Summary

The `Project` schema defines `materializationStorage` at the top level (per `api-doc.yaml` and the SDK's `Project` type), and clients send it there, but `addProjectMetadata` in `project_store.ts` only ever read it from `project.metadata.materializationStorage`. The internal `Project` class's `metadata` field - built fresh in the constructor and `reloadProjectMetadata()` - was never populated with the field from the inbound payload, so the `if (catalogUrl && dataPath)` check at `project_store.ts:358` always saw `undefined`. Net effect: `StorageManager.initializeDuckLakeForProject` was never called, and every project silently fell back to the default per-worker DuckDB manifest store instead of the configured shared DuckLake catalog.

This patch copies the field on both code paths:

- `Project.update()` for existing projects (sets `this.metadata.materializationStorage` when `payload.materializationStorage !== undefined`).
- `ProjectStore.addProject()` (new-project branch) post-`Project.create()`, mirroring the existing `metadata.location` assignment.