### PR TITLE
fix(server): version package directories and use the database as the swap ordering point

### DIFF
--- a/packages/server/src/controller/package.controller.ts
+++ b/packages/server/src/controller/package.controller.ts
@@ -1,23 +1,45 @@
+import { randomUUID } from "crypto";
+import * as fs from "fs";
 import * as path from "path";
 import { components } from "../api";
 import { PUBLISHER_DATA_DIR } from "../constants";
 import { BadRequestError, FrozenConfigError } from "../errors";
 import { logger } from "../logger";
+import { Environment } from "../service/environment";
 import { EnvironmentStore } from "../service/environment_store";
 import { ManifestService } from "../service/manifest_service";
+import {
+   buildVersionedPackagePath,
+   PackageSweeper,
+} from "../service/package_sweeper";
 
 type ApiPackage = components["schemas"]["Package"];
 
+/**
+ * Strategy: every API write that produces new package contents goes into a
+ * fresh, UUID-scoped versioned directory under
+ * `<env>/<pkg>.versions/<uuid>/`. The DB row's `manifest_path` is then
+ * atomically swung from the old directory to the new one via
+ * `repository.swapPackageDirectory`. The old directory (if any) is handed
+ * to `PackageSweeper` for deferred deletion so in-flight readers that hold
+ * a `Package` cached against the old path keep working until the
+ * quiescence window elapses. There are no per-package mutexes — concurrent
+ * writers download into different staging dirs and rely on the database as
+ * the single ordering point.
+ */
 export class PackageController {
    private environmentStore: EnvironmentStore;
    private manifestService: ManifestService;
+   private sweeper: PackageSweeper;
 
    constructor(
       environmentStore: EnvironmentStore,
       manifestService: ManifestService,
+      sweeper: PackageSweeper,
    ) {
       this.environmentStore = environmentStore;
       this.manifestService = manifestService;
+      this.sweeper = sweeper;
    }
 
    public async listPackages(environmentName: string): Promise<ApiPackage[]> {
@@ -37,16 +59,28 @@ export class PackageController {
          environmentName,
          false,
       );
-      const _package = await environment.getPackage(packageName, reload);
-      const packageLocation = _package.getPackageMetadata().location;
-      if (reload && packageLocation) {
-         await this.downloadPackage(
-            environmentName,
-            packageName,
-            packageLocation,
-         );
+
+      if (!reload) {
+         const _package = await environment.getPackage(packageName);
+         return _package.getPackageMetadata();
       }
-      return _package.getPackageMetadata();
+
+      // `?reload=true` is the API contract for "re-download from `location` and
+      // start serving the new contents immediately." Re-uses the same
+      // versioned-dir + DB-CAS write path the controller's add/update paths
+      // take so the race profile is identical and the in-memory cache picks
+      // up the new version on the very next read.
+      const cached = await environment.getPackage(packageName);
+      const packageLocation = cached.getPackageMetadata().location;
+      if (!packageLocation) {
+         return cached.getPackageMetadata();
+      }
+      await this.swapInVersionedDirectory(environment, packageName, {
+         location: packageLocation,
+         description: cached.getPackageMetadata().description,
+      });
+      const reloaded = await environment.getPackage(packageName);
+      return reloaded.getPackageMetadata();
    }
 
    async addPackage(
@@ -64,17 +98,25 @@ export class PackageController {
          environmentName,
          false,
       );
+      const packageName = body.name;
+
       if (body.location) {
-         await this.downloadPackage(environmentName, body.name, body.location);
+         await this.swapInVersionedDirectory(environment, packageName, body);
+      } else {
+         // Mount-style add with no `location`: ensure a row exists so future
+         // resolves go through the DB. The directory is whatever already
+         // exists at `<env>/<pkg>` (legacy fallback).
+         await this.ensureDatabaseRowForExistingDirectory(
+            environment,
+            packageName,
+            body,
+         );
       }
-      const result = await environment.addPackage(body.name);
-      await this.environmentStore.addPackageToDatabase(
-         environmentName,
-         body.name,
-      );
+
+      const result = (await environment.getPackage(packageName)).getPackageMetadata();
 
       if (options?.autoLoadManifest === true) {
-         await this.tryLoadExistingManifest(environmentName, body.name);
+         await this.tryLoadExistingManifest(environmentName, packageName);
       }
 
       return result;
@@ -129,13 +171,15 @@ export class PackageController {
          environmentName,
          false,
       );
-      const result = await environment.deletePackage(packageName);
+      const oldDirectoryPath = await environment.deletePackage(packageName);
       await this.environmentStore.deletePackageFromDatabase(
          environmentName,
          packageName,
       );
-
-      return result;
+      if (oldDirectoryPath) {
+         this.sweeper.scheduleSweep(environmentName, oldDirectoryPath);
+      }
+      return undefined;
    }
 
    public async updatePackage(
@@ -150,33 +194,149 @@ export class PackageController {
          environmentName,
          false,
       );
+
       if (body.location) {
-         await this.downloadPackage(
+         await this.swapInVersionedDirectory(environment, packageName, body);
+      } else if (body.description !== undefined) {
+         // Description-only update: write straight through to the DB row,
+         // leaving the on-disk version untouched.
+         await this.persistMetadataOnly(environment, packageName, body);
+      }
+
+      // Refresh the in-memory `Package` so its metadata reflects the latest
+      // description. The directory swap (if any) already invalidated the
+      // path-keyed cache on its own.
+      return environment.updatePackage(packageName, body);
+   }
+
+   /**
+    * Download into a fresh `<env>/<pkg>.versions/<uuid>/` directory, atomically
+    * swing the package row to point at it, and queue the previous directory
+    * for sweeper-driven cleanup. Two concurrent calls for the same package
+    * download into different UUID dirs and serialize through the DB CAS;
+    * neither blocks on the other and the sweeper backstops any orphan that
+    * results from the race.
+    */
+   private async swapInVersionedDirectory(
+      environment: Environment,
+      packageName: string,
+      body: ApiPackage,
+   ): Promise<void> {
+      if (!body.location) return;
+
+      const environmentName = environment.getEnvironmentName();
+      const versionId = randomUUID();
+      const newDirectoryPath = buildVersionedPackagePath(
+         environment.getEnvironmentPath(),
+         packageName,
+         versionId,
+      );
+
+      try {
+         await fs.promises.mkdir(path.dirname(newDirectoryPath), {
+            recursive: true,
+         });
+         await this.downloadIntoTarget(
             environmentName,
             packageName,
             body.location,
+            newDirectoryPath,
+         );
+      } catch (error) {
+         await this.bestEffortRm(newDirectoryPath);
+         throw error;
+      }
+
+      const repository = this.environmentStore.storageManager.getRepository();
+      const dbEnvironment =
+         await repository.getEnvironmentByName(environmentName);
+      if (!dbEnvironment) {
+         await this.bestEffortRm(newDirectoryPath);
+         throw new Error(
+            `Environment "${environmentName}" not found in database`,
          );
       }
-      const result = await environment.updatePackage(packageName, body);
-      await this.environmentStore.addPackageToDatabase(
-         environmentName,
-         packageName,
-      );
 
-      return result;
+      const swapResult = await repository.swapPackageDirectory({
+         environmentId: dbEnvironment.id,
+         name: packageName,
+         newDirectoryPath,
+         description: body.description,
+         metadata: { location: body.location },
+      });
+
+      if (swapResult.oldDirectoryPath) {
+         this.sweeper.scheduleSweep(
+            environmentName,
+            swapResult.oldDirectoryPath,
+         );
+      }
    }
 
-   private async downloadPackage(
+   private async ensureDatabaseRowForExistingDirectory(
+      environment: Environment,
+      packageName: string,
+      body: ApiPackage,
+   ): Promise<void> {
+      const environmentName = environment.getEnvironmentName();
+      const repository = this.environmentStore.storageManager.getRepository();
+      const dbEnvironment =
+         await repository.getEnvironmentByName(environmentName);
+      if (!dbEnvironment) {
+         throw new Error(
+            `Environment "${environmentName}" not found in database`,
+         );
+      }
+      const legacyPath = path.join(
+         environment.getEnvironmentPath(),
+         packageName,
+      );
+      await repository.swapPackageDirectory({
+         environmentId: dbEnvironment.id,
+         name: packageName,
+         newDirectoryPath: legacyPath,
+         description: body.description,
+         metadata: body.location ? { location: body.location } : undefined,
+      });
+   }
+
+   private async persistMetadataOnly(
+      environment: Environment,
+      packageName: string,
+      body: ApiPackage,
+   ): Promise<void> {
+      const environmentName = environment.getEnvironmentName();
+      const repository = this.environmentStore.storageManager.getRepository();
+      const dbEnvironment =
+         await repository.getEnvironmentByName(environmentName);
+      if (!dbEnvironment) {
+         throw new Error(
+            `Environment "${environmentName}" not found in database`,
+         );
+      }
+      const existing = await repository.getPackageByName(
+         dbEnvironment.id,
+         packageName,
+      );
+      if (!existing) {
+         await this.ensureDatabaseRowForExistingDirectory(
+            environment,
+            packageName,
+            body,
+         );
+         return;
+      }
+      await repository.updatePackage(existing.id, {
+         description: body.description,
+      });
+   }
+
+   private async downloadIntoTarget(
       environmentName: string,
       packageName: string,
       packageLocation: string,
-   ) {
-      const absoluteTargetPath = path.join(
-         this.environmentStore.serverRootPath,
-         PUBLISHER_DATA_DIR,
-         environmentName,
-         packageName,
-      );
+      targetPath: string,
+   ): Promise<void> {
       const isCompressedFile = packageLocation.endsWith(".zip");
       if (
          packageLocation.startsWith("https://") ||
@@ -184,33 +344,68 @@ export class PackageController {
       ) {
          await this.environmentStore.downloadGitHubDirectory(
             packageLocation,
-            absoluteTargetPath,
+            targetPath,
          );
-      } else if (packageLocation.startsWith("gs://")) {
+         return;
+      }
+      if (packageLocation.startsWith("gs://")) {
          await this.environmentStore.downloadGcsDirectory(
             packageLocation,
             environmentName,
-            absoluteTargetPath,
+            targetPath,
             isCompressedFile,
          );
-      } else if (packageLocation.startsWith("s3://")) {
+         return;
+      }
+      if (packageLocation.startsWith("s3://")) {
          await this.environmentStore.downloadS3Directory(
             packageLocation,
             environmentName,
-            absoluteTargetPath,
+            targetPath,
             isCompressedFile,
          );
+         return;
       }
-
       if (packageLocation.startsWith("/")) {
-         // Absolute paths from the publisher.config could be placed outside of /etc/publisher,
-         // so we need to mount them on the right place.
+         // Absolute paths from publisher.config could live outside the
+         // publisher data dir; mount (cp -r) into the versioned target.
          await this.environmentStore.mountLocalDirectory(
             packageLocation,
-            absoluteTargetPath,
+            targetPath,
             environmentName,
             packageName,
          );
+         return;
       }
+      throw new BadRequestError(
+         `Unsupported package location scheme: ${packageLocation}`,
+      );
+   }
+
+   private async bestEffortRm(targetPath: string): Promise<void> {
+      try {
+         await fs.promises.rm(targetPath, { recursive: true, force: true });
+      } catch (error) {
+         logger.warn("Failed to clean up partial download", {
+            targetPath,
+            error,
+         });
+      }
+   }
+
+   /**
+    * Helper used in tests / migration paths to spell out the legacy data
+    * dir for a package. Kept here for symmetry with `buildVersionedPackagePath`.
+    */
+   public legacyPackagePath(
+      environmentName: string,
+      packageName: string,
+   ): string {
+      return path.join(
+         this.environmentStore.serverRootPath,
+         PUBLISHER_DATA_DIR,
+         environmentName,
+         packageName,
+      );
    }
 }

--- a/packages/server/src/server-old.ts
+++ b/packages/server/src/server-old.ts
@@ -662,7 +662,7 @@ export function registerLegacyRoutes(
                req.body,
                { autoLoadManifest },
             );
-            res.status(200).json(_package?.getPackageMetadata());
+            res.status(200).json(_package);
          } catch (error) {
             logger.error(error);
             const { json, status } = internalErrorToHttpError(error as Error);

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -40,6 +40,7 @@ import { registerLegacyRoutes } from "./server-old";
 import { EnvironmentStore } from "./service/environment_store";
 import { ManifestService } from "./service/manifest_service";
 import { MaterializationService } from "./service/materialization_service";
+import { PackageSweeper } from "./service/package_sweeper";
 
 /** Normalize an Express query param into a string[] or undefined. */
 export function normalizeQueryArray(value: unknown): string[] | undefined {
@@ -158,9 +159,14 @@ const manifestService = new ManifestService(environmentStore);
 const watchModeController = new WatchModeController(environmentStore);
 const connectionController = new ConnectionController(environmentStore);
 const modelController = new ModelController(environmentStore);
+const packageSweeper = new PackageSweeper(environmentStore);
+// Defer the periodic sweep until the environment store has finished its
+// initial bootstrap so we don't race the very first batch of package loads.
+void environmentStore.finishedInitialization.then(() => packageSweeper.start());
 const packageController = new PackageController(
    environmentStore,
    manifestService,
+   packageSweeper,
 );
 const databaseController = new DatabaseController(environmentStore);
 const queryController = new QueryController(environmentStore);
@@ -918,7 +924,7 @@ app.post(
             req.body,
             { autoLoadManifest },
          );
-         res.status(200).json(_package?.getPackageMetadata());
+         res.status(200).json(_package);
       } catch (error) {
          logger.error(error);
          const { json, status } = internalErrorToHttpError(error as Error);

--- a/packages/server/src/service/environment.ts
+++ b/packages/server/src/service/environment.ts
@@ -11,6 +11,7 @@ import {
    PackageNotFoundError,
 } from "../errors";
 import { logger } from "../logger";
+import { ResourceRepository } from "../storage/DatabaseInterface";
 import { URL_READER } from "../utils";
 import {
    buildEnvironmentMalloyConfig,
@@ -44,13 +45,26 @@ type RetiredConnectionGeneration = {
 const RETIRED_CONNECTION_DRAIN_MS = 30_000;
 
 export class Environment {
-   private packages: Map<string, Package> = new Map();
-   // Lock ordering: connectionMutex (environment) MUST be acquired before any
-   // packageMutex. Connection updates may invalidate cached package
-   // MalloyConfigs and force reloads, so the environment lock is the outer one.
-   // Never acquire connectionMutex while holding a packageMutex — that's the
-   // AB/BA deadlock path.
-   private packageMutexes = new Map<string, Mutex>();
+   /**
+    * Compiled-package cache, keyed by the package's *current on-disk
+    * directory*. Two writes for the same package name produce two distinct
+    * directory paths (UUID-scoped versioned dirs) and therefore two distinct
+    * cache entries; the package row in the DB carries the indirection from
+    * name → path. Entries are evicted by `PackageSweeper` once their
+    * directory is no longer referenced and the quiescence window has
+    * elapsed, so an in-flight reader holding a `Package` for an older path
+    * can keep using it until the sweeper retires both the cache entry and
+    * the directory together.
+    */
+   private packagesByPath: Map<string, Package> = new Map();
+   /**
+    * Promise-dedup for concurrent first-loads of the same path. Two readers
+    * arriving simultaneously after a swap both miss `packagesByPath`; without
+    * this map they would each call `Package.create` and one would leak its
+    * MalloyConfig into the cache only to be overwritten. With it, the second
+    * arrival simply awaits the first arrival's promise.
+    */
+   private loadsByPath: Map<string, Promise<Package>> = new Map();
    private packageStatuses: Map<string, PackageInfo> = new Map();
    private malloyConfig: EnvironmentMalloyConfig;
    private connectionMutex = new Mutex();
@@ -59,6 +73,15 @@ export class Environment {
    private apiConnections: ApiConnection[];
    private environmentPath: string;
    private environmentName: string;
+   /**
+    * Optional repository injection. When present, package paths are resolved
+    * via the database and the controller's UUID-versioned write path is in
+    * effect. When absent (unit tests, callers that construct Environment
+    * without the storage layer) the resolver falls back to the deterministic
+    * legacy path `<environmentPath>/<packageName>`.
+    */
+   private repository?: ResourceRepository;
+   private cachedEnvironmentDbId?: string;
    public metadata: ApiEnvironment;
 
    constructor(
@@ -66,17 +89,27 @@ export class Environment {
       environmentPath: string,
       malloyConfig: EnvironmentMalloyConfig,
       apiConnections: InternalConnection[],
+      repository?: ResourceRepository,
    ) {
       this.environmentName = environmentName;
       this.environmentPath = environmentPath;
       this.malloyConfig = malloyConfig;
       this.apiConnections = apiConnections;
+      this.repository = repository;
       this.metadata = {
          resource: `${API_PREFIX}/environments/${this.environmentName}`,
          name: this.environmentName,
          location: this.environmentPath,
       };
       void this.reloadEnvironmentMetadata();
+   }
+
+   public getEnvironmentName(): string {
+      return this.environmentName;
+   }
+
+   public getEnvironmentPath(): string {
+      return this.environmentPath;
    }
 
    private async writeEnvironmentReadme(readme?: string): Promise<void> {
@@ -139,6 +172,7 @@ export class Environment {
       environmentName: string,
       environmentPath: string,
       connections: ApiConnection[],
+      repository?: ResourceRepository,
    ): Promise<Environment> {
       if (!(await fs.promises.stat(environmentPath))?.isDirectory()) {
          throw new EnvironmentNotFoundError(
@@ -164,6 +198,7 @@ export class Environment {
          environmentPath,
          malloyConfig,
          malloyConfig.apiConnections,
+         repository,
       );
 
       return environment;
@@ -195,16 +230,22 @@ export class Environment {
       source: string,
       includeSql: boolean = false,
    ): Promise<{ problems: LogMessage[]; sql?: string }> {
+      // Resolve the package against its current on-disk directory (the
+      // versioned UUID dir, or the legacy `<env>/<pkg>` fallback) so the
+      // virtual file lives under the same root that `getPackage` will use
+      // for compilation. Computing it from `<env>/<pkg>` directly would
+      // break any package that has been re-downloaded since startup.
+      const pkg = await this.getPackage(packageName);
+      const packagePath = pkg.getPackagePath();
+
       // Place the virtual file in the model's directory so relative imports resolve correctly.
-      const modelDir = path.dirname(
-         path.join(this.environmentPath, packageName, modelName),
-      );
+      const modelDir = path.dirname(path.join(packagePath, modelName));
       const virtualUri = `file://${path.join(modelDir, "__compile_check.malloy")}`;
       const virtualUrl = new URL(virtualUri);
 
       // Read the full model file so the submitted source inherits the model's
       // complete namespace — imports, source definitions, queries, etc.
-      const modelPath = path.join(this.environmentPath, packageName, modelName);
+      const modelPath = path.join(packagePath, modelName);
       let modelContent = "";
       try {
          modelContent = await fs.promises.readFile(modelPath, "utf8");
@@ -224,8 +265,6 @@ export class Environment {
             return URL_READER.readURL(url);
          },
       };
-
-      const pkg = await this.getPackage(packageName);
 
       // Initialize Runtime with the package's active MalloyConfig so compile
       // checks see the same package-scoped duckdb as execution. This runtime
@@ -347,14 +386,12 @@ export class Environment {
          environmentPath: this.environmentPath,
       });
       try {
+         const packageNames = await this.listPackageNames();
          const packageMetadata = await Promise.all(
-            Array.from(this.packageStatuses.keys()).map(async (packageName) => {
+            packageNames.map(async (packageName) => {
                try {
                   const packageMetadata = (
-                     this.packageStatuses.get(packageName)?.status ===
-                     PackageStatus.LOADING
-                        ? undefined
-                        : await this.getPackage(packageName, false)
+                     await this.getPackage(packageName)
                   )?.getPackageMetadata();
                   if (packageMetadata) {
                      packageMetadata.name = packageName;
@@ -364,18 +401,20 @@ export class Environment {
                   logger.error(
                      `Failed to load package: ${packageName} due to : ${error}`,
                   );
-                  // Directory did not contain a valid package.json file -- therefore, it's not a package.
-                  // Or it timed out
+                  // Directory did not contain a valid publisher.json — therefore,
+                  // it's not a package; or it timed out.
                   return undefined;
                }
             }),
          );
-         // Get rid of undefined entries (i.e, directories without publisher.json files).
+
          const filteredMetadata = packageMetadata.filter(
             (metadata) => metadata,
          ) as ApiPackage[];
 
-         // Filter out packages that are being unloaded
+         // Hide packages that are mid-unload (deletePackage already retired
+         // their connections; their cache entry may briefly survive until the
+         // sweeper claims the directory).
          const finalMetadata = filteredMetadata.filter((metadata) => {
             const packageStatus = this.packageStatuses.get(metadata.name || "");
             return packageStatus?.status !== PackageStatus.UNLOADING;
@@ -389,203 +428,178 @@ export class Environment {
       }
    }
 
-   /** One mutex per package name; never replace after create (avoids parallel loads). */
-   private getOrCreatePackageMutex(packageName: string): Mutex {
-      let packageMutex = this.packageMutexes.get(packageName);
-      if (packageMutex === undefined) {
-         packageMutex = new Mutex();
-         this.packageMutexes.set(packageName, packageMutex);
+   /**
+    * Source of truth for "what packages exist in this environment".
+    *
+    * Returns the union of:
+    *   1. Names of every row in `packages` for this environment, when a
+    *      repository was injected. This is the durable source of truth in
+    *      production.
+    *   2. Keys of `packageStatuses`. This catches the bootstrap window
+    *      where the environment row exists but `addPackages` has not yet
+    *      written package rows — the names live in `packageStatuses` until
+    *      that sync completes — and also unit-test fixtures that construct
+    *      `Environment` without a repository at all.
+    *
+    * Names that are mid-unload (UNLOADING) are excluded. The downstream
+    * `listPackages` loops `getPackage` over each remaining name, which
+    * tolerates a name appearing only in `packageStatuses` (legacy fallback
+    * resolver) or only in the database (full DB-driven path) interchangeably.
+    */
+   private async listPackageNames(): Promise<string[]> {
+      const names = new Set<string>();
+      for (const [name, info] of this.packageStatuses) {
+         if (info.status === PackageStatus.UNLOADING) continue;
+         names.add(name);
       }
-      return packageMutex;
+      if (this.repository) {
+         const dbId = await this.getEnvironmentDbId();
+         if (dbId) {
+            const rows = await this.repository.listPackages(dbId);
+            for (const row of rows) names.add(row.name);
+         }
+      }
+      return Array.from(names);
    }
 
+   private async getEnvironmentDbId(): Promise<string | undefined> {
+      if (this.cachedEnvironmentDbId) return this.cachedEnvironmentDbId;
+      if (!this.repository) return undefined;
+      const dbEnv = await this.repository.getEnvironmentByName(
+         this.environmentName,
+      );
+      this.cachedEnvironmentDbId = dbEnv?.id;
+      return this.cachedEnvironmentDbId;
+   }
+
+   /**
+    * Resolve a package name to its current physical directory. Reads the
+    * `manifest_path` column written by `swapPackageDirectory`. Falls back to
+    * `<environmentPath>/<packageName>` for legacy / test callers that do
+    * not go through the repository — that fallback only succeeds when the
+    * directory actually exists, so an unknown package still surfaces as
+    * "not found".
+    */
+   public async resolvePackagePath(
+      packageName: string,
+   ): Promise<string | undefined> {
+      if (this.repository) {
+         const dbId = await this.getEnvironmentDbId();
+         if (dbId) {
+            const pkg = await this.repository.getPackageByName(
+               dbId,
+               packageName,
+            );
+            if (pkg?.manifestPath) return pkg.manifestPath;
+         }
+      }
+      const legacy = path.join(this.environmentPath, packageName);
+      try {
+         const stat = await fs.promises.stat(legacy);
+         if (stat.isDirectory()) return legacy;
+      } catch {
+         // Falls through to undefined.
+      }
+      return undefined;
+   }
+
+   /**
+    * Look up the package's current directory and return the cached compiled
+    * `Package`, loading it on first access. Concurrent first-loads of the
+    * same path are deduped through `loadsByPath` so the cost is paid once
+    * even under a request storm.
+    *
+    * The `_reloadDeprecated` argument is preserved for source compatibility
+    * with the old API. Reloads are now driven by the controller writing a
+    * fresh directory and calling `swapPackageDirectory`; that pivots the
+    * resolver to a new path, which automatically misses the cache and
+    * triggers a fresh load with no extra logic here.
+    */
    public async getPackage(
       packageName: string,
-      reload: boolean = false,
+      _reloadDeprecated: boolean = false,
    ): Promise<Package> {
-      // Check if package is already loaded first
-      const _package = this.packages.get(packageName);
-      if (_package !== undefined && !reload) {
-         return _package;
-      }
-
-      // Serialize load per package name so concurrent callers share one Mutex and
-      // failed loads cannot rm the tree while another load is still scanning it.
-      const packageMutex = this.getOrCreatePackageMutex(packageName);
-
-      if (packageMutex.isLocked()) {
-         logger.debug(
-            `Package ${packageName} is being loaded, waiting for unlock...`,
-         );
-         await packageMutex.waitForUnlock();
-         logger.debug(`Package ${packageName} unlocked`);
-         const existingPackage = this.packages.get(packageName);
-         if (existingPackage !== undefined && !reload) {
-            logger.debug(`Package ${packageName} loaded by another request`);
-            return existingPackage;
-         }
-         // Reload, or prior load failed — continue under the same mutex.
-      }
-
-      return packageMutex.runExclusive(async () => {
-         // Double-check after acquiring mutex
-         const existingPackage = this.packages.get(packageName);
-         if (existingPackage !== undefined && !reload) {
-            return existingPackage;
-         }
-
-         // Set package status to loading
-         this.setPackageStatus(packageName, PackageStatus.LOADING);
-
-         try {
-            logger.debug(`Loading package ${packageName}...`);
-            const packagePath = path.join(this.environmentPath, packageName);
-            const _package = await Package.create(
-               this.environmentName,
-               packageName,
-               packagePath,
-               () => this.malloyConfig.malloyConfig,
-            );
-            if (existingPackage !== undefined && reload) {
-               this.retireConnectionGeneration(`package ${packageName}`, () =>
-                  existingPackage.getMalloyConfig().releaseConnections(),
-               );
-            }
-            this.packages.set(packageName, _package);
-
-            // Set package status to serving
-            this.setPackageStatus(packageName, PackageStatus.SERVING);
-            logger.debug(`Successfully loaded package ${packageName}`);
-
-            return _package;
-         } catch (error) {
-            logger.error(`Failed to load package ${packageName}`, { error });
-            // Clean up on error - mutex will be automatically released by runExclusive
-            this.packages.delete(packageName);
-            this.packageStatuses.delete(packageName);
-            throw error;
-         }
-         // Mutex is automatically released here by runExclusive
-      });
-   }
-
-   public async addPackage(packageName: string) {
-      const packagePath = path.join(this.environmentPath, packageName);
-      if (
-         !(await fs.promises
-            .access(packagePath)
-            .then(() => true)
-            .catch(() => false)) ||
-         !(await fs.promises.stat(packagePath))?.isDirectory()
-      ) {
+      const packagePath = await this.resolvePackagePath(packageName);
+      if (!packagePath) {
          throw new PackageNotFoundError(`Package ${packageName} not found`);
       }
-      logger.info(
-         `Adding package ${packageName} to environment ${this.environmentName}`,
-         {
-            packagePath,
-            malloyConfig: this.malloyConfig.malloyConfig,
-         },
-      );
+      return this.loadPackageAtPath(packageName, packagePath);
+   }
 
-      const packageMutex = this.getOrCreatePackageMutex(packageName);
-      if (packageMutex.isLocked()) {
-         logger.debug(
-            `Package ${packageName} is being loaded, waiting before addPackage...`,
-         );
-         await packageMutex.waitForUnlock();
-         const alreadyLoaded = this.packages.get(packageName);
-         if (alreadyLoaded !== undefined) {
-            return alreadyLoaded;
-         }
-      }
+   private async loadPackageAtPath(
+      packageName: string,
+      packagePath: string,
+   ): Promise<Package> {
+      const cached = this.packagesByPath.get(packagePath);
+      if (cached !== undefined) return cached;
 
-      return packageMutex.runExclusive(async () => {
-         const existingPackage = this.packages.get(packageName);
-         if (existingPackage !== undefined) {
-            return existingPackage;
-         }
+      const inflight = this.loadsByPath.get(packagePath);
+      if (inflight) return inflight;
 
-         this.setPackageStatus(packageName, PackageStatus.LOADING);
-         try {
-            this.packages.set(
-               packageName,
-               await Package.create(
-                  this.environmentName,
-                  packageName,
-                  packagePath,
-                  () => this.malloyConfig.malloyConfig,
-               ),
-            );
-         } catch (error) {
-            logger.error("Error adding package", { error });
+      this.setPackageStatus(packageName, PackageStatus.LOADING);
+      const promise = Package.create(
+         this.environmentName,
+         packageName,
+         packagePath,
+         () => this.malloyConfig.malloyConfig,
+      )
+         .then((pkg) => {
+            this.packagesByPath.set(packagePath, pkg);
+            this.setPackageStatus(packageName, PackageStatus.SERVING);
+            return pkg;
+         })
+         .catch((error) => {
+            // Roll status forward only on success; failed loads leave no
+            // entry in `packagesByPath` so the next caller will retry.
             this.deletePackageStatus(packageName);
             throw error;
-         }
-         this.setPackageStatus(packageName, PackageStatus.SERVING);
-         return this.packages.get(packageName);
-      });
+         })
+         .finally(() => {
+            this.loadsByPath.delete(packagePath);
+         });
+
+      this.loadsByPath.set(packagePath, promise);
+      return promise;
    }
 
-   private async writePackageManifest(
+   /**
+    * Drop the cached `Package` for `packagePath` and retire the connections
+    * it owns. Called by `PackageSweeper` immediately before the directory is
+    * `rm -rf`'d so we never observe a `Package` whose backing files are
+    * gone.
+    */
+   public evictPackageAtPath(packagePath: string): void {
+      const pkg = this.packagesByPath.get(packagePath);
+      if (!pkg) return;
+      this.packagesByPath.delete(packagePath);
+      this.retireConnectionGeneration(`package-evict ${packagePath}`, () =>
+         pkg.getMalloyConfig().releaseConnections(),
+      );
+   }
+
+   /**
+    * Update the in-memory metadata for a package after the controller has
+    * persisted the same change to the database. The directory swap (if
+    * any) is the controller's responsibility; this method only refreshes
+    * what the cached `Package` reports as its metadata so reads coming
+    * back from the cache reflect the latest description / location until
+    * the next directory swap repaves it.
+    */
+   public async updatePackage(
       packageName: string,
-      metadata: { name: string; description?: string },
-   ): Promise<void> {
-      const packagePath = path.join(this.environmentPath, packageName);
-      const manifestPath = path.join(packagePath, "publisher.json");
-
-      try {
-         // Read existing manifest
-         let existingManifest: Record<string, unknown> = {};
-         try {
-            const content = await fs.promises.readFile(manifestPath, "utf-8");
-            existingManifest = JSON.parse(content);
-         } catch (_err) {
-            logger.warn(`Could not read manifest for ${packageName}`);
-         }
-
-         // Update with new metadata
-         const updatedManifest = {
-            ...existingManifest,
-            name: metadata.name,
-            description: metadata.description,
-         };
-
-         // Write back to file
-         await fs.promises.writeFile(
-            manifestPath,
-            JSON.stringify(updatedManifest, null, 2),
-            "utf-8",
-         );
-
-         logger.info(`Updated publisher.json for ${packageName}`);
-      } catch (error) {
-         logger.error(`Failed to update publisher.json`, { error });
-         throw new Error(`Failed to update package manifest`);
-      }
-   }
-
-   public async updatePackage(packageName: string, body: ApiPackage) {
-      const _package = this.packages.get(packageName);
-      if (!_package) {
-         throw new PackageNotFoundError(`Package ${packageName} not found`);
-      }
+      body: ApiPackage,
+   ): Promise<ApiPackage> {
+      const pkg = await this.getPackage(packageName);
       if (body.name) {
-         _package.setName(body.name);
+         pkg.setName(body.name);
       }
-      _package.setPackageMetadata({
+      pkg.setPackageMetadata({
          name: body.name,
          description: body.description,
          resource: body.resource,
          location: body.location,
       });
-
-      await this.writePackageManifest(packageName, {
-         name: packageName,
-         description: body.description,
-      });
-
-      return _package.getPackageMetadata();
+      return pkg.getPackageMetadata();
    }
 
    public getPackageStatus(packageName: string): PackageInfo | undefined {
@@ -605,13 +619,17 @@ export class Environment {
       this.packageStatuses.delete(packageName);
    }
 
-   public async deletePackage(packageName: string): Promise<void> {
-      const _package = this.packages.get(packageName);
-      if (!_package) {
-         return;
-      }
+   /**
+    * Tear down the in-memory state for a package. Returns the directory
+    * the package was bound to so the controller can hand it to the sweeper
+    * for deferred deletion. The actual `rm -rf` does NOT happen here:
+    * dropping the directory while in-flight readers still hold a reference
+    * to the cached `Package` would yank files out from under their lazy
+    * imports. The sweeper owns that step and waits out the quiescence
+    * window first.
+    */
+   public async deletePackage(packageName: string): Promise<string | undefined> {
       const packageStatus = this.packageStatuses.get(packageName);
-
       if (packageStatus?.status === PackageStatus.LOADING) {
          logger.error("Package loading. Can't unload.", {
             environmentName: this.environmentName,
@@ -623,31 +641,16 @@ export class Environment {
                " " +
                packageName,
          );
-      } else if (packageStatus?.status === PackageStatus.SERVING) {
-         this.setPackageStatus(packageName, PackageStatus.UNLOADING);
+      }
+      this.setPackageStatus(packageName, PackageStatus.UNLOADING);
+
+      const packagePath = await this.resolvePackagePath(packageName);
+      if (packagePath) {
+         this.evictPackageAtPath(packagePath);
       }
 
-      await _package.getMalloyConfig().releaseConnections();
-
-      try {
-         await fs.promises.rm(path.join(this.environmentPath, packageName), {
-            recursive: true,
-            force: true,
-         });
-      } catch (err) {
-         logger.error(
-            "Error removing package directory while unloading package",
-            {
-               error: err,
-               environmentName: this.environmentName,
-               packageName,
-            },
-         );
-      }
-
-      // Remove from internal tracking
-      this.packages.delete(packageName);
       this.packageStatuses.delete(packageName);
+      return packagePath;
    }
 
    public updateConnections(
@@ -697,7 +700,7 @@ export class Environment {
       // sandbox `duckdb` connection) before tearing down the environment config
       // they wrap. Without this, hard unload leaks per-package DuckDB handles.
       const packageReleases = await Promise.allSettled(
-         Array.from(this.packages.values(), (pkg) =>
+         Array.from(this.packagesByPath.values(), (pkg) =>
             pkg.getMalloyConfig().releaseConnections(),
          ),
       );
@@ -709,7 +712,8 @@ export class Environment {
             );
          }
       }
-      this.packages.clear();
+      this.packagesByPath.clear();
+      this.loadsByPath.clear();
       this.packageStatuses.clear();
 
       try {

--- a/packages/server/src/service/environment_store.spec.ts
+++ b/packages/server/src/service/environment_store.spec.ts
@@ -139,6 +139,24 @@ mock.module("../storage/StorageManager", () => {
 
                deletePackage: async (_id: string): Promise<void> => {},
 
+               swapPackageDirectory: async (args: {
+                  environmentId: string;
+                  name: string;
+                  newDirectoryPath: string;
+                  description?: string;
+                  metadata?: Record<string, unknown>;
+               }): Promise<{
+                  id: string;
+                  oldDirectoryPath: string | null;
+               }> => ({
+                  id: `swap-${args.name}`,
+                  oldDirectoryPath: null,
+               }),
+
+               listPackageDirectoryPaths: async (
+                  _environmentId: string,
+               ): Promise<Set<string>> => new Set<string>(),
+
                // ===== CONNECTION METHODS =====
                listConnections: async (
                   _environmentId: string,

--- a/packages/server/src/service/environment_store.ts
+++ b/packages/server/src/service/environment_store.ts
@@ -237,6 +237,7 @@ export class EnvironmentStore {
                               resource: `${API_PREFIX}/connections/${conn.name}`,
                               ...conn.config,
                            })),
+                           repository,
                         );
 
                         // Get packages from database
@@ -398,76 +399,33 @@ export class EnvironmentStore {
    ): Promise<void> {
       const packages = await environment.listPackages();
 
-      // Sync each package
+      // Bootstrap-time sync. Each package was downloaded into the legacy
+      // `<env>/<pkg>` path by `scaffoldEnvironment`, so we point the row at
+      // that path. Subsequent API writes go through the controller's
+      // versioned-dir + `swapPackageDirectory` path and pivot the row to a
+      // UUID-scoped directory.
       for (const pkg of packages) {
          if (!pkg.name) {
             logger.warn("Skipping package with undefined name");
             continue;
          }
 
-         await this.addPackage(pkg, environmentId, repository);
-      }
-   }
-
-   private async addPackage(
-      pkg: components["schemas"]["Package"],
-      environmentId: string,
-      repository: ReturnType<typeof this.storageManager.getRepository>,
-   ): Promise<void> {
-      const pkgs = pkg as {
-         name: string;
-         description?: string;
-         manifestPath?: string;
-         metadata?: Record<string, unknown>;
-      };
-
-      const packageData = {
-         environmentId,
-         name: pkgs.name,
-         description: pkgs.description ?? undefined,
-         manifestPath: pkgs.manifestPath ?? "",
-         metadata: pkgs.metadata ?? {},
-      };
-
-      try {
-         await repository.createPackage(packageData);
-         logger.info(`Synced package: ${pkg.name}`);
-      } catch (err: unknown) {
-         const error = err as Error;
-         if (
-            error.message?.includes("UNIQUE") ||
-            error.message?.includes("Constraint")
-         ) {
-            await this.updatePackage(
-               pkgs.name,
+         try {
+            await repository.swapPackageDirectory({
                environmentId,
-               packageData,
-               repository,
-            );
-         } else {
+               name: pkg.name,
+               newDirectoryPath: path.join(
+                  environment.getEnvironmentPath(),
+                  pkg.name,
+               ),
+               description: pkg.description,
+               metadata: pkg.location ? { location: pkg.location } : undefined,
+            });
+            logger.info(`Synced package: ${pkg.name}`);
+         } catch (err: unknown) {
+            const error = err as Error;
             logger.warn(`Failed to sync package ${pkg.name}:`, error.message);
          }
-      }
-   }
-
-   private async updatePackage(
-      packageName: string,
-      environmentId: string,
-      packageData: {
-         description: string | undefined;
-         manifestPath: string;
-         metadata: Record<string, unknown>;
-      },
-      repository: ReturnType<typeof this.storageManager.getRepository>,
-   ): Promise<void> {
-      const existingPackage = await repository.getPackageByName(
-         environmentId,
-         packageName,
-      );
-
-      if (existingPackage) {
-         await repository.updatePackage(existingPackage.id, packageData);
-         logger.info(`Updated existing package: ${packageName}`);
       }
    }
 
@@ -569,6 +527,14 @@ export class EnvironmentStore {
       }
    }
 
+   /**
+    * Legacy compatibility shim. The controller's add/update/delete paths
+    * now write to the database directly via `swapPackageDirectory`, so this
+    * is retained only for callers that bootstrap a package's row from a
+    * pre-existing on-disk directory (e.g. integration tests that scaffold
+    * a package by hand). It always points the row at the legacy
+    * `<env>/<pkg>` path.
+    */
    public async addPackageToDatabase(
       environmentName: string,
       packageName: string,
@@ -576,7 +542,6 @@ export class EnvironmentStore {
       const environment = await this.getEnvironment(environmentName, false);
       const repository = this.storageManager.getRepository();
 
-      // Get the environment ID from database
       const dbEnvironment =
          await repository.getEnvironmentByName(environmentName);
 
@@ -587,17 +552,23 @@ export class EnvironmentStore {
          );
       }
 
-      // Get the package from the environment
       const packages = await environment.listPackages();
       const pkg = packages.find((p) => p.name === packageName);
-
       if (!pkg) {
          logger.warn(`Package "${packageName}" not found in environment`);
          return;
       }
 
-      // Sync the specific package
-      await this.addPackage(pkg, dbEnvironment.id, repository);
+      await repository.swapPackageDirectory({
+         environmentId: dbEnvironment.id,
+         name: packageName,
+         newDirectoryPath: path.join(
+            environment.getEnvironmentPath(),
+            packageName,
+         ),
+         description: pkg.description,
+         metadata: pkg.location ? { location: pkg.location } : undefined,
+      });
       logger.info(`Synced package "${packageName}" to database`);
    }
 
@@ -668,6 +639,17 @@ export class EnvironmentStore {
 
       const uploadDocsPath = path.join(this.serverRootPath, PUBLISHER_DATA_DIR);
       await fs.promises.mkdir(uploadDocsPath, { recursive: true });
+   }
+
+   /**
+    * Snapshot of the currently in-memory `Environment` instances. Used by
+    * `PackageSweeper` to walk every environment without serializing each
+    * one through `Environment.serialize()`. Returns a fresh array so callers
+    * can iterate without worrying about live mutations of the underlying
+    * `Map`.
+    */
+   public listInMemoryEnvironments(): Environment[] {
+      return Array.from(this.environments.values());
    }
 
    public async listEnvironments(skipInitializationCheck: boolean = false) {
@@ -836,6 +818,7 @@ export class EnvironmentStore {
          environmentName,
          absoluteEnvironmentPath,
          environment.connections || [],
+         this.storageManager.getRepository(),
       );
 
       if (!newEnvironment.metadata) newEnvironment.metadata = {};

--- a/packages/server/src/service/package_sweeper.spec.ts
+++ b/packages/server/src/service/package_sweeper.spec.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+   buildVersionedPackagePath,
+   PackageSweeper,
+   VERSIONED_PACKAGE_DIR_SUFFIX,
+} from "./package_sweeper";
+
+interface FakeRepository {
+   getEnvironmentByName(name: string): Promise<{ id: string } | null>;
+   listPackageDirectoryPaths(environmentId: string): Promise<Set<string>>;
+}
+
+interface FakeEnvironment {
+   getEnvironmentName(): string;
+   getEnvironmentPath(): string;
+   evictPackageAtPath(path: string): void;
+   evictedPaths: string[];
+}
+
+function buildEnv(name: string, envPath: string): FakeEnvironment {
+   const evicted: string[] = [];
+   return {
+      getEnvironmentName: () => name,
+      getEnvironmentPath: () => envPath,
+      evictPackageAtPath: (p: string) => evicted.push(p),
+      evictedPaths: evicted,
+   };
+}
+
+function buildStore(
+   environments: FakeEnvironment[],
+   referenced: Map<string, Set<string>>,
+) {
+   return {
+      listInMemoryEnvironments: () => environments,
+      getEnvironment: async (name: string) =>
+         environments.find((e) => e.getEnvironmentName() === name) ??
+         (() => {
+            throw new Error(`unknown env ${name}`);
+         })(),
+      storageManager: {
+         getRepository: (): FakeRepository => ({
+            getEnvironmentByName: async (name: string) => ({
+               id: `id-${name}`,
+            }),
+            listPackageDirectoryPaths: async (environmentId: string) => {
+               return referenced.get(environmentId) ?? new Set<string>();
+            },
+         }),
+      },
+   };
+}
+
+function ageMs(): number {
+   return 60 * 1000;
+}
+
+describe("PackageSweeper", () => {
+   let tmpRoot: string;
+
+   beforeEach(async () => {
+      tmpRoot = await fs.promises.mkdtemp(
+         path.join(os.tmpdir(), "pkg-sweeper-"),
+      );
+   });
+
+   afterEach(async () => {
+      await fs.promises.rm(tmpRoot, { recursive: true, force: true });
+   });
+
+   it("removes orphaned versioned directories that age past quiescence", async () => {
+      const envName = "env-a";
+      const envPath = path.join(tmpRoot, envName);
+      await fs.promises.mkdir(envPath, { recursive: true });
+
+      const live = buildVersionedPackagePath(envPath, "pkg-a", "v-live");
+      const orphan = buildVersionedPackagePath(envPath, "pkg-a", "v-orphan");
+      await fs.promises.mkdir(live, { recursive: true });
+      await fs.promises.mkdir(orphan, { recursive: true });
+
+      // Backdate both directories so they are older than the quiescence window.
+      const old = new Date(Date.now() - 10 * 60_000);
+      await fs.promises.utimes(live, old, old);
+      await fs.promises.utimes(orphan, old, old);
+
+      const env = buildEnv(envName, envPath);
+      // v-live is referenced by the database; v-orphan is not.
+      const referenced = new Map([[`id-${envName}`, new Set([live])]]);
+      const store = buildStore([env], referenced) as never;
+
+      const sweeper = new PackageSweeper(store, {
+         quiescenceMs: ageMs(),
+         periodicIntervalMs: 60_000,
+      });
+      await sweeper.sweepAllEnvironments();
+
+      expect(fs.existsSync(live)).toBe(true);
+      expect(fs.existsSync(orphan)).toBe(false);
+      expect(env.evictedPaths).toEqual([orphan]);
+   });
+
+   it("preserves orphans that are still inside the quiescence window", async () => {
+      const envName = "env-b";
+      const envPath = path.join(tmpRoot, envName);
+      const orphan = buildVersionedPackagePath(envPath, "pkg-b", "fresh");
+      await fs.promises.mkdir(orphan, { recursive: true });
+
+      const env = buildEnv(envName, envPath);
+      // Empty referenced set — every dir is unreferenced.
+      const store = buildStore([env], new Map()) as never;
+
+      const sweeper = new PackageSweeper(store, {
+         quiescenceMs: 60 * 60_000, // 1 hour, won't elapse
+         periodicIntervalMs: 60_000,
+      });
+      await sweeper.sweepAllEnvironments();
+
+      expect(fs.existsSync(orphan)).toBe(true);
+      expect(env.evictedPaths).toEqual([]);
+   });
+
+   it("never touches paths outside an *.versions/ directory", async () => {
+      const envName = "env-c";
+      const envPath = path.join(tmpRoot, envName);
+      await fs.promises.mkdir(envPath, { recursive: true });
+
+      // A bare `<env>/<pkg>/` directory that mimics a legacy or
+      // mount-style package; the sweeper must leave it alone even when
+      // the DB does not reference it.
+      const legacyMount = path.join(envPath, "mount-style-pkg");
+      await fs.promises.mkdir(legacyMount, { recursive: true });
+
+      const env = buildEnv(envName, envPath);
+      const store = buildStore([env], new Map()) as never;
+      const sweeper = new PackageSweeper(store, {
+         quiescenceMs: ageMs(),
+         periodicIntervalMs: 60_000,
+      });
+      await sweeper.sweepAllEnvironments();
+
+      expect(fs.existsSync(legacyMount)).toBe(true);
+   });
+
+   it("scheduleSweep refuses paths that are not under an *.versions/ parent", async () => {
+      const envName = "env-d";
+      const envPath = path.join(tmpRoot, envName);
+      await fs.promises.mkdir(envPath, { recursive: true });
+      const externallyMounted = path.join(envPath, "absolute-mount");
+      await fs.promises.mkdir(externallyMounted, { recursive: true });
+
+      const env = buildEnv(envName, envPath);
+      const store = buildStore([env], new Map()) as never;
+
+      // Custom sweeper with a tiny quiescence so the scheduled timer fires.
+      const sweeper = new PackageSweeper(store, {
+         quiescenceMs: 1,
+         periodicIntervalMs: 60_000,
+      });
+      sweeper.scheduleSweep(envName, externallyMounted);
+      // Allow any pending timers to fire.
+      await new Promise((r) => setTimeout(r, 50));
+      expect(fs.existsSync(externallyMounted)).toBe(true);
+
+      sweeper.stop();
+   });
+
+   it("scheduleSweep deletes a versioned directory once the quiescence window elapses", async () => {
+      const envName = "env-e";
+      const envPath = path.join(tmpRoot, envName);
+      const orphan = buildVersionedPackagePath(envPath, "pkg", "to-sweep");
+      await fs.promises.mkdir(orphan, { recursive: true });
+
+      const env = buildEnv(envName, envPath);
+      const store = buildStore([env], new Map()) as never;
+
+      const quiescenceMs = 50;
+      const sweeper = new PackageSweeper(store, {
+         quiescenceMs,
+         periodicIntervalMs: 60_000,
+      });
+      // Backdate the directory so it is already older than the quiescence
+      // window when the timer fires.
+      const old = new Date(Date.now() - 60_000);
+      await fs.promises.utimes(orphan, old, old);
+
+      sweeper.scheduleSweep(envName, orphan);
+
+      // Wait for the scheduled timer to fire and the rm to complete.
+      await new Promise((r) => setTimeout(r, quiescenceMs + 100));
+
+      expect(fs.existsSync(orphan)).toBe(false);
+      expect(env.evictedPaths).toEqual([orphan]);
+      sweeper.stop();
+   });
+
+   it("buildVersionedPackagePath co-locates every version of a package", () => {
+      const a = buildVersionedPackagePath("/env", "pkg", "v1");
+      const b = buildVersionedPackagePath("/env", "pkg", "v2");
+      expect(path.dirname(a)).toBe(path.dirname(b));
+      expect(path.basename(path.dirname(a))).toBe(
+         `pkg${VERSIONED_PACKAGE_DIR_SUFFIX}`,
+      );
+   });
+});

--- a/packages/server/src/service/package_sweeper.ts
+++ b/packages/server/src/service/package_sweeper.ts
@@ -1,0 +1,294 @@
+import * as fs from "fs";
+import * as path from "path";
+import { logger } from "../logger";
+import { Environment } from "./environment";
+import type { EnvironmentStore } from "./environment_store";
+
+/**
+ * Marker suffix for the parent directory that holds versioned package
+ * checkouts: `<env>/<pkg>.versions/<uuid>`. The sweeper only ever touches
+ * directories inside a `*.versions/` folder so externally-mounted package
+ * paths (absolute paths from `publisher.config.json`) are not at risk.
+ */
+export const VERSIONED_PACKAGE_DIR_SUFFIX = ".versions";
+
+/**
+ * Default time a versioned package directory must be unreferenced before the
+ * sweeper deletes it. Sized comfortably larger than any expected query so
+ * an in-flight reader holding a cached `Package` against the old directory
+ * always finishes before the directory disappears.
+ */
+const DEFAULT_QUIESCENCE_MS = 30 * 60 * 1000;
+/** Default cadence for the periodic full-environment sweep. */
+const DEFAULT_PERIODIC_SWEEP_INTERVAL_MS = 15 * 60 * 1000;
+
+/**
+ * Reclaims orphaned versioned package directories produced by the
+ * UUID-staging + DB-CAS write path in `PackageController`.
+ *
+ * Two entry points:
+ *
+ *   - `scheduleSweep(env, dir)` — deferred per-path cleanup the controller
+ *     calls after a successful swap. The directory is `rm -rf`'d after the
+ *     quiescence window so any in-flight reader that picked the path up
+ *     before the swap has finished its query.
+ *
+ *   - `sweepEnvironment` / periodic `start()` — backstop that catches
+ *     orphans from process crashes (download committed to disk but the
+ *     `swapPackageDirectory` row never landed, or the inverse).
+ *
+ * Both paths drop the corresponding entry from the environment's path-keyed
+ * package cache and retire the package's MalloyConfig connections through
+ * the existing `retireConnectionGeneration` machinery so connection cleanup
+ * follows directory cleanup automatically.
+ */
+export class PackageSweeper {
+   private readonly quiescenceMs: number;
+   private readonly periodicIntervalMs: number;
+   private readonly scheduledTimers = new Map<string, NodeJS.Timeout>();
+   private periodicTimer?: NodeJS.Timeout;
+   private stopped = false;
+
+   constructor(
+      private store: EnvironmentStore,
+      options?: { quiescenceMs?: number; periodicIntervalMs?: number },
+   ) {
+      this.quiescenceMs = options?.quiescenceMs ?? DEFAULT_QUIESCENCE_MS;
+      this.periodicIntervalMs =
+         options?.periodicIntervalMs ?? DEFAULT_PERIODIC_SWEEP_INTERVAL_MS;
+   }
+
+   /**
+    * Start the periodic full sweep. Idempotent — a second call is a no-op
+    * so callers do not have to track lifecycle separately. The very first
+    * sweep also runs immediately so orphans from the previous process exit
+    * are reclaimed at startup, not the next interval boundary.
+    */
+   public start(): void {
+      if (this.stopped) return;
+      if (this.periodicTimer) return;
+
+      void this.sweepAllEnvironments().catch((error) => {
+         logger.warn("Initial package sweep failed", { error });
+      });
+
+      this.periodicTimer = setInterval(() => {
+         void this.sweepAllEnvironments().catch((error) => {
+            logger.warn("Periodic package sweep failed", { error });
+         });
+      }, this.periodicIntervalMs);
+      this.periodicTimer.unref?.();
+   }
+
+   /**
+    * Stop the periodic sweep and cancel any pending scheduled cleanups so
+    * the process can exit cleanly.
+    */
+   public stop(): void {
+      this.stopped = true;
+      if (this.periodicTimer) {
+         clearInterval(this.periodicTimer);
+         this.periodicTimer = undefined;
+      }
+      for (const timer of this.scheduledTimers.values()) {
+         clearTimeout(timer);
+      }
+      this.scheduledTimers.clear();
+   }
+
+   /**
+    * Schedule a versioned package directory for cleanup after the quiescence
+    * window. Idempotent on `(envName, dirPath)`; repeated calls coalesce.
+    *
+    * Skips paths that fall outside an `*.versions/` directory, which is how
+    * we avoid sweeping externally-mounted package paths declared in
+    * `publisher.config.json`.
+    */
+   public scheduleSweep(envName: string, dirPath: string): void {
+      if (this.stopped) return;
+      if (!dirPath || !this.isVersionedPackagePath(dirPath)) return;
+
+      const key = `${envName}|${dirPath}`;
+      if (this.scheduledTimers.has(key)) return;
+
+      const timer = setTimeout(() => {
+         this.scheduledTimers.delete(key);
+         void this.sweepPath(envName, dirPath).catch((error) => {
+            logger.warn("Scheduled package sweep failed", {
+               envName,
+               dirPath,
+               error,
+            });
+         });
+      }, this.quiescenceMs);
+      timer.unref?.();
+      this.scheduledTimers.set(key, timer);
+   }
+
+   /**
+    * Visible for tests / startup hooks: run a single full sweep across every
+    * environment immediately. Reads each environment's referenced directory
+    * set from the database and reclaims everything else under
+    * `<envPath>/*.versions/*` that is older than the quiescence window.
+    */
+   public async sweepAllEnvironments(): Promise<void> {
+      const environments = this.store.listInMemoryEnvironments();
+      for (const environment of environments) {
+         try {
+            await this.sweepEnvironment(environment);
+         } catch (error) {
+            logger.warn("Failed to sweep environment", {
+               envName: environment.getEnvironmentName(),
+               error,
+            });
+         }
+      }
+   }
+
+   private async sweepEnvironment(environment: Environment): Promise<void> {
+      const envName = environment.getEnvironmentName();
+      const repository = this.store.storageManager.getRepository();
+      const dbEnv = await repository.getEnvironmentByName(envName);
+      if (!dbEnv) return;
+
+      const referenced =
+         await repository.listPackageDirectoryPaths(dbEnv.id);
+      const versionsRoots = await this.findVersionsRoots(
+         environment.getEnvironmentPath(),
+      );
+      const now = Date.now();
+
+      for (const versionsRoot of versionsRoots) {
+         let entries: fs.Dirent[];
+         try {
+            entries = await fs.promises.readdir(versionsRoot, {
+               withFileTypes: true,
+            });
+         } catch (error) {
+            const code = (error as NodeJS.ErrnoException).code;
+            if (code === "ENOENT") continue;
+            throw error;
+         }
+
+         for (const entry of entries) {
+            if (!entry.isDirectory()) continue;
+            const dirPath = path.join(versionsRoot, entry.name);
+            if (referenced.has(dirPath)) continue;
+
+            try {
+               const stat = await fs.promises.stat(dirPath);
+               if (now - stat.mtimeMs < this.quiescenceMs) continue;
+            } catch {
+               continue;
+            }
+
+            await this.removeOrphan(environment, dirPath);
+         }
+      }
+   }
+
+   /**
+    * Removes one specific directory if (a) it falls under a versions root,
+    * (b) it is no longer referenced by the database, and (c) it has aged
+    * past the quiescence window. The triple-check makes scheduled sweeps
+    * safe to call even when something else races to swap the package back
+    * to the same path between the schedule and the timer firing.
+    */
+   private async sweepPath(envName: string, dirPath: string): Promise<void> {
+      if (!this.isVersionedPackagePath(dirPath)) return;
+
+      const environment = await this.store
+         .getEnvironment(envName, false)
+         .catch(() => undefined);
+      if (!environment) {
+         await this.bestEffortRm(dirPath);
+         return;
+      }
+
+      const repository = this.store.storageManager.getRepository();
+      const dbEnv = await repository.getEnvironmentByName(envName);
+      if (dbEnv) {
+         const referenced =
+            await repository.listPackageDirectoryPaths(dbEnv.id);
+         if (referenced.has(dirPath)) return;
+      }
+
+      try {
+         const stat = await fs.promises.stat(dirPath);
+         if (Date.now() - stat.mtimeMs < this.quiescenceMs) {
+            // Race: someone touched the directory after we scheduled it.
+            // Treat it like a fresh write and let the next periodic sweep
+            // re-check.
+            return;
+         }
+      } catch {
+         return;
+      }
+
+      await this.removeOrphan(environment, dirPath);
+   }
+
+   private async removeOrphan(
+      environment: Environment,
+      dirPath: string,
+   ): Promise<void> {
+      environment.evictPackageAtPath(dirPath);
+      await this.bestEffortRm(dirPath);
+      logger.info("Reclaimed orphaned package directory", {
+         envName: environment.getEnvironmentName(),
+         dirPath,
+      });
+   }
+
+   private async bestEffortRm(dirPath: string): Promise<void> {
+      try {
+         await fs.promises.rm(dirPath, { recursive: true, force: true });
+      } catch (error) {
+         logger.warn("Failed to remove orphaned package directory", {
+            dirPath,
+            error,
+         });
+      }
+   }
+
+   private isVersionedPackagePath(dirPath: string): boolean {
+      const parent = path.basename(path.dirname(dirPath));
+      return parent.endsWith(VERSIONED_PACKAGE_DIR_SUFFIX);
+   }
+
+   private async findVersionsRoots(envPath: string): Promise<string[]> {
+      let entries: fs.Dirent[];
+      try {
+         entries = await fs.promises.readdir(envPath, { withFileTypes: true });
+      } catch (error) {
+         const code = (error as NodeJS.ErrnoException).code;
+         if (code === "ENOENT") return [];
+         throw error;
+      }
+      return entries
+         .filter(
+            (entry) =>
+               entry.isDirectory() &&
+               entry.name.endsWith(VERSIONED_PACKAGE_DIR_SUFFIX),
+         )
+         .map((entry) => path.join(envPath, entry.name));
+   }
+}
+
+/**
+ * Helper used by `PackageController` to construct a fresh, unique versioned
+ * directory path for an upcoming download. Using `<pkgName>.versions/<uuid>`
+ * keeps every version of a single package co-located on disk so the sweeper
+ * can reclaim them with a single readdir per package.
+ */
+export function buildVersionedPackagePath(
+   environmentPath: string,
+   packageName: string,
+   versionId: string,
+): string {
+   return path.join(
+      environmentPath,
+      `${packageName}${VERSIONED_PACKAGE_DIR_SUFFIX}`,
+      versionId,
+   );
+}

--- a/packages/server/src/storage/DatabaseInterface.ts
+++ b/packages/server/src/storage/DatabaseInterface.ts
@@ -34,6 +34,24 @@ export interface ResourceRepository {
    ): Promise<Package>;
    updatePackage(id: string, updates: Partial<Package>): Promise<Package>;
    deletePackage(id: string): Promise<void>;
+   /**
+    * Atomically point a package at a new on-disk directory.
+    *
+    * Inserts the package row when it does not exist, otherwise updates the
+    * existing row. Returns the directory path the package was previously
+    * pointed at (`null` for a brand-new row) so the caller can schedule the
+    * obsolete directory for sweeping. This is the ordering point that
+    * replaces filesystem mutexes for package write operations.
+    */
+   swapPackageDirectory(args: {
+      environmentId: string;
+      name: string;
+      newDirectoryPath: string;
+      description?: string;
+      metadata?: Record<string, unknown>;
+   }): Promise<{ id: string; oldDirectoryPath: string | null }>;
+   /** Set of every directory path currently referenced by some package row in the env. */
+   listPackageDirectoryPaths(environmentId: string): Promise<Set<string>>;
 
    // Connections
    listConnections(environmentId: string): Promise<Connection[]>;
@@ -105,6 +123,13 @@ export interface Package {
    environmentId: string;
    name: string;
    description?: string;
+   /**
+    * Absolute path to the directory that currently holds the package's
+    * contents on disk. Updated atomically via `swapPackageDirectory` whenever
+    * a write operation produces a new version of the package. Empty string
+    * for legacy rows that predate versioned directories — callers should
+    * fall back to `<environmentPath>/<packageName>` in that case.
+    */
    manifestPath: string;
    createdAt: Date;
    updatedAt: Date;

--- a/packages/server/src/storage/duckdb/DuckDBRepository.ts
+++ b/packages/server/src/storage/duckdb/DuckDBRepository.ts
@@ -113,6 +113,22 @@ export class DuckDBRepository implements ResourceRepository {
       return this.packageRepo.deletePackagesByEnvironmentId(id);
    }
 
+   async swapPackageDirectory(args: {
+      environmentId: string;
+      name: string;
+      newDirectoryPath: string;
+      description?: string;
+      metadata?: Record<string, unknown>;
+   }): Promise<{ id: string; oldDirectoryPath: string | null }> {
+      return this.packageRepo.swapPackageDirectory(args);
+   }
+
+   async listPackageDirectoryPaths(
+      environmentId: string,
+   ): Promise<Set<string>> {
+      return this.packageRepo.listPackageDirectoryPaths(environmentId);
+   }
+
    // ==================== CONNECTIONS ====================
 
    async listConnections(environmentId: string): Promise<Connection[]> {

--- a/packages/server/src/storage/duckdb/PackageRepository.ts
+++ b/packages/server/src/storage/duckdb/PackageRepository.ts
@@ -1,7 +1,18 @@
+import { Mutex } from "async-mutex";
 import { Package } from "../DatabaseInterface";
 import { DuckDBConnection } from "./DuckDBConnection";
 
 export class PackageRepository {
+   /**
+    * `swapPackageDirectory` is a SELECT-then-INSERT/UPDATE compound operation;
+    * DuckDB's connection-level mutex serializes individual statements but does
+    * not bracket the read-modify-write. This per-process mutex makes the
+    * compound operation atomic so two concurrent swaps for the same package
+    * cannot both observe the same `oldDirectoryPath` and miss orphaning the
+    * loser's directory.
+    */
+   private swapMutex = new Mutex();
+
    constructor(private db: DuckDBConnection) {}
 
    private generateId(): string {
@@ -116,6 +127,82 @@ export class PackageRepository {
 
    async deletePackagesByEnvironmentId(id: string): Promise<void> {
       await this.db.run("DELETE FROM packages WHERE environment_id = ?", [id]);
+   }
+
+   /**
+    * Atomic upsert of a package's `manifest_path` (the directory that holds
+    * its contents on disk). Returns the directory the row previously pointed
+    * at so the caller can schedule it for sweep — `null` if this insert is
+    * creating the row for the first time.
+    *
+    * Holding `swapMutex` makes the read-old + write-new sequence indivisible
+    * within this Node process, which is the ordering point that replaces the
+    * old per-package filesystem mutex.
+    */
+   async swapPackageDirectory(args: {
+      environmentId: string;
+      name: string;
+      newDirectoryPath: string;
+      description?: string;
+      metadata?: Record<string, unknown>;
+   }): Promise<{ id: string; oldDirectoryPath: string | null }> {
+      return this.swapMutex.runExclusive(async () => {
+         const existing = await this.getPackageByName(
+            args.environmentId,
+            args.name,
+         );
+         const now = this.now().toISOString();
+         const metadataJson =
+            args.metadata !== undefined ? JSON.stringify(args.metadata) : null;
+         if (existing) {
+            const oldDirectoryPath = existing.manifestPath || null;
+            await this.db.run(
+               `UPDATE packages
+                SET manifest_path = ?, description = COALESCE(?, description),
+                    metadata = COALESCE(?, metadata), updated_at = ?
+                WHERE id = ?`,
+               [
+                  args.newDirectoryPath,
+                  args.description ?? null,
+                  metadataJson,
+                  now,
+                  existing.id,
+               ],
+            );
+            return { id: existing.id, oldDirectoryPath };
+         }
+
+         const id = this.generateId();
+         await this.db.run(
+            `INSERT INTO packages (id, environment_id, name, description, manifest_path, metadata, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+            [
+               id,
+               args.environmentId,
+               args.name,
+               args.description ?? null,
+               args.newDirectoryPath,
+               metadataJson,
+               now,
+               now,
+            ],
+         );
+         return { id, oldDirectoryPath: null };
+      });
+   }
+
+   async listPackageDirectoryPaths(
+      environmentId: string,
+   ): Promise<Set<string>> {
+      const rows = await this.db.all<{ manifest_path: string | null }>(
+         "SELECT manifest_path FROM packages WHERE environment_id = ?",
+         [environmentId],
+      );
+      const paths = new Set<string>();
+      for (const row of rows) {
+         if (row.manifest_path) paths.add(row.manifest_path);
+      }
+      return paths;
    }
 
    private mapToPackage(row: Record<string, unknown>): Package {

--- a/packages/server/tests/integration/concurrent_package/concurrent_package.integration.spec.ts
+++ b/packages/server/tests/integration/concurrent_package/concurrent_package.integration.spec.ts
@@ -1,0 +1,192 @@
+/// <reference types="bun-types" />
+
+/**
+ * Regression test for the concurrent-package directory race that PR #752
+ * tried to address. The publisher used to load packages directly out of
+ * `<env>/<pkg>/`, so a `POST /packages` re-downloading the directory while
+ * a `GET /packages/:name?reload=true` was scanning the same directory would
+ * crash the loader with "Package manifest for ... does not exist" or
+ * "model path not found". With the versioned-dir + database-CAS write path
+ * the controller stages every download into a fresh
+ * `<env>/<pkg>.versions/<uuid>/` directory and atomically swings the
+ * package row at it; readers always resolve to whichever directory the
+ * database currently points at, and any in-flight reader holding the old
+ * directory keeps using it until the sweeper retires it.
+ *
+ * This suite hammers the public REST surface with overlapping POST / GET
+ * / PATCH cycles for the same package and asserts that none of them
+ * surface the symptomatic error fragments. Any reintroduction of the race
+ * should make this test flake.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import path from "path";
+import { fileURLToPath } from "url";
+import { RestE2EEnv, startRestE2E } from "../../harness/rest_e2e";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const ENVIRONMENT_NAME = "concurrent-package-test-env";
+const PACKAGE_NAME = "persist-test";
+
+/**
+ * Substrings the loader emits when it observes a torn package directory.
+ * The new design must never produce any of these because the directory a
+ * reader has acquired is never mutated in place.
+ */
+const FORBIDDEN_ERROR_FRAGMENTS = [
+   "Package manifest for",
+   "does not exist",
+   "compiling model path not found",
+   "model path not found",
+];
+
+interface Outcome {
+   label: string;
+   status: number;
+   bodyText: string;
+}
+
+function assertNoTornReads(outcomes: Outcome[]): void {
+   for (const outcome of outcomes) {
+      if (outcome.status >= 200 && outcome.status < 300) continue;
+      for (const fragment of FORBIDDEN_ERROR_FRAGMENTS) {
+         expect(
+            outcome.bodyText.includes(fragment),
+            `${outcome.label} (status ${outcome.status}) leaked race-symptom fragment "${fragment}":\n${outcome.bodyText}`,
+         ).toBe(false);
+      }
+   }
+}
+
+async function captureOutcome(
+   label: string,
+   request: Promise<Response>,
+): Promise<Outcome> {
+   try {
+      const res = await request;
+      const bodyText = await res.text();
+      return { label, status: res.status, bodyText };
+   } catch (error) {
+      return { label, status: -1, bodyText: String(error) };
+   }
+}
+
+describe("Concurrent package operations (REST E2E)", () => {
+   let env: (RestE2EEnv & { stop(): Promise<void> }) | null = null;
+   let baseUrl: string;
+   let fixtureDir: string;
+
+   beforeAll(async () => {
+      env = await startRestE2E();
+      baseUrl = env.baseUrl;
+      fixtureDir = path.resolve(__dirname, "../../fixtures/persist-test");
+
+      // Create the environment up front; tests reuse it.
+      const createRes = await fetch(`${baseUrl}/api/v0/environments`, {
+         method: "POST",
+         headers: { "Content-Type": "application/json" },
+         body: JSON.stringify({
+            name: ENVIRONMENT_NAME,
+            packages: [],
+            connections: [],
+         }),
+      });
+      if (!createRes.ok && createRes.status !== 409) {
+         throw new Error(
+            `Failed to create test environment: ${createRes.status} ${await createRes.text()}`,
+         );
+      }
+   });
+
+   afterAll(async () => {
+      if (baseUrl) {
+         try {
+            await fetch(`${baseUrl}/api/v0/environments/${ENVIRONMENT_NAME}`, {
+               method: "DELETE",
+            });
+         } catch {
+            // best-effort
+         }
+      }
+      await env?.stop();
+      env = null;
+   });
+
+   it("interleaves POST add, GET reload, and PATCH without leaking torn-read errors", async () => {
+      const outcomes: Outcome[] = [];
+
+      const post = (label: string) =>
+         captureOutcome(
+            label,
+            fetch(
+               `${baseUrl}/api/v0/environments/${ENVIRONMENT_NAME}/packages`,
+               {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({
+                     name: PACKAGE_NAME,
+                     location: fixtureDir,
+                  }),
+               },
+            ),
+         );
+
+      const get = (label: string, reload: boolean) =>
+         captureOutcome(
+            label,
+            fetch(
+               `${baseUrl}/api/v0/environments/${ENVIRONMENT_NAME}/packages/${PACKAGE_NAME}${
+                  reload ? "?reload=true" : ""
+               }`,
+            ),
+         );
+
+      const patch = (label: string, description: string) =>
+         captureOutcome(
+            label,
+            fetch(
+               `${baseUrl}/api/v0/environments/${ENVIRONMENT_NAME}/packages/${PACKAGE_NAME}`,
+               {
+                  method: "PATCH",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({
+                     name: PACKAGE_NAME,
+                     description,
+                     location: fixtureDir,
+                  }),
+               },
+            ),
+         );
+
+      // Initial create. After this the package row exists in the DB and
+      // the cache is warm.
+      outcomes.push(await post("initial-post"));
+      assertNoTornReads(outcomes);
+
+      // Spawn two waves of concurrent traffic. Each wave fans out the
+      // three write/read paths against the same package name.
+      for (let wave = 0; wave < 3; wave++) {
+         const fan = await Promise.all([
+            post(`wave-${wave}-post-1`),
+            post(`wave-${wave}-post-2`),
+            get(`wave-${wave}-get-reload-1`, true),
+            get(`wave-${wave}-get-reload-2`, true),
+            get(`wave-${wave}-get-1`, false),
+            get(`wave-${wave}-get-2`, false),
+            patch(`wave-${wave}-patch-1`, `desc-${wave}-1`),
+            patch(`wave-${wave}-patch-2`, `desc-${wave}-2`),
+         ]);
+         outcomes.push(...fan);
+         assertNoTornReads(outcomes);
+      }
+
+      // Final consistency check: the package must still resolve cleanly.
+      const finalGet = await get("final-get", false);
+      outcomes.push(finalGet);
+      assertNoTornReads(outcomes);
+      expect(finalGet.status).toBe(200);
+      expect(finalGet.bodyText).toContain(PACKAGE_NAME);
+   }, 60_000);
+});

--- a/packages/server/tests/unit/duckdb/package_repository_swap.test.ts
+++ b/packages/server/tests/unit/duckdb/package_repository_swap.test.ts
@@ -1,0 +1,197 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { DuckDBConnection } from "../../../src/storage/duckdb/DuckDBConnection";
+import { PackageRepository } from "../../../src/storage/duckdb/PackageRepository";
+import { initializeSchema } from "../../../src/storage/duckdb/schema";
+
+const TEST_DB_DIR = path.join(os.tmpdir(), "duckdb-swap-package-dir-tests");
+
+async function freshDb(): Promise<{
+   db: DuckDBConnection;
+   repo: PackageRepository;
+   environmentId: string;
+   cleanup: () => Promise<void>;
+}> {
+   await fs.mkdir(TEST_DB_DIR, { recursive: true });
+   const dbPath = path.join(
+      TEST_DB_DIR,
+      `swap-${Date.now()}-${Math.random().toString(36).slice(2)}.duckdb`,
+   );
+   const db = new DuckDBConnection(dbPath);
+   await db.initialize();
+   await initializeSchema(db, false);
+
+   // Seed an environment row so foreign keys are satisfied.
+   const environmentId = "env-1";
+   await db.run(
+      `INSERT INTO environments (id, name, path, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)`,
+      [
+         environmentId,
+         "test-env",
+         "/tmp/test-env",
+         new Date().toISOString(),
+         new Date().toISOString(),
+      ],
+   );
+
+   const repo = new PackageRepository(db);
+
+   return {
+      db,
+      repo,
+      environmentId,
+      cleanup: async () => {
+         await db.close();
+         await fs.rm(dbPath, { force: true });
+      },
+   };
+}
+
+describe("PackageRepository.swapPackageDirectory", () => {
+   beforeEach(async () => {
+      await fs.mkdir(TEST_DB_DIR, { recursive: true });
+   });
+
+   afterEach(async () => {
+      await fs.rm(TEST_DB_DIR, { recursive: true, force: true });
+   });
+
+   it("inserts a new row and reports no previous directory", async () => {
+      const { repo, environmentId, cleanup } = await freshDb();
+      try {
+         const result = await repo.swapPackageDirectory({
+            environmentId,
+            name: "pkg-a",
+            newDirectoryPath: "/var/data/pkg-a.versions/v1",
+            description: "first version",
+            metadata: { location: "https://example.com/pkg-a.git" },
+         });
+
+         expect(result.oldDirectoryPath).toBeNull();
+         expect(result.id).toBeTruthy();
+
+         const row = await repo.getPackageByName(environmentId, "pkg-a");
+         expect(row?.manifestPath).toBe("/var/data/pkg-a.versions/v1");
+         expect(row?.description).toBe("first version");
+         expect(row?.metadata).toEqual({
+            location: "https://example.com/pkg-a.git",
+         });
+      } finally {
+         await cleanup();
+      }
+   });
+
+   it("updates an existing row and reports the previous directory", async () => {
+      const { repo, environmentId, cleanup } = await freshDb();
+      try {
+         await repo.swapPackageDirectory({
+            environmentId,
+            name: "pkg-b",
+            newDirectoryPath: "/var/data/pkg-b.versions/v1",
+            description: "v1",
+         });
+
+         const swap = await repo.swapPackageDirectory({
+            environmentId,
+            name: "pkg-b",
+            newDirectoryPath: "/var/data/pkg-b.versions/v2",
+            description: "v2",
+         });
+
+         expect(swap.oldDirectoryPath).toBe("/var/data/pkg-b.versions/v1");
+
+         const row = await repo.getPackageByName(environmentId, "pkg-b");
+         expect(row?.manifestPath).toBe("/var/data/pkg-b.versions/v2");
+         expect(row?.description).toBe("v2");
+      } finally {
+         await cleanup();
+      }
+   });
+
+   it("serializes concurrent swaps so the database always points at one of the new directories", async () => {
+      const { repo, environmentId, cleanup } = await freshDb();
+      try {
+         await repo.swapPackageDirectory({
+            environmentId,
+            name: "pkg-c",
+            newDirectoryPath: "/var/data/pkg-c.versions/v0",
+         });
+
+         // Fire 10 concurrent swaps. Each one must observe a non-null
+         // `oldDirectoryPath` (the row exists from v0 onward) and the
+         // database must end up pointing at exactly one of the candidate
+         // directories.
+         const candidates = Array.from(
+            { length: 10 },
+            (_, i) => `/var/data/pkg-c.versions/v${i + 1}`,
+         );
+
+         const results = await Promise.all(
+            candidates.map((newDirectoryPath) =>
+               repo.swapPackageDirectory({
+                  environmentId,
+                  name: "pkg-c",
+                  newDirectoryPath,
+               }),
+            ),
+         );
+
+         for (const result of results) {
+            expect(result.oldDirectoryPath).not.toBeNull();
+         }
+         const oldsReported = results.map((r) => r.oldDirectoryPath as string);
+         // Every old-path returned must be either v0 or one of the v1..v10
+         // values (i.e. it was observed by some swap as the previous
+         // value). No swap may report a path that was never written.
+         const validOlds = new Set([
+            "/var/data/pkg-c.versions/v0",
+            ...candidates,
+         ]);
+         for (const old of oldsReported) {
+            expect(validOlds.has(old)).toBe(true);
+         }
+
+         const row = await repo.getPackageByName(environmentId, "pkg-c");
+         expect(candidates).toContain(row!.manifestPath);
+      } finally {
+         await cleanup();
+      }
+   });
+});
+
+describe("PackageRepository.listPackageDirectoryPaths", () => {
+   it("returns every referenced directory and skips empty paths", async () => {
+      const { repo, environmentId, cleanup } = await freshDb();
+      try {
+         await repo.swapPackageDirectory({
+            environmentId,
+            name: "pkg-a",
+            newDirectoryPath: "/var/data/pkg-a.versions/v1",
+         });
+         await repo.swapPackageDirectory({
+            environmentId,
+            name: "pkg-b",
+            newDirectoryPath: "/var/data/pkg-b.versions/v1",
+         });
+         // Insert a legacy row with an empty manifest_path to confirm the
+         // helper does not include the sentinel value.
+         await repo.createPackage({
+            environmentId,
+            name: "legacy",
+            manifestPath: "",
+         });
+
+         const paths = await repo.listPackageDirectoryPaths(environmentId);
+         expect(paths.size).toBe(2);
+         expect(paths.has("/var/data/pkg-a.versions/v1")).toBe(true);
+         expect(paths.has("/var/data/pkg-b.versions/v1")).toBe(true);
+      } finally {
+         await cleanup();
+      }
+   });
+});


### PR DESCRIPTION
## Summary

Alternative fix for the package-directory race [PR #752](https://github.com/malloydata/publisher/pull/752) is targeting. Replaces the in-place `<env>/<pkg>/` mutate-and-hope strategy with a versioned directory layout (`<env>/<pkg>.versions/<uuid>/`) and uses the database as the single ordering point for the swap. No per-package filesystem mutexes; concurrent writers download into separate staging directories and serialize at the DB row.

I think this lands the same correctness fix with less moving machinery, so I'm putting it up as an alternative for the #752 reviewer to evaluate alongside that PR.

## Why not #752?

#752 keeps `<env>/<pkg>/` as the canonical on-disk location, then guards mutations of that directory with a second per-package mutex (`packageDirectoryMutexes`) layered on top of the existing `packageMutexes`. A few things felt fragile to me there:

1. **Reader-vs-writer race still open on cache hits.** `getPackage(name, false)` returns the cached `Package` without taking the directory mutex. A concurrent writer can `rm -rf <env>/<pkg>/` and start re-downloading mid-query, and the reader holding the cached `Package` will see ENOENT on a lazy import.
2. **Empty-directory window during swap.** `rm -rf <dir>` followed by `rename <staging> <dir>` is not atomic; there is a window where `<dir>` is gone or partially populated. Unrelated readers that arrive in that window blow up.
3. **Stale in-memory cache after reload.** `updatePackage` swaps the directory but never invalidates the cached `Package`, so the next read serves the previous compile.
4. **Lock ordering complexity.** Two mutexes per package plus the `connectionMutex` is enough nesting to invite future deadlocks.
5. **Scope creep.** Reverts the operational-state work from #751 without justification (already addressed on `main` by [PR #756](https://github.com/malloydata/publisher/pull/756), so we don't need to re-litigate that here).

## What this PR does instead

### Versioned write path

Every write that produces new package contents (POST add, PATCH with `location`, GET `?reload=true`) lands in a fresh, UUID-scoped directory:

```
<envPath>/<pkgName>.versions/<uuid>/...
```

After the download succeeds, the controller calls `repository.swapPackageDirectory(...)`, which atomically swings the package row's `manifest_path` from the old directory to the new one and returns the previous path. The previous directory is handed to `PackageSweeper.scheduleSweep` for deferred deletion. There is no in-place `rm + rename` and no per-package mutex.

### Path-keyed cache + promise dedup

`Environment` now maintains:

- `packagesByPath: Map<string, Package>` — compiled packages keyed by their on-disk directory, not by name.
- `loadsByPath: Map<string, Promise<Package>>` — promise dedup so two concurrent first-loads of the same path share one `Package.create` call.

`getPackage(name)` resolves the current directory from the database, then either returns the cached `Package` or starts a load. A swap pivots `manifest_path` to a new directory, which automatically misses the cache and triggers a fresh load — readers that picked up the old directory before the swap keep using it.

### Sweeper-driven cleanup

`PackageSweeper`:

- Runs an immediate startup sweep (reclaims orphans from a previous crashed process where the download committed but the DB write didn't, or vice versa).
- Runs a periodic full sweep (defaults to 15 min) over every environment.
- Honors a configurable quiescence window (defaults to 30 min) so in-flight readers still holding the old directory finish before we delete it.
- Only ever touches directories under a `*.versions/` parent, so externally-mounted package paths declared in `publisher.config.json` are not at risk.
- Before deleting, it evicts the cache entry and retires the package's MalloyConfig connections through the existing `retireConnectionGeneration` machinery.

### Migration / compatibility

- The `manifest_path` column is repurposed (was previously written as the empty string in most code paths). Existing rows with empty `manifest_path` fall through to the legacy `<env>/<pkg>/` resolver, which is what the bootstrap path also continues to use. Nothing requires a schema migration.
- `Environment.deletePackage(name)` now returns the directory to schedule for sweeping rather than `rm`'ing inline, but the public method name and arity are preserved for downstream callers.

## Test plan

New unit and integration tests added under `packages/server`:

- [x] `tests/unit/duckdb/package_repository_swap.test.ts` — covers `swapPackageDirectory` insert / update / concurrent-serialization, plus `listPackageDirectoryPaths`.
- [x] `src/service/package_sweeper.spec.ts` — covers orphan reclamation, quiescence window, mount-style paths untouched, scheduled per-path sweep.
- [x] `tests/integration/concurrent_package/concurrent_package.integration.spec.ts` — REST E2E that fans out overlapping POST/GET-reload/PATCH waves at the same package and asserts none of the responses carry the symptomatic torn-read fragments (`"Package manifest for ... does not exist"`, `"model path not found"`). This is the regression test #752 was after.

Existing test suites:

- [x] `bun test src` — 389 pass / 0 fail (no regressions).
- [x] `bun test tests/integration/legacy_routes` — 11 pass / 0 fail (was 10 pass / 1 fail on `main` because of the bootstrap-package-list path; this PR fixes that incidentally by unioning `packageStatuses` with the DB rows during the bootstrap window).
- [x] `bun test tests/integration` — 23 pass / 3 fail; the 3 failures are pre-existing MCP `describe.serial` issues on `main` and are unrelated to this PR.

Sign-off: Kyle Nesbit <kjnesbit@ms2.co>


Made with [Cursor](https://cursor.com)