### PR TITLE
docs: drop "Starter" from givens migration plan title

### DIFF
--- a/docs/givens-migration-plan.md
+++ b/docs/givens-migration-plan.md
@@ -1,4 +1,4 @@
-# Givens Migration — Starter Project Plan
+# Givens Migration — Project Plan
 
 Adopt Malloy native [`given:`](https://docs.malloydata.dev/documentation/experiments/givens) (givens) as the going-forward way for callers to supply runtime parameters, while keeping the existing `#(filter)` + `filterParams` path working unchanged so the current customer integration doesn't break. Builds on top of upstream PR #744, which already lands the basic per-query plumbing.
 


### PR DESCRIPTION
## Summary

Tiny title cleanup on `docs/givens-migration-plan.md` — drop the "Starter" qualifier so the doc title reads as a plan we're committing to, not a stand-alone starter exercise.

Follow-up to #745.

Made with [Cursor](https://cursor.com)