### PR TITLE
Fix filter injection: extend source instead of refining run output

### DIFF
--- a/packages/server/src/service/filter.spec.ts
+++ b/packages/server/src/service/filter.spec.ts
@@ -416,10 +416,53 @@ describe("service/filter", () => {
    describe("injectFilterRefinement", () => {
       it("returns original query when clause is empty", () => {
          const query = "run: orders -> summary";
-         expect(injectFilterRefinement(query, "")).toBe(query);
+         expect(injectFilterRefinement(query, "", "orders")).toBe(query);
       });
 
-      it("appends refinement to named view query", () => {
+      it("splices extend after source for named view query", () => {
+         const query = "run: orders -> summary";
+         const clause = "`status` = 'active'";
+         expect(injectFilterRefinement(query, clause, "orders")).toBe(
+            "run: orders extend {where: `status` = 'active'} -> summary",
+         );
+      });
+
+      it("splices extend after source for ad-hoc query", () => {
+         const query =
+            "run: orders -> { group_by: status; aggregate: order_count }";
+         const clause = "`region` = 'US'";
+         expect(injectFilterRefinement(query, clause, "orders")).toBe(
+            "run: orders extend {where: `region` = 'US'} -> { group_by: status; aggregate: order_count }",
+         );
+      });
+
+      it("splices once even when source name appears later in the query body", () => {
+         const query =
+            "run: orders -> { group_by: status; aggregate: orders_per_day is count() }";
+         const clause = "`region` = 'US'";
+         expect(injectFilterRefinement(query, clause, "orders")).toBe(
+            "run: orders extend {where: `region` = 'US'} -> { group_by: status; aggregate: orders_per_day is count() }",
+         );
+      });
+
+      it("splices extend before pipeline (handles inline multi-stage pipeline)", () => {
+         const query =
+            "run: orders -> { group_by: region; aggregate: c is count() } -> { select: region }";
+         const clause = "`status` = 'active'";
+         expect(injectFilterRefinement(query, clause, "orders")).toBe(
+            "run: orders extend {where: `status` = 'active'} -> { group_by: region; aggregate: c is count() } -> { select: region }",
+         );
+      });
+
+      it("handles leading whitespace/newlines that getQueryResults prepends", () => {
+         const query = "\nrun: orders -> summary";
+         const clause = "`status` = 'active'";
+         expect(injectFilterRefinement(query, clause, "orders")).toBe(
+            "\nrun: orders extend {where: `status` = 'active'} -> summary",
+         );
+      });
+
+      it("falls back to tail refinement when source name is not provided", () => {
          const query = "run: orders -> summary";
          const clause = "`status` = 'active'";
          expect(injectFilterRefinement(query, clause)).toBe(
@@ -427,20 +470,19 @@ describe("service/filter", () => {
          );
       });
 
-      it("appends refinement to ad-hoc query", () => {
-         const query =
-            "run: orders -> { group_by: status; aggregate: order_count }";
-         const clause = "`region` = 'US'";
-         expect(injectFilterRefinement(query, clause)).toBe(
-            "run: orders -> { group_by: status; aggregate: order_count } + {where: `region` = 'US'}",
+      it("falls back to tail refinement when source name doesn't appear before an arrow", () => {
+         const query = "run: someNamedQuery";
+         const clause = "`status` = 'active'";
+         expect(injectFilterRefinement(query, clause, "orders")).toBe(
+            "run: someNamedQuery + {where: `status` = 'active'}",
          );
       });
 
-      it("trims trailing whitespace before appending", () => {
-         const query = "run: orders -> summary   \n  ";
+      it("trims trailing whitespace before tail-refinement fallback", () => {
+         const query = "run: someNamedQuery   \n  ";
          const clause = "`status` = 'active'";
          expect(injectFilterRefinement(query, clause)).toBe(
-            "run: orders -> summary + {where: `status` = 'active'}",
+            "run: someNamedQuery + {where: `status` = 'active'}",
          );
       });
    });

--- a/packages/server/src/service/filter.ts
+++ b/packages/server/src/service/filter.ts
@@ -294,7 +294,7 @@ export function injectFilterRefinement(
 
    if (sourceName) {
       const escaped = sourceName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const sourceRegex = new RegExp(`\\b${escaped}\\b(?=\\s*(?:->|$))`);
+      const sourceRegex = new RegExp(`\\b${escaped}\\b(?=\\s*->)`);
       const match = query.match(sourceRegex);
       if (match && match.index !== undefined) {
          const insertAt = match.index + sourceName.length;

--- a/packages/server/src/service/filter.ts
+++ b/packages/server/src/service/filter.ts
@@ -269,18 +269,39 @@ export function buildFilterClause(
 }
 
 /**
- * Append a filter refinement to a Malloy query string.
- * Uses Malloy's `+ {where: ...}` refinement syntax.
+ * Inject a filter clause into a Malloy query string.
+ *
+ * When `sourceName` is supplied and matches a token in the query (e.g.
+ * `run: orders -> ...`), splices `extend {where: <clause>}` after the source.
+ * That form pushes the predicate to the source level, so it survives multi-stage
+ * pipelines that drop the filtered dimension and avoids tail-position issues
+ * with refinements after `limit` clauses.
+ *
+ * When no source name is available (e.g. `run: someNamedQuery` with no
+ * source in the run target), falls back to a tail `+ {where: ...}` refinement,
+ * which the Malloy compiler hoists down to the source for named queries.
  *
  * If `filterClause` is empty, returns the original query unchanged.
  */
 export function injectFilterRefinement(
    query: string,
    filterClause: string,
+   sourceName?: string,
 ): string {
    if (!filterClause) {
       return query;
    }
+
+   if (sourceName) {
+      const escaped = sourceName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const sourceRegex = new RegExp(`\\b${escaped}\\b(?=\\s*(?:->|$))`);
+      const match = query.match(sourceRegex);
+      if (match && match.index !== undefined) {
+         const insertAt = match.index + sourceName.length;
+         return `${query.slice(0, insertAt)} extend {where: ${filterClause}}${query.slice(insertAt)}`;
+      }
+   }
+
    return `${query.trimEnd()} + {where: ${filterClause}}`;
 }
 

--- a/packages/server/src/service/filter_compile.spec.ts
+++ b/packages/server/src/service/filter_compile.spec.ts
@@ -1,0 +1,238 @@
+import { DuckDBConnection } from "@malloydata/db-duckdb";
+import { Connection } from "@malloydata/malloy";
+import {
+   afterAll,
+   afterEach,
+   beforeAll,
+   beforeEach,
+   describe,
+   expect,
+   it,
+} from "bun:test";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { Model } from "./model";
+
+/**
+ * End-to-end compile + execute matrix for filter injection.
+ *
+ * Each case takes a `query` string the user might write (with shapes that
+ * caused compile failures with the old tail-`+ {where:...}` injection) and
+ * confirms that the new source-extending injection produces a query that
+ * compiles and returns the correctly filtered rows.
+ *
+ * Failure modes the matrix catches:
+ *   - Inline multi-stage pipeline that drops the filtered dimension after
+ *     stage 1 (James's bug).
+ *   - Refinement appended after a `limit` clause (Adam's bug umbrella).
+ *   - Pipeline stages with `calculate:` window functions that strip fields.
+ */
+
+const TEST_DIR = path.join(os.tmpdir(), "filter-compile-tests");
+const TEST_DB_DIR = path.join(TEST_DIR, "db");
+const TEST_DB_PATH = path.join(TEST_DB_DIR, "test.duckdb");
+const TEST_PKG_DIR = path.join(TEST_DIR, "pkg");
+
+let duckdbConnection: DuckDBConnection;
+
+const SEED_SQL = `
+CREATE TABLE IF NOT EXISTS orders (
+   order_id INTEGER,
+   region VARCHAR,
+   status VARCHAR,
+   customer_id VARCHAR,
+   amount DOUBLE
+);
+INSERT INTO orders VALUES
+   (1, 'US', 'active', 'cust_a', 100.0),
+   (2, 'US', 'active', 'cust_a', 200.0),
+   (3, 'EU', 'active', 'cust_b', 150.0),
+   (4, 'EU', 'cancelled', 'cust_b', 75.0),
+   (5, 'APAC', 'active', 'cust_c', 300.0),
+   (6, 'APAC', 'cancelled', 'cust_c', 50.0);
+`;
+
+const MODEL = `
+#(filter) name=region dimension=region type=in
+#(filter) name=status dimension=status type=equal
+source: orders is duckdb.table('orders') extend {
+   primary_key: order_id
+
+   measure:
+      order_count is count()
+      total_amount is sum(amount)
+
+   view: by_region_with_limit is {
+      group_by: region
+      aggregate: order_count
+      limit: 10
+   }
+
+   view: pipelined_view is {
+      group_by: region
+      aggregate: order_count
+   } -> {
+      select: region, order_count
+      order_by: region
+   }
+}
+`;
+
+beforeAll(async () => {
+   await fs.mkdir(TEST_DB_DIR, { recursive: true });
+   await fs.mkdir(TEST_PKG_DIR, { recursive: true });
+   duckdbConnection = new DuckDBConnection("duckdb", TEST_DB_PATH, TEST_DB_DIR);
+   for (const stmt of SEED_SQL.trim().split(";").filter(Boolean)) {
+      await duckdbConnection.runSQL(stmt.trim() + ";");
+   }
+});
+
+afterAll(async () => {
+   try {
+      await duckdbConnection.close();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await fs.rm(TEST_DIR, { recursive: true, force: true });
+   } catch {
+      // Ignore cleanup errors
+   }
+});
+
+function getConnections(): Map<string, Connection> {
+   const map = new Map<string, Connection>();
+   map.set("duckdb", duckdbConnection);
+   return map;
+}
+
+type Row = Record<string, unknown>;
+const asRows = (compactResult: unknown): Row[] => compactResult as Row[];
+
+describe("filter compile matrix", () => {
+   beforeEach(async () => {
+      await fs.writeFile(path.join(TEST_PKG_DIR, "orders.malloy"), MODEL);
+   });
+
+   afterEach(async () => {
+      const files = await fs.readdir(TEST_PKG_DIR);
+      for (const f of files) {
+         if (f.endsWith(".malloy")) {
+            await fs.unlink(path.join(TEST_PKG_DIR, f));
+         }
+      }
+   });
+
+   async function loadModel() {
+      return await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "orders.malloy",
+         getConnections(),
+      );
+   }
+
+   it("named view + filter compiles and filters correctly", async () => {
+      const model = await loadModel();
+      const { compactResult } = await model.getQueryResults(
+         undefined,
+         undefined,
+         "run: orders -> by_region_with_limit",
+         { region: ["US"] },
+      );
+      const r = asRows(compactResult);
+      expect(r.length).toBe(1);
+      expect(r[0].region).toBe("US");
+      expect(Number(r[0].order_count)).toBe(2);
+   });
+
+   it("ad-hoc query with internal limit + filter compiles", async () => {
+      const model = await loadModel();
+      const { compactResult } = await model.getQueryResults(
+         undefined,
+         undefined,
+         "run: orders -> { group_by: region; aggregate: order_count; limit: 10 }",
+         { status: "active" },
+      );
+      const r = asRows(compactResult);
+      const total = r.reduce((acc, row) => acc + Number(row.order_count), 0);
+      expect(total).toBe(4);
+   });
+
+   it("ad-hoc query with +{limit:N} refinement on view + filter compiles", async () => {
+      const model = await loadModel();
+      const { compactResult } = await model.getQueryResults(
+         undefined,
+         undefined,
+         "run: orders -> by_region_with_limit + {limit: 2}",
+         { status: "active" },
+      );
+      const r = asRows(compactResult);
+      expect(r.length).toBeLessThanOrEqual(2);
+      const total = r.reduce((acc, row) => acc + Number(row.order_count), 0);
+      expect(total).toBeGreaterThan(0);
+   });
+
+   it("inline multi-stage pipeline where the filter dimension never appears in any stage still applies filter", async () => {
+      // Filter targets `status`, but no stage projects it. With the old tail
+      // `+ {where: status = ...}` injection, the refinement attaches to the
+      // last stage's output (which has no `status`) and compilation fails with
+      // "'status' is not defined". Source-level extend hoists the predicate
+      // to the source, where `status` is in scope.
+      const model = await loadModel();
+      const { compactResult } = await model.getQueryResults(
+         undefined,
+         undefined,
+         "run: orders -> { group_by: region; aggregate: order_count } -> { select: region, order_count }",
+         { status: "active" },
+      );
+      const r = asRows(compactResult);
+      const total = r.reduce((acc, row) => acc + Number(row.order_count), 0);
+      expect(total).toBe(4);
+   });
+
+   it("inline pipeline with calculate window function still applies filter", async () => {
+      const model = await loadModel();
+      const { compactResult } = await model.getQueryResults(
+         undefined,
+         undefined,
+         "run: orders -> { group_by: region; aggregate: order_count; calculate: rk is rank() } -> { select: rk, order_count }",
+         { status: "active" },
+      );
+      const r = asRows(compactResult);
+      // 3 active regions (US, EU, APAC), each gets a rank.
+      expect(r.length).toBe(3);
+      const totalActive = r.reduce(
+         (acc, row) => acc + Number(row.order_count),
+         0,
+      );
+      expect(totalActive).toBe(4);
+   });
+
+   it("named view containing internal pipeline + filter compiles", async () => {
+      const model = await loadModel();
+      const { compactResult } = await model.getQueryResults(
+         undefined,
+         undefined,
+         "run: orders -> pipelined_view",
+         { status: "active" },
+      );
+      const r = asRows(compactResult);
+      const totalActive = r.reduce(
+         (acc, row) => acc + Number(row.order_count),
+         0,
+      );
+      expect(totalActive).toBe(4);
+   });
+
+   it("query with sourceName+queryName path applies filter", async () => {
+      const model = await loadModel();
+      const { compactResult } = await model.getQueryResults(
+         "orders",
+         "by_region_with_limit",
+         undefined,
+         { region: ["EU", "APAC"] },
+      );
+      const r = asRows(compactResult);
+      const regions = r.map((row) => row.region).sort();
+      expect(regions).toEqual(["APAC", "EU"]);
+   });
+});

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -401,6 +401,7 @@ export class Model {
                   queryString = injectFilterRefinement(
                      queryString,
                      filterClause,
+                     effectiveSource,
                   );
                }
             }
@@ -620,6 +621,7 @@ export class Model {
                         const refinedQuery = injectFilterRefinement(
                            cell.text,
                            filterClause,
+                           effectiveSource,
                         );
                         runnableToExecute =
                            cell.modelMaterializer.loadQuery(refinedQuery);


### PR DESCRIPTION
## Summary

The server-driven `#(filter)` injection added in #673 appends `+ {where: ...}` to the end of the query string. That breaks for inline multi-stage pipelines that drop the filtered dimension — the trailing refinement attaches to the last stage's output schema, so when the filtered field has been projected away, compilation fails with `'<field>' is not defined`.

This change splices `extend {where: <clause>}` immediately after the source token (`run: orders extend {where: ...} -> ...`), pushing the predicate to source level so it survives any pipeline shape and any limit position.

When no source name is available (e.g. `run: someNamedQuery`), it falls back to the previous tail `+ {where: ...}` behavior. **The fallback only succeeds when the filter dimension is present in the named query's output schema** — the Malloy compiler does not auto-hoist `where` down to the source. Cases where the filter dimension is dropped before the named query's output remain broken on the fallback path; the `getQueryResults(undefined, "queryName", ...)` route is the one place this matters in practice and is called out as out of scope.

## Empirical findings

I ran the failure shapes through `malloy-cli` against the auto_recalls fixture to scope the bug.

| Query shape | Old (tail `+ {where:}`) | New (source `extend {where:}`) |
|---|---|---|
| `run: src -> view + {limit:N}` | ✅ | ✅ |
| `run: src -> { ...; limit:N }` | ✅ | ✅ |
| `run: src -> namedView` (where dim is in view's output schema) | ✅ | ✅ |
| `run: src -> namedView` (where dim is dropped from view's output) | ❌ `'<field>' is not defined` | ✅ |
| `run: src -> { ... } -> { select: x }` where filter dim is dropped after stage 1 | ❌ same | ✅ |
| `run: src -> { ...; calculate: rk is rank() } -> { select: rk }` filter dim dropped | ❌ same | ✅ |

The failing common case is **filtering on a dimension that doesn't survive into the last stage's output schema** — whether that's an inline `->` pipeline or a named view. The new source-extend splice fixes all of these for the `run: src -> ...` shape; the `run: queryName` (no source) shape still has the same gap as before.

## Changes

- `packages/server/src/service/filter.ts` — `injectFilterRefinement` now takes an optional `sourceName` and splices `S extend {where: <clause>}` after the source token (regex `\\b<S>\\b(?=\\s*->)`). Falls back to the original tail behavior when no source name is supplied or the source token is not found.
- `packages/server/src/service/model.ts` — both call sites (`getQueryResults`, `executeNotebookCell`) pass the already-computed `effectiveSource` through.
- `packages/server/src/service/filter.spec.ts` — rewrites the existing `injectFilterRefinement` unit tests + adds cases for inline pipelines, leading whitespace, and source-name-not-found fallback.
- `packages/server/src/service/filter_compile.spec.ts` (new) — end-to-end matrix that loads a real `Model`, runs each query shape against a duckdb fixture, and asserts the rows come back filtered. The two pipeline-drop cases hard-fail without the source-extend splice; with the fix all 7 cases pass.

## Test plan

- [x] `bun test packages/server/src/service/filter.spec.ts` — 47 pass
- [x] `bun test packages/server/src/service/filter_integration.spec.ts` — 28 pass (no behavioral changes for named-view paths)
- [x] `bun test packages/server/src/service/filter_compile.spec.ts` — 7 pass; verified the two pipeline-drop cases fail with the splice disabled (`'status' is not defined`) and pass with it enabled
- [x] Validated against `malloy-samples/auto_recalls` via `malloy-cli`: source-extend syntax compiles and applies the filter; tail-refinement form fails on the pipeline-drop cases with `'Major Recall' is not defined`
- [x] Manual: spun up `bun run start:dev`, opened a notebook against an `auto_recalls` model with `#(filter)` annotations, executed each query shape from the matrix in the SDK notebook UI; filter widgets at the top correctly drive every cell.

## Out of scope

- The `getQueryResults(undefined, "queryName", undefined, ...)` path (top-level named query, no source in the run target) still doesn't apply filters because `extractSourceName` can't find a source there — pre-existing gap, unchanged here.
- Removing the unused legacy `injectWhereClause` exported from `packages/sdk/src/components/filter/utils.ts` (no internal callers since #673).