### PR TITLE
Monty/docker audit fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,6 +228,31 @@ jobs:
           tags: malloy-publisher:smoke-test
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Inspect image metadata
+        run: |
+          # Lock in the Dockerfile claims made for audit findings #7 and #8:
+          # both runtime ports must be EXPOSEd, and the OCI image labels
+          # that surface mount-path docs must be present. A LABEL syntax
+          # typo or a dropped EXPOSE line would otherwise only surface to
+          # users at deploy time.
+          set -e
+          exposed=$(docker inspect malloy-publisher:smoke-test \
+            --format='{{json .Config.ExposedPorts}}')
+          echo "ExposedPorts: $exposed"
+          echo "$exposed" | jq -e '."4000/tcp"' >/dev/null \
+            || { echo "✗ Missing EXPOSE 4000"; exit 1; }
+          echo "$exposed" | jq -e '."4040/tcp"' >/dev/null \
+            || { echo "✗ Missing EXPOSE 4040"; exit 1; }
+          echo "✓ Both runtime ports declared"
+          labels=$(docker inspect malloy-publisher:smoke-test \
+            --format='{{json .Config.Labels}}')
+          echo "Labels: $labels"
+          for key in title description source documentation licenses; do
+            echo "$labels" | jq -e --arg k "org.opencontainers.image.$key" \
+              '.[$k] | strings | length > 0' >/dev/null \
+              || { echo "✗ Missing/empty OCI label: org.opencontainers.image.$key"; exit 1; }
+          done
+          echo "✓ All five OCI image labels present"
       - name: Start container
         run: |
           docker run -d --name malloy-publisher-smoke \

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,16 @@ RUN --mount=type=cache,target=/root/.bun \
 FROM base-deps AS final
 WORKDIR /publisher
 
+# OCI image metadata — surfaces in `docker inspect`, registry UIs
+# (Docker Hub / GHCR), and Docker Desktop. The description calls out the
+# mount path explicitly because that's the single most-asked Docker
+# question (the audit reports nothing else in the repo documents it).
+LABEL org.opencontainers.image.title="Malloy Publisher"
+LABEL org.opencontainers.image.description="Open-source semantic model server for Malloy. REST API on :4000, MCP API on :4040. Mount your publisher.config.json at /publisher/publisher.config.json (the server's WORKDIR)."
+LABEL org.opencontainers.image.source="https://github.com/malloydata/publisher"
+LABEL org.opencontainers.image.documentation="https://github.com/malloydata/publisher#docker"
+LABEL org.opencontainers.image.licenses="MIT"
+
 # Copy built artifacts from builder
 COPY --from=builder /publisher/package.json /publisher/bun.lock ./
 COPY --from=builder /publisher/packages/app/dist/ /publisher/packages/app/dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,14 +62,14 @@ FROM base-deps AS final
 WORKDIR /publisher
 
 # OCI image metadata — surfaces in `docker inspect`, registry UIs
-# (Docker Hub / GHCR), and Docker Desktop. The description calls out the
-# mount path explicitly because that's the single most-asked Docker
-# question (the audit reports nothing else in the repo documents it).
-LABEL org.opencontainers.image.title="Malloy Publisher"
-LABEL org.opencontainers.image.description="Open-source semantic model server for Malloy. REST API on :4000, MCP API on :4040. Mount your publisher.config.json at /publisher/publisher.config.json (the server's WORKDIR)."
-LABEL org.opencontainers.image.source="https://github.com/malloydata/publisher"
-LABEL org.opencontainers.image.documentation="https://github.com/malloydata/publisher#docker"
-LABEL org.opencontainers.image.licenses="MIT"
+# (Docker Hub / GHCR), and Docker Desktop. The description is kept short
+# (some tools truncate at 80–120 chars); the `documentation` URL points
+# at the root README's Docker section for build/run/mount-path details.
+LABEL org.opencontainers.image.title="Malloy Publisher" \
+      org.opencontainers.image.description="Open-source semantic model server for Malloy (REST :4000, MCP :4040)." \
+      org.opencontainers.image.source="https://github.com/malloydata/publisher" \
+      org.opencontainers.image.documentation="https://github.com/malloydata/publisher#docker" \
+      org.opencontainers.image.licenses="MIT"
 
 # Copy built artifacts from builder
 COPY --from=builder /publisher/package.json /publisher/bun.lock ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,10 @@ RUN --mount=type=cache,target=/root/.bun/install/cache \
 ENV NODE_ENV=production
 ENV PATH="/root/.duckdb/cli/latest:$PATH"
 RUN mkdir -p /etc/publisher
-EXPOSE 4000
+# Declare both runtime ports so `docker run -P` and Docker Desktop's
+# port-preview surface MCP as well as REST. The server already listens
+# on both — this just makes them discoverable.
+EXPOSE 4000 4040
 
 # Pass --server_root explicitly so the zero-arg bundled-default trigger
 # in server.ts (added for `npx @malloy-publisher/server` UX) does NOT fire

--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ curl -s http://localhost:4000/api/v0/environments | jq '.[].name'    # → list 
 - **`degraded`** — initialization completed, but one or more environments failed to load. The surviving environments are served; the failures are listed under `failedEnvironments` in the status response (`curl -s http://localhost:4000/api/v0/status | jq .failedEnvironments`).
 - **`draining`** — graceful shutdown in progress: the server is waiting for in-flight requests to finish before closing. Controlled by `SHUTDOWN_DRAIN_DURATION_SECONDS` and `SHUTDOWN_GRACEFUL_CLOSE_TIMEOUT_SECONDS` (see [Configuration](#configuration)).
 
+## Docker
+
+Build the image and run it with your own `publisher.config.json` mounted in:
+
+```bash
+docker build -t malloy-publisher .
+docker run -d \
+  -p 4000:4000 -p 4040:4040 \
+  -v $(pwd)/publisher.config.json:/publisher/publisher.config.json:ro \
+  malloy-publisher
+```
+
+The container's `WORKDIR` is `/publisher`, so your config belongs at `/publisher/publisher.config.json`. REST is on `:4000`, MCP on `:4040`. If you don't have a config yet, copy [`packages/server/publisher.config.json`](packages/server/publisher.config.json) (DuckDB-only samples, no credentials needed) as a starting point.
+
+For env-var configuration, persistent `publisher_data/` volumes, and advanced options, see [`packages/server/README.docker.md`](packages/server/README.docker.md).
+
 ## Documentation
 
 Full documentation is available at **[docs.malloydata.dev/documentation/user_guides/publishing](https://docs.malloydata.dev/documentation/user_guides/publishing/publishing)**:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ curl -s http://localhost:4000/api/v0/environments | jq '.[].name'    # → list 
 - **`degraded`** — initialization completed, but one or more environments failed to load. The surviving environments are served; the failures are listed under `failedEnvironments` in the status response (`curl -s http://localhost:4000/api/v0/status | jq .failedEnvironments`).
 - **`draining`** — graceful shutdown in progress: the server is waiting for in-flight requests to finish before closing. Controlled by `SHUTDOWN_DRAIN_DURATION_SECONDS` and `SHUTDOWN_GRACEFUL_CLOSE_TIMEOUT_SECONDS` (see [Configuration](#configuration)).
 
+---
+
 ## Docker
 
 Build the image and run it with your own `publisher.config.json` mounted in:
@@ -66,7 +68,7 @@ docker run -d \
   malloy-publisher
 ```
 
-The container's `WORKDIR` is `/publisher`, so your config belongs at `/publisher/publisher.config.json`. REST is on `:4000`, MCP on `:4040`. If you don't have a config yet, copy [`packages/server/publisher.config.json`](packages/server/publisher.config.json) (DuckDB-only samples, no credentials needed) as a starting point.
+The container's `WORKDIR` is `/publisher`, so your config belongs at `/publisher/publisher.config.json`. REST is on `:4000`, MCP on `:4040`. If you don't have a config yet, copy [`packages/server/publisher.config.example.duckdb.json`](packages/server/publisher.config.example.duckdb.json) (DuckDB-only samples, no credentials needed) as a starting point.
 
 For env-var configuration, persistent `publisher_data/` volumes, and advanced options, see [`packages/server/README.docker.md`](packages/server/README.docker.md).
 

--- a/packages/server/README.docker.md
+++ b/packages/server/README.docker.md
@@ -1,32 +1,83 @@
-# Creating a Publisher Docker Image
+# Publisher in Docker
 
-There are 2 docker files in the repo. A base `production.docker` which creates the base image and `malloy-samples.docker` which is layered on top and copies the malloy samples into the Docker image so they can be served by the publisher.
+The canonical build is the root [`Dockerfile`](../../Dockerfile) and the CI smoke test (`docker_smoke_test` in `.github/workflows/build.yml`) builds and runs that exact image. The two-port REST + MCP server, the Snowflake ADBC driver, the DuckDB CLI, and the production app bundle all ship in it.
 
-To create a Docker image for your own packages, follow the example of `docker/malloy-samples.docker` which copies in the publisher config and malloy files.
+A short Docker section in the [repo root README](../../README.md#docker) covers the canonical build + run; this doc goes deeper on runtime layout, environment variables, persistent storage, and credentials.
 
-## To create & run the malloy-samples Docker image:
-
-1. Clone the Publisher repository + malloy-sample submodule as outline in the README.
-
-2. Build the Docker imagee using the provided Dockerfiles:
-
-   ```bash
-   docker build -t malloy-publisher:latest -f docker/production.docker .
-   docker build -t malloy-samples:latest -f docker/malloy-samples.docker .
-   ```
-
-3. Run the Docker container.
-   The Publisher server runs at port 4000, the MCP server at port 4040.
-
-   ```bash
-   docker run -p 4000:4000 -p 4040:4040 malloy-samples:latest
-   ```
-
-4. (Optional) For BigQuery access, mount your GCP credentials.
-   Note that you cannot use personal credentials- only service account credentials can be used in the docker image.
+## Build and run
 
 ```bash
-docker run -p 4000:4000 -p 4040:4040 \
-  -v /path/to/your/service_credentials.json:/app/gcp-credentials/key.json \
-  malloy-samples:latest
+docker build -t malloy-publisher .
+docker run -d \
+  --name malloy-publisher \
+  -p 4000:4000 -p 4040:4040 \
+  -v $(pwd)/publisher.config.json:/publisher/publisher.config.json:ro \
+  malloy-publisher
 ```
+
+Once `/api/v0/status` reports `operationalState: "serving"`, the REST API is at `http://localhost:4000` and MCP at `http://localhost:4040/mcp`.
+
+If you don't have a config of your own yet, copy [`packages/server/publisher.config.json`](./publisher.config.json) (DuckDB-only samples, no credentials required) and mount that.
+
+## Runtime layout
+
+| Path inside container | What's there |
+|---|---|
+| `/publisher/` | `WORKDIR`. The server reads `<WORKDIR>/publisher.config.json` by default — that's the file you mount. |
+| `/publisher/packages/server/dist/` | The bundled server (built by `bun run build` in CI). |
+| `/publisher/packages/app/dist/` | The static SPA the server serves. |
+| `/publisher/publisher_data/` | Per-environment package clones, DuckDB extension cache, and per-package sandbox DBs. Created at runtime; **persist this as a named volume if you want first-run sample clones to survive a container restart.** |
+| `/root/.duckdb/` | DuckDB CLI + extension install dir. Bundled into the image. |
+
+To keep `publisher_data/` across restarts:
+
+```bash
+docker run -d \
+  --name malloy-publisher \
+  -p 4000:4000 -p 4040:4040 \
+  -v $(pwd)/publisher.config.json:/publisher/publisher.config.json:ro \
+  -v publisher_data:/publisher/publisher_data \
+  malloy-publisher
+```
+
+The first request after a fresh start clones sample packages from GitHub — a named volume turns that one-time cost into a one-time cost across all container lifecycles.
+
+## Configuration via environment variables
+
+All flags exposed by `bin/malloy-publisher --help` have an equivalent env var, so they're easy to set from `docker run -e` or compose:
+
+| Env var | Equivalent flag | Default | Purpose |
+|---|---|---|---|
+| `PUBLISHER_PORT` | `--port <n>` | `4000` | REST API port. |
+| `PUBLISHER_HOST` | `--host <h>` | `0.0.0.0` | Bind address. |
+| `MCP_PORT` | `--mcp_port <n>` | `4040` | MCP API port. |
+| `SERVER_ROOT` | `--server_root <path>` | `/publisher` (set by CMD) | Directory the server treats as its working dir. The default in the image is set so the zero-arg `npx` bundled-default trigger doesn't fire — override only if you also override CMD. |
+| `PUBLISHER_CONFIG_PATH` | `--config <path>` | unset | Absolute path to a `publisher.config.json`. Wins over `<SERVER_ROOT>/publisher.config.json`. Use this if you want to mount your config somewhere other than `/publisher/`. |
+| `INITIALIZE_STORAGE` | `--init` | `false` | Wipes persisted storage state on startup. Useful when `frozenConfig: false` has let `publisher_data/` drift from the on-disk config; destructive otherwise. |
+| `SHUTDOWN_DRAIN_DURATION_SECONDS` | — | `0` | On SIGTERM, how long to keep accepting requests while draining before closing server sockets. Set this to your typical request duration to avoid 502s from K8s rolling deploys. |
+| `SHUTDOWN_GRACEFUL_CLOSE_TIMEOUT_SECONDS` | — | `0` | Additional grace period after server close before `process.exit`. |
+| `GOOGLE_APPLICATION_CREDENTIALS` | — | unset | Path inside the container to a GCP service-account JSON. Required for BigQuery-backed environments. Personal user credentials don't work inside the container — use a service account. |
+
+## BigQuery credentials
+
+To enable BigQuery samples or your own BigQuery connections, mount a service-account key and point `GOOGLE_APPLICATION_CREDENTIALS` at it:
+
+```bash
+docker run -d \
+  --name malloy-publisher \
+  -p 4000:4000 -p 4040:4040 \
+  -v $(pwd)/publisher.config.json:/publisher/publisher.config.json:ro \
+  -v $(pwd)/gcp-sa.json:/etc/publisher/gcp-sa.json:ro \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/etc/publisher/gcp-sa.json \
+  malloy-publisher
+```
+
+`/etc/publisher/` is created by the Dockerfile specifically as a place to mount credential material — it isn't part of the application tree.
+
+## The CI Dockerfile (`docker/Dockerfile.ci`)
+
+`docker/Dockerfile.ci` exists for the CI integration-test path (referenced from the repo's `docker-compose.yml`). It is **not** the production image and should not be used for deployment. Production users build the root [`Dockerfile`](../../Dockerfile).
+
+## Deprecated build paths
+
+`docker/production.docker` and `docker/malloy-samples.docker` are leftover from a previous Docker layout. They are not built by CI, are not referenced by any current workflow, and produce a different image than what is deployed. Don't use them. They will be removed in a follow-up cleanup PR; the audit and tracking is in `publisher-audit-docker.md` (finding #1).

--- a/packages/server/README.docker.md
+++ b/packages/server/README.docker.md
@@ -17,7 +17,7 @@ docker run -d \
 
 Once `/api/v0/status` reports `operationalState: "serving"`, the REST API is at `http://localhost:4000` and MCP at `http://localhost:4040/mcp`.
 
-If you don't have a config of your own yet, copy [`packages/server/publisher.config.json`](./publisher.config.json) (DuckDB-only samples, no credentials required) and mount that.
+If you don't have a config of your own yet, copy [`packages/server/publisher.config.example.duckdb.json`](./publisher.config.example.duckdb.json) (DuckDB-only samples, no credentials required) and mount that. There's also a [`publisher.config.example.bigquery.json`](./publisher.config.example.bigquery.json) sibling for the BigQuery samples.
 
 ## Runtime layout
 
@@ -51,7 +51,7 @@ All flags exposed by `bin/malloy-publisher --help` have an equivalent env var, s
 | `PUBLISHER_PORT` | `--port <n>` | `4000` | REST API port. |
 | `PUBLISHER_HOST` | `--host <h>` | `0.0.0.0` | Bind address. |
 | `MCP_PORT` | `--mcp_port <n>` | `4040` | MCP API port. |
-| `SERVER_ROOT` | `--server_root <path>` | `/publisher` (set by CMD) | Directory the server treats as its working dir. The default in the image is set so the zero-arg `npx` bundled-default trigger doesn't fire — override only if you also override CMD. |
+| `SERVER_ROOT` | `--server_root <path>` | `.` (cwd) at the server level; overridden to `/publisher` by the bundled CMD | Directory the server treats as its working dir. The image's CMD passes `--server_root /publisher` explicitly so the zero-arg `npx` bundled-default trigger doesn't fire inside the container. If you override CMD with your own entrypoint, set `SERVER_ROOT` yourself to keep this behaviour. |
 | `PUBLISHER_CONFIG_PATH` | `--config <path>` | unset | Absolute path to a `publisher.config.json`. Wins over `<SERVER_ROOT>/publisher.config.json`. Use this if you want to mount your config somewhere other than `/publisher/`. |
 | `INITIALIZE_STORAGE` | `--init` | `false` | Wipes persisted storage state on startup. Useful when `frozenConfig: false` has let `publisher_data/` drift from the on-disk config; destructive otherwise. |
 | `SHUTDOWN_DRAIN_DURATION_SECONDS` | — | `0` | On SIGTERM, how long to keep accepting requests while draining before closing server sockets. Set this to your typical request duration to avoid 502s from K8s rolling deploys. |
@@ -72,7 +72,7 @@ docker run -d \
   malloy-publisher
 ```
 
-`/etc/publisher/` is created by the Dockerfile specifically as a place to mount credential material — it isn't part of the application tree.
+The Dockerfile creates `/etc/publisher/` as an empty directory outside the application tree at `/publisher/`. By the convention this doc establishes, mount credential material there to keep it separated from the app — but any writable path inside the container works.
 
 ## The CI Dockerfile (`docker/Dockerfile.ci`)
 

--- a/packages/server/publisher.config.example.duckdb.json
+++ b/packages/server/publisher.config.example.duckdb.json
@@ -1,0 +1,23 @@
+{
+  "frozenConfig": false,
+  "environments": [
+    {
+      "name": "malloy-samples",
+      "packages": [
+        {
+          "name": "ecommerce",
+          "location": "https://github.com/credibledata/malloy-samples/tree/main/ecommerce"
+        },
+        {
+          "name": "imdb",
+          "location": "https://github.com/credibledata/malloy-samples/tree/main/imdb"
+        },
+        {
+          "name": "faa",
+          "location": "https://github.com/credibledata/malloy-samples/tree/main/faa"
+        }
+      ],
+      "connections": []
+    }
+  ]
+}

--- a/packages/server/src/config.spec.ts
+++ b/packages/server/src/config.spec.ts
@@ -969,6 +969,7 @@ describe("Committed example configs", () => {
 
    it.each([
       ["publisher.config.json", false],
+      ["publisher.config.example.duckdb.json", false],
       ["publisher.config.example.bigquery.json", true],
    ])(
       "%s parses as a valid PublisherConfig",


### PR DESCRIPTION
## Summary
  
  Issue: https://github.com/malloydata/publisher/issues/727
  
  Docker audit fixes: added `EXPOSE 4040` (so MCP is discoverable via `docker run -P`), added five `org.opencontainers.image.*` labels documenting the mount path, added a Docker section to the root README,
  and rewrote `packages/server/README.docker.md` to point at the canonical root Dockerfile instead of the stale `docker/*.docker` paths. 
  
  ## Audit findings addressed
  
  | # | Finding | Commit | What changed |
  |---|---|---|---|
  | #8 | Only `EXPOSE 4000` declared even though the server listens on `:4040` too — `docker run -P` silently dropped MCP; Docker Desktop's port-preview missed it | [`2125fac`](../../commit/2125fac) |
  `Dockerfile`: `EXPOSE 4000 4040` |
  | #7 | Nothing in the Dockerfile, root README, or `README.docker.md` documents the mount path (`/publisher/publisher.config.json`) | [`cf9ca5b`](../../commit/cf9ca5b) | `Dockerfile`: added 5
  `org.opencontainers.image.*` labels (title, description, source, documentation, licenses). The `description` calls out both ports; the `documentation` URL points at the new root-README Docker section. |
  | #2 | Root `README.md` had no Docker section at all — only signal that Docker exists is the Dockerfile sitting in the repo root | [`07f6225`](../../commit/07f6225) | `README.md`: added a `## Docker` section
  after the verify block with build/run snippet, mount path, port info, and a pointer to `packages/server/README.docker.md` |
  | #1 | `packages/server/README.docker.md` documented two build paths (`docker/production.docker`, `docker/malloy-samples.docker`) that neither CI nor any deployment uses; users following it built a different
  image than the one CI tests | [`e97335c`](../../commit/e97335c) | Rewrote against the root `Dockerfile`: runtime-layout table, env-var table cross-checked against `server.ts`, BigQuery credentials guidance, note
   on `docker/Dockerfile.ci` being CI-only, note on the deprecated build paths |

  Plus a self-review pass that cleaned up 7 polish items ([`f1ff3af`](../../commit/f1ff3af)): SERVER_ROOT default accuracy in the env-var table, softened invented `/etc/publisher/` framing, decoupled docs from the
   production config via a new `publisher.config.example.duckdb.json`, consolidated the 5 LABELs into one continuation-line block, shortened the OCI description, added a visual `---` rule before the Docker section
   in the root README, and added a new `Inspect image metadata` step to the `docker_smoke_test` CI workflow that asserts EXPOSE + OCI labels are present.
  
  ## Local verification — full fresh `docker build` + `docker run`

  End-to-end test against a freshly built image from this branch:

  | Check | Result |
  |---|---|
  | `docker build -t malloy-publisher:audit-test -f Dockerfile .` | ✅ exit 0 (image: 2.88 GB) |
  | `EXPOSE 4000` declared (jq assertion from new CI step) | ✅ |
  | `EXPOSE 4040` declared (jq assertion from new CI step) | ✅ |
  | All 5 OCI labels present + non-empty (jq assertions from new CI step) | ✅ |
  | Container starts, reaches `operationalState: "serving"` within seconds | ✅ |
  | REST API on `:4000` responds (`/api/v0/status`, `/api/v0/environments`) | ✅ |
  | MCP on `:4040/health` returns K8s-shaped JSON (`livenessState: UP`, `readinessState: UP`) | ✅ |

  The new `Inspect image metadata` CI step in `docker_smoke_test` was validated locally against the actual image — no jq syntax bugs, no LABEL key typos.

  ## Breaking changes

  **None.**

  - `EXPOSE 4000 4040` is additive — the server already listened on both; this just declares them in image metadata.
  - The new `LABEL` block sets image metadata only; no runtime behavior change.
  - The new `publisher.config.example.duckdb.json` is a new file that mirrors the current `publisher.config.json` content. Existing tooling (the `Committed example configs` table-test in `config.spec.ts`) was
  extended to cover it; nothing was removed.
  - `README.docker.md` was rewritten in place. The old file still existed but documented build paths that didn't work anymore — the rewrite is a clear functional improvement, not a behavior change.

