### PR TITLE
Refactor import handling in model.ts to improve URL base path management

### DIFF
--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -22,10 +22,10 @@ import {
    MalloySQLParser,
    MalloySQLStatementType,
 } from "@malloydata/malloy-sql";
-import { createRequire } from "module";
 import { DataStyles } from "@malloydata/render";
 import { metrics } from "@opentelemetry/api";
 import * as fs from "fs/promises";
+import { createRequire } from "module";
 import * as path from "path";
 import { components } from "../api";
 import {
@@ -703,7 +703,7 @@ export class Model {
 
       const modelURL = new URL(`file://${fullModelPath}`);
       const baseUrl = new URL(".", modelURL);
-      const importBaseURL = new URL(baseUrl.pathname + "/", "file:");
+      const importBaseURL = baseUrl;
       const urlReader = new HackyDataStylesAccumulator(URL_READER);
 
       // Request runtimes borrow the cached package MalloyConfig. The package


### PR DESCRIPTION
- Simplified the calculation of `importBaseURL` to directly use `baseUrl`, enhancing clarity and maintainability.

baseUrl.pathname already was ending with "/". The previous code was appending another "/" and produced ".../models//", which broke "../" imports (and as a fallback DuckDB behavior, they got resolved to models/data/... instead of package data/).