### PR TITLE
Prebuilt docker audit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ curl -s http://localhost:4000/api/v0/environments | jq '.[].name'    # → list 
 
 ## Docker
 
-Build the image and run it with your own `publisher.config.json` mounted in:
+Two ways to run the Publisher in Docker: build the image from source, or pull the pre-built image from Docker Hub. Either way, the container's `WORKDIR` is `/publisher` (mount your `publisher.config.json` there), REST is on `:4000`, and MCP is on `:4040`.
+
+### Build from source
 
 ```bash
 docker build -t malloy-publisher .
@@ -68,7 +70,27 @@ docker run -d \
   malloy-publisher
 ```
 
-The container's `WORKDIR` is `/publisher`, so your config belongs at `/publisher/publisher.config.json`. REST is on `:4000`, MCP on `:4040`. If you don't have a config yet, copy [`packages/server/publisher.config.example.duckdb.json`](packages/server/publisher.config.example.duckdb.json) (DuckDB-only samples, no credentials needed) as a starting point.
+If you don't have a config yet, copy [`packages/server/publisher.config.example.duckdb.json`](packages/server/publisher.config.example.duckdb.json) (DuckDB-only samples, no credentials needed) as a starting point.
+
+### Pre-built image
+
+The official pre-built image is published to Docker Hub at [`ms2data/malloy-publisher`](https://hub.docker.com/r/ms2data/malloy-publisher).
+
+```bash
+docker pull ms2data/malloy-publisher
+docker run -d \
+  -p 4000:4000 -p 4040:4040 \
+  -v $(pwd)/publisher.config.json:/publisher/publisher.config.json:ro \
+  ms2data/malloy-publisher
+```
+
+**Tags:**
+
+- `:latest` — most recent stable release.
+- `:X.Y.Z` — pinned to a specific release; recommended for production.
+- `:next` — pre-release builds; not recommended for production.
+
+`*-dev` tags (e.g. `:0.0.198-dev`) are deprecated in favor of `:next`; pin to a specific `:X.Y.Z` for stable deployments.
 
 For env-var configuration, persistent `publisher_data/` volumes, and advanced options, see [`packages/server/README.docker.md`](packages/server/README.docker.md).
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ docker run -d \
 
 `*-dev` tags (e.g. `:0.0.198-dev`) are deprecated in favor of `:next`; pin to a specific `:X.Y.Z` for stable deployments.
 
+### Docker Compose
+
+A ready-to-use Compose file lives at [`docker-compose.example.yml`](docker-compose.example.yml) — it runs the pre-built image with both ports mapped and a named volume for `publisher_data/` so first-boot package clones survive restarts:
+
+```bash
+cp docker-compose.example.yml docker-compose.yml
+docker compose up -d
+```
+
+Adjust the `publisher.config.json` volume mount to point at your own config before bringing the stack up.
+
 For env-var configuration, persistent `publisher_data/` volumes, and advanced options, see [`packages/server/README.docker.md`](packages/server/README.docker.md).
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -90,18 +90,15 @@ docker run -d \
 - `:X.Y.Z` — pinned to a specific release; recommended for production.
 - `:next` — pre-release builds; not recommended for production.
 
-`*-dev` tags (e.g. `:0.0.198-dev`) are deprecated in favor of `:next`; pin to a specific `:X.Y.Z` for stable deployments.
+`*-dev` tags (e.g. `:0.0.198-dev`) are frozen — no new ones are being published, and `:next` is the current pre-release channel. Existing `*-dev` tags still resolve in the registry; don't use them for new deployments.
 
 ### Docker Compose
 
-A ready-to-use Compose file lives at [`docker-compose.example.yml`](docker-compose.example.yml) — it runs the pre-built image with both ports mapped and a named volume for `publisher_data/` so first-boot package clones survive restarts:
+A ready-to-use Compose file lives at [`docker-compose.example.yml`](docker-compose.example.yml) — it runs the pre-built image with both ports mapped, a healthcheck against `/api/v0/status`, and a named volume for `publisher_data/` so first-boot package clones survive restarts. To use it:
 
-```bash
-cp docker-compose.example.yml docker-compose.yml
-docker compose up -d
-```
-
-Adjust the `publisher.config.json` volume mount to point at your own config before bringing the stack up.
+1. Copy it into your project: `cp docker-compose.example.yml docker-compose.yml`.
+2. Place a `publisher.config.json` next to it (or change the volume mount). No config of your own yet? Copy [`packages/server/publisher.config.example.duckdb.json`](packages/server/publisher.config.example.duckdb.json) — DuckDB-only samples, no credentials needed.
+3. `docker compose up -d`
 
 For env-var configuration, persistent `publisher_data/` volumes, and advanced options, see [`packages/server/README.docker.md`](packages/server/README.docker.md).
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,9 +1,10 @@
 # docker-compose.example.yml
 #
-# Production-shaped Compose file for running the Malloy Publisher
-# from the pre-built `ms2data/malloy-publisher` image. Copy this to
-# `docker-compose.yml` in your own project (or symlink it) and adjust
-# the volume mounts to point at your own publisher.config.json.
+# Example Compose file for running the Malloy Publisher from the
+# pre-built `ms2data/malloy-publisher` image. Copy this to
+# `docker-compose.yml` in your own project (or symlink it) and
+# adjust the volume mounts to point at your own publisher.config.json
+# before bringing the stack up.
 #
 # REST is on :4000; MCP is on :4040. See the root README "Docker"
 # section for tag-scheme guidance (`:latest`, `:X.Y.Z`, `:next`).
@@ -15,6 +16,8 @@
 
 services:
   publisher:
+    # For production deployments, pin a specific release rather than
+    # tracking `:latest` (e.g. `ms2data/malloy-publisher:0.0.196`).
     image: ms2data/malloy-publisher:latest
     ports:
       - "4000:4000" # REST
@@ -22,7 +25,25 @@ services:
     volumes:
       - ./publisher.config.json:/publisher/publisher.config.json:ro
       - publisher_data:/publisher/publisher_data
+    # Uncomment to override defaults. See packages/server/README.docker.md
+    # for the full env-var table.
+    # environment:
+    #   LOG_LEVEL: info
+    #   SHUTDOWN_DRAIN_DURATION_SECONDS: "10"
     restart: unless-stopped
+    # The first boot clones sample packages from GitHub, which can
+    # take ~30s on a slow link; `start_period` keeps the container
+    # marked "starting" (not "unhealthy") during that window.
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -fs http://localhost:4000/api/v0/status | grep -q '\"operationalState\":\"serving\"' || exit 1",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 90s
 
 volumes:
   publisher_data:

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,28 @@
+# docker-compose.example.yml
+#
+# Production-shaped Compose file for running the Malloy Publisher
+# from the pre-built `ms2data/malloy-publisher` image. Copy this to
+# `docker-compose.yml` in your own project (or symlink it) and adjust
+# the volume mounts to point at your own publisher.config.json.
+#
+# REST is on :4000; MCP is on :4040. See the root README "Docker"
+# section for tag-scheme guidance (`:latest`, `:X.Y.Z`, `:next`).
+#
+# The `publisher_data` named volume persists the per-environment
+# package clones and DuckDB extension cache across container
+# restarts, so the first-boot clone of sample packages from GitHub
+# only happens once.
+
+services:
+  publisher:
+    image: ms2data/malloy-publisher:latest
+    ports:
+      - "4000:4000" # REST
+      - "4040:4040" # MCP
+    volumes:
+      - ./publisher.config.json:/publisher/publisher.config.json:ro
+      - publisher_data:/publisher/publisher_data
+    restart: unless-stopped
+
+volumes:
+  publisher_data:

--- a/packages/server/README.docker.md
+++ b/packages/server/README.docker.md
@@ -57,7 +57,7 @@ docker run -d \
 
 The first request after a fresh start clones sample packages from GitHub — a named volume turns that one-time cost into a one-time cost across all container lifecycles.
 
-The repo ships a ready-to-use [`docker-compose.example.yml`](../../docker-compose.example.yml) that wires up the same named-volume pattern against the pre-built image; copy it to `docker-compose.yml` in your own project and `docker compose up -d`.
+For the same pattern as a complete Compose file (with a healthcheck against `/api/v0/status` and both ports mapped), see [`docker-compose.example.yml`](../../docker-compose.example.yml) at the repo root.
 
 ## Configuration via environment variables
 

--- a/packages/server/README.docker.md
+++ b/packages/server/README.docker.md
@@ -57,6 +57,8 @@ docker run -d \
 
 The first request after a fresh start clones sample packages from GitHub — a named volume turns that one-time cost into a one-time cost across all container lifecycles.
 
+The repo ships a ready-to-use [`docker-compose.example.yml`](../../docker-compose.example.yml) that wires up the same named-volume pattern against the pre-built image; copy it to `docker-compose.yml` in your own project and `docker compose up -d`.
+
 ## Configuration via environment variables
 
 All flags exposed by `bin/malloy-publisher --help` have an equivalent env var, so they're easy to set from `docker run -e` or compose:

--- a/packages/server/README.docker.md
+++ b/packages/server/README.docker.md
@@ -19,6 +19,21 @@ Once `/api/v0/status` reports `operationalState: "serving"`, the REST API is at 
 
 If you don't have a config of your own yet, copy [`packages/server/publisher.config.example.duckdb.json`](./publisher.config.example.duckdb.json) (DuckDB-only samples, no credentials required) and mount that. There's also a [`publisher.config.example.bigquery.json`](./publisher.config.example.bigquery.json) sibling for the BigQuery samples.
 
+## Pre-built image
+
+If you don't want to build the image yourself, the official pre-built image is published to Docker Hub under the **`ms2data/`** namespace (not `malloydata/`):
+
+```bash
+docker pull ms2data/malloy-publisher
+docker run -d \
+  --name malloy-publisher \
+  -p 4000:4000 -p 4040:4040 \
+  -v $(pwd)/publisher.config.json:/publisher/publisher.config.json:ro \
+  ms2data/malloy-publisher
+```
+
+See the [Docker Hub tags page](https://hub.docker.com/r/ms2data/malloy-publisher/tags) for available versions. Tag-scheme guidance (`:latest`, `:X.Y.Z`, `:next`) lives in the root README's [Docker section](../../README.md#docker).
+
 ## Runtime layout
 
 | Path inside container | What's there |


### PR DESCRIPTION
Issue: https://github.com/malloydata/publisher/issues/728
Audit doc: https://docs.google.com/document/d/1cIIxJhXUCVYxG_09auQeKBWXwtSdJRRjPJFYF1eAY5c/edit?usp=sharing

 ## Summary
  
  Publisher-side fixes for the **pre-built Docker audit** (testing `docker pull ms2data/malloy-publisher` and the docs.malloydata.dev "Option 3: Docker" command). This PR stacks on `monty/docker-audit-fixes` (the
  local-build audit follow-up) — set that as the base, or merge it first.

  - **Audit #1 — namespace mismatch.** The GitHub repo is `malloydata/publisher` but the published image is `ms2data/malloy-publisher` (Credible's namespace). Documented the official Docker Hub location in the
  root README and `packages/server/README.docker.md` so users searching for `malloydata/publisher` on Docker Hub aren't left empty-handed.
  - **Audit #3 — missing 4040 in compose.** Per Sagar's Slack ask, added a new top-level `docker-compose.example.yml` that maps both `:4000` (REST) and `:4040` (MCP), runs the pre-built image, persists
  `publisher_data/` via a named volume, and includes a healthcheck against `/api/v0/status` with a 90s `start_period` for the cold-start clone. The existing `docker-compose.yml` only defines a `publisher.ci`
  service for CI smoke-tests, so mixing a user-facing service into it would conflate CI and end-user concerns.
  - **Audit #5 — tag scheme.** Documented `:latest` / `:X.Y.Z` / `:next` in the root README. `*-dev` tags are flagged as **frozen** (Sagar has stopped publishing new ones, but pre-existing ones still resolve in
  the registry — verified by `docker pull ms2data/malloy-publisher:0.0.196-dev`).

  After this PR the root README's `## Docker` section reads top-to-bottom as `### Build from source` → `### Pre-built image` → `### Docker Compose`.

  ## Test plan

  - [ ] Check out this branch
  - [ ] `docker compose -f docker-compose.example.yml config` parses cleanly
  - [ ] In a fresh directory: `cp docker-compose.example.yml docker-compose.yml`, copy `packages/server/publisher.config.example.duckdb.json` to `publisher.config.json`, then `docker compose up -d`
  - [ ] After ~35s: `curl http://localhost:4000/api/v0/status` reports `operationalState: "serving"`
  - [ ] `curl http://localhost:4040/health` returns 200
  - [ ] `docker inspect <container> --format '{{.State.Health.Status}}'` reports `healthy` (and never reported `unhealthy` during the cold-start window)
  - [ ] `docker compose down --volumes` cleans up the container, network, and named volume
  - [ ] Render the README on GitHub and walk the new `## Docker` section top-to-bottom

