### PR TITLE
[725] Bun setup fixes

### DIFF
--- a/.github/workflows/app-playwright.yml
+++ b/.github/workflows/app-playwright.yml
@@ -57,6 +57,19 @@ jobs:
         working-directory: packages/app
         run: bunx playwright install --with-deps chromium
 
+      # Tests in packages/app/tests/playwright/package-databases.spec.ts assume
+      # the malloy-samples environment exposes a top-level `bigquery`
+      # connection (rows for list/edit/delete affordances). The committed
+      # default config ships only DuckDB sandboxes for first-run UX, so swap
+      # in the BigQuery example fixture before the suite runs. No
+      # GOOGLE_APPLICATION_CREDENTIALS is set here — the connection-row tests
+      # only check that the row renders from config; they don't query
+      # BigQuery. Once the BigQuery service-account secret lands, add
+      # `GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.BIGQUERY_TEST_SA }}` to
+      # the env block on the next step to enable bigquery-hackernews queries.
+      - name: Use BigQuery example config (CI fixture)
+        run: cp packages/server/publisher.config.example.bigquery.json packages/server/publisher.config.json
+
       # playwright.config.ts spawns `npm run start:init` from the repo root as
       # its webServer, polls /api/v0/status in global-setup until the publisher
       # reaches operationalState=serving, then runs the suite.

--- a/.github/workflows/app-playwright.yml
+++ b/.github/workflows/app-playwright.yml
@@ -60,17 +60,24 @@ jobs:
       # Tests in packages/app/tests/playwright/package-databases.spec.ts assume
       # the malloy-samples environment exposes a top-level `bigquery`
       # connection (rows for list/edit/delete affordances). The committed
-      # default config ships only DuckDB sandboxes for first-run UX, so swap
-      # in the BigQuery example fixture before the suite runs. The
-      # connection-row tests only check that the row renders from config;
-      # they don't query BigQuery, so no service-account credentials are
-      # needed at this stage. To enable real bigquery-hackernews query
-      # tests later, follow the decode-and-expose pattern already used in
+      # default config ships only DuckDB sandboxes for first-run UX, so
+      # inject a stub BigQuery connection into the existing default before
+      # the suite runs. We deliberately don't swap in the full
+      # publisher.config.example.bigquery.json fixture — that adds a fourth
+      # sample package (bigquery-hackernews) whose extra clone + failed
+      # compile (no GCP credentials) pushes cold-init past the 5-min
+      # global-setup timeout in CI. The connection-row tests only need the
+      # connection metadata to be present; they don't query BigQuery. To
+      # enable real bigquery-hackernews query tests later, follow the
+      # decode-and-expose pattern already used in
       # `connection-integration-tests.yml` and `k6-tests.yml` (decode the
       # BQ secret to `/tmp/bq-credentials.json`, then export
       # `GOOGLE_APPLICATION_CREDENTIALS`).
-      - name: Use BigQuery example config (CI fixture)
-        run: cp packages/server/publisher.config.example.bigquery.json packages/server/publisher.config.json
+      - name: Inject BigQuery connection (CI fixture for connection-row tests)
+        run: |
+          jq '.environments[0].connections = [{"name":"bigquery","type":"bigquery","bigqueryConnection":{}}]' \
+            packages/server/publisher.config.json > /tmp/publisher.config.json
+          mv /tmp/publisher.config.json packages/server/publisher.config.json
 
       # playwright.config.ts spawns `npm run start:init` from the repo root as
       # its webServer, polls /api/v0/status in global-setup until the publisher

--- a/.github/workflows/app-playwright.yml
+++ b/.github/workflows/app-playwright.yml
@@ -2,7 +2,7 @@ name: App Playwright E2E
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
   BUN_VERSION: 1.3.13
@@ -61,12 +61,14 @@ jobs:
       # the malloy-samples environment exposes a top-level `bigquery`
       # connection (rows for list/edit/delete affordances). The committed
       # default config ships only DuckDB sandboxes for first-run UX, so swap
-      # in the BigQuery example fixture before the suite runs. No
-      # GOOGLE_APPLICATION_CREDENTIALS is set here — the connection-row tests
-      # only check that the row renders from config; they don't query
-      # BigQuery. Once the BigQuery service-account secret lands, add
-      # `GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.BIGQUERY_TEST_SA }}` to
-      # the env block on the next step to enable bigquery-hackernews queries.
+      # in the BigQuery example fixture before the suite runs. The
+      # connection-row tests only check that the row renders from config;
+      # they don't query BigQuery, so no service-account credentials are
+      # needed at this stage. To enable real bigquery-hackernews query
+      # tests later, follow the decode-and-expose pattern already used in
+      # `connection-integration-tests.yml` and `k6-tests.yml` (decode the
+      # BQ secret to `/tmp/bq-credentials.json`, then export
+      # `GOOGLE_APPLICATION_CREDENTIALS`).
       - name: Use BigQuery example config (CI fixture)
         run: cp packages/server/publisher.config.example.bigquery.json packages/server/publisher.config.json
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,4 +12,4 @@ repos:
         entry: bash -c 'packages/python-client/scripts/build-python-sdk.sh && git diff --exit-code'
         language: system
         pass_filenames: false
-        always_run: true 
+        files: ^api-doc\.yaml$

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,4 @@
+bun 1.3.13
+node 24
+python 3.12
+java corretto-21

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 # Run `make` or `make help` for the target list.
 
 URL := http://localhost:4000
-MCP_URL := http://localhost:4040
 
 .DEFAULT_GOAL := help
 .PHONY: help doctor \
@@ -16,7 +15,7 @@ MCP_URL := http://localhost:4040
         lint format prettier-check typecheck \
         regen-api
 
-# ── workspace ─────────────────────────────────────────────────────────
+# ── general ───────────────────────────────────────────────────────────
 help: ## Show this help
 	@grep -E '^[a-zA-Z][a-zA-Z0-9_-]*:.*?## ' $(MAKEFILE_LIST) \
 		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'
@@ -83,8 +82,8 @@ status: ## GET /api/v0/status
 environments: ## List environments
 	@curl -sf $(URL)/api/v0/environments | python3 -m json.tool
 
-packages: ## List packages in malloy-samples
-	@curl -sf $(URL)/api/v0/environments/malloy-samples/packages | python3 -m json.tool
+packages: ## List packages in the default `malloy-samples` env (override: ENV=foo make packages)
+	@curl -sf $(URL)/api/v0/environments/$(or $(ENV),malloy-samples)/packages | python3 -m json.tool
 
 open: ## Open the Publisher UI in the default browser (macOS)
 	@open $(URL)

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ MCP_URL := http://localhost:4040
 .DEFAULT_GOAL := help
 .PHONY: help doctor \
         install reinstall clean \
-        build start stop \
-        dev dev-server dev-react \
+        build start start-init stop \
+        dev dev-init dev-server dev-react \
         status environments packages \
         open \
         test test-unit test-integration \
@@ -42,6 +42,9 @@ build: ## Production build: SDK → app → server bundle
 start: ## Run the built server (production, foreground; Ctrl+C to stop)
 	bun run start
 
+start-init: ## Run the built server with INITIALIZE_STORAGE=true (clears persisted state)
+	bun run start:init
+
 stop: ## Kill any process listening on port 4000 or 4040
 	@kill $$(lsof -ti:4000) 2>/dev/null || true
 	@kill $$(lsof -ti:4040) 2>/dev/null || true
@@ -57,6 +60,14 @@ dev: ## Run Express (:4000) + Vite (:5173) together, combined logs
 		--prefix-colors "cyan,magenta" \
 		--kill-others-on-fail \
 		"bun run start:dev" \
+		"bun run start:dev:react"
+
+dev-init: ## Same as `dev` but with INITIALIZE_STORAGE=true on the server
+	bunx concurrently \
+		--names "server,react" \
+		--prefix-colors "cyan,magenta" \
+		--kill-others-on-fail \
+		"bun run start:dev:init" \
 		"bun run start:dev:react"
 
 dev-server: ## Express server alone (NODE_ENV=development, watch mode)

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ format: ## prettier --write across sdk/app/server
 prettier-check: ## CI's exact prettier check (fails on unformatted files)
 	bun run prettier:check
 
-typecheck: ## tsc --noEmit across sdk/app/server (chains codegen + SDK build)
+typecheck: ## tsc --noEmit across sdk/app/server (run `make build` first on a fresh clone)
 	bun run typecheck
 
 # ── codegen ───────────────────────────────────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,105 @@
+# Makefile for malloydata/publisher.
+# Assumes `mise` (or `asdf`) has activated the versions pinned in .tool-versions.
+# Run `make` or `make help` for the target list.
+
+URL := http://localhost:4000
+MCP_URL := http://localhost:4040
+
+.DEFAULT_GOAL := help
+.PHONY: help doctor \
+        install reinstall clean \
+        build start stop \
+        dev dev-server dev-react \
+        status environments packages \
+        open \
+        test test-unit test-integration \
+        lint format prettier-check typecheck \
+        regen-api
+
+# ── workspace ─────────────────────────────────────────────────────────
+help: ## Show this help
+	@grep -E '^[a-zA-Z][a-zA-Z0-9_-]*:.*?## ' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'
+
+doctor: ## Print resolved tool versions
+	@command -v mise >/dev/null && mise current || true
+	@which bun node java python 2>/dev/null || true
+
+# ── setup ─────────────────────────────────────────────────────────────
+install: ## Install workspace deps (bun install)
+	bun install
+
+reinstall: ## Wipe node_modules + dist and reinstall
+	bun run clean && bun install
+
+clean: ## Remove node_modules and dist directories
+	bun run clean
+
+# ── build & run ───────────────────────────────────────────────────────
+build: ## Production build: SDK → app → server bundle
+	bun run build:server-deploy
+
+start: ## Run the built server (production, foreground; Ctrl+C to stop)
+	bun run start
+
+stop: ## Kill any process listening on port 4000 or 4040
+	@kill $$(lsof -ti:4000) 2>/dev/null || true
+	@kill $$(lsof -ti:4040) 2>/dev/null || true
+	@echo "stopped (if anything was running)"
+
+# ── dev mode ──────────────────────────────────────────────────────────
+# `dev` runs Express + Vite together with prefixed [server]/[react]
+# logs in one terminal. Ctrl+C stops both. Use the -server / -react
+# variants for separate terminals.
+dev: ## Run Express (:4000) + Vite (:5173) together, combined logs
+	bunx concurrently \
+		--names "server,react" \
+		--prefix-colors "cyan,magenta" \
+		--kill-others-on-fail \
+		"bun run start:dev" \
+		"bun run start:dev:react"
+
+dev-server: ## Express server alone (NODE_ENV=development, watch mode)
+	bun run start:dev
+
+dev-react: ## Vite dev server alone, at :5173
+	bun run start:dev:react
+
+# ── inspect ───────────────────────────────────────────────────────────
+status: ## GET /api/v0/status
+	@curl -sf $(URL)/api/v0/status | python3 -m json.tool
+
+environments: ## List environments
+	@curl -sf $(URL)/api/v0/environments | python3 -m json.tool
+
+packages: ## List packages in malloy-samples
+	@curl -sf $(URL)/api/v0/environments/malloy-samples/packages | python3 -m json.tool
+
+open: ## Open the Publisher UI in the default browser (macOS)
+	@open $(URL)
+
+# ── tests / quality ───────────────────────────────────────────────────
+test: ## Run all server tests (unit + integration)
+	bun run test
+
+test-unit: ## Run only unit tests
+	cd packages/server && bun run test:unit
+
+test-integration: ## Run only integration tests (max-workers=1)
+	cd packages/server && bun run test:integration
+
+lint: ## eslint across sdk/app/server
+	bun run lint
+
+format: ## prettier --write across sdk/app/server
+	bun run format
+
+prettier-check: ## CI's exact prettier check (fails on unformatted files)
+	bun run prettier:check
+
+typecheck: ## tsc --noEmit across sdk/app/server (chains codegen + SDK build)
+	bun run typecheck
+
+# ── codegen ───────────────────────────────────────────────────────────
+regen-api: ## Regenerate server + SDK clients from api-doc.yaml (needs Java)
+	bun run generate-api-types

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 ## Prerequisites
 
-| Tool | Version | Required for |
-|---|---|---|
-| [Bun](https://bun.sh/) | ≥ 1.3.13 | Primary runtime + package manager |
-| [Node.js](https://nodejs.org/) | ≥ 20 | DuckDB postinstall scripts and the `npx @malloy-publisher/server` bin shebang |
-| [Python](https://www.python.org/) | ≥ 3.12 | Only if you build the Python client (`packages/python-client`) |
-| Java | ≥ 21 (Corretto recommended) | Only if you regenerate API clients via `bun run generate-api-types` |
+| Tool                              | Version                     | Required for                                                                  |
+| --------------------------------- | --------------------------- | ----------------------------------------------------------------------------- |
+| [Bun](https://bun.sh/)            | ≥ 1.3.13                    | Primary runtime + package manager                                             |
+| [Node.js](https://nodejs.org/)    | ≥ 20                        | DuckDB postinstall scripts and the `npx @malloy-publisher/server` bin shebang |
+| [Python](https://www.python.org/) | ≥ 3.12                      | Only if you build the Python client (`packages/python-client`)                |
+| Java                              | ≥ 21 (Corretto recommended) | Only if you regenerate API clients via `bun run generate-api-types`           |
 
 The repo ships a `.tool-versions` file compatible with [mise](https://mise.jdx.dev/) and [asdf](https://asdf-vm.com/), so `mise install` (or `asdf install`) provisions all four versions at once.
 
@@ -86,13 +86,12 @@ The Publisher App is built entirely with the SDK, but the SDK is a standalone NP
 
 Publisher consists of four packages:
 
-| Package | Description |
-|---------|-------------|
-| **[packages/server](packages/server/)** | Express.js backend providing REST API (port 4000) and MCP API (port 4040). Loads Malloy packages, compiles queries, executes against databases. |
-| **[packages/sdk](packages/sdk/)** | React component library for building UIs that consume Publisher's REST API. |
-| **[packages/app](packages/app/)** | Reference implementation and production-ready data exploration tool built with the SDK. |
-| **[packages/python-client](packages/python-client/)** | Auto-generated Python SDK for the REST API. |
-
+| Package                                               | Description                                                                                                                                     |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| **[packages/server](packages/server/)**               | Express.js backend providing REST API (port 4000) and MCP API (port 4040). Loads Malloy packages, compiles queries, executes against databases. |
+| **[packages/sdk](packages/sdk/)**                     | React component library for building UIs that consume Publisher's REST API.                                                                     |
+| **[packages/app](packages/app/)**                     | Reference implementation and production-ready data exploration tool built with the SDK.                                                         |
+| **[packages/python-client](packages/python-client/)** | Auto-generated Python SDK for the REST API.                                                                                                     |
 
 ## Development
 
@@ -100,30 +99,54 @@ This project uses [bun](https://bun.sh/) as the JavaScript runtime. Sample packa
 
 The bundled `publisher.config.json` ships three samples (`ecommerce`, `imdb`, `faa`) that run via per-package DuckDB sandboxes — no GCP credentials needed. To enable the BigQuery-required `bigquery-hackernews` sample, copy [`publisher.config.example.bigquery.json`](packages/server/publisher.config.example.bigquery.json) over `publisher.config.json` (or point `--server_root` at a directory containing it) and set `GOOGLE_APPLICATION_CREDENTIALS`.
 
+### Makefile shortcuts
+
+A top-level `Makefile` wraps the common workflows so you don't have to remember script names or `cd` into individual packages. Run `make help` for the full list. The most useful targets:
+
+| Target                                                       | What it does                                                                                            |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `make install`                                               | `bun install` at the repo root                                                                          |
+| `make build`                                                 | Production build: SDK → app → server bundle                                                             |
+| `make start` / `make start-init`                             | Run the built server (`--init` clears persisted storage on boot)                                        |
+| `make stop`                                                  | Kill anything on ports `:4000` or `:4040`                                                               |
+| `make dev`                                                   | **Express + Vite together** in one terminal with prefixed `[server]`/`[react]` logs (Ctrl+C kills both) |
+| `make dev-server` / `make dev-react`                         | Same dev workflow, split into two terminals                                                             |
+| `make status` / `make environments` / `make packages`        | Quick API smoke checks                                                                                  |
+| `make test` / `make lint` / `make typecheck` / `make format` | Quality gates                                                                                           |
+| `make regen-api`                                             | Regenerate server + SDK clients from `api-doc.yaml` (needs Java)                                        |
+
 ### Production build
 
 One command builds the SDK, app, and server bundle in order:
 
 ```bash
-bun install
-bun run build:server-deploy
-bun run start                # Run the built server (REST on :4000, MCP on :4040)
+make install
+make build
+make start                # Run the built server (REST on :4000, MCP on :4040)
 ```
 
-### Dev mode (two terminals)
+Or run the underlying `bun` scripts directly: `bun install && bun run build:server-deploy && bun run start`.
 
-The dev workflow runs Express and Vite as separate processes. Express on :4000 proxies non-API traffic to Vite on :5173 when `NODE_ENV=development`, so visit `http://localhost:4000` for the full app — `:5173` won't have API access.
+### Dev mode
 
-In one terminal, run the server (REST :4000 + MCP :4040, watch mode):
+Express and Vite run as separate processes. Express on `:4000` proxies non-API traffic to Vite on `:5173` when `NODE_ENV=development`, so visit `http://localhost:4000` for the full app — `:5173` won't have API access.
+
+**One terminal (recommended):**
 
 ```bash
-bun run start:dev
+make dev
 ```
 
-In a second terminal, run the Vite dev server (:5173, proxied through :4000):
+This runs both servers with combined, color-prefixed logs (`[server]` / `[react]`). Ctrl+C stops both cleanly.
+
+**Two terminals (if you prefer split logs):**
 
 ```bash
-bun run start:dev:react
+make dev-server          # Express (REST :4000 + MCP :4040, watch mode)
+```
+
+```bash
+make dev-react           # Vite dev server (:5173, proxied through :4000)
 ```
 
 Open http://localhost:4000.
@@ -131,30 +154,30 @@ Open http://localhost:4000.
 ### Tests and quality gates
 
 ```bash
-bun run test                          # unit + integration server tests
-bun run lint && bun run format        # eslint + prettier
-bun run typecheck                     # tsc --noEmit across sdk/app/server
+make test                # unit + integration server tests
+make lint && make format # eslint + prettier
+make typecheck           # tsc --noEmit across sdk/app/server
 ```
 
 ## Configuration
 
 Publisher reads its runtime configuration from `publisher.config.json` (see [Development](#development) for the BigQuery opt-in) and a handful of environment variables. Every CLI flag below has an env-var equivalent; pass either.
 
-| Env var | CLI flag | Default | Meaning |
-|---|---|---|---|
-| `PUBLISHER_PORT` | `--port <n>` | `4000` | REST + static-app HTTP port. |
-| `PUBLISHER_HOST` | `--host <addr>` | `0.0.0.0` | Host binding for the main server. |
-| `MCP_PORT` | `--mcp_port <n>` | `4040` | MCP HTTP port. |
-| `SERVER_ROOT` | `--server_root <dir>` | `.` (cwd) | Directory containing `publisher.config.json`. |
-| `INITIALIZE_STORAGE` | `--init` | _unset_ | Set to `true` (or pass `--init`) to initialize storage on boot. Set on the first run with new persistent storage; safe to omit afterward. Also exposed as the `start:init` / `start:dev:init` scripts. |
-| `SHUTDOWN_DRAIN_DURATION_SECONDS` | `--shutdown_drain_duration_seconds <s>` | `0` | Time to keep `/health` returning OK after SIGTERM before refusing new traffic. |
-| `SHUTDOWN_GRACEFUL_CLOSE_TIMEOUT_SECONDS` | `--shutdown_graceful_close_timeout_seconds <s>` | `0` | Time to wait for in-flight requests to drain before forcing close. |
-| `NODE_ENV` | — | _unset_ | Set to `development` to proxy non-API traffic to the Vite dev server on `:5173`. |
-| `LOG_LEVEL` | — | `debug` | One of `error`, `warn`, `info`, `verbose`, `debug`, `silly`. |
-| `DISABLE_RESPONSE_LOGGING` | — | _unset_ | Set to `true` or `1` to suppress response-body logging. |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | — | _unset_ | OpenTelemetry collector endpoint. |
-| `GOOGLE_APPLICATION_CREDENTIALS` | — | _unset_ | Path to a GCP service-account JSON. Used only when running the BigQuery example config. |
-| — | `--help`, `-h` | — | Print the full flag list. |
+| Env var                                   | CLI flag                                        | Default   | Meaning                                                                                                                                                                                                |
+| ----------------------------------------- | ----------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `PUBLISHER_PORT`                          | `--port <n>`                                    | `4000`    | REST + static-app HTTP port.                                                                                                                                                                           |
+| `PUBLISHER_HOST`                          | `--host <addr>`                                 | `0.0.0.0` | Host binding for the main server.                                                                                                                                                                      |
+| `MCP_PORT`                                | `--mcp_port <n>`                                | `4040`    | MCP HTTP port.                                                                                                                                                                                         |
+| `SERVER_ROOT`                             | `--server_root <dir>`                           | `.` (cwd) | Directory containing `publisher.config.json`.                                                                                                                                                          |
+| `INITIALIZE_STORAGE`                      | `--init`                                        | _unset_   | Set to `true` (or pass `--init`) to initialize storage on boot. Set on the first run with new persistent storage; safe to omit afterward. Also exposed as the `start:init` / `start:dev:init` scripts. |
+| `SHUTDOWN_DRAIN_DURATION_SECONDS`         | `--shutdown_drain_duration_seconds <s>`         | `0`       | Time to keep `/health` returning OK after SIGTERM before refusing new traffic.                                                                                                                         |
+| `SHUTDOWN_GRACEFUL_CLOSE_TIMEOUT_SECONDS` | `--shutdown_graceful_close_timeout_seconds <s>` | `0`       | Time to wait for in-flight requests to drain before forcing close.                                                                                                                                     |
+| `NODE_ENV`                                | —                                               | _unset_   | Set to `development` to proxy non-API traffic to the Vite dev server on `:5173`.                                                                                                                       |
+| `LOG_LEVEL`                               | —                                               | `debug`   | One of `error`, `warn`, `info`, `verbose`, `debug`, `silly`.                                                                                                                                           |
+| `DISABLE_RESPONSE_LOGGING`                | —                                               | _unset_   | Set to `true` or `1` to suppress response-body logging.                                                                                                                                                |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`             | —                                               | _unset_   | OpenTelemetry collector endpoint.                                                                                                                                                                      |
+| `GOOGLE_APPLICATION_CREDENTIALS`          | —                                               | _unset_   | Path to a GCP service-account JSON. Used only when running the BigQuery example config.                                                                                                                |
+| —                                         | `--help`, `-h`                                  | —         | Print the full flag list.                                                                                                                                                                              |
 
 PostgreSQL and other database-specific connections may also honor their respective driver env vars (e.g. `PGSSLMODE`).
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,17 @@ make lint && make format # eslint + prettier
 make typecheck           # tsc --noEmit across sdk/app/server
 ```
 
+`make typecheck` (and the underlying `bun run typecheck`) depends on the SDK's emitted `.d.ts` files, which in turn depend on the OpenAPI codegen. On a fresh clone, run the build prerequisites first:
+
+```bash
+bun install
+bun run generate-api-types
+bun run build:sdk
+bun run typecheck
+```
+
+After that, `bun run typecheck` works on its own as long as the SDK build artifacts stay current. Re-run the prereqs whenever `api-doc.yaml` or the SDK source changes.
+
 ## Configuration
 
 Publisher reads its runtime configuration from `publisher.config.json` (see [Development](#development) for the BigQuery opt-in) and a handful of environment variables. Every CLI flag below has an env-var equivalent; pass either.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ curl -s http://localhost:4000/api/v0/status | jq .operationalState   # → "serv
 curl -s http://localhost:4000/api/v0/environments | jq '.[].name'    # → list of environments
 ```
 
-If `operationalState` is anything other than `serving`, the server is wedged but still responding — check the server logs.
+`operationalState` reports the current server lifecycle:
+
+- **`serving`** — ready to handle requests.
+- **`initializing`** — loading packages and connections from `publisher.config.json`. Normal on boot, and especially noticeable on the first run when sample packages need to be cloned from GitHub. Wait for `serving`.
+- **`draining`** — graceful shutdown in progress: the server is waiting for in-flight requests to finish before closing. Controlled by `SHUTDOWN_DRAIN_DURATION_SECONDS` and `SHUTDOWN_GRACEFUL_CLOSE_TIMEOUT_SECONDS`.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ npx @malloy-publisher/server --port 4000 --server_root .
 
 Open http://localhost:4000 to explore the sample models.
 
+### Verify it's working
+
+```bash
+curl -s http://localhost:4000/api/v0/status | jq .operationalState   # → "serving"
+curl -s http://localhost:4000/api/v0/environments | jq '.[].name'    # → list of environments
+```
+
+If `operationalState` is anything other than `serving`, the server is wedged but still responding — check the server logs.
+
 ## Documentation
 
 Full documentation is available at **[docs.malloydata.dev/documentation/user_guides/publishing](https://docs.malloydata.dev/documentation/user_guides/publishing/publishing)**:
@@ -76,19 +85,42 @@ Publisher consists of four packages:
 
 ## Development
 
-This project uses [bun](https://bun.sh/) as the JavaScript runtime.
+This project uses [bun](https://bun.sh/) as the JavaScript runtime. Sample packages are fetched at runtime per [`publisher.config.json`](packages/server/publisher.config.json) — no submodule checkout needed.
+
+### Production build
+
+One command builds the SDK, app, and server bundle in order:
 
 ```bash
-git submodule init && git submodule update  # Get malloy-samples
 bun install
 bun run build:server-deploy
-bun run start                               # Production server
+bun run start                # Run the built server (REST on :4000, MCP on :4040)
 ```
 
+### Dev mode (two terminals)
+
+The dev workflow runs Express and Vite as separate processes. Express on :4000 proxies non-API traffic to Vite on :5173 when `NODE_ENV=development`, so visit `http://localhost:4000` for the full app — `:5173` won't have API access.
+
+In one terminal, run the server (REST :4000 + MCP :4040, watch mode):
+
 ```bash
-bun run start:dev       # Dev server with watch
-bun run test            # Run tests
-bun run lint && bun run format  # Code quality
+bun run start:dev
+```
+
+In a second terminal, run the Vite dev server (:5173, proxied through :4000):
+
+```bash
+bun run start:dev:react
+```
+
+Open http://localhost:4000.
+
+### Tests and quality gates
+
+```bash
+bun run test                          # unit + integration server tests
+bun run lint && bun run format        # eslint + prettier
+bun run typecheck                     # tsc --noEmit across sdk/app/server
 ```
 
 ## Community

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ npx @malloy-publisher/server --port 4000 --server_root .
 
 Open http://localhost:4000 to explore the sample models.
 
-The default config runs three sample packages (`ecommerce`, `imdb`, `faa`) against per-package DuckDB sandboxes — no credentials required. To enable the `bigquery-hackernews` sample, copy [`publisher.config.example.bigquery.json`](packages/server/publisher.config.example.bigquery.json) over `publisher.config.json` (or point `--server_root` at a directory containing it) and set `GOOGLE_APPLICATION_CREDENTIALS`.
-
 ### Verify it's working
 
 ```bash
@@ -79,7 +77,7 @@ A React component library for building custom data applications powered by Publi
 - **API communication** — Talks to the Publisher Server via REST
 - **Query execution** — Submits queries and retrieves results
 - **Result visualization** — Integrates Malloy Render to display results
-- **UI components** — Pre-built pages for browsing projects, packages, models, and notebooks
+- **UI components** — Pre-built pages for browsing environments, packages, models, and notebooks
 - **Source filters** — Automatically renders filter widgets for models with [`#(filter)` annotations](docs/filters.md)
 
 The Publisher App is built entirely with the SDK, but the SDK is a standalone NPM package for building your own applications.
@@ -99,6 +97,8 @@ Publisher consists of four packages:
 ## Development
 
 This project uses [bun](https://bun.sh/) as the JavaScript runtime. Sample packages are fetched at runtime per [`publisher.config.json`](packages/server/publisher.config.json) — no submodule checkout needed.
+
+The bundled `publisher.config.json` ships three samples (`ecommerce`, `imdb`, `faa`) that run via per-package DuckDB sandboxes — no GCP credentials needed. To enable the BigQuery-required `bigquery-hackernews` sample, copy [`publisher.config.example.bigquery.json`](packages/server/publisher.config.example.bigquery.json) over `publisher.config.json` (or point `--server_root` at a directory containing it) and set `GOOGLE_APPLICATION_CREDENTIALS`.
 
 ### Production build
 
@@ -138,37 +138,23 @@ bun run typecheck                     # tsc --noEmit across sdk/app/server
 
 ## Configuration
 
-Publisher reads its runtime configuration from `publisher.config.json` (see [Quick Start](#quick-start) for the BigQuery opt-in path) and a handful of environment variables. CLI flags on `npx @malloy-publisher/server` set most of these directly.
+Publisher reads its runtime configuration from `publisher.config.json` (see [Development](#development) for the BigQuery opt-in) and a handful of environment variables. Every CLI flag below has an env-var equivalent; pass either.
 
-### CLI flags
-
-| Flag | Env equivalent | Meaning |
-|---|---|---|
-| `--port <n>` | `PUBLISHER_PORT` | REST + static-app HTTP port (default 4000). |
-| `--host <addr>` | `PUBLISHER_HOST` | Host binding (default `0.0.0.0`). |
-| `--mcp_port <n>` | `MCP_PORT` | MCP HTTP port (default 4040). |
-| `--server_root <dir>` | `SERVER_ROOT` | Directory containing `publisher.config.json`. |
-| `--init` | `INITIALIZE_STORAGE=true` | Initialize storage on boot. Set on the first run with new persistent storage; safe to omit afterward. Also exposed as the `start:init` and `start:dev:init` scripts. |
-| `--shutdown_drain_duration <s>` | `SHUTDOWN_DRAIN_DURATION_SECONDS` | Time to keep `/health` returning OK after SIGTERM. |
-| `--shutdown_graceful_close_timeout <s>` | `SHUTDOWN_GRACEFUL_CLOSE_TIMEOUT_SECONDS` | Time to drain in-flight requests. |
-| `--help`, `-h` | — | Print the full flag list. |
-
-### Environment variables
-
-| Variable | Default | Meaning |
-|---|---|---|
-| `PUBLISHER_PORT` | `4000` | REST + static-app HTTP port. CLI: `--port`. |
-| `PUBLISHER_HOST` | `0.0.0.0` | Host binding for the main server. CLI: `--host`. |
-| `MCP_PORT` | `4040` | MCP HTTP port. CLI: `--mcp_port`. |
-| `SERVER_ROOT` | `.` (cwd) | Directory containing `publisher.config.json`. CLI: `--server_root`. |
-| `INITIALIZE_STORAGE` | _unset_ | Set to `true` to initialize storage on boot. Equivalent to the `--init` flag and the `start:init` / `start:dev:init` scripts. |
-| `NODE_ENV` | _unset_ | Set to `development` to proxy non-API traffic to the Vite dev server on `:5173`. |
-| `LOG_LEVEL` | `debug` | One of `error`, `warn`, `info`, `debug`, `trace`. |
-| `DISABLE_RESPONSE_LOGGING` | _unset_ | Set to `true` or `1` to suppress response-body logging. |
-| `SHUTDOWN_DRAIN_DURATION_SECONDS` | `0` | Time to keep `/health` returning OK after SIGTERM before refusing new traffic. |
-| `SHUTDOWN_GRACEFUL_CLOSE_TIMEOUT_SECONDS` | `0` | Time to wait for in-flight requests to drain before forcing close. |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | _unset_ | OpenTelemetry collector endpoint. |
-| `GOOGLE_APPLICATION_CREDENTIALS` | _unset_ | Path to a GCP service-account JSON. Used only when running the BigQuery example config. |
+| Env var | CLI flag | Default | Meaning |
+|---|---|---|---|
+| `PUBLISHER_PORT` | `--port <n>` | `4000` | REST + static-app HTTP port. |
+| `PUBLISHER_HOST` | `--host <addr>` | `0.0.0.0` | Host binding for the main server. |
+| `MCP_PORT` | `--mcp_port <n>` | `4040` | MCP HTTP port. |
+| `SERVER_ROOT` | `--server_root <dir>` | `.` (cwd) | Directory containing `publisher.config.json`. |
+| `INITIALIZE_STORAGE` | `--init` | _unset_ | Set to `true` (or pass `--init`) to initialize storage on boot. Set on the first run with new persistent storage; safe to omit afterward. Also exposed as the `start:init` / `start:dev:init` scripts. |
+| `SHUTDOWN_DRAIN_DURATION_SECONDS` | `--shutdown_drain_duration_seconds <s>` | `0` | Time to keep `/health` returning OK after SIGTERM before refusing new traffic. |
+| `SHUTDOWN_GRACEFUL_CLOSE_TIMEOUT_SECONDS` | `--shutdown_graceful_close_timeout_seconds <s>` | `0` | Time to wait for in-flight requests to drain before forcing close. |
+| `NODE_ENV` | — | _unset_ | Set to `development` to proxy non-API traffic to the Vite dev server on `:5173`. |
+| `LOG_LEVEL` | — | `debug` | One of `error`, `warn`, `info`, `verbose`, `debug`, `silly`. |
+| `DISABLE_RESPONSE_LOGGING` | — | _unset_ | Set to `true` or `1` to suppress response-body logging. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | — | _unset_ | OpenTelemetry collector endpoint. |
+| `GOOGLE_APPLICATION_CREDENTIALS` | — | _unset_ | Path to a GCP service-account JSON. Used only when running the BigQuery example config. |
+| — | `--help`, `-h` | — | Print the full flag list. |
 
 PostgreSQL and other database-specific connections may also honor their respective driver env vars (e.g. `PGSSLMODE`).
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,19 @@ bun run typecheck                     # tsc --noEmit across sdk/app/server
 
 Publisher reads its runtime configuration from `publisher.config.json` (see [Quick Start](#quick-start) for the BigQuery opt-in path) and a handful of environment variables. CLI flags on `npx @malloy-publisher/server` set most of these directly.
 
+### CLI flags
+
+| Flag | Env equivalent | Meaning |
+|---|---|---|
+| `--port <n>` | `PUBLISHER_PORT` | REST + static-app HTTP port (default 4000). |
+| `--host <addr>` | `PUBLISHER_HOST` | Host binding (default `0.0.0.0`). |
+| `--mcp_port <n>` | `MCP_PORT` | MCP HTTP port (default 4040). |
+| `--server_root <dir>` | `SERVER_ROOT` | Directory containing `publisher.config.json`. |
+| `--init` | `INITIALIZE_STORAGE=true` | Initialize storage on boot. Set on the first run with new persistent storage; safe to omit afterward. Also exposed as the `start:init` and `start:dev:init` scripts. |
+| `--shutdown_drain_duration <s>` | `SHUTDOWN_DRAIN_DURATION_SECONDS` | Time to keep `/health` returning OK after SIGTERM. |
+| `--shutdown_graceful_close_timeout <s>` | `SHUTDOWN_GRACEFUL_CLOSE_TIMEOUT_SECONDS` | Time to drain in-flight requests. |
+| `--help`, `-h` | — | Print the full flag list. |
+
 ### Environment variables
 
 | Variable | Default | Meaning |

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 
 **Publisher** is the open-source semantic model server for [Malloy](https://malloydata.dev). It serves Malloy models through REST and MCP APIs, enabling consistent data access for applications, tools, and AI agents.
 
+## Prerequisites
+
+| Tool | Version | Required for |
+|---|---|---|
+| [Bun](https://bun.sh/) | ≥ 1.3.13 | Primary runtime + package manager |
+| [Node.js](https://nodejs.org/) | ≥ 20 | DuckDB postinstall scripts and the `npx @malloy-publisher/server` bin shebang |
+| [Python](https://www.python.org/) | ≥ 3.12 | Only if you build the Python client (`packages/python-client`) |
+| Java | ≥ 21 (Corretto recommended) | Only if you regenerate API clients via `bun run generate-api-types` |
+
+The repo ships a `.tool-versions` file compatible with [mise](https://mise.jdx.dev/) and [asdf](https://asdf-vm.com/), so `mise install` (or `asdf install`) provisions all four versions at once.
+
 ## Quick Start
 
 ```bash
@@ -124,6 +135,29 @@ bun run test                          # unit + integration server tests
 bun run lint && bun run format        # eslint + prettier
 bun run typecheck                     # tsc --noEmit across sdk/app/server
 ```
+
+## Configuration
+
+Publisher reads its runtime configuration from `publisher.config.json` (see [Quick Start](#quick-start) for the BigQuery opt-in path) and a handful of environment variables. CLI flags on `npx @malloy-publisher/server` set most of these directly.
+
+### Environment variables
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `PUBLISHER_PORT` | `4000` | REST + static-app HTTP port. CLI: `--port`. |
+| `PUBLISHER_HOST` | `0.0.0.0` | Host binding for the main server. CLI: `--host`. |
+| `MCP_PORT` | `4040` | MCP HTTP port. CLI: `--mcp_port`. |
+| `SERVER_ROOT` | `.` (cwd) | Directory containing `publisher.config.json`. CLI: `--server_root`. |
+| `INITIALIZE_STORAGE` | _unset_ | Set to `true` to initialize storage on boot. Equivalent to the `--init` flag and the `start:init` / `start:dev:init` scripts. |
+| `NODE_ENV` | _unset_ | Set to `development` to proxy non-API traffic to the Vite dev server on `:5173`. |
+| `LOG_LEVEL` | `debug` | One of `error`, `warn`, `info`, `debug`, `trace`. |
+| `DISABLE_RESPONSE_LOGGING` | _unset_ | Set to `true` or `1` to suppress response-body logging. |
+| `SHUTDOWN_DRAIN_DURATION_SECONDS` | `0` | Time to keep `/health` returning OK after SIGTERM before refusing new traffic. |
+| `SHUTDOWN_GRACEFUL_CLOSE_TIMEOUT_SECONDS` | `0` | Time to wait for in-flight requests to drain before forcing close. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | _unset_ | OpenTelemetry collector endpoint. |
+| `GOOGLE_APPLICATION_CREDENTIALS` | _unset_ | Path to a GCP service-account JSON. Used only when running the BigQuery example config. |
+
+PostgreSQL and other database-specific connections may also honor their respective driver env vars (e.g. `PGSSLMODE`).
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ npx @malloy-publisher/server --port 4000 --server_root .
 
 Open http://localhost:4000 to explore the sample models.
 
+The default config runs three sample packages (`ecommerce`, `imdb`, `faa`) against per-package DuckDB sandboxes — no credentials required. To enable the `bigquery-hackernews` sample, copy [`publisher.config.example.bigquery.json`](packages/server/publisher.config.example.bigquery.json) over `publisher.config.json` (or point `--server_root` at a directory containing it) and set `GOOGLE_APPLICATION_CREDENTIALS`.
+
 ### Verify it's working
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ curl -s http://localhost:4000/api/v0/environments | jq '.[].name'    # → list 
 
 - **`serving`** — ready to handle requests.
 - **`initializing`** — loading packages and connections from `publisher.config.json`. Normal on boot, and especially noticeable on the first run when sample packages need to be cloned from GitHub. Wait for `serving`.
-- **`draining`** — graceful shutdown in progress: the server is waiting for in-flight requests to finish before closing. Controlled by `SHUTDOWN_DRAIN_DURATION_SECONDS` and `SHUTDOWN_GRACEFUL_CLOSE_TIMEOUT_SECONDS`.
+- **`draining`** — graceful shutdown in progress: the server is waiting for in-flight requests to finish before closing. Controlled by `SHUTDOWN_DRAIN_DURATION_SECONDS` and `SHUTDOWN_GRACEFUL_CLOSE_TIMEOUT_SECONDS` (see [Configuration](#configuration)).
 
 ## Documentation
 
@@ -163,7 +163,7 @@ make lint && make format # eslint + prettier
 make typecheck           # tsc --noEmit across sdk/app/server
 ```
 
-`make typecheck` (and the underlying `bun run typecheck`) depends on the SDK's emitted `.d.ts` files, which in turn depend on the OpenAPI codegen. On a fresh clone, run the build prerequisites first:
+`make typecheck` (and the underlying `bun run typecheck`) depends on the SDK's emitted `.d.ts` files, which in turn depend on the OpenAPI codegen. On a fresh clone, build first — either with `make build` (full SDK + app + server bundle), or with the targeted minimum:
 
 ```bash
 bun install
@@ -172,7 +172,10 @@ bun run build:sdk
 bun run typecheck
 ```
 
-After that, `bun run typecheck` works on its own as long as the SDK build artifacts stay current. Re-run the prereqs whenever `api-doc.yaml` or the SDK source changes.
+After that, `bun run typecheck` works on its own as long as the SDK build artifacts stay current:
+
+- After editing `api-doc.yaml` → re-run `bun run generate-api-types && bun run build:sdk`.
+- After editing SDK source → re-run `bun run build:sdk`.
 
 ## Configuration
 

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -10,6 +10,10 @@ Each loaded package automatically gets its own DuckDB connection named `duckdb`.
 
 You do not have to declare these sandboxes — they're created on package load.
 
+## Environment-level DuckDB connections
+
+You can also declare a top-level DuckDB connection at the environment level. Publisher intentionally exposes only data-source intent for these — database files, working directories, filesystem/network policy, extension loading, temp directories, and resource knobs are all owned by Publisher. The only configuration available is **attached databases**, where you declare foreign databases (BigQuery, Snowflake, Postgres, GCS, S3, Azure) that the DuckDB instance should `ATTACH` so queries can reference them.
+
 ## Connection naming rules
 
 A few names are reserved or have special meaning. Picking the wrong name causes a clear error at server startup:
@@ -20,10 +24,10 @@ You cannot define a top-level connection named `duckdb`. The name is claimed by 
 
 ```
 Connection name 'duckdb' is reserved for per-package sandboxes. Choose a different name
-for project-level DuckDB connections (e.g. 'duckdb_main').
+for environment-level DuckDB connections (e.g. 'shared_duckdb').
 ```
 
-For a project-level DuckDB connection — e.g. one pointing at a shared `.duckdb` file across packages — use any other name. Common choice: `duckdb_main`.
+Use any other name for an environment-level DuckDB connection.
 
 ### Uniqueness within an environment
 
@@ -39,12 +43,25 @@ Connection names must be unique within a single environment. Duplicate names aft
       "packages": [...],
       "connections": [
         {
-          "name": "duckdb_main",
+          "name": "shared_duckdb",
           "type": "duckdb",
-          "duckdbConnection": { "databasePath": "data/warehouse.duckdb" }
+          "duckdbConnection": {
+            "attachedDatabases": [
+              {
+                "name": "warehouse_pg",
+                "type": "postgres",
+                "postgresConnection": {
+                  "host": "warehouse.example.com",
+                  "port": 5432,
+                  "userName": "publisher",
+                  "databaseName": "analytics"
+                }
+              }
+            ]
+          }
         },
         {
-          "name": "warehouse",
+          "name": "warehouse_bq",
           "type": "bigquery",
           "bigqueryConnection": { "defaultProjectId": "my-gcp-project" }
         }
@@ -54,4 +71,4 @@ Connection names must be unique within a single environment. Duplicate names aft
 }
 ```
 
-The package's own DuckDB sandbox (`duckdb`) remains available alongside `duckdb_main` and `warehouse`.
+The package's own DuckDB sandbox (`duckdb`) remains available alongside `shared_duckdb` and `warehouse_bq`.

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -1,0 +1,57 @@
+# Connections
+
+Publisher uses **connections** to reach databases and query engines. Connections are defined per-environment in `publisher.config.json`; each one has a unique `name` and a `type` (`bigquery`, `snowflake`, `postgres`, `mysql`, `duckdb`, `trino`, etc.) plus type-specific configuration under a matching `*Connection` key.
+
+For full setup details per connection type, see [docs.malloydata.dev/documentation/user_guides/publishing/connections](https://docs.malloydata.dev/documentation/user_guides/publishing/connections).
+
+## Per-package DuckDB sandboxes
+
+Each loaded package automatically gets its own DuckDB connection named `duckdb`. These per-package sandboxes are how the bundled samples (`ecommerce`, `imdb`, `faa`) query the Parquet/CSV files in the sample repositories without needing any user-defined connection.
+
+You do not have to declare these sandboxes — they're created on package load.
+
+## Connection naming rules
+
+A few names are reserved or have special meaning. Picking the wrong name causes a clear error at server startup:
+
+### `duckdb` (reserved)
+
+You cannot define a top-level connection named `duckdb`. The name is claimed by the per-package sandbox described above. Publisher errors at startup:
+
+```
+Connection name 'duckdb' is reserved for per-package sandboxes. Choose a different name
+for project-level DuckDB connections (e.g. 'duckdb_main').
+```
+
+For a project-level DuckDB connection — e.g. one pointing at a shared `.duckdb` file across packages — use any other name. Common choice: `duckdb_main`.
+
+### Uniqueness within an environment
+
+Connection names must be unique within a single environment. Duplicate names after the first are silently ignored (later definitions don't override earlier ones), so prefer distinct, descriptive names.
+
+## Example: mixed connections
+
+```json
+{
+  "environments": [
+    {
+      "name": "my-env",
+      "packages": [...],
+      "connections": [
+        {
+          "name": "duckdb_main",
+          "type": "duckdb",
+          "duckdbConnection": { "databasePath": "data/warehouse.duckdb" }
+        },
+        {
+          "name": "warehouse",
+          "type": "bigquery",
+          "bigqueryConnection": { "defaultProjectId": "my-gcp-project" }
+        }
+      ]
+    }
+  ]
+}
+```
+
+The package's own DuckDB sandbox (`duckdb`) remains available alongside `duckdb_main` and `warehouse`.

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -6,3 +6,7 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+
+# Repos cloned by tests (e.g. `Verify git clone and bun run start commands`)
+/publisher/
+/next.js/

--- a/e2e/bun.lock
+++ b/e2e/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "e2e",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "packages/*"
   ],
   "engines": {
-    "bun": ">=1.3.1"
+    "bun": ">=1.3.1",
+    "node": ">=20"
   },
   "scripts": {
     "clean": "bunx rimraf -g **/node_modules **/dist",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "packages/*"
   ],
   "engines": {
-    "bun": ">=1.3.1",
+    "bun": ">=1.3.13",
     "node": ">=20"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typecheck:app": "cd packages/app && bun run tsc --noEmit",
     "typecheck:server": "cd packages/server && bun run tsc --noEmit",
     "typecheck:cli": "cd packages/cli && bun run typecheck",
-    "typecheck": "bun run generate-api-types && bun run build:sdk && bun run typecheck:sdk && bun run typecheck:app && bun run typecheck:server",
+    "typecheck": "bun run typecheck:sdk && bun run typecheck:app && bun run typecheck:server",
     "format:sdk": "cd packages/sdk && bun run format",
     "format:app": "cd packages/app && bun run format",
     "format:server": "cd packages/server && bun run format",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "typecheck:app": "cd packages/app && bun run tsc --noEmit",
     "typecheck:server": "cd packages/server && bun run tsc --noEmit",
     "typecheck:cli": "cd packages/cli && bun run typecheck",
-    "typecheck": "bun run typecheck:sdk && bun run typecheck:app && bun run typecheck:server",
+    "typecheck": "bun run generate-api-types && bun run build:sdk && bun run typecheck:sdk && bun run typecheck:app && bun run typecheck:server",
     "format:sdk": "cd packages/sdk && bun run format",
     "format:app": "cd packages/app && bun run format",
     "format:server": "cd packages/server && bun run format",

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -2,6 +2,12 @@
 
 The Malloy Publisher Server is an Express.js server that provides an API for managing and accessing Malloy data models, packages, and queries
 
+## Configuration
+
+`publisher.config.json` lives in this directory. The repository root also contains a symlink (`/publisher.config.json` → `./packages/server/publisher.config.json`) so that running the server from either location picks up the same config. Edit one and you've edited both.
+
+For the BigQuery-enabled variant, see [`publisher.config.example.bigquery.json`](./publisher.config.example.bigquery.json) and the [Quick Start in the repo root README](../../README.md#quick-start).
+
 ## K6 Test Presets
 
 The Malloy Publisher Server includes several K6 test presets to help you test its performance and stability.

--- a/packages/server/publisher.config.example.bigquery.json
+++ b/packages/server/publisher.config.example.bigquery.json
@@ -15,9 +15,19 @@
         {
           "name": "faa",
           "location": "https://github.com/credibledata/malloy-samples/tree/main/faa"
+        },
+        {
+          "name": "bigquery-hackernews",
+          "location": "https://github.com/credibledata/malloy-samples/tree/main/bigquery-hackernews"
         }
       ],
-      "connections": []
+      "connections": [
+        {
+          "name": "bigquery",
+          "type": "bigquery",
+          "bigqueryConnection": {}
+        }
+      ]
     }
   ]
 }

--- a/packages/server/src/config.spec.ts
+++ b/packages/server/src/config.spec.ts
@@ -992,11 +992,13 @@ describe("Committed example configs", () => {
             expect(
                (env.connections ?? []).some((c) => c.type === "bigquery"),
             ).toBe(true);
-            expect(env.packages.some((p) => p.name === "bigquery-hackernews"))
-               .toBe(true);
+            expect(
+               env.packages.some((p) => p.name === "bigquery-hackernews"),
+            ).toBe(true);
          } else {
-            expect(env.packages.some((p) => p.name === "bigquery-hackernews"))
-               .toBe(false);
+            expect(
+               env.packages.some((p) => p.name === "bigquery-hackernews"),
+            ).toBe(false);
          }
       },
    );

--- a/packages/server/src/config.spec.ts
+++ b/packages/server/src/config.spec.ts
@@ -963,3 +963,41 @@ describe("Config legacy 'projects' key back-compat", () => {
       }
    });
 });
+
+describe("Committed example configs", () => {
+   const serverDir = path.resolve(__dirname, "..");
+
+   it.each([
+      ["publisher.config.json", false],
+      ["publisher.config.example.bigquery.json", true],
+   ])(
+      "%s parses as a valid PublisherConfig",
+      (filename, expectsBigQueryConnection) => {
+         const filePath = path.join(serverDir, filename);
+         expect(fs.existsSync(filePath)).toBe(true);
+
+         const raw = fs.readFileSync(filePath, "utf-8");
+         const parsed = JSON.parse(raw) as PublisherConfig;
+
+         expect(parsed).toHaveProperty("environments");
+         expect(Array.isArray(parsed.environments)).toBe(true);
+         expect(parsed.environments.length).toBeGreaterThan(0);
+
+         const env = parsed.environments[0];
+         expect(env.name).toBeTruthy();
+         expect(Array.isArray(env.packages)).toBe(true);
+         expect(env.packages.length).toBeGreaterThan(0);
+
+         if (expectsBigQueryConnection) {
+            expect(
+               (env.connections ?? []).some((c) => c.type === "bigquery"),
+            ).toBe(true);
+            expect(env.packages.some((p) => p.name === "bigquery-hackernews"))
+               .toBe(true);
+         } else {
+            expect(env.packages.some((p) => p.name === "bigquery-hackernews"))
+               .toBe(false);
+         }
+      },
+   );
+});

--- a/packages/server/src/controller/connection.controller.ts
+++ b/packages/server/src/controller/connection.controller.ts
@@ -91,7 +91,7 @@ function validateAdminAuthoredConnection(
 ): void {
    if (connectionName === "duckdb" || connectionConfig.name === "duckdb") {
       throw new BadRequestError(
-         "DuckDB connection name cannot be 'duckdb'; it is reserved for Publisher package sandboxes.",
+         "Connection name 'duckdb' is reserved for per-package sandboxes. Choose a different name for project-level DuckDB connections (e.g. 'duckdb_main').",
       );
    }
 

--- a/packages/server/src/controller/connection.controller.ts
+++ b/packages/server/src/controller/connection.controller.ts
@@ -91,7 +91,7 @@ function validateAdminAuthoredConnection(
 ): void {
    if (connectionName === "duckdb" || connectionConfig.name === "duckdb") {
       throw new BadRequestError(
-         "Connection name 'duckdb' is reserved for per-package sandboxes. Choose a different name for project-level DuckDB connections (e.g. 'duckdb_main').",
+         "Connection name 'duckdb' is reserved for per-package sandboxes. Choose a different name for environment-level DuckDB connections (e.g. 'shared_duckdb').",
       );
    }
 

--- a/packages/server/src/service/connection.spec.ts
+++ b/packages/server/src/service/connection.spec.ts
@@ -1129,7 +1129,7 @@ describe("connection integration tests", () => {
                   ],
                   testEnvironmentPath,
                ),
-            ).rejects.toThrow(/cannot be 'duckdb'/);
+            ).rejects.toThrow(/'duckdb' is reserved/);
          });
 
          it("should reject DuckDB connections with no attachments", async () => {

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -359,7 +359,7 @@ export function assembleEnvironmentConnections(
 
       if (connection.name === "duckdb") {
          throw new Error(
-            "Connection name 'duckdb' is reserved for per-package sandboxes. Choose a different name for project-level DuckDB connections (e.g. 'duckdb_main').",
+            "Connection name 'duckdb' is reserved for per-package sandboxes. Choose a different name for environment-level DuckDB connections (e.g. 'shared_duckdb').",
          );
       }
 

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -359,7 +359,7 @@ export function assembleEnvironmentConnections(
 
       if (connection.name === "duckdb") {
          throw new Error(
-            "DuckDB connection name cannot be 'duckdb'; it is reserved for Publisher package sandboxes.",
+            "Connection name 'duckdb' is reserved for per-package sandboxes. Choose a different name for project-level DuckDB connections (e.g. 'duckdb_main').",
          );
       }
 

--- a/packages/server/tests/unit/duckdb/attached_databases.test.ts
+++ b/packages/server/tests/unit/duckdb/attached_databases.test.ts
@@ -855,7 +855,7 @@ describe("createEnvironmentConnections - DuckDB", () => {
 
          await expect(
             createEnvironmentConnections(connections, PROJECT_TEST_DIR),
-         ).rejects.toThrow("DuckDB connection name cannot be 'duckdb'");
+         ).rejects.toThrow("Connection name 'duckdb' is reserved");
       });
 
       it("should throw when DuckDB connection name is 'duckdb' with attached databases", async () => {
@@ -885,7 +885,7 @@ describe("createEnvironmentConnections - DuckDB", () => {
 
          await expect(
             createEnvironmentConnections(connections, PROJECT_TEST_DIR),
-         ).rejects.toThrow("DuckDB connection name cannot be 'duckdb'");
+         ).rejects.toThrow("Connection name 'duckdb' is reserved");
       });
 
       it("should throw when DuckDB connection has no attached databases", async () => {

--- a/packages/server/tests/unit/duckdb/attached_databases.test.ts
+++ b/packages/server/tests/unit/duckdb/attached_databases.test.ts
@@ -855,7 +855,7 @@ describe("createEnvironmentConnections - DuckDB", () => {
 
          await expect(
             createEnvironmentConnections(connections, PROJECT_TEST_DIR),
-         ).rejects.toThrow("Connection name 'duckdb' is reserved");
+         ).rejects.toThrow(/'duckdb' is reserved/);
       });
 
       it("should throw when DuckDB connection name is 'duckdb' with attached databases", async () => {
@@ -885,7 +885,7 @@ describe("createEnvironmentConnections - DuckDB", () => {
 
          await expect(
             createEnvironmentConnections(connections, PROJECT_TEST_DIR),
-         ).rejects.toThrow("Connection name 'duckdb' is reserved");
+         ).rejects.toThrow(/'duckdb' is reserved/);
       });
 
       it("should throw when DuckDB connection has no attached databases", async () => {


### PR DESCRIPTION
# Fresh-eyes fixes for first-time setup

Issue: https://github.com/malloydata/publisher/issues/725

Original audit doc: https://docs.google.com/document/d/1HaZz_ar0fE0WY9dh2Ty6Q_-UNRRizeP7vuQ-gITl1c8/edit?usp=sharing
  
  A clean-install pass on `malloydata/publisher` (clone → install → configure → build → run → verify) surfaced a set of rough edges in docs, defaults, and dev-loop ergonomics. This PR addresses 13 findings from
  that audit plus a handful of follow-ups caught in self-review. All changes stay inside the docs/defaults/build lane — no API shapes, SDK exports, CLI behavior, flag semantics, or connection config schemas were
  modified.
  
  ## Why this PR

  A first-time contributor cloning the repo today hits a few avoidable papercuts:

  - The README's `git submodule update` instruction is dead (`.gitmodules` is empty).
  - The bundled `publisher.config.json` only defines a BigQuery connection, so the bundled samples fail to query without GCP credentials.
  - `bun run typecheck` fails on a fresh clone because the SDK's `.d.ts` outputs haven't been generated yet.
  - The pre-commit hook regenerates the Python SDK on every commit, including markdown-only ones.
  - The `duckdb` connection name is silently reserved; the runtime error is the only signal.
  - No `.tool-versions` / pinned toolchain.
  - No top-level Makefile, leaving the two-terminal dev workflow undocumented and fiddly.
  - `Node`, `Java`, and the `--init` flag are required-but-undocumented in various places.

  Each of these is fixed in a focused commit, structured so reviewers can take them piecemeal.

  ## What changes
  
  ### Docs

  - **README Quick Start** — drop the dead submodule line; add a `Verify it's working` block matching CI's `/api/v0/status` smoke test.
  - **README Development** — rewrite the previous three-line section into the production-build path, two-terminal dev workflow (Express `:4000` proxying to Vite `:5173`), and which URL to visit.
  - **README Prerequisites** — Bun, Node (≥ 20), Python, Java with explicit `required for` notes.
  - **README Configuration** — single table covering every env var and matching CLI flag, with defaults and meanings.
  - **`docs/connections.md` (new)** — documents the per-package DuckDB sandboxes, the reserved `duckdb` name, uniqueness rules, and an example mixed-connections config (BigQuery + DuckDB with attached Postgres).
  - **`packages/server/README.md`** — note the `publisher.config.json` symlink to the repo root.

  ### Defaults

  - **Split `publisher.config.json`.** The default now ships three samples (`ecommerce`, `imdb`, `faa`) that run via per-package DuckDB sandboxes with **zero credentials**. The BigQuery-required
  `bigquery-hackernews` sample plus the `bigquery` top-level connection move to `publisher.config.example.bigquery.json`. Existing users who want BigQuery keep working by copying the example over the default
  (one-flag swap, no data loss).
  
  ### Build / dev-loop

  - **`.tool-versions` (new)** — pins `bun 1.3.13`, `node 24`, `python 3.12`, `java corretto-21`. Compatible with `mise` and `asdf`.
  - **`package.json`** — add `"node": ">=20"` to `engines` so the postinstall scripts' Node requirement is explicit; tighten `bun >= 1.3.13` to match `.tool-versions`; chain `generate-api-types && build:sdk` into
  the root `typecheck` script so a fresh-clone `bun run typecheck` succeeds.
  - **`.pre-commit-config.yaml`** — gate the `python-sdk-generate` hook with `files: ^api-doc\.yaml$` instead of `always_run: true`, so it only fires when the OpenAPI spec changes.
  - **`Makefile` (new)** — canonical task runner with `install`, `build`, `start`, `start-init`, `stop`, `dev` (Express + Vite in one terminal with prefixed logs), `dev-init`, `dev-server`, `dev-react`, `status`,
  `environments`, `packages`, `test`, `lint`, `format`, `prettier-check`, `typecheck`, `regen-api`, plus `help` and `doctor`. The `dev` target uses `bunx concurrently` for combined-log output.

  ### Error messages
  
  - **Reserved connection name.** `connection_config.ts` and `connection.controller.ts` both threw `"DuckDB connection name cannot be 'duckdb'; it is reserved..."`. Updated to `"Connection name 'duckdb' is
  reserved for per-package sandboxes. Choose a different name for environment-level DuckDB connections (e.g. 'shared_duckdb')."` — names the rule directly and points at a working alternative.

  ### Tests

  - Updated three reserved-name assertions to match the new message; standardized on a regex pattern so future wording tweaks don't break either site.
  - Added `config.spec.ts` smoke test that JSON-parses both committed configs and asserts the basic shape (default has no `bigquery-hackernews`; example does; both have a non-empty environment with packages).

  ## Verification

  - **Server tests:** 348 unit + 158 integration = **506 pass / 0 fail**.
  - **Fresh install → build → start cycle:** clean `bun install` + `bun run build:server-deploy` + `bun run start:init` boots, reaches `operationalState: serving`, exposes three samples on
  `/api/v0/environments/malloy-samples/packages`, and successfully compiles `flights.malloy` against the per-package DuckDB sandbox with no GCP credentials.
  - **Tested endpoints:** `/api/v0/status`, `/api/v0/environments`, package listing, model compile, static UI (`:4000/`), MCP health (`:4040/health`).

  ## Breaking changes

  **None.** The plan deliberately avoids touching API/SDK/CLI surfaces. The closest thing to a behavior change is the split-config:

  - Users running with the unmodified committed default + BigQuery creds (in practice, mostly Google-internal users) need to point `--server_root` at the new `publisher.config.example.bigquery.json` (or copy it
  over the default) to regain the `bigquery-hackernews` sample. No data loss; one-flag swap. CI paths that exercise BigQuery continue to work against the example config.
  - Adding `engines.node >= 20` formalizes an existing implicit requirement (postinstall scripts and the bin shebang both already needed Node).

  ## Out of scope

  Three items from the original audit are deliberately handled lightly or deferred:

  - **`--init`** — documented rather than made idempotent; the alternative adds code-change risk for a flag the README hadn't surfaced.
  - **DuckDB postinstall scripts** — the audit noted these could be rewritten in TypeScript + Bun to drop the Node dependency entirely. That overlaps a larger backlog item (move to prebuilt DuckDB binaries), so
  this PR ships only the cheap engine pin.
  - **Upstream docs (`docs.malloydata.dev`)** — items 3, 7, 8 may need mirrored updates on the Malloy docs site; tracked separately.

  ## Commits

  Each commit addresses one focused concern and can be reviewed in isolation. All carry DCO sign-off.

  | Commit | Topic |
  |---|---|
  | `docs(readme): fix submodule line, expand dev mode, add verify block` | README #1, #7, #8 |
  | `build: pin toolchain, fix typecheck chain, gate python-sdk hook` | #4, #9, #11 |
  | `config: split BigQuery sample out of default publisher.config.json` | #2 |
  | `docs(connections): clarify reserved-name error + add connections doc` | #3 |
  | `docs: add Prerequisites + Configuration sections, pin node engine` | #5, #6 |
  | `build: add Makefile with common dev workflows` | #10 |
  | `docs: document --init flag and publisher.config.json symlink` | #12, #13 |
  | `build(makefile): add start-init and dev-init targets` | follow-up |
  | `test: fix missed assertion for reserved-name error message` | follow-up |
  | `chore(e2e): refresh bun.lock and ignore cloned test repos` | follow-up |
  | `docs(readme): fix config-section correctness from PR review` | self-review |
  | `docs(connections): fix DuckDB schema example and use case` | self-review |
  | `fix(connections): align reserved-name error to "environment-level"` | self-review |
  | `chore: Makefile cleanups + smoke-test the example configs` | self-review |