### PR TITLE
Share DuckLake manifest catalog per materializationStorage config

### DIFF
--- a/packages/server/src/service/project_store.spec.ts
+++ b/packages/server/src/service/project_store.spec.ts
@@ -12,6 +12,7 @@ type MockData = Record<string, unknown>;
 
 const initializeDuckLakeCalls: Array<{
    projectId: string;
+   projectName: string;
    config: { catalogUrl: string; dataPath: string };
 }> = [];
 
@@ -24,9 +25,10 @@ mock.module("../storage/StorageManager", () => {
 
          async initializeDuckLakeForProject(
             projectId: string,
+            projectName: string,
             config: { catalogUrl: string; dataPath: string },
          ): Promise<void> {
-            initializeDuckLakeCalls.push({ projectId, config });
+            initializeDuckLakeCalls.push({ projectId, projectName, config });
          }
 
          getRepository() {

--- a/packages/server/src/service/project_store.ts
+++ b/packages/server/src/service/project_store.ts
@@ -359,10 +359,14 @@ export class ProjectStore {
          materializationStorage?.catalogUrl &&
          materializationStorage?.dataPath
       ) {
-         await this.storageManager.initializeDuckLakeForProject(dbProject.id, {
-            catalogUrl: materializationStorage.catalogUrl,
-            dataPath: materializationStorage.dataPath,
-         });
+         await this.storageManager.initializeDuckLakeForProject(
+            dbProject.id,
+            dbProject.name,
+            {
+               catalogUrl: materializationStorage.catalogUrl,
+               dataPath: materializationStorage.dataPath,
+            },
+         );
       }
 
       return dbProject;

--- a/packages/server/src/storage/StorageManager.ts
+++ b/packages/server/src/storage/StorageManager.ts
@@ -1,3 +1,4 @@
+import * as crypto from "crypto";
 import { logger } from "../logger";
 import {
    DatabaseConnection,
@@ -42,6 +43,19 @@ function escapeSQL(value: string): string {
    return value.replace(/'/g, "''");
 }
 
+function configKey(c: DuckLakeManifestConfig): string {
+   return `${c.catalogUrl}|${c.dataPath}`;
+}
+
+function catalogNameForConfig(c: DuckLakeManifestConfig): string {
+   const hash = crypto
+      .createHash("sha256")
+      .update(configKey(c))
+      .digest("hex")
+      .slice(0, 8);
+   return `manifest_lake_${hash}`;
+}
+
 /**
  * Manages the storage backend (DuckDB, Postgres, etc.) and per-project
  * manifest stores. Projects without `materializationStorage` config use
@@ -57,8 +71,12 @@ export class StorageManager {
    /** Per-project DuckLake manifest stores, keyed by projectId. */
    private projectManifestStores = new Map<string, ManifestStore>();
 
-   /** Tracks which catalogs have been attached to avoid duplicate ATTACHes. */
-   private attachedCatalogs = new Set<string>();
+   /**
+    * Tracks attached DuckLake catalogs as `configKey -> catalogName`. Each
+    * unique materializationStorage config gets its own ATTACHment under a
+    * deterministic catalog name, so multiple configs can coexist on one worker.
+    */
+   private attachedCatalogs = new Map<string, string>();
 
    private config: StorageConfig;
 
@@ -105,32 +123,44 @@ export class StorageManager {
 
    /**
     * Lazily initializes a DuckLake manifest store for a project.
-    * The DuckLake catalog is attached to the shared DuckDB connection
-    * and persists for the lifetime of the process.
+    *
+    * One shared catalog per materializationStorage config: every project
+    * pointing at the same (catalogUrl, dataPath) shares one `build_manifests`
+    * table inside it, partitioned by `project_id` (set to the project's name
+    * so it's stable across worker replicas — required for cross-pod manifest
+    * visibility in orchestrated mode). Different configs (e.g. different
+    * orgs) attach as separate catalogs under distinct deterministic aliases.
     */
    async initializeDuckLakeForProject(
       projectId: string,
+      projectName: string,
       config: DuckLakeManifestConfig,
    ): Promise<void> {
       if (!this.duckDbConnection) {
          throw new Error("Storage not initialized. Call initialize() first.");
       }
 
-      const catalogName = `manifest_lake_${projectId.replace(/[^a-zA-Z0-9_]/g, "_")}`;
-
-      if (!this.attachedCatalogs.has(catalogName)) {
+      const key = configKey(config);
+      let catalogName = this.attachedCatalogs.get(key);
+      if (!catalogName) {
+         // Catalog name derived from the config so multiple configs can coexist as
+         // separate ATTACHments without colliding on the name.
+         catalogName = catalogNameForConfig(config);
          await this.attachDuckLakeCatalog(config, catalogName);
+         this.attachedCatalogs.set(key, catalogName);
       }
 
       const store = new DuckLakeManifestStore(
          this.duckDbConnection,
          catalogName,
+         projectName,
       );
       await store.bootstrapSchema();
 
       this.projectManifestStores.set(projectId, store);
       logger.info("DuckLake manifest store initialized for project", {
          projectId,
+         projectName,
          catalogName,
       });
    }
@@ -155,7 +185,14 @@ export class StorageManager {
          config.dataPath.startsWith("s3://");
 
       let attachCmd = `ATTACH 'ducklake:${escapedCatalogUrl}' AS ${catalogName}`;
-      const attachOpts: string[] = [`DATA_PATH '${escapedDataPath}'`];
+      const attachOpts: string[] = [
+         `DATA_PATH '${escapedDataPath}'`,
+         // The manifest table is small relational metadata (one row per build).
+         // Set a high inlining limit so writes always land transactionally in
+         // the postgres catalog rather than as parquet files in object storage,
+         // sidestepping object-storage auth issues entirely for this path.
+         "DATA_INLINING_ROW_LIMIT 100000",
+      ];
       if (isCloudStorage) {
          attachOpts.push("OVERRIDE_DATA_PATH true");
       }
@@ -163,8 +200,6 @@ export class StorageManager {
 
       logger.info(`Attaching DuckLake manifest catalog: ${attachCmd}`);
       await connection.run(attachCmd);
-
-      this.attachedCatalogs.add(catalogName);
    }
 
    getRepository(): ResourceRepository {

--- a/packages/server/src/storage/ducklake/DuckLakeManifestStore.ts
+++ b/packages/server/src/storage/ducklake/DuckLakeManifestStore.ts
@@ -31,23 +31,32 @@ import { DuckDBConnection } from "../duckdb/DuckDBConnection";
  */
 export class DuckLakeManifestStore implements ManifestStore {
    private readonly table: string;
+   private readonly projectName: string;
 
    constructor(
       private db: DuckDBConnection,
       catalogName: string,
+      projectName: string,
    ) {
       this.table = `${catalogName}.build_manifests`;
+      this.projectName = projectName;
    }
 
    /**
     * Idempotently creates the `build_manifests` table and indices in the
     * DuckLake catalog. Safe to call from every worker on startup.
+    *
+    * Note: this table uses `project_name` for the partition column, unlike
+    * the local DuckDB `build_manifests` table (in `storage/duckdb/schema.ts`)
+    * which uses `project_id` and FK-references `projects.id`. The two stores
+    * partition by different identifiers — local random id vs cross-pod-stable
+    * project name — so they intentionally diverge here.
     */
    async bootstrapSchema(): Promise<void> {
       await this.db.run(`
          CREATE TABLE IF NOT EXISTS ${this.table} (
             id VARCHAR,
-            project_id VARCHAR NOT NULL,
+            project_name VARCHAR NOT NULL,
             package_name VARCHAR NOT NULL,
             build_id VARCHAR NOT NULL,
             table_name VARCHAR NOT NULL,
@@ -61,12 +70,12 @@ export class DuckLakeManifestStore implements ManifestStore {
    }
 
    async getManifest(
-      projectId: string,
+      _projectId: string,
       packageName: string,
    ): Promise<BuildManifest> {
       const rows = await this.db.all<Record<string, unknown>>(
-         `SELECT * FROM ${this.table} WHERE project_id = ? AND package_name = ? ORDER BY created_at DESC`,
-         [projectId, packageName],
+         `SELECT * FROM ${this.table} WHERE project_name = ? AND package_name = ? ORDER BY created_at DESC`,
+         [this.projectName, packageName],
       );
       const manifest: BuildManifest = { entries: {}, strict: false };
       for (const row of rows) {
@@ -88,7 +97,7 @@ export class DuckLakeManifestStore implements ManifestStore {
     * {@link getManifest} deduplicates by build_id keeping the newest row.
     */
    async writeEntry(
-      projectId: string,
+      _projectId: string,
       packageName: string,
       buildId: string,
       tableName: string,
@@ -99,11 +108,11 @@ export class DuckLakeManifestStore implements ManifestStore {
       const id = `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
 
       await this.db.run(
-         `INSERT INTO ${this.table} (id, project_id, package_name, build_id, table_name, source_name, connection_name, created_at, updated_at)
+         `INSERT INTO ${this.table} (id, project_name, package_name, build_id, table_name, source_name, connection_name, created_at, updated_at)
           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
          [
             id,
-            projectId,
+            this.projectName,
             packageName,
             buildId,
             tableName,
@@ -120,12 +129,12 @@ export class DuckLakeManifestStore implements ManifestStore {
    }
 
    async listEntries(
-      projectId: string,
+      _projectId: string,
       packageName: string,
    ): Promise<ManifestEntry[]> {
       const rows = await this.db.all<Record<string, unknown>>(
-         `SELECT * FROM ${this.table} WHERE project_id = ? AND package_name = ? ORDER BY created_at DESC`,
-         [projectId, packageName],
+         `SELECT * FROM ${this.table} WHERE project_name = ? AND package_name = ? ORDER BY created_at DESC`,
+         [this.projectName, packageName],
       );
       return rows.map(this.mapToEntry);
    }
@@ -133,7 +142,7 @@ export class DuckLakeManifestStore implements ManifestStore {
    private mapToEntry(row: Record<string, unknown>): ManifestEntry {
       return {
          id: row.id as string,
-         projectId: row.project_id as string,
+         projectId: row.project_name as string,
          packageName: row.package_name as string,
          buildId: row.build_id as string,
          tableName: row.table_name as string,


### PR DESCRIPTION
## Summary
- Use a single shared `manifest_lake_<config-hash>` catalog per unique `(catalogUrl, dataPath)` so all worker replicas pointing at the same materializationStorage attach the same DuckLake catalog.
- Manifest writes inline into the postgres catalog via `DATA_INLINING_ROW_LIMIT 100000` — sidesteps object-storage auth entirely for this path; manifests are small relational metadata, no need for parquet on GCS/S3.
- Rename the DuckLake-side `project_id` column to `project_name` and partition by it, so the partition key is stable across replicas. Required for cross-pod manifest visibility in orchestrated mode.
- The local DuckDB `build_manifests` table (`storage/duckdb/schema.ts`) keeps `project_id` and its FK to `projects.id` — different store, different identifier; the two intentionally diverge.

## Why
Before this PR, each worker generated a per-process random `projectId`, used it for both the catalog alias and the `project_id` column, so different workers serving the same logical project read/wrote different physical manifest tables. Cross-pod manifest sync silently no-op'd: the writer pod saw its own writes, every other pod saw zero, and the materialization safety guard tripped on retries because the BQ table existed but the manifest looked empty.

This change makes the catalog identity the materializationStorage config itself, and the partition key the project's name (which is already org-scoped via the `<org>___<project>` convention) — so every replica converges on the same shared manifest.