### PR TITLE
feat: per-query givens overrides (graft of #744)

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -2789,6 +2789,13 @@ components:
           type: boolean
           default: false
           description: When true, skip server-side \#(filter) injection entirely.
+        givens:
+          type: object
+          description: Per-query given values that override model defaults. Keys are
+            given names declared in the model's `given:` block. Values must match
+            the declared type (string, number, boolean, date, etc.). See Malloy
+            givens documentation for accepted value shapes.
+          additionalProperties: true
 
     NotebookCell:
       type: object

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3466,6 +3466,13 @@ components:
           description: If true, returns the generated SQL alongside compilation results
             (only available when compilation succeeds and the source contains a
             runnable query).
+        givens:
+          type: object
+          description: Per-query given values that override model defaults. Keys are
+            given names declared in the model's `given:` block. Values must match
+            the declared type (string, number, boolean, date, etc.). See Malloy
+            givens documentation for accepted value shapes.
+          additionalProperties: true
       required:
         - source
 

--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -3,1189 +3,1192 @@
  * Do not make direct changes to the file.
  */
 
+
 export interface paths {
-   "/status": {
-      /**
-       * Get server status and health information
-       * @description Returns the current status of the Malloy Publisher server, including initialization state,
-       * available environments, and server timestamp. This endpoint is useful for health checks and
-       * monitoring server availability.
-       */
-      get: operations["get-status"];
-   };
-   "/environments": {
-      /**
-       * List all available environments
-       * @description Retrieves a list of all environments currently hosted on this Malloy Publisher server.
-       * Each environment contains metadata about its packages, connections, and configuration.
-       * This endpoint is typically used to discover available environments and their basic information.
-       */
-      get: operations["list-environments"];
-      /**
-       * Create a new environment
-       * @description Creates a new Malloy environment with the specified configuration. An environment serves as a
-       * container for packages, connections, and other resources. The environment will be initialized
-       * with the provided metadata and can immediately accept packages and connections.
-       */
-      post: operations["create-environment"];
-   };
-   "/environments/{environmentName}": {
-      /**
-       * Get environment details and metadata
-       * @description Retrieves detailed information about a specific environment, including its packages,
-       * connections, configuration, and metadata. The reload parameter can be used to
-       * refresh the environment state from disk before returning the information.
-       */
-      get: operations["get-environment"];
-      /**
-       * Delete an environment
-       * @description Permanently deletes an environment and all its associated resources including packages,
-       * connections, and metadata. This operation cannot be undone, so use with caution.
-       * The environment must exist and be accessible for deletion.
-       */
-      delete: operations["delete-environment"];
-      /**
-       * Update environment configuration
-       * @description Updates the configuration and metadata of an existing environment. This allows you to
-       * modify environment settings, update the README, change the location, or update other
-       * environment-level properties. The environment must exist and be accessible.
-       */
-      patch: operations["update-environment"];
-   };
-   "/environments/{environmentName}/connections": {
-      /**
-       * List environment database connections
-       * @description Retrieves a list of all database connections configured for the specified environment.
-       * Each connection includes its configuration, type, and status information. This endpoint
-       * is useful for discovering available data sources within an environment.
-       */
-      get: operations["list-connections"];
-   };
-   "/environments/{environmentName}/connections/{connectionName}": {
-      /**
-       * Get connection details
-       * @description Retrieves detailed information about a specific database connection within an environment.
-       * This includes connection configuration, credentials (if accessible), and metadata.
-       * Useful for inspecting connection settings and troubleshooting connectivity issues.
-       */
-      get: operations["get-connection"];
-      /**
-       * Create a new database connection
-       * @description Creates a new database connection in the specified environment.
-       */
-      post: operations["create-connection"];
-      /**
-       * Delete a database connection
-       * @description Permanently deletes a database connection from the environment.
-       */
-      delete: operations["delete-connection"];
-      /**
-       * Update an existing database connection
-       * @description Updates the configuration of an existing database connection.
-       */
-      patch: operations["update-connection"];
-   };
-   "/environments/{environmentName}/connections/{connectionName}/schemas": {
-      /**
-       * List database schemas
-       * @description Retrieves a list of all schemas (databases) available in the specified connection.
-       * Each schema includes metadata such as name, description, and whether it's the default schema.
-       * This endpoint is useful for exploring the database structure and discovering available data sources.
-       */
-      get: operations["list-schemas"];
-   };
-   "/environments/{environmentName}/connections/{connectionName}/schemas/{schemaName}/tables": {
-      /**
-       * List tables in database
-       * @description Retrieves a list of all tables and views available in the specified database schema.
-       * This endpoint is useful for discovering available data sources and exploring the database
-       * structure. The schema must exist in the connection for this operation to succeed.
-       */
-      get: operations["list-tables"];
-   };
-   "/environments/{environmentName}/connections/{connectionName}/schemas/{schemaName}/tables/{tablePath}": {
-      /**
-       * Get table details from database
-       * @description Retrieves a table from the specified database schema.
-       * This endpoint is useful for discovering available data sources and exploring the database
-       * structure. The schema must exist in the connection for this operation to succeed.
-       * The tablePath is the full path to the table, including the schema name.
-       */
-      get: operations["get-table"];
-   };
-   "/environments/{environmentName}/connections/{connectionName}/sqlSource": {
-      /**
-       * Get SQL source (deprecated)
-       * @deprecated
-       * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
-       * Use the POST version instead for better security and functionality.
-       *
-       * Creates a Malloy source from a SQL statement using the specified connection.
-       * The SQL statement is executed to generate a source definition that can be used in Malloy models.
-       */
-      get: operations["get-sqlsource"];
-      /**
-       * Create SQL source from statement
-       * @description Creates a Malloy source from a SQL statement using the specified database connection.
-       * The SQL statement is executed to generate a source definition that can be used in Malloy models.
-       */
-      post: operations["post-sqlsource"];
-   };
-   "/environments/{environmentName}/connections/{connectionName}/sqlQuery": {
-      /**
-       * Execute SQL query
-       * @description Executes a SQL statement against the specified database connection and returns the results.
-       * The results include data, metadata, and execution information.
-       */
-      post: operations["post-querydata"];
-   };
-   "/environments/{environmentName}/connections/{connectionName}/sqlTemporaryTable": {
-      /**
-       * Create temporary table
-       * @description Creates a temporary table from a SQL statement using the specified database connection.
-       * Temporary tables are useful for storing intermediate results during complex queries and data processing workflows.
-       */
-      post: operations["post-temporarytable"];
-   };
-   "/environments/{environmentName}/connections/{connectionName}/temporaryTable": {
-      /**
-       * Create temporary table (deprecated)
-       * @deprecated
-       * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
-       * Use the POST version instead for better security and functionality.
-       *
-       * Creates a temporary table from a SQL statement using the specified connection.
-       * Temporary tables are useful for storing intermediate results during complex queries.
-       */
-      get: operations["get-temporarytable"];
-   };
-   "/environments/{environmentName}/connections/{connectionName}/queryData": {
-      /**
-       * Execute SQL query (deprecated)
-       * @deprecated
-       * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
-       * Use the POST version instead for better security and functionality.
-       *
-       * Executes a SQL statement against the specified database connection and returns the results.
-       * The query results include data, metadata, and execution information.
-       */
-      get: operations["get-querydata"];
-   };
-   "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/schemas": {
-      /**
-       * List database schemas (per-package)
-       * @description Retrieves a list of all schemas (databases) available in the specified
-       * connection, resolved in the context of the named package. Required for
-       * `connectionName="duckdb"`, which is per-package; works for any other
-       * connection name as well (resolution falls through to the environment).
-       */
-      get: operations["list-schemas-in-package"];
-   };
-   "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/schemas/{schemaName}/tables": {
-      /**
-       * List tables in database (per-package)
-       * @description Retrieves a list of all tables and views available in the specified
-       * database schema, resolved in the context of the named package.
-       */
-      get: operations["list-tables-in-package"];
-   };
-   "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/schemas/{schemaName}/tables/{tablePath}": {
-      /**
-       * Get table details from database (per-package)
-       * @description Retrieves a table from the specified database schema, resolved in
-       * the context of the named package.
-       */
-      get: operations["get-table-in-package"];
-   };
-   "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/sqlSource": {
-      /**
-       * Get SQL source (per-package, deprecated)
-       * @deprecated
-       * @description **DEPRECATED**: Use the POST version instead.
-       *
-       * Creates a Malloy source from a SQL statement using the specified
-       * connection, resolved in the context of the named package.
-       */
-      get: operations["get-sqlsource-in-package"];
-      /**
-       * Create SQL source from statement (per-package)
-       * @description Creates a Malloy source from a SQL statement using the specified
-       * connection, resolved in the context of the named package.
-       */
-      post: operations["post-sqlsource-in-package"];
-   };
-   "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/sqlQuery": {
-      /**
-       * Execute SQL query (per-package)
-       * @description Executes a SQL statement against the specified database connection,
-       * resolved in the context of the named package, and returns the results.
-       */
-      post: operations["post-querydata-in-package"];
-   };
-   "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/sqlTemporaryTable": {
-      /**
-       * Create temporary table (per-package)
-       * @description Creates a temporary table from a SQL statement using the specified
-       * database connection, resolved in the context of the named package.
-       */
-      post: operations["post-temporarytable-in-package"];
-   };
-   "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/temporaryTable": {
-      /**
-       * Create temporary table (per-package, deprecated)
-       * @deprecated
-       * @description **DEPRECATED**: Use the POST version instead.
-       *
-       * Creates a temporary table from a SQL statement using the specified
-       * connection, resolved in the context of the named package.
-       */
-      get: operations["get-temporarytable-in-package"];
-   };
-   "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/queryData": {
-      /**
-       * Execute SQL query (per-package, deprecated)
-       * @deprecated
-       * @description **DEPRECATED**: Use the POST version instead.
-       *
-       * Executes a SQL statement against the specified database connection,
-       * resolved in the context of the named package, and returns the results.
-       */
-      get: operations["get-querydata-in-package"];
-   };
-   "/environments/{environmentName}/packages": {
-      /**
-       * List environment packages
-       * @description Retrieves a list of all Malloy packages within the specified environment. Each package
-       * contains models, notebooks, databases, and other resources. This endpoint is useful
-       * for discovering available packages and their basic metadata.
-       */
-      get: operations["list-packages"];
-      /**
-       * Create a new package
-       * @description Creates a new Malloy package within the specified environment. A package serves as a
-       * container for models, notebooks, embedded databases, and other resources. The package
-       * will be initialized with the provided metadata and can immediately accept content.
-       */
-      post: operations["create-package"];
-   };
-   "/environments/{environmentName}/packages/{packageName}": {
-      /**
-       * Get package details and metadata
-       * @description Retrieves detailed information about a specific package, including its models, notebooks,
-       * databases, and metadata. The reload parameter can be used to refresh the package state
-       * from disk before returning the information. The versionId parameter allows access to
-       * specific package versions.
-       */
-      get: operations["get-package"];
-      /**
-       * Delete a package
-       * @description Permanently deletes a package and all its associated resources including models,
-       * notebooks, databases, and metadata. This operation cannot be undone, so use with caution.
-       * The package must exist and be accessible for deletion.
-       */
-      delete: operations["delete-package"];
-      /**
-       * Update package configuration
-       * @description Updates the configuration and metadata of an existing package. This allows you to
-       * modify package settings, update the description, change the location, or update other
-       * package-level properties. The package must exist and be accessible.
-       */
-      patch: operations["update-package"];
-   };
-   "/environments/{environmentName}/packages/{packageName}/models": {
-      /**
-       * List package models
-       * @description Retrieves a list of all Malloy models within the specified package. Each model entry
-       * includes the relative path, package name, and any compilation errors. This endpoint
-       * is useful for discovering available models and checking their status.
-       */
-      get: operations["list-models"];
-   };
-   "/environments/{environmentName}/packages/{packageName}/models/{path}": {
-      /**
-       * Get compiled Malloy model
-       * @description Retrieves a compiled Malloy model with its source information, queries, and metadata.
-       * The model is compiled using the specified version of the Malloy compiler. This endpoint
-       * provides access to the model's structure, sources, and named queries for use in applications.
-       */
-      get: operations["get-model"];
-   };
-   "/environments/{environmentName}/packages/{packageName}/models/{path}/query": {
-      /**
-       * Execute Malloy query
-       * @description Executes a Malloy query against a model and returns the results. The query can be specified
-       * as a raw Malloy query string or by referencing a named query within the model. This endpoint
-       * supports both ad-hoc queries and predefined model queries, making it flexible for various
-       * use cases including data exploration, reporting, and application integration.
-       */
-      post: operations["execute-query-model"];
-   };
-   "/environments/{environmentName}/packages/{packageName}/models/{path}/compile": {
-      /**
-       * Compile Malloy source code
-       * @description Compiles Malloy source code in the context of a specific model file.
-       * The submitted source is appended to the full model content, giving it
-       * access to all sources, imports, and queries defined in the model.
-       * Relative imports resolve correctly against sibling model files.
-       * Returns compilation status and any problems (errors or warnings) found.
-       */
-      post: operations["compile-model-source"];
-   };
-   "/environments/{environmentName}/packages/{packageName}/notebooks": {
-      /**
-       * List package notebooks
-       * @description Retrieves a list of all Malloy notebooks within the specified package. Each notebook entry
-       * includes the relative path, package name, and any compilation errors. This endpoint
-       * is useful for discovering available notebooks and checking their status.
-       */
-      get: operations["list-notebooks"];
-   };
-   "/environments/{environmentName}/packages/{packageName}/notebooks/{path}": {
-      /**
-       * Get Malloy notebook cells
-       * @description Retrieves a Malloy notebook with its raw cell contents (markdown and code).
-       * Cell execution should be done separately via the execute-notebook-cell endpoint.
-       */
-      get: operations["get-notebook"];
-   };
-   "/environments/{environmentName}/packages/{packageName}/notebooks/{path}/cells/{cellIndex}": {
-      /**
-       * Execute a specific notebook cell
-       * @description Executes a specific cell in a Malloy notebook by index. For code cells, this compiles
-       * and runs the Malloy code, returning query results and any new sources defined.
-       * For markdown cells, this simply returns the cell content.
-       */
-      get: operations["execute-notebook-cell"];
-   };
-   "/environments/{environmentName}/packages/{packageName}/databases": {
-      /**
-       * List embedded databases
-       * @description Retrieves a list of all embedded databases within the specified package. These are typically
-       * DuckDB databases stored as .parquet files that provide local data storage for the package.
-       * Each database entry includes metadata about the database structure and content.
-       */
-      get: operations["list-databases"];
-   };
-   "/connections/test": {
-      /**
-       * Test database connection configuration
-       * @description Validates a database connection configuration without adding it to any environment.
-       * This endpoint allows you to test connection parameters, credentials, and network
-       * connectivity before committing the connection to an environment. Useful for troubleshooting
-       * connection issues and validating configurations during setup.
-       */
-      post: operations["test-connection-configuration"];
-   };
-   "/watch-mode/status": {
-      /**
-       * Get watch mode status
-       * @description Retrieves the current status of the file watching system. This includes whether watch mode
-       * is enabled, which environment is being watched, and the path being monitored. Useful for
-       * monitoring the development workflow and ensuring file changes are being detected.
-       */
-      get: operations["get-watch-status"];
-   };
-   "/watch-mode/start": {
-      /**
-       * Start file watching
-       * @description Initiates file watching for the specified environment. This enables real-time monitoring of
-       * file changes within the environment directory, allowing for automatic reloading and updates
-       * during development. Only one environment can be watched at a time.
-       */
-      post: operations["start-watching"];
-   };
-   "/watch-mode/stop": {
-      /**
-       * Stop file watching
-       * @description Stops the current file watching session. This disables real-time monitoring of file changes
-       * and releases system resources. Use this when development is complete or when switching
-       * to a different environment.
-       */
-      post: operations["stop-watching"];
-   };
-   "/environments/{environmentName}/packages/{packageName}/materializations": {
-      /**
-       * List materializations for a package
-       * @description Returns the materialization history for the package, ordered by most recent first.
-       */
-      get: operations["list-materializations"];
-      /**
-       * Create a materialization
-       * @description Creates a new materialization in PENDING state for all persist sources across all
-       * models in the package. Use POST .../materializations/{materializationId}?action=start to begin execution.
-       */
-      post: operations["create-materialization"];
-   };
-   "/environments/{environmentName}/packages/{packageName}/materializations/{materializationId}": {
-      /** Get a specific materialization */
-      get: operations["get-materialization"];
-      /**
-       * Perform an action on a materialization
-       * @description Performs an action on a materialization. The action is specified via
-       * the `action` query parameter:
-       *   * `start` - Transitions a PENDING materialization to RUNNING and begins execution in the background. Returns 202.
-       *   * `stop` - Cancels a PENDING or RUNNING materialization. Returns 200.
-       */
-      post: operations["materialization-action"];
-      /**
-       * Delete a materialization
-       * @description Deletes a terminal (SUCCESS, FAILED, or CANCELLED) materialization record.
-       */
-      delete: operations["delete-materialization"];
-   };
-   "/environments/{environmentName}/packages/{packageName}/manifest": {
-      /**
-       * Get the build manifest for a package
-       * @description Returns the current build manifest containing buildId-to-tableName mappings
-       * for all materialized sources in the package.
-       */
-      get: operations["get-manifest"];
-      /**
-       * Perform an action on the package manifest
-       * @description Performs an action on the package manifest. The action is specified via
-       * the `action` query parameter:
-       *   * `reload` - Reads the build manifest from the shared store (DuckLake
-       *     in orchestrated mode, local DuckDB in standalone mode) and recompiles
-       *     every model in the package so subsequent queries resolve persisted
-       *     sources to their materialized tables. Intended for orchestrated
-       *     workers that did not themselves run the build; the endpoint does
-       *     not write anything *into* storage.
-       */
-      post: operations["manifest-action"];
-   };
+  "/status": {
+    /**
+     * Get server status and health information
+     * @description Returns the current status of the Malloy Publisher server, including initialization state,
+     * available environments, and server timestamp. This endpoint is useful for health checks and
+     * monitoring server availability.
+     */
+    get: operations["get-status"];
+  };
+  "/environments": {
+    /**
+     * List all available environments
+     * @description Retrieves a list of all environments currently hosted on this Malloy Publisher server.
+     * Each environment contains metadata about its packages, connections, and configuration.
+     * This endpoint is typically used to discover available environments and their basic information.
+     */
+    get: operations["list-environments"];
+    /**
+     * Create a new environment
+     * @description Creates a new Malloy environment with the specified configuration. An environment serves as a
+     * container for packages, connections, and other resources. The environment will be initialized
+     * with the provided metadata and can immediately accept packages and connections.
+     */
+    post: operations["create-environment"];
+  };
+  "/environments/{environmentName}": {
+    /**
+     * Get environment details and metadata
+     * @description Retrieves detailed information about a specific environment, including its packages,
+     * connections, configuration, and metadata. The reload parameter can be used to
+     * refresh the environment state from disk before returning the information.
+     */
+    get: operations["get-environment"];
+    /**
+     * Delete an environment
+     * @description Permanently deletes an environment and all its associated resources including packages,
+     * connections, and metadata. This operation cannot be undone, so use with caution.
+     * The environment must exist and be accessible for deletion.
+     */
+    delete: operations["delete-environment"];
+    /**
+     * Update environment configuration
+     * @description Updates the configuration and metadata of an existing environment. This allows you to
+     * modify environment settings, update the README, change the location, or update other
+     * environment-level properties. The environment must exist and be accessible.
+     */
+    patch: operations["update-environment"];
+  };
+  "/environments/{environmentName}/connections": {
+    /**
+     * List environment database connections
+     * @description Retrieves a list of all database connections configured for the specified environment.
+     * Each connection includes its configuration, type, and status information. This endpoint
+     * is useful for discovering available data sources within an environment.
+     */
+    get: operations["list-connections"];
+  };
+  "/environments/{environmentName}/connections/{connectionName}": {
+    /**
+     * Get connection details
+     * @description Retrieves detailed information about a specific database connection within an environment.
+     * This includes connection configuration, credentials (if accessible), and metadata.
+     * Useful for inspecting connection settings and troubleshooting connectivity issues.
+     */
+    get: operations["get-connection"];
+    /**
+     * Create a new database connection
+     * @description Creates a new database connection in the specified environment.
+     */
+    post: operations["create-connection"];
+    /**
+     * Delete a database connection
+     * @description Permanently deletes a database connection from the environment.
+     */
+    delete: operations["delete-connection"];
+    /**
+     * Update an existing database connection
+     * @description Updates the configuration of an existing database connection.
+     */
+    patch: operations["update-connection"];
+  };
+  "/environments/{environmentName}/connections/{connectionName}/schemas": {
+    /**
+     * List database schemas
+     * @description Retrieves a list of all schemas (databases) available in the specified connection.
+     * Each schema includes metadata such as name, description, and whether it's the default schema.
+     * This endpoint is useful for exploring the database structure and discovering available data sources.
+     */
+    get: operations["list-schemas"];
+  };
+  "/environments/{environmentName}/connections/{connectionName}/schemas/{schemaName}/tables": {
+    /**
+     * List tables in database
+     * @description Retrieves a list of all tables and views available in the specified database schema.
+     * This endpoint is useful for discovering available data sources and exploring the database
+     * structure. The schema must exist in the connection for this operation to succeed.
+     */
+    get: operations["list-tables"];
+  };
+  "/environments/{environmentName}/connections/{connectionName}/schemas/{schemaName}/tables/{tablePath}": {
+    /**
+     * Get table details from database
+     * @description Retrieves a table from the specified database schema.
+     * This endpoint is useful for discovering available data sources and exploring the database
+     * structure. The schema must exist in the connection for this operation to succeed.
+     * The tablePath is the full path to the table, including the schema name.
+     */
+    get: operations["get-table"];
+  };
+  "/environments/{environmentName}/connections/{connectionName}/sqlSource": {
+    /**
+     * Get SQL source (deprecated)
+     * @deprecated
+     * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
+     * Use the POST version instead for better security and functionality.
+     *
+     * Creates a Malloy source from a SQL statement using the specified connection.
+     * The SQL statement is executed to generate a source definition that can be used in Malloy models.
+     */
+    get: operations["get-sqlsource"];
+    /**
+     * Create SQL source from statement
+     * @description Creates a Malloy source from a SQL statement using the specified database connection.
+     * The SQL statement is executed to generate a source definition that can be used in Malloy models.
+     */
+    post: operations["post-sqlsource"];
+  };
+  "/environments/{environmentName}/connections/{connectionName}/sqlQuery": {
+    /**
+     * Execute SQL query
+     * @description Executes a SQL statement against the specified database connection and returns the results.
+     * The results include data, metadata, and execution information.
+     */
+    post: operations["post-querydata"];
+  };
+  "/environments/{environmentName}/connections/{connectionName}/sqlTemporaryTable": {
+    /**
+     * Create temporary table
+     * @description Creates a temporary table from a SQL statement using the specified database connection.
+     * Temporary tables are useful for storing intermediate results during complex queries and data processing workflows.
+     */
+    post: operations["post-temporarytable"];
+  };
+  "/environments/{environmentName}/connections/{connectionName}/temporaryTable": {
+    /**
+     * Create temporary table (deprecated)
+     * @deprecated
+     * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
+     * Use the POST version instead for better security and functionality.
+     *
+     * Creates a temporary table from a SQL statement using the specified connection.
+     * Temporary tables are useful for storing intermediate results during complex queries.
+     */
+    get: operations["get-temporarytable"];
+  };
+  "/environments/{environmentName}/connections/{connectionName}/queryData": {
+    /**
+     * Execute SQL query (deprecated)
+     * @deprecated
+     * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
+     * Use the POST version instead for better security and functionality.
+     *
+     * Executes a SQL statement against the specified database connection and returns the results.
+     * The query results include data, metadata, and execution information.
+     */
+    get: operations["get-querydata"];
+  };
+  "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/schemas": {
+    /**
+     * List database schemas (per-package)
+     * @description Retrieves a list of all schemas (databases) available in the specified
+     * connection, resolved in the context of the named package. Required for
+     * `connectionName="duckdb"`, which is per-package; works for any other
+     * connection name as well (resolution falls through to the environment).
+     */
+    get: operations["list-schemas-in-package"];
+  };
+  "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/schemas/{schemaName}/tables": {
+    /**
+     * List tables in database (per-package)
+     * @description Retrieves a list of all tables and views available in the specified
+     * database schema, resolved in the context of the named package.
+     */
+    get: operations["list-tables-in-package"];
+  };
+  "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/schemas/{schemaName}/tables/{tablePath}": {
+    /**
+     * Get table details from database (per-package)
+     * @description Retrieves a table from the specified database schema, resolved in
+     * the context of the named package.
+     */
+    get: operations["get-table-in-package"];
+  };
+  "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/sqlSource": {
+    /**
+     * Get SQL source (per-package, deprecated)
+     * @deprecated
+     * @description **DEPRECATED**: Use the POST version instead.
+     *
+     * Creates a Malloy source from a SQL statement using the specified
+     * connection, resolved in the context of the named package.
+     */
+    get: operations["get-sqlsource-in-package"];
+    /**
+     * Create SQL source from statement (per-package)
+     * @description Creates a Malloy source from a SQL statement using the specified
+     * connection, resolved in the context of the named package.
+     */
+    post: operations["post-sqlsource-in-package"];
+  };
+  "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/sqlQuery": {
+    /**
+     * Execute SQL query (per-package)
+     * @description Executes a SQL statement against the specified database connection,
+     * resolved in the context of the named package, and returns the results.
+     */
+    post: operations["post-querydata-in-package"];
+  };
+  "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/sqlTemporaryTable": {
+    /**
+     * Create temporary table (per-package)
+     * @description Creates a temporary table from a SQL statement using the specified
+     * database connection, resolved in the context of the named package.
+     */
+    post: operations["post-temporarytable-in-package"];
+  };
+  "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/temporaryTable": {
+    /**
+     * Create temporary table (per-package, deprecated)
+     * @deprecated
+     * @description **DEPRECATED**: Use the POST version instead.
+     *
+     * Creates a temporary table from a SQL statement using the specified
+     * connection, resolved in the context of the named package.
+     */
+    get: operations["get-temporarytable-in-package"];
+  };
+  "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/queryData": {
+    /**
+     * Execute SQL query (per-package, deprecated)
+     * @deprecated
+     * @description **DEPRECATED**: Use the POST version instead.
+     *
+     * Executes a SQL statement against the specified database connection,
+     * resolved in the context of the named package, and returns the results.
+     */
+    get: operations["get-querydata-in-package"];
+  };
+  "/environments/{environmentName}/packages": {
+    /**
+     * List environment packages
+     * @description Retrieves a list of all Malloy packages within the specified environment. Each package
+     * contains models, notebooks, databases, and other resources. This endpoint is useful
+     * for discovering available packages and their basic metadata.
+     */
+    get: operations["list-packages"];
+    /**
+     * Create a new package
+     * @description Creates a new Malloy package within the specified environment. A package serves as a
+     * container for models, notebooks, embedded databases, and other resources. The package
+     * will be initialized with the provided metadata and can immediately accept content.
+     */
+    post: operations["create-package"];
+  };
+  "/environments/{environmentName}/packages/{packageName}": {
+    /**
+     * Get package details and metadata
+     * @description Retrieves detailed information about a specific package, including its models, notebooks,
+     * databases, and metadata. The reload parameter can be used to refresh the package state
+     * from disk before returning the information. The versionId parameter allows access to
+     * specific package versions.
+     */
+    get: operations["get-package"];
+    /**
+     * Delete a package
+     * @description Permanently deletes a package and all its associated resources including models,
+     * notebooks, databases, and metadata. This operation cannot be undone, so use with caution.
+     * The package must exist and be accessible for deletion.
+     */
+    delete: operations["delete-package"];
+    /**
+     * Update package configuration
+     * @description Updates the configuration and metadata of an existing package. This allows you to
+     * modify package settings, update the description, change the location, or update other
+     * package-level properties. The package must exist and be accessible.
+     */
+    patch: operations["update-package"];
+  };
+  "/environments/{environmentName}/packages/{packageName}/models": {
+    /**
+     * List package models
+     * @description Retrieves a list of all Malloy models within the specified package. Each model entry
+     * includes the relative path, package name, and any compilation errors. This endpoint
+     * is useful for discovering available models and checking their status.
+     */
+    get: operations["list-models"];
+  };
+  "/environments/{environmentName}/packages/{packageName}/models/{path}": {
+    /**
+     * Get compiled Malloy model
+     * @description Retrieves a compiled Malloy model with its source information, queries, and metadata.
+     * The model is compiled using the specified version of the Malloy compiler. This endpoint
+     * provides access to the model's structure, sources, and named queries for use in applications.
+     */
+    get: operations["get-model"];
+  };
+  "/environments/{environmentName}/packages/{packageName}/models/{path}/query": {
+    /**
+     * Execute Malloy query
+     * @description Executes a Malloy query against a model and returns the results. The query can be specified
+     * as a raw Malloy query string or by referencing a named query within the model. This endpoint
+     * supports both ad-hoc queries and predefined model queries, making it flexible for various
+     * use cases including data exploration, reporting, and application integration.
+     */
+    post: operations["execute-query-model"];
+  };
+  "/environments/{environmentName}/packages/{packageName}/models/{path}/compile": {
+    /**
+     * Compile Malloy source code
+     * @description Compiles Malloy source code in the context of a specific model file.
+     * The submitted source is appended to the full model content, giving it
+     * access to all sources, imports, and queries defined in the model.
+     * Relative imports resolve correctly against sibling model files.
+     * Returns compilation status and any problems (errors or warnings) found.
+     */
+    post: operations["compile-model-source"];
+  };
+  "/environments/{environmentName}/packages/{packageName}/notebooks": {
+    /**
+     * List package notebooks
+     * @description Retrieves a list of all Malloy notebooks within the specified package. Each notebook entry
+     * includes the relative path, package name, and any compilation errors. This endpoint
+     * is useful for discovering available notebooks and checking their status.
+     */
+    get: operations["list-notebooks"];
+  };
+  "/environments/{environmentName}/packages/{packageName}/notebooks/{path}": {
+    /**
+     * Get Malloy notebook cells
+     * @description Retrieves a Malloy notebook with its raw cell contents (markdown and code).
+     * Cell execution should be done separately via the execute-notebook-cell endpoint.
+     */
+    get: operations["get-notebook"];
+  };
+  "/environments/{environmentName}/packages/{packageName}/notebooks/{path}/cells/{cellIndex}": {
+    /**
+     * Execute a specific notebook cell
+     * @description Executes a specific cell in a Malloy notebook by index. For code cells, this compiles
+     * and runs the Malloy code, returning query results and any new sources defined.
+     * For markdown cells, this simply returns the cell content.
+     */
+    get: operations["execute-notebook-cell"];
+  };
+  "/environments/{environmentName}/packages/{packageName}/databases": {
+    /**
+     * List embedded databases
+     * @description Retrieves a list of all embedded databases within the specified package. These are typically
+     * DuckDB databases stored as .parquet files that provide local data storage for the package.
+     * Each database entry includes metadata about the database structure and content.
+     */
+    get: operations["list-databases"];
+  };
+  "/connections/test": {
+    /**
+     * Test database connection configuration
+     * @description Validates a database connection configuration without adding it to any environment.
+     * This endpoint allows you to test connection parameters, credentials, and network
+     * connectivity before committing the connection to an environment. Useful for troubleshooting
+     * connection issues and validating configurations during setup.
+     */
+    post: operations["test-connection-configuration"];
+  };
+  "/watch-mode/status": {
+    /**
+     * Get watch mode status
+     * @description Retrieves the current status of the file watching system. This includes whether watch mode
+     * is enabled, which environment is being watched, and the path being monitored. Useful for
+     * monitoring the development workflow and ensuring file changes are being detected.
+     */
+    get: operations["get-watch-status"];
+  };
+  "/watch-mode/start": {
+    /**
+     * Start file watching
+     * @description Initiates file watching for the specified environment. This enables real-time monitoring of
+     * file changes within the environment directory, allowing for automatic reloading and updates
+     * during development. Only one environment can be watched at a time.
+     */
+    post: operations["start-watching"];
+  };
+  "/watch-mode/stop": {
+    /**
+     * Stop file watching
+     * @description Stops the current file watching session. This disables real-time monitoring of file changes
+     * and releases system resources. Use this when development is complete or when switching
+     * to a different environment.
+     */
+    post: operations["stop-watching"];
+  };
+  "/environments/{environmentName}/packages/{packageName}/materializations": {
+    /**
+     * List materializations for a package
+     * @description Returns the materialization history for the package, ordered by most recent first.
+     */
+    get: operations["list-materializations"];
+    /**
+     * Create a materialization
+     * @description Creates a new materialization in PENDING state for all persist sources across all
+     * models in the package. Use POST .../materializations/{materializationId}?action=start to begin execution.
+     */
+    post: operations["create-materialization"];
+  };
+  "/environments/{environmentName}/packages/{packageName}/materializations/{materializationId}": {
+    /** Get a specific materialization */
+    get: operations["get-materialization"];
+    /**
+     * Perform an action on a materialization
+     * @description Performs an action on a materialization. The action is specified via
+     * the `action` query parameter:
+     *   * `start` - Transitions a PENDING materialization to RUNNING and begins execution in the background. Returns 202.
+     *   * `stop` - Cancels a PENDING or RUNNING materialization. Returns 200.
+     */
+    post: operations["materialization-action"];
+    /**
+     * Delete a materialization
+     * @description Deletes a terminal (SUCCESS, FAILED, or CANCELLED) materialization record.
+     */
+    delete: operations["delete-materialization"];
+  };
+  "/environments/{environmentName}/packages/{packageName}/manifest": {
+    /**
+     * Get the build manifest for a package
+     * @description Returns the current build manifest containing buildId-to-tableName mappings
+     * for all materialized sources in the package.
+     */
+    get: operations["get-manifest"];
+    /**
+     * Perform an action on the package manifest
+     * @description Performs an action on the package manifest. The action is specified via
+     * the `action` query parameter:
+     *   * `reload` - Reads the build manifest from the shared store (DuckLake
+     *     in orchestrated mode, local DuckDB in standalone mode) and recompiles
+     *     every model in the package so subsequent queries resolve persisted
+     *     sources to their materialized tables. Intended for orchestrated
+     *     workers that did not themselves run the build; the endpoint does
+     *     not write anything *into* storage.
+     */
+    post: operations["manifest-action"];
+  };
 }
 
 export type webhooks = Record<string, never>;
 
 export interface components {
-   schemas: {
-      /** @description Standard identifier pattern for resource names */
-      IdentifierPattern: string;
-      /** @description Version identifier pattern supporting dots and dashes */
-      VersionIdPattern: string;
-      /** @description Path pattern supporting slashes, dots, and dashes */
-      PathPattern: string;
-      /** @description Current server status and health information */
-      ServerStatus: {
-         /** @description Unix timestamp of the status check */
-         timestamp?: number;
-         /** @description List of available environments */
-         environments?: components["schemas"]["Environment"][];
-         /** @description Whether the server is fully initialized and ready to serve requests */
-         initialized?: boolean;
-         /**
-          * @description Status of the server; initializing when the server is loading environments, packages and connections, serving when the server is initialized and ready to serve requests, and draining when the server is going to shut down
-          * @enum {string}
-          */
-         operationalState?: "initializing" | "serving" | "draining";
-         /** @description Whether the server configuration is frozen (read-only mode). When true, all mutation operations are disabled. */
-         frozenConfig?: boolean;
+  schemas: {
+    /** @description Standard identifier pattern for resource names */
+    IdentifierPattern: string;
+    /** @description Version identifier pattern supporting dots and dashes */
+    VersionIdPattern: string;
+    /** @description Path pattern supporting slashes, dots, and dashes */
+    PathPattern: string;
+    /** @description Current server status and health information */
+    ServerStatus: {
+      /** @description Unix timestamp of the status check */
+      timestamp?: number;
+      /** @description List of available environments */
+      environments?: components["schemas"]["Environment"][];
+      /** @description Whether the server is fully initialized and ready to serve requests */
+      initialized?: boolean;
+      /**
+       * @description Status of the server; initializing when the server is loading environments, packages and connections, serving when the server is initialized and ready to serve requests, degraded when initialization completed but one or more environments failed to load (the surviving environments are served; see failedEnvironments), and draining when the server is going to shut down
+       * @enum {string}
+       */
+      operationalState?: "initializing" | "serving" | "degraded" | "draining";
+      /** @description Environments that failed to initialize. Present only when operationalState is "degraded". Healthy environments are listed under "environments". */
+      failedEnvironments?: {
+          /** @description Environment name as declared in publisher.config.json */
+          name: string;
+          /** @description Error message from the initialization failure */
+          error: string;
+        }[];
+      /** @description Whether the server configuration is frozen (read-only mode). When true, all mutation operations are disabled. */
+      frozenConfig?: boolean;
+    };
+    /** @description Represents a Malloy environment containing packages, connections, and other resources */
+    Environment: {
+      /** @description Resource path to the environment */
+      resource?: string;
+      /** @description Environment name */
+      name?: string;
+      /** @description Environment README content */
+      readme?: string;
+      /** @description Environment location, can be an absolute path or URI (e.g. github, s3, gcs, etc.) */
+      location?: string;
+      /** @description List of database connections configured for this environment */
+      connections?: components["schemas"]["Connection"][];
+      /** @description List of Malloy packages in this environment */
+      packages?: components["schemas"]["Package"][];
+      /** @description Optional DuckLake-backed storage for materialization manifests (orchestrated mode). When set, manifests are stored in a shared DuckLake catalog instead of the local DuckDB database. */
+      materializationStorage?: {
+        /** @description PostgreSQL connection URL for the DuckLake catalog metadata store */
+        catalogUrl?: string;
+        /** @description Cloud storage path (s3:// or gs://) for DuckLake data files */
+        dataPath?: string;
+      } | null;
+    };
+    /** @description Represents a Malloy package containing models, notebooks, and embedded databases */
+    Package: {
+      /** @description Resource path to the package */
+      resource?: string;
+      /** @description Package name */
+      name?: string;
+      /** @description Package description */
+      description?: string;
+      /** @description Package location, can be an absolute path or URI (e.g. github, s3, gcs, etc.) */
+      location?: string;
+    };
+    /** @description Malloy model metadata and status information */
+    Model: {
+      /** @description Resource path to the model */
+      resource?: string;
+      /** @description Name of the package containing this model */
+      packageName?: string;
+      /** @description Relative path to the model file within its package directory */
+      path?: string;
+      /** @description Error message if the model failed to compile or load */
+      error?: string;
+    };
+    /** @description Malloy notebook metadata and status information */
+    Notebook: {
+      /** @description Resource path to the notebook */
+      resource?: string;
+      /** @description Name of the package containing this notebook */
+      packageName?: string;
+      /** @description Relative path to the notebook file within its package directory */
+      path?: string;
+      /** @description Error message if the notebook failed to compile or load */
+      error?: string;
+    };
+    /** @description Raw Malloy notebook with unexecuted cell contents */
+    RawNotebook: {
+      /** @description Resource path to the notebook */
+      resource?: string;
+      /** @description Name of the package containing this notebook */
+      packageName?: string;
+      /** @description Relative path to the notebook file within its package directory */
+      path?: string;
+      /** @description Version of the Malloy compiler used to generate the notebook data */
+      malloyVersion?: string;
+      /** @description Array of notebook cells containing raw markdown and code content */
+      notebookCells?: components["schemas"]["NotebookCell"][];
+      /** @description Array of file-level (##) annotations attached to the notebook */
+      annotations?: string[];
+      /** @description Sources defined in the notebook's model */
+      sources?: components["schemas"]["Source"][];
+    };
+    /** @description Compiled Malloy model with sources, queries, and metadata */
+    CompiledModel: {
+      /** @description Resource path to the model */
+      resource?: string;
+      /** @description Name of the package containing this model */
+      packageName?: string;
+      /** @description Relative path to the model file within its package directory */
+      path?: string;
+      /** @description Version of the Malloy compiler used to generate the model data */
+      malloyVersion?: string;
+      /** @description JSON string containing model metadata and structure information */
+      modelInfo?: string;
+      /** @description Array of JSON strings containing source information for each data source */
+      sourceInfos?: string[];
+      /** @description Array of named queries defined in the model */
+      queries?: components["schemas"]["Query"][];
+      /** @description Sources defined in this model */
+      sources?: components["schemas"]["Source"][];
+    };
+    /** @description Named model view definition */
+    View: {
+      /** @description Name of the view */
+      name?: string;
+      /** @description Annotations attached to the view */
+      annotations?: string[];
+    };
+    /** @description Named model query definition */
+    Query: {
+      /** @description Name of the query */
+      name?: string;
+      /** @description Name of the source this query operates on */
+      sourceName?: string;
+      /** @description Annotations attached to the query */
+      annotations?: string[];
+    };
+    /** @description A filter declared via */
+    Filter: {
+      /** @description Display name of the filter */
+      name?: string;
+      /** @description Dimension this filter targets */
+      dimension?: string;
+      /**
+       * @description Comparator type
+       * @enum {string}
+       */
+      type?: "equal" | "in" | "like" | "greater_than" | "less_than";
+      /** @description Whether this filter is hidden from users */
+      implicit?: boolean;
+      /** @description Whether a value must be provided */
+      required?: boolean;
+      /** @description Malloy data type of the dimension (e.g. string, number, boolean, date, timestamp) */
+      dimensionType?: string;
+    };
+    /** @description A Malloy source defined in a model */
+    Source: {
+      /** @description Name of the source */
+      name?: string;
+      /** @description Annotations attached to the source */
+      annotations?: string[];
+      /** @description Views defined in this source */
+      views?: components["schemas"]["View"][];
+      /** @description Filters declared on this source via */
+      filters?: components["schemas"]["Filter"][];
+    };
+    /** @description Request body for executing a Malloy query */
+    QueryRequest: {
+      /** @description Query string to execute on the model. If the query parameter is set, the queryName parameter must be empty. */
+      query?: string;
+      /** @description Name of the source in the model to use for queryName, search, and topValue requests. */
+      sourceName?: string;
+      /** @description Name of a query to execute on a source in the model. Requires the sourceName parameter is set. If the queryName parameter is set, the query parameter must be empty. */
+      queryName?: string;
+      /**
+       * @description If true, returns a simple JSON array of row objects in the form {"columnName": value}. If false (default), returns the full Malloy result with type metadata for rendering.
+       * @default false
+       */
+      compactJson?: boolean;
+      /** @description Version ID */
+      versionId?: string;
+      /** @description Filter parameter values keyed by filter name. Used with sources that declare \#(filter) annotations. Each value is either a string or an array of strings. */
+      filterParams?: {
+        [key: string]: unknown;
       };
-      /** @description Represents a Malloy environment containing packages, connections, and other resources */
-      Environment: {
-         /** @description Resource path to the environment */
-         resource?: string;
-         /** @description Environment name */
-         name?: string;
-         /** @description Environment README content */
-         readme?: string;
-         /** @description Environment location, can be an absolute path or URI (e.g. github, s3, gcs, etc.) */
-         location?: string;
-         /** @description List of database connections configured for this environment */
-         connections?: components["schemas"]["Connection"][];
-         /** @description List of Malloy packages in this environment */
-         packages?: components["schemas"]["Package"][];
-         /** @description Optional DuckLake-backed storage for materialization manifests (orchestrated mode). When set, manifests are stored in a shared DuckLake catalog instead of the local DuckDB database. */
-         materializationStorage?: {
-            /** @description PostgreSQL connection URL for the DuckLake catalog metadata store */
-            catalogUrl?: string;
-            /** @description Cloud storage path (s3:// or gs://) for DuckLake data files */
-            dataPath?: string;
-         } | null;
+      /**
+       * @description When true, skip server-side \#(filter) injection entirely.
+       * @default false
+       */
+      bypassFilters?: boolean;
+      /** @description Per-query given values that override model defaults. Keys are given names declared in the model's `given:` block. Values must match the declared type (string, number, boolean, date, etc.). See Malloy givens documentation for accepted value shapes. */
+      givens?: {
+        [key: string]: unknown;
       };
-      /** @description Represents a Malloy package containing models, notebooks, and embedded databases */
-      Package: {
-         /** @description Resource path to the package */
-         resource?: string;
-         /** @description Package name */
-         name?: string;
-         /** @description Package description */
-         description?: string;
-         /** @description Package location, can be an absolute path or URI (e.g. github, s3, gcs, etc.) */
-         location?: string;
+    };
+    /** @description Individual cell within a Malloy notebook */
+    NotebookCell: {
+      /**
+       * @description Type of notebook cell
+       * @enum {string}
+       */
+      type?: "markdown" | "code";
+      /** @description Text contents of the notebook cell (either markdown or Malloy code) */
+      text?: string;
+      /** @description Array of JSON strings containing SourceInfo objects made available in this cell */
+      newSources?: string[];
+      /** @description JSON string containing QueryInfo object for the query in this cell (if the cell contains a query) */
+      queryInfo?: string;
+    };
+    /** @description Result of executing a notebook cell */
+    NotebookCellResult: {
+      /**
+       * @description Type of notebook cell
+       * @enum {string}
+       */
+      type?: "markdown" | "code";
+      /** @description Text contents of the notebook cell */
+      text?: string;
+      /** @description JSON string containing the execution result for this cell */
+      result?: string;
+      /** @description Array of JSON strings containing SourceInfo objects made available in this cell */
+      newSources?: string[];
+    };
+    /** @description Results from executing a Malloy query */
+    QueryResult: {
+      /** @description JSON string containing the query results, metadata, and execution information */
+      result?: string;
+      /** @description Resource path to the query result */
+      resource?: string;
+      /** @description Render tag validation messages (errors, warnings) detected during query preparation */
+      renderLogs?: components["schemas"]["LogMessage"][];
+    };
+    /** @description A log message from render tag validation */
+    LogMessage: {
+      /** @description URL of the source file related to this message */
+      url?: string;
+      /** @description Source location range for this message */
+      range?: {
+        start?: {
+          line?: number;
+          character?: number;
+        };
+        end?: {
+          line?: number;
+          character?: number;
+        };
       };
-      /** @description Malloy model metadata and status information */
-      Model: {
-         /** @description Resource path to the model */
-         resource?: string;
-         /** @description Name of the package containing this model */
-         packageName?: string;
-         /** @description Relative path to the model file within its package directory */
-         path?: string;
-         /** @description Error message if the model failed to compile or load */
-         error?: string;
+      /**
+       * @description Severity level of the log message
+       * @enum {string}
+       */
+      severity?: "debug" | "info" | "warn" | "error";
+      /** @description Human-readable log message */
+      message?: string;
+    };
+    /** @description Embedded database within a Malloy package */
+    Database: {
+      /** @description Resource path to the database */
+      resource?: string;
+      /** @description Relative path to the database file within its package directory */
+      path?: string;
+      info?: components["schemas"]["TableDescription"];
+      /**
+       * @description Type of embedded database
+       * @enum {string}
+       */
+      type?: "embedded" | "materialized";
+    };
+    /** @description A schema name in a Connection. */
+    Schema: {
+      /** @description Name of the schema */
+      name?: string;
+      /** @description Description of the schema */
+      description?: string;
+      /** @description Whether this schema is the default schema */
+      isDefault?: boolean;
+      /** @description Whether this schema is hidden */
+      isHidden?: boolean;
+    };
+    /** @description Database connection configuration and metadata */
+    Connection: {
+      /** @description Resource path to the connection */
+      resource?: string;
+      /** @description Name of the connection */
+      name?: string;
+      /**
+       * @description Type of database connection
+       * @enum {string}
+       */
+      type?: "postgres" | "bigquery" | "snowflake" | "trino" | "databricks" | "mysql" | "duckdb" | "motherduck" | "ducklake";
+      attributes?: components["schemas"]["ConnectionAttributes"];
+      postgresConnection?: components["schemas"]["PostgresConnection"];
+      bigqueryConnection?: components["schemas"]["BigqueryConnection"];
+      snowflakeConnection?: components["schemas"]["SnowflakeConnection"];
+      trinoConnection?: components["schemas"]["TrinoConnection"];
+      databricksConnection?: components["schemas"]["DatabricksConnection"];
+      mysqlConnection?: components["schemas"]["MysqlConnection"];
+      duckdbConnection?: components["schemas"]["DuckdbConnection"];
+      motherduckConnection?: components["schemas"]["MotherDuckConnection"];
+      ducklakeConnection?: components["schemas"]["DucklakeConnection"];
+    };
+    /** @description Connection capabilities and configuration attributes */
+    ConnectionAttributes: {
+      /** @description SQL dialect name for the connection */
+      dialectName?: string;
+      /** @description Whether the connection uses connection pooling */
+      isPool?: boolean;
+      /** @description Whether the connection supports persistent storage operations */
+      canPersist?: boolean;
+      /** @description Whether the connection supports streaming query results */
+      canStream?: boolean;
+    };
+    /** @description PostgreSQL database connection configuration */
+    PostgresConnection: {
+      /** @description PostgreSQL server hostname or IP address */
+      host?: string;
+      /** @description PostgreSQL server port number */
+      port?: number;
+      /** @description Name of the PostgreSQL database */
+      databaseName?: string;
+      /** @description PostgreSQL username for authentication */
+      userName?: string;
+      /** @description PostgreSQL password for authentication */
+      password?: string;
+      /** @description Complete PostgreSQL connection string (alternative to individual parameters) */
+      connectionString?: string;
+    };
+    /** @description MySQL database connection configuration */
+    MysqlConnection: {
+      /** @description MySQL server hostname or IP address */
+      host?: string;
+      /** @description MySQL server port number */
+      port?: number;
+      /** @description Name of the MySQL database */
+      database?: string;
+      /** @description MySQL username for authentication */
+      user?: string;
+      /** @description MySQL password for authentication */
+      password?: string;
+    };
+    /** @description Google Cloud Storage connection configuration for DuckDB */
+    GCSConnection: {
+      /** @description GCS HMAC access key ID */
+      keyId: string;
+      /** @description GCS HMAC secret key */
+      secret: string;
+    };
+    /** @description AWS S3 connection configuration for DuckDB */
+    S3Connection: {
+      /** @description AWS access key ID */
+      accessKeyId: string;
+      /** @description AWS secret access key */
+      secretAccessKey: string;
+      /**
+       * @description AWS region (e.g., us-east-1)
+       * @default us-east-1
+       */
+      region?: string;
+      /** @description Custom S3-compatible endpoint URL (optional, for MinIO, etc.) */
+      endpoint?: string;
+      /** @description AWS session token for temporary credentials (optional) */
+      sessionToken?: string;
+    };
+    /** @description Azure Data Lake Storage (ADLS Gen2) / Blob Storage connection configuration Supports https://, http://, abfss://, and az:// URL schemes. */
+    AzureConnection: {
+      /**
+       * @description Authentication method for Azure Storage
+       * @enum {string}
+       */
+      authType: "service_principal" | "sas_token";
+      /** @description Full SAS URL including token; required for sas_token auth. Supports single file, directory glob (*.ext), or recursive (**) patterns. Example: https://account.blob.core.windows.net/container/path/*.parquet?sp=rl&st=... */
+      sasUrl?: string;
+      /** @description Azure AD tenant ID (required for service_principal) */
+      tenantId?: string;
+      /** @description Azure AD application (client) ID (required for service_principal) */
+      clientId?: string;
+      /** @description Azure AD client secret (required for service_principal) */
+      clientSecret?: string;
+      /** @description Azure Storage account name (required for service_principal) */
+      accountName?: string;
+      /** @description Azure file URL to query; required for service_principal auth. Supports single file, directory glob (*.ext), or recursive (**) patterns. Example: https://account.blob.core.windows.net/container/path/** */
+      fileUrl?: string;
+    };
+    /** @description DuckLake lakehouse connection configuration */
+    DucklakeConnection: {
+      /** @description Data storage connection configuration (S3 or GCS) */
+      storage: {
+        /** @description URL of the storage bucket (e.g. s3://my-bucket/path or gs://my-bucket/path) */
+        bucketUrl: string;
+        /** @description AWS S3 connection configuration for data storage */
+        s3Connection?: components["schemas"]["S3Connection"];
+        /** @description Google Cloud Storage connection configuration for data storage */
+        gcsConnection?: components["schemas"]["GCSConnection"];
       };
-      /** @description Malloy notebook metadata and status information */
-      Notebook: {
-         /** @description Resource path to the notebook */
-         resource?: string;
-         /** @description Name of the package containing this notebook */
-         packageName?: string;
-         /** @description Relative path to the notebook file within its package directory */
-         path?: string;
-         /** @description Error message if the notebook failed to compile or load */
-         error?: string;
+      /** @description Catalog metadata connection configuration */
+      catalog: {
+        /** @description PostgreSQL connection for DuckLake metadata catalog */
+        postgresConnection: components["schemas"]["PostgresConnection"];
       };
-      /** @description Raw Malloy notebook with unexecuted cell contents */
-      RawNotebook: {
-         /** @description Resource path to the notebook */
-         resource?: string;
-         /** @description Name of the package containing this notebook */
-         packageName?: string;
-         /** @description Relative path to the notebook file within its package directory */
-         path?: string;
-         /** @description Version of the Malloy compiler used to generate the notebook data */
-         malloyVersion?: string;
-         /** @description Array of notebook cells containing raw markdown and code content */
-         notebookCells?: components["schemas"]["NotebookCell"][];
-         /** @description Array of file-level (##) annotations attached to the notebook */
-         annotations?: string[];
-         /** @description Sources defined in the notebook's model */
-         sources?: components["schemas"]["Source"][];
-      };
-      /** @description Compiled Malloy model with sources, queries, and metadata */
-      CompiledModel: {
-         /** @description Resource path to the model */
-         resource?: string;
-         /** @description Name of the package containing this model */
-         packageName?: string;
-         /** @description Relative path to the model file within its package directory */
-         path?: string;
-         /** @description Version of the Malloy compiler used to generate the model data */
-         malloyVersion?: string;
-         /** @description JSON string containing model metadata and structure information */
-         modelInfo?: string;
-         /** @description Array of JSON strings containing source information for each data source */
-         sourceInfos?: string[];
-         /** @description Array of named queries defined in the model */
-         queries?: components["schemas"]["Query"][];
-         /** @description Sources defined in this model */
-         sources?: components["schemas"]["Source"][];
-      };
-      /** @description Named model view definition */
-      View: {
-         /** @description Name of the view */
-         name?: string;
-         /** @description Annotations attached to the view */
-         annotations?: string[];
-      };
-      /** @description Named model query definition */
-      Query: {
-         /** @description Name of the query */
-         name?: string;
-         /** @description Name of the source this query operates on */
-         sourceName?: string;
-         /** @description Annotations attached to the query */
-         annotations?: string[];
-      };
-      /** @description A filter declared via */
-      Filter: {
-         /** @description Display name of the filter */
-         name?: string;
-         /** @description Dimension this filter targets */
-         dimension?: string;
-         /**
-          * @description Comparator type
-          * @enum {string}
-          */
-         type?: "equal" | "in" | "like" | "greater_than" | "less_than";
-         /** @description Whether this filter is hidden from users */
-         implicit?: boolean;
-         /** @description Whether a value must be provided */
-         required?: boolean;
-         /** @description Malloy data type of the dimension (e.g. string, number, boolean, date, timestamp) */
-         dimensionType?: string;
-      };
-      /** @description A Malloy source defined in a model */
-      Source: {
-         /** @description Name of the source */
-         name?: string;
-         /** @description Annotations attached to the source */
-         annotations?: string[];
-         /** @description Views defined in this source */
-         views?: components["schemas"]["View"][];
-         /** @description Filters declared on this source via */
-         filters?: components["schemas"]["Filter"][];
-      };
-      /** @description Request body for executing a Malloy query */
-      QueryRequest: {
-         /** @description Query string to execute on the model. If the query parameter is set, the queryName parameter must be empty. */
-         query?: string;
-         /** @description Name of the source in the model to use for queryName, search, and topValue requests. */
-         sourceName?: string;
-         /** @description Name of a query to execute on a source in the model. Requires the sourceName parameter is set. If the queryName parameter is set, the query parameter must be empty. */
-         queryName?: string;
-         /**
-          * @description If true, returns a simple JSON array of row objects in the form {"columnName": value}. If false (default), returns the full Malloy result with type metadata for rendering.
-          * @default false
-          */
-         compactJson?: boolean;
-         /** @description Version ID */
-         versionId?: string;
-         /** @description Filter parameter values keyed by filter name. Used with sources that declare \#(filter) annotations. Each value is either a string or an array of strings. */
-         filterParams?: {
-            [key: string]: unknown;
-         };
-         /**
-          * @description When true, skip server-side \#(filter) injection entirely.
-          * @default false
-          */
-         bypassFilters?: boolean;
-      };
-      /** @description Individual cell within a Malloy notebook */
-      NotebookCell: {
-         /**
-          * @description Type of notebook cell
-          * @enum {string}
-          */
-         type?: "markdown" | "code";
-         /** @description Text contents of the notebook cell (either markdown or Malloy code) */
-         text?: string;
-         /** @description Array of JSON strings containing SourceInfo objects made available in this cell */
-         newSources?: string[];
-         /** @description JSON string containing QueryInfo object for the query in this cell (if the cell contains a query) */
-         queryInfo?: string;
-      };
-      /** @description Result of executing a notebook cell */
-      NotebookCellResult: {
-         /**
-          * @description Type of notebook cell
-          * @enum {string}
-          */
-         type?: "markdown" | "code";
-         /** @description Text contents of the notebook cell */
-         text?: string;
-         /** @description JSON string containing the execution result for this cell */
-         result?: string;
-         /** @description Array of JSON strings containing SourceInfo objects made available in this cell */
-         newSources?: string[];
-      };
-      /** @description Results from executing a Malloy query */
-      QueryResult: {
-         /** @description JSON string containing the query results, metadata, and execution information */
-         result?: string;
-         /** @description Resource path to the query result */
-         resource?: string;
-         /** @description Render tag validation messages (errors, warnings) detected during query preparation */
-         renderLogs?: components["schemas"]["LogMessage"][];
-      };
-      /** @description A log message from render tag validation */
-      LogMessage: {
-         /** @description URL of the source file related to this message */
-         url?: string;
-         /** @description Source location range for this message */
-         range?: {
-            start?: {
-               line?: number;
-               character?: number;
-            };
-            end?: {
-               line?: number;
-               character?: number;
-            };
-         };
-         /**
-          * @description Severity level of the log message
-          * @enum {string}
-          */
-         severity?: "debug" | "info" | "warn" | "error";
-         /** @description Human-readable log message */
-         message?: string;
-      };
-      /** @description Embedded database within a Malloy package */
-      Database: {
-         /** @description Resource path to the database */
-         resource?: string;
-         /** @description Relative path to the database file within its package directory */
-         path?: string;
-         info?: components["schemas"]["TableDescription"];
-         /**
-          * @description Type of embedded database
-          * @enum {string}
-          */
-         type?: "embedded" | "materialized";
-      };
-      /** @description A schema name in a Connection. */
-      Schema: {
-         /** @description Name of the schema */
-         name?: string;
-         /** @description Description of the schema */
-         description?: string;
-         /** @description Whether this schema is the default schema */
-         isDefault?: boolean;
-         /** @description Whether this schema is hidden */
-         isHidden?: boolean;
-      };
-      /** @description Database connection configuration and metadata */
-      Connection: {
-         /** @description Resource path to the connection */
-         resource?: string;
-         /** @description Name of the connection */
-         name?: string;
-         /**
-          * @description Type of database connection
-          * @enum {string}
-          */
-         type?:
-            | "postgres"
-            | "bigquery"
-            | "snowflake"
-            | "trino"
-            | "databricks"
-            | "mysql"
-            | "duckdb"
-            | "motherduck"
-            | "ducklake";
-         attributes?: components["schemas"]["ConnectionAttributes"];
-         postgresConnection?: components["schemas"]["PostgresConnection"];
-         bigqueryConnection?: components["schemas"]["BigqueryConnection"];
-         snowflakeConnection?: components["schemas"]["SnowflakeConnection"];
-         trinoConnection?: components["schemas"]["TrinoConnection"];
-         databricksConnection?: components["schemas"]["DatabricksConnection"];
-         mysqlConnection?: components["schemas"]["MysqlConnection"];
-         duckdbConnection?: components["schemas"]["DuckdbConnection"];
-         motherduckConnection?: components["schemas"]["MotherDuckConnection"];
-         ducklakeConnection?: components["schemas"]["DucklakeConnection"];
-      };
-      /** @description Connection capabilities and configuration attributes */
-      ConnectionAttributes: {
-         /** @description SQL dialect name for the connection */
-         dialectName?: string;
-         /** @description Whether the connection uses connection pooling */
-         isPool?: boolean;
-         /** @description Whether the connection supports persistent storage operations */
-         canPersist?: boolean;
-         /** @description Whether the connection supports streaming query results */
-         canStream?: boolean;
-      };
-      /** @description PostgreSQL database connection configuration */
-      PostgresConnection: {
-         /** @description PostgreSQL server hostname or IP address */
-         host?: string;
-         /** @description PostgreSQL server port number */
-         port?: number;
-         /** @description Name of the PostgreSQL database */
-         databaseName?: string;
-         /** @description PostgreSQL username for authentication */
-         userName?: string;
-         /** @description PostgreSQL password for authentication */
-         password?: string;
-         /** @description Complete PostgreSQL connection string (alternative to individual parameters) */
-         connectionString?: string;
-      };
-      /** @description MySQL database connection configuration */
-      MysqlConnection: {
-         /** @description MySQL server hostname or IP address */
-         host?: string;
-         /** @description MySQL server port number */
-         port?: number;
-         /** @description Name of the MySQL database */
-         database?: string;
-         /** @description MySQL username for authentication */
-         user?: string;
-         /** @description MySQL password for authentication */
-         password?: string;
-      };
-      /** @description Google Cloud Storage connection configuration for DuckDB */
-      GCSConnection: {
-         /** @description GCS HMAC access key ID */
-         keyId: string;
-         /** @description GCS HMAC secret key */
-         secret: string;
-      };
-      /** @description AWS S3 connection configuration for DuckDB */
-      S3Connection: {
-         /** @description AWS access key ID */
-         accessKeyId: string;
-         /** @description AWS secret access key */
-         secretAccessKey: string;
-         /**
-          * @description AWS region (e.g., us-east-1)
-          * @default us-east-1
-          */
-         region?: string;
-         /** @description Custom S3-compatible endpoint URL (optional, for MinIO, etc.) */
-         endpoint?: string;
-         /** @description AWS session token for temporary credentials (optional) */
-         sessionToken?: string;
-      };
-      /** @description Azure Data Lake Storage (ADLS Gen2) / Blob Storage connection configuration Supports https://, http://, abfss://, and az:// URL schemes. */
-      AzureConnection: {
-         /**
-          * @description Authentication method for Azure Storage
-          * @enum {string}
-          */
-         authType: "service_principal" | "sas_token";
-         /** @description Full SAS URL including token; required for sas_token auth. Supports single file, directory glob (*.ext), or recursive (**) patterns. Example: https://account.blob.core.windows.net/container/path/*.parquet?sp=rl&st=... */
-         sasUrl?: string;
-         /** @description Azure AD tenant ID (required for service_principal) */
-         tenantId?: string;
-         /** @description Azure AD application (client) ID (required for service_principal) */
-         clientId?: string;
-         /** @description Azure AD client secret (required for service_principal) */
-         clientSecret?: string;
-         /** @description Azure Storage account name (required for service_principal) */
-         accountName?: string;
-         /** @description Azure file URL to query; required for service_principal auth. Supports single file, directory glob (*.ext), or recursive (**) patterns. Example: https://account.blob.core.windows.net/container/path/** */
-         fileUrl?: string;
-      };
-      /** @description DuckLake lakehouse connection configuration */
-      DucklakeConnection: {
-         /** @description Data storage connection configuration (S3 or GCS) */
-         storage: {
-            /** @description URL of the storage bucket (e.g. s3://my-bucket/path or gs://my-bucket/path) */
-            bucketUrl: string;
-            /** @description AWS S3 connection configuration for data storage */
-            s3Connection?: components["schemas"]["S3Connection"];
-            /** @description Google Cloud Storage connection configuration for data storage */
-            gcsConnection?: components["schemas"]["GCSConnection"];
-         };
-         /** @description Catalog metadata connection configuration */
-         catalog: {
-            /** @description PostgreSQL connection for DuckLake metadata catalog */
-            postgresConnection: components["schemas"]["PostgresConnection"];
-         };
-      };
-      /** @description Google BigQuery database connection configuration */
-      BigqueryConnection: {
-         /** @description Default BigQuery project ID for queries */
-         defaultProjectId?: string;
-         /** @description BigQuery project ID for billing purposes */
-         billingProjectId?: string;
-         /** @description BigQuery dataset location/region */
-         location?: string;
-         /** @description JSON string containing Google Cloud service account credentials */
-         serviceAccountKeyJson?: string;
-         /** @description Maximum bytes to bill for query execution (prevents runaway costs) */
-         maximumBytesBilled?: string;
-         /** @description Query timeout in milliseconds */
-         queryTimeoutMilliseconds?: string;
-      };
-      /** @description Snowflake database connection configuration */
-      SnowflakeConnection: {
-         /** @description Snowflake account identifier */
-         account?: string;
-         /** @description Snowflake username for authentication */
-         username?: string;
-         /** @description Snowflake password for authentication */
-         password?: string;
-         /** @description Snowflake private key for authentication */
-         privateKey?: string;
-         /** @description Passphrase for the Snowflake private key */
-         privateKeyPass?: string;
-         /** @description Snowflake warehouse name */
-         warehouse?: string;
-         /** @description Snowflake database name */
-         database?: string;
-         /** @description Snowflake schema name */
-         schema?: string;
-         /** @description Snowflake role name */
-         role?: string;
-         /** @description Query response timeout in milliseconds */
-         responseTimeoutMilliseconds?: number;
-      };
-      /** @description Trino database connection configuration */
-      TrinoConnection: {
-         /** @description Trino server hostname or IP address */
-         server?: string;
-         /** @description Trino server port number */
-         port?: number;
-         /** @description Trino catalog name */
-         catalog?: string;
-         /** @description Trino schema name */
-         schema?: string;
-         /** @description Trino username for authentication */
-         user?: string;
-         /** @description Trino password for authentication */
-         password?: string;
-         /** @description Peaka API key for authentication with Peaka-hosted Trino clusters */
-         peakaKey?: string;
-      };
-      /** @description Databricks SQL warehouse connection configuration */
-      DatabricksConnection: {
-         /** @description Databricks workspace host (e.g. dbc-xxxxxxxx-xxxx.cloud.databricks.com) */
-         host?: string;
-         /** @description SQL warehouse HTTP path (e.g. /sql/1.0/warehouses/<warehouse-id>) */
-         path?: string;
-         /** @description Personal access token for authentication */
-         token?: string;
-         /** @description OAuth M2M client ID (service principal) */
-         oauthClientId?: string;
-         /** @description OAuth M2M client secret (service principal) */
-         oauthClientSecret?: string;
-         /** @description Default Unity Catalog to use for queries */
-         defaultCatalog?: string;
-         /** @description Default schema to use for queries */
-         defaultSchema?: string;
-         /** @description SQL statements to run when the connection is established */
-         setupSQL?: string;
-      };
-      /** @description MotherDuck database connection configuration */
-      MotherDuckConnection: {
-         /** @description MotherDuck access token */
-         accessToken?: string;
-         /** @description MotherDuck database name */
-         database?: string;
-      };
-      /** @description DuckDB database connection configuration. Publisher intentionally exposes only data-source intent here. Database files, working directories, filesystem/network policy, extension loading, setup SQL, temp directories, and resource knobs are owned by Publisher so environment configs cannot widen deployment policy through low-level DuckDB settings. */
-      DuckdbConnection: {
-         attachedDatabases?: components["schemas"]["AttachedDatabase"][];
-      };
-      /** @description Attached DuckDB database */
-      AttachedDatabase: {
-         /** @example test_connection, _connection, test_connection_1 */
-         name?: string;
-         /**
-          * @description Type of database connection
-          * @enum {string}
-          */
-         type?: "bigquery" | "snowflake" | "postgres" | "gcs" | "s3" | "azure";
-         attributes?: components["schemas"]["ConnectionAttributes"];
-         bigqueryConnection?: components["schemas"]["BigqueryConnection"];
-         snowflakeConnection?: components["schemas"]["SnowflakeConnection"];
-         postgresConnection?: components["schemas"]["PostgresConnection"];
-         gcsConnection?: components["schemas"]["GCSConnection"];
-         s3Connection?: components["schemas"]["S3Connection"];
-         azureConnection?: components["schemas"]["AzureConnection"];
-      };
-      SqlSource: {
-         /** @description Resource path to the sql source. */
-         resource?: string;
-         source?: string;
-      };
-      Table: {
-         /** @description Resource path to the table. */
-         resource?: string;
-         /** @description Table source as a JSON string. */
-         source?: string;
-         /** @description Table fields */
-         columns?: components["schemas"]["Column"][];
-      };
-      /** @deprecated */
-      TableSource: {
-         /** @description Resource path to the table source. */
-         resource?: string;
-         source?: string;
-         /** @description Table fields */
-         columns?: components["schemas"]["Column"][];
-      };
-      TemporaryTable: {
-         /** @description Resource path to the temporary table. */
-         resource?: string;
-         table?: string;
-      };
-      QueryData: {
-         /** @description Resource path to the query data. */
-         resource?: string;
-         data?: string;
-      };
-      /** @description Standard error response format */
-      Error: {
-         /** @description Human-readable error message describing what went wrong */
-         message: string;
-         /** @description Additional error details or context */
-         details?: string;
-      };
-      /** @description Database column definition */
-      Column: {
-         /** @description Name of the column */
-         name?: string;
-         /** @description Data type of the column */
-         type?: string;
-      };
-      /** @description Database table structure and metadata */
-      TableDescription: {
-         /** @description Name of the table */
-         name?: string;
-         /** @description Number of rows in the table */
-         rowCount?: number;
-         /** @description List of columns in the table */
-         columns?: components["schemas"]["Column"][];
-      };
-      /** @description Current file watching status and configuration */
-      WatchStatus: {
-         /** @description Whether file watching is currently active */
-         enabled: boolean;
-         /** @description Name of the environment being watched for file changes */
-         environmentName: string;
-         /** @description The file system path being monitored for changes, null if not watching */
-         watchingPath: string;
-      };
-      /** @description Request to start file watching for an environment */
-      StartWatchRequest: {
-         /** @description Name of the environment to start watching for file changes */
-         environmentName: string;
-      };
-      /** @description Result of testing a database connection */
-      ConnectionStatus: {
-         /**
-          * @description Connection test result status
-          * @enum {string}
-          */
-         status?: "ok" | "failed";
-         /** @description Error message if the connection test failed, null if successful */
-         errorMessage?: string;
-      };
-      /** @description Request body for compiling Malloy source code */
-      CompileRequest: {
-         /** @description Malloy source code to compile */
-         source: string;
-         /**
-          * @description If true, returns the generated SQL alongside compilation results (only available when compilation succeeds and the source contains a runnable query).
-          * @default false
-          */
-         includeSql?: boolean;
-      };
-      /** @description Result of a Malloy source compilation check */
-      CompileResult: {
-         /**
-          * @description Overall compilation status — "error" if any problems have error severity
-          * @enum {string}
-          */
-         status?: "success" | "error";
-         /** @description List of compilation problems (errors and warnings) */
-         problems?: components["schemas"]["CompileProblem"][];
-         /** @description Generated SQL for the compiled query. Only present when includeSql is true and compilation succeeds with a runnable query. */
-         sql?: string;
-      };
-      /** @description A compilation problem reported by the Malloy compiler */
-      CompileProblem: {
-         /** @description Human-readable problem description */
-         message?: string;
-         /**
-          * @description Severity level of the problem
-          * @enum {string}
-          */
-         severity?: "error" | "warn" | "debug";
-         /** @description Machine-readable error code */
-         code?: string;
-         /** @description Source location of the problem */
-         at?: {
-            /** @description URL of the source file */
-            url?: string;
-            /** @description Character range within the source file */
-            range?: Record<string, never>;
-         };
-      };
-      /** @description Options for creating a materialization */
-      CreateMaterializationRequest: {
-         /**
-          * @description If true, forces rebuild of all sources even if their BuildID is unchanged
-          * @default false
-          */
-         forceRefresh?: boolean;
-         /**
-          * @description If true, automatically reloads the manifest into the Malloy Runtime after a successful materialization
-          * @default false
-          */
-         autoLoadManifest?: boolean;
-      };
-      /** @description A record of a package materialization */
-      Materialization: {
-         id?: string;
-         environmentId?: string;
-         packageName?: string;
-         /** @enum {string} */
-         status?: "PENDING" | "RUNNING" | "SUCCESS" | "FAILED" | "CANCELLED";
-         /** Format: date-time */
-         startedAt?: string | null;
-         /** Format: date-time */
-         completedAt?: string | null;
-         /** @description Error message if the materialization failed */
-         error?: string | null;
-         /** @description Materialization metadata including build options, source counts, and durations */
-         metadata?: Record<string, never> | null;
-         /** Format: date-time */
-         createdAt?: string;
-         /** Format: date-time */
-         updatedAt?: string;
-      };
-      /** @description Manifest mapping BuildIDs to materialized table names */
-      BuildManifest: {
-         /** @description Map of BuildID to manifest entry */
-         entries?: {
-            [key: string]: components["schemas"]["ManifestEntry"];
-         };
-         /** @description Whether the manifest is in strict mode */
-         strict?: boolean;
-      };
-      /** @description A single entry in the build manifest */
-      ManifestEntry: {
-         /** @description Name of the materialized table */
-         tableName?: string;
-      };
-   };
-   responses: {
-      /** @description The request was malformed or cannot be performed given the current state of the system */
-      BadRequest: {
-         content: {
-            "application/json": components["schemas"]["Error"];
-         };
-      };
-      /** @description Unauthorized - authentication required */
-      Unauthorized: {
-         content: {
-            "application/json": components["schemas"]["Error"];
-         };
-      };
-      /** @description Forbidden - insufficient permissions to perform the operation */
-      Forbidden: {
-         content: {
-            "application/json": components["schemas"]["Error"];
-         };
-      };
-      /** @description The specified resource was not found */
-      NotFound: {
-         content: {
-            "application/json": components["schemas"]["Error"];
-         };
-      };
-      /** @description The server encountered an internal error */
-      InternalServerError: {
-         content: {
-            "application/json": components["schemas"]["Error"];
-         };
-      };
-      /** @description The requested operation is not implemented */
-      NotImplemented: {
-         content: {
-            "application/json": components["schemas"]["Error"];
-         };
-      };
-      /** @description Model compilation failed due to syntax or semantic errors */
-      ModelCompilationError: {
-         content: {
-            "application/json": components["schemas"]["Error"];
-         };
-      };
-      /** @description The service is temporarily unavailable, typically due to initialization, or draining state (Rolling updates, etc.) */
-      ServiceUnavailable: {
-         content: {
-            "application/json": components["schemas"]["Error"];
-         };
-      };
-   };
-   parameters: {
-      /** @description Name of the environment */
+    };
+    /** @description Google BigQuery database connection configuration */
+    BigqueryConnection: {
+      /** @description Default BigQuery project ID for queries */
+      defaultProjectId?: string;
+      /** @description BigQuery project ID for billing purposes */
+      billingProjectId?: string;
+      /** @description BigQuery dataset location/region */
+      location?: string;
+      /** @description JSON string containing Google Cloud service account credentials */
+      serviceAccountKeyJson?: string;
+      /** @description Maximum bytes to bill for query execution (prevents runaway costs) */
+      maximumBytesBilled?: string;
+      /** @description Query timeout in milliseconds */
+      queryTimeoutMilliseconds?: string;
+    };
+    /** @description Snowflake database connection configuration */
+    SnowflakeConnection: {
+      /** @description Snowflake account identifier */
+      account?: string;
+      /** @description Snowflake username for authentication */
+      username?: string;
+      /** @description Snowflake password for authentication */
+      password?: string;
+      /** @description Snowflake private key for authentication */
+      privateKey?: string;
+      /** @description Passphrase for the Snowflake private key */
+      privateKeyPass?: string;
+      /** @description Snowflake warehouse name */
+      warehouse?: string;
+      /** @description Snowflake database name */
+      database?: string;
+      /** @description Snowflake schema name */
+      schema?: string;
+      /** @description Snowflake role name */
+      role?: string;
+      /** @description Query response timeout in milliseconds */
+      responseTimeoutMilliseconds?: number;
+    };
+    /** @description Trino database connection configuration */
+    TrinoConnection: {
+      /** @description Trino server hostname or IP address */
+      server?: string;
+      /** @description Trino server port number */
+      port?: number;
+      /** @description Trino catalog name */
+      catalog?: string;
+      /** @description Trino schema name */
+      schema?: string;
+      /** @description Trino username for authentication */
+      user?: string;
+      /** @description Trino password for authentication */
+      password?: string;
+      /** @description Peaka API key for authentication with Peaka-hosted Trino clusters */
+      peakaKey?: string;
+    };
+    /** @description Databricks SQL warehouse connection configuration */
+    DatabricksConnection: {
+      /** @description Databricks workspace host (e.g. dbc-xxxxxxxx-xxxx.cloud.databricks.com) */
+      host?: string;
+      /** @description SQL warehouse HTTP path (e.g. /sql/1.0/warehouses/<warehouse-id>) */
+      path?: string;
+      /** @description Personal access token for authentication */
+      token?: string;
+      /** @description OAuth M2M client ID (service principal) */
+      oauthClientId?: string;
+      /** @description OAuth M2M client secret (service principal) */
+      oauthClientSecret?: string;
+      /** @description Default Unity Catalog to use for queries */
+      defaultCatalog?: string;
+      /** @description Default schema to use for queries */
+      defaultSchema?: string;
+      /** @description SQL statements to run when the connection is established */
+      setupSQL?: string;
+    };
+    /** @description MotherDuck database connection configuration */
+    MotherDuckConnection: {
+      /** @description MotherDuck access token */
+      accessToken?: string;
+      /** @description MotherDuck database name */
+      database?: string;
+    };
+    /** @description DuckDB database connection configuration. Publisher intentionally exposes only data-source intent here. Database files, working directories, filesystem/network policy, extension loading, setup SQL, temp directories, and resource knobs are owned by Publisher so environment configs cannot widen deployment policy through low-level DuckDB settings. */
+    DuckdbConnection: {
+      attachedDatabases?: components["schemas"]["AttachedDatabase"][];
+    };
+    /** @description Attached DuckDB database */
+    AttachedDatabase: {
+      /** @example test_connection, _connection, test_connection_1 */
+      name?: string;
+      /**
+       * @description Type of database connection
+       * @enum {string}
+       */
+      type?: "bigquery" | "snowflake" | "postgres" | "gcs" | "s3" | "azure";
+      attributes?: components["schemas"]["ConnectionAttributes"];
+      bigqueryConnection?: components["schemas"]["BigqueryConnection"];
+      snowflakeConnection?: components["schemas"]["SnowflakeConnection"];
+      postgresConnection?: components["schemas"]["PostgresConnection"];
+      gcsConnection?: components["schemas"]["GCSConnection"];
+      s3Connection?: components["schemas"]["S3Connection"];
+      azureConnection?: components["schemas"]["AzureConnection"];
+    };
+    SqlSource: {
+      /** @description Resource path to the sql source. */
+      resource?: string;
+      source?: string;
+    };
+    Table: {
+      /** @description Resource path to the table. */
+      resource?: string;
+      /** @description Table source as a JSON string. */
+      source?: string;
+      /** @description Table fields */
+      columns?: components["schemas"]["Column"][];
+    };
+    /** @deprecated */
+    TableSource: {
+      /** @description Resource path to the table source. */
+      resource?: string;
+      source?: string;
+      /** @description Table fields */
+      columns?: components["schemas"]["Column"][];
+    };
+    TemporaryTable: {
+      /** @description Resource path to the temporary table. */
+      resource?: string;
+      table?: string;
+    };
+    QueryData: {
+      /** @description Resource path to the query data. */
+      resource?: string;
+      data?: string;
+    };
+    /** @description Standard error response format */
+    Error: {
+      /** @description Human-readable error message describing what went wrong */
+      message: string;
+      /** @description Additional error details or context */
+      details?: string;
+    };
+    /** @description Database column definition */
+    Column: {
+      /** @description Name of the column */
+      name?: string;
+      /** @description Data type of the column */
+      type?: string;
+    };
+    /** @description Database table structure and metadata */
+    TableDescription: {
+      /** @description Name of the table */
+      name?: string;
+      /** @description Number of rows in the table */
+      rowCount?: number;
+      /** @description List of columns in the table */
+      columns?: components["schemas"]["Column"][];
+    };
+    /** @description Current file watching status and configuration */
+    WatchStatus: {
+      /** @description Whether file watching is currently active */
+      enabled: boolean;
+      /** @description Name of the environment being watched for file changes */
       environmentName: string;
-      /** @description Name of the package */
-      packageName: string;
-      /** @description ID of the materialization */
-      materializationId: string;
-   };
-   requestBodies: never;
-   headers: never;
-   pathItems: never;
+      /** @description The file system path being monitored for changes, null if not watching */
+      watchingPath: string;
+    };
+    /** @description Request to start file watching for an environment */
+    StartWatchRequest: {
+      /** @description Name of the environment to start watching for file changes */
+      environmentName: string;
+    };
+    /** @description Result of testing a database connection */
+    ConnectionStatus: {
+      /**
+       * @description Connection test result status
+       * @enum {string}
+       */
+      status?: "ok" | "failed";
+      /** @description Error message if the connection test failed, null if successful */
+      errorMessage?: string;
+    };
+    /** @description Request body for compiling Malloy source code */
+    CompileRequest: {
+      /** @description Malloy source code to compile */
+      source: string;
+      /**
+       * @description If true, returns the generated SQL alongside compilation results (only available when compilation succeeds and the source contains a runnable query).
+       * @default false
+       */
+      includeSql?: boolean;
+    };
+    /** @description Result of a Malloy source compilation check */
+    CompileResult: {
+      /**
+       * @description Overall compilation status — "error" if any problems have error severity
+       * @enum {string}
+       */
+      status?: "success" | "error";
+      /** @description List of compilation problems (errors and warnings) */
+      problems?: components["schemas"]["CompileProblem"][];
+      /** @description Generated SQL for the compiled query. Only present when includeSql is true and compilation succeeds with a runnable query. */
+      sql?: string;
+    };
+    /** @description A compilation problem reported by the Malloy compiler */
+    CompileProblem: {
+      /** @description Human-readable problem description */
+      message?: string;
+      /**
+       * @description Severity level of the problem
+       * @enum {string}
+       */
+      severity?: "error" | "warn" | "debug";
+      /** @description Machine-readable error code */
+      code?: string;
+      /** @description Source location of the problem */
+      at?: {
+        /** @description URL of the source file */
+        url?: string;
+        /** @description Character range within the source file */
+        range?: Record<string, never>;
+      };
+    };
+    /** @description Options for creating a materialization */
+    CreateMaterializationRequest: {
+      /**
+       * @description If true, forces rebuild of all sources even if their BuildID is unchanged
+       * @default false
+       */
+      forceRefresh?: boolean;
+      /**
+       * @description If true, automatically reloads the manifest into the Malloy Runtime after a successful materialization
+       * @default false
+       */
+      autoLoadManifest?: boolean;
+    };
+    /** @description A record of a package materialization */
+    Materialization: {
+      id?: string;
+      environmentId?: string;
+      packageName?: string;
+      /** @enum {string} */
+      status?: "PENDING" | "RUNNING" | "SUCCESS" | "FAILED" | "CANCELLED";
+      /** Format: date-time */
+      startedAt?: string | null;
+      /** Format: date-time */
+      completedAt?: string | null;
+      /** @description Error message if the materialization failed */
+      error?: string | null;
+      /** @description Materialization metadata including build options, source counts, and durations */
+      metadata?: Record<string, never> | null;
+      /** Format: date-time */
+      createdAt?: string;
+      /** Format: date-time */
+      updatedAt?: string;
+    };
+    /** @description Manifest mapping BuildIDs to materialized table names */
+    BuildManifest: {
+      /** @description Map of BuildID to manifest entry */
+      entries?: {
+        [key: string]: components["schemas"]["ManifestEntry"];
+      };
+      /** @description Whether the manifest is in strict mode */
+      strict?: boolean;
+    };
+    /** @description A single entry in the build manifest */
+    ManifestEntry: {
+      /** @description Name of the materialized table */
+      tableName?: string;
+    };
+  };
+  responses: {
+    /** @description The request was malformed or cannot be performed given the current state of the system */
+    BadRequest: {
+      content: {
+        "application/json": components["schemas"]["Error"];
+      };
+    };
+    /** @description Unauthorized - authentication required */
+    Unauthorized: {
+      content: {
+        "application/json": components["schemas"]["Error"];
+      };
+    };
+    /** @description Forbidden - insufficient permissions to perform the operation */
+    Forbidden: {
+      content: {
+        "application/json": components["schemas"]["Error"];
+      };
+    };
+    /** @description The specified resource was not found */
+    NotFound: {
+      content: {
+        "application/json": components["schemas"]["Error"];
+      };
+    };
+    /** @description The server encountered an internal error */
+    InternalServerError: {
+      content: {
+        "application/json": components["schemas"]["Error"];
+      };
+    };
+    /** @description The requested operation is not implemented */
+    NotImplemented: {
+      content: {
+        "application/json": components["schemas"]["Error"];
+      };
+    };
+    /** @description Model compilation failed due to syntax or semantic errors */
+    ModelCompilationError: {
+      content: {
+        "application/json": components["schemas"]["Error"];
+      };
+    };
+    /** @description The service is temporarily unavailable, typically due to initialization, or draining state (Rolling updates, etc.) */
+    ServiceUnavailable: {
+      content: {
+        "application/json": components["schemas"]["Error"];
+      };
+    };
+  };
+  parameters: {
+    /** @description Name of the environment */
+    environmentName: string;
+    /** @description Name of the package */
+    packageName: string;
+    /** @description ID of the materialization */
+    materializationId: string;
+  };
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
 
 export type $defs = Record<string, never>;
@@ -1193,1701 +1196,1702 @@ export type $defs = Record<string, never>;
 export type external = Record<string, never>;
 
 export interface operations {
-   /**
-    * Get server status and health information
-    * @description Returns the current status of the Malloy Publisher server, including initialization state,
-    * available environments, and server timestamp. This endpoint is useful for health checks and
-    * monitoring server availability.
-    */
-   "get-status": {
-      responses: {
-         /** @description Returns server status */
-         200: {
-            content: {
-               "application/json": components["schemas"]["ServerStatus"];
-            };
-         };
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * List all available environments
-    * @description Retrieves a list of all environments currently hosted on this Malloy Publisher server.
-    * Each environment contains metadata about its packages, connections, and configuration.
-    * This endpoint is typically used to discover available environments and their basic information.
-    */
-   "list-environments": {
-      responses: {
-         /** @description A list of all available environments */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Environment"][];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Create a new environment
-    * @description Creates a new Malloy environment with the specified configuration. An environment serves as a
-    * container for packages, connections, and other resources. The environment will be initialized
-    * with the provided metadata and can immediately accept packages and connections.
-    */
-   "create-environment": {
-      requestBody: {
-         content: {
-            "application/json": components["schemas"]["Environment"];
-         };
-      };
-      responses: {
-         /** @description Returns the environment created */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Environment"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Get environment details and metadata
-    * @description Retrieves detailed information about a specific environment, including its packages,
-    * connections, configuration, and metadata. The reload parameter can be used to
-    * refresh the environment state from disk before returning the information.
-    */
-   "get-environment": {
-      parameters: {
-         query?: {
-            /** @description Load / reload the environment before returning result */
-            reload?: boolean;
-         };
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description Environment details and metadata */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Environment"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Delete an environment
-    * @description Permanently deletes an environment and all its associated resources including packages,
-    * connections, and metadata. This operation cannot be undone, so use with caution.
-    * The environment must exist and be accessible for deletion.
-    */
-   "delete-environment": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description Returns the environment deleted */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Environment"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Update environment configuration
-    * @description Updates the configuration and metadata of an existing environment. This allows you to
-    * modify environment settings, update the README, change the location, or update other
-    * environment-level properties. The environment must exist and be accessible.
-    */
-   "update-environment": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      requestBody: {
-         content: {
-            "application/json": components["schemas"]["Environment"];
-         };
-      };
-      responses: {
-         /** @description Returns the environment updated */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Environment"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * List environment database connections
-    * @description Retrieves a list of all database connections configured for the specified environment.
-    * Each connection includes its configuration, type, and status information. This endpoint
-    * is useful for discovering available data sources within an environment.
-    */
-   "list-connections": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description A list of database connections in the environment */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Connection"][];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Get connection details
-    * @description Retrieves detailed information about a specific database connection within an environment.
-    * This includes connection configuration, credentials (if accessible), and metadata.
-    * Useful for inspecting connection settings and troubleshooting connectivity issues.
-    */
-   "get-connection": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description Connection details and configuration */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Connection"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Create a new database connection
-    * @description Creates a new database connection in the specified environment.
-    */
-   "create-connection": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      requestBody: {
-         content: {
-            "application/json": components["schemas"]["Connection"];
-         };
-      };
-      responses: {
-         /** @description Connection created successfully */
-         201: {
-            content: {
-               "application/json": {
-                  message?: string;
-               };
-            };
-         };
-         400: components["responses"]["BadRequest"];
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         /** @description Connection already exists */
-         409: {
-            content: {
-               "application/json": {
-                  error?: string;
-               };
-            };
-         };
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Delete a database connection
-    * @description Permanently deletes a database connection from the environment.
-    */
-   "delete-connection": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection to delete */
-            connectionName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description Connection deleted successfully */
-         200: {
-            content: {
-               "application/json": {
-                  message?: string;
-               };
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Update an existing database connection
-    * @description Updates the configuration of an existing database connection.
-    */
-   "update-connection": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection to update */
-            connectionName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      requestBody: {
-         content: {
-            "application/json": {
-               postgresConnection?: components["schemas"]["PostgresConnection"];
-               mysqlConnection?: components["schemas"]["MysqlConnection"];
-               bigqueryConnection?: components["schemas"]["BigqueryConnection"];
-               snowflakeConnection?: components["schemas"]["SnowflakeConnection"];
-               duckdbConnection?: components["schemas"]["DuckdbConnection"];
-               motherduckConnection?: components["schemas"]["MotherDuckConnection"];
-               trinoConnection?: components["schemas"]["TrinoConnection"];
-               databricksConnection?: components["schemas"]["DatabricksConnection"];
-               ducklakeConnection?: components["schemas"]["DucklakeConnection"];
-            };
-         };
-      };
-      responses: {
-         /** @description Connection updated successfully */
-         200: {
-            content: {
-               "application/json": {
-                  message?: string;
-               };
-            };
-         };
-         400: components["responses"]["BadRequest"];
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * List database schemas
-    * @description Retrieves a list of all schemas (databases) available in the specified connection.
-    * Each schema includes metadata such as name, description, and whether it's the default schema.
-    * This endpoint is useful for exploring the database structure and discovering available data sources.
-    */
-   "list-schemas": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description A list of schemas available in the connection with metadata */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Schema"][];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * List tables in database
-    * @description Retrieves a list of all tables and views available in the specified database schema.
-    * This endpoint is useful for discovering available data sources and exploring the database
-    * structure. The schema must exist in the connection for this operation to succeed.
-    */
-   "list-tables": {
-      parameters: {
-         query?: {
-            /**
-             * @description List of table names to filter results. When provided, only returns metadata
-             * for the specified tables. When omitted, returns all tables in the schema.
-             */
-            tableNames?: string[];
-         };
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the schema */
-            schemaName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description A list of table names available in the specified schema */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Table"][];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Get table details from database
-    * @description Retrieves a table from the specified database schema.
-    * This endpoint is useful for discovering available data sources and exploring the database
-    * structure. The schema must exist in the connection for this operation to succeed.
-    * The tablePath is the full path to the table, including the schema name.
-    */
-   "get-table": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the schema */
-            schemaName: components["schemas"]["IdentifierPattern"];
-            /** @description Full path to the table */
-            tablePath: components["schemas"]["PathPattern"];
-         };
-      };
-      responses: {
-         /** @description Table information */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Table"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Get SQL source (deprecated)
-    * @deprecated
-    * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
-    * Use the POST version instead for better security and functionality.
-    *
-    * Creates a Malloy source from a SQL statement using the specified connection.
-    * The SQL statement is executed to generate a source definition that can be used in Malloy models.
-    */
-   "get-sqlsource": {
-      parameters: {
-         query?: {
-            /** @description SQL statement */
-            sqlStatement?: string;
-         };
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description SQL source information */
-         200: {
-            content: {
-               "application/json": components["schemas"]["SqlSource"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Create SQL source from statement
-    * @description Creates a Malloy source from a SQL statement using the specified database connection.
-    * The SQL statement is executed to generate a source definition that can be used in Malloy models.
-    */
-   "post-sqlsource": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      /** @description SQL statement to fetch the SQL source */
-      requestBody: {
-         content: {
-            "application/json": {
-               sqlStatement?: string;
-            };
-         };
-      };
-      responses: {
-         /** @description SQL source information */
-         200: {
-            content: {
-               "application/json": components["schemas"]["SqlSource"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Execute SQL query
-    * @description Executes a SQL statement against the specified database connection and returns the results.
-    * The results include data, metadata, and execution information.
-    */
-   "post-querydata": {
-      parameters: {
-         query?: {
-            /**
-             * @deprecated
-             * @description Options (deprecated; pass in body instead)
-             */
-            options?: string;
-         };
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      /** @description SQL statement to execute */
-      requestBody: {
-         content: {
-            "application/json": {
-               sqlStatement?: string;
-               /** @description Options */
-               options?: string;
-            };
-         };
-      };
-      responses: {
-         /** @description Query execution results */
-         200: {
-            content: {
-               "application/json": components["schemas"]["QueryData"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Create temporary table
-    * @description Creates a temporary table from a SQL statement using the specified database connection.
-    * Temporary tables are useful for storing intermediate results during complex queries and data processing workflows.
-    */
-   "post-temporarytable": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      /** @description SQL statement to create the temporary table */
-      requestBody: {
-         content: {
-            "application/json": {
-               sqlStatement?: string;
-            };
-         };
-      };
-      responses: {
-         /** @description Temporary table information */
-         200: {
-            content: {
-               "application/json": components["schemas"]["TemporaryTable"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Create temporary table (deprecated)
-    * @deprecated
-    * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
-    * Use the POST version instead for better security and functionality.
-    *
-    * Creates a temporary table from a SQL statement using the specified connection.
-    * Temporary tables are useful for storing intermediate results during complex queries.
-    */
-   "get-temporarytable": {
-      parameters: {
-         query?: {
-            /** @description SQL statement */
-            sqlStatement?: string;
-         };
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description Temporary table information */
-         200: {
-            content: {
-               "application/json": components["schemas"]["TemporaryTable"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Execute SQL query (deprecated)
-    * @deprecated
-    * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
-    * Use the POST version instead for better security and functionality.
-    *
-    * Executes a SQL statement against the specified database connection and returns the results.
-    * The query results include data, metadata, and execution information.
-    */
-   "get-querydata": {
-      parameters: {
-         query?: {
-            /** @description SQL statement */
-            sqlStatement?: string;
-            /** @description Options */
-            options?: string;
-         };
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description Query execution results */
-         200: {
-            content: {
-               "application/json": components["schemas"]["QueryData"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-      };
-   };
-   /**
-    * List database schemas (per-package)
-    * @description Retrieves a list of all schemas (databases) available in the specified
-    * connection, resolved in the context of the named package. Required for
-    * `connectionName="duckdb"`, which is per-package; works for any other
-    * connection name as well (resolution falls through to the environment).
-    */
-   "list-schemas-in-package": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the package whose connection context to use */
-            packageName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description A list of schemas available in the connection with metadata */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Schema"][];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * List tables in database (per-package)
-    * @description Retrieves a list of all tables and views available in the specified
-    * database schema, resolved in the context of the named package.
-    */
-   "list-tables-in-package": {
-      parameters: {
-         query?: {
-            /**
-             * @description List of table names to filter results. When provided, only returns metadata
-             * for the specified tables. When omitted, returns all tables in the schema.
-             */
-            tableNames?: string[];
-         };
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the package whose connection context to use */
-            packageName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the schema */
-            schemaName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description A list of table names available in the specified schema */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Table"][];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Get table details from database (per-package)
-    * @description Retrieves a table from the specified database schema, resolved in
-    * the context of the named package.
-    */
-   "get-table-in-package": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the package whose connection context to use */
-            packageName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the schema */
-            schemaName: components["schemas"]["IdentifierPattern"];
-            /** @description Full path to the table */
-            tablePath: components["schemas"]["PathPattern"];
-         };
-      };
-      responses: {
-         /** @description Table information */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Table"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Get SQL source (per-package, deprecated)
-    * @deprecated
-    * @description **DEPRECATED**: Use the POST version instead.
-    *
-    * Creates a Malloy source from a SQL statement using the specified
-    * connection, resolved in the context of the named package.
-    */
-   "get-sqlsource-in-package": {
-      parameters: {
-         query?: {
-            /** @description SQL statement */
-            sqlStatement?: string;
-         };
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the package whose connection context to use */
-            packageName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description SQL source information */
-         200: {
-            content: {
-               "application/json": components["schemas"]["SqlSource"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Create SQL source from statement (per-package)
-    * @description Creates a Malloy source from a SQL statement using the specified
-    * connection, resolved in the context of the named package.
-    */
-   "post-sqlsource-in-package": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the package whose connection context to use */
-            packageName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      /** @description SQL statement to fetch the SQL source */
-      requestBody: {
-         content: {
-            "application/json": {
-               sqlStatement?: string;
-            };
-         };
-      };
-      responses: {
-         /** @description SQL source information */
-         200: {
-            content: {
-               "application/json": components["schemas"]["SqlSource"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Execute SQL query (per-package)
-    * @description Executes a SQL statement against the specified database connection,
-    * resolved in the context of the named package, and returns the results.
-    */
-   "post-querydata-in-package": {
-      parameters: {
-         query?: {
-            /**
-             * @deprecated
-             * @description Options (deprecated; pass in body instead)
-             */
-            options?: string;
-         };
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the package whose connection context to use */
-            packageName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      /** @description SQL statement to execute */
-      requestBody: {
-         content: {
-            "application/json": {
-               sqlStatement?: string;
-               /** @description Options */
-               options?: string;
-            };
-         };
-      };
-      responses: {
-         /** @description Query execution results */
-         200: {
-            content: {
-               "application/json": components["schemas"]["QueryData"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Create temporary table (per-package)
-    * @description Creates a temporary table from a SQL statement using the specified
-    * database connection, resolved in the context of the named package.
-    */
-   "post-temporarytable-in-package": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the package whose connection context to use */
-            packageName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      /** @description SQL statement to create the temporary table */
-      requestBody: {
-         content: {
-            "application/json": {
-               sqlStatement?: string;
-            };
-         };
-      };
-      responses: {
-         /** @description Temporary table information */
-         200: {
-            content: {
-               "application/json": components["schemas"]["TemporaryTable"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Create temporary table (per-package, deprecated)
-    * @deprecated
-    * @description **DEPRECATED**: Use the POST version instead.
-    *
-    * Creates a temporary table from a SQL statement using the specified
-    * connection, resolved in the context of the named package.
-    */
-   "get-temporarytable-in-package": {
-      parameters: {
-         query?: {
-            /** @description SQL statement */
-            sqlStatement?: string;
-         };
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the package whose connection context to use */
-            packageName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description Temporary table information */
-         200: {
-            content: {
-               "application/json": components["schemas"]["TemporaryTable"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Execute SQL query (per-package, deprecated)
-    * @deprecated
-    * @description **DEPRECATED**: Use the POST version instead.
-    *
-    * Executes a SQL statement against the specified database connection,
-    * resolved in the context of the named package, and returns the results.
-    */
-   "get-querydata-in-package": {
-      parameters: {
-         query?: {
-            /** @description SQL statement */
-            sqlStatement?: string;
-            /** @description Options */
-            options?: string;
-         };
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the package whose connection context to use */
-            packageName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the connection */
-            connectionName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description Query execution results */
-         200: {
-            content: {
-               "application/json": components["schemas"]["QueryData"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-      };
-   };
-   /**
-    * List environment packages
-    * @description Retrieves a list of all Malloy packages within the specified environment. Each package
-    * contains models, notebooks, databases, and other resources. This endpoint is useful
-    * for discovering available packages and their basic metadata.
-    */
-   "list-packages": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description A list of all packages in the environment */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Package"][];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         500: components["responses"]["InternalServerError"];
-         501: components["responses"]["NotImplemented"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Create a new package
-    * @description Creates a new Malloy package within the specified environment. A package serves as a
-    * container for models, notebooks, embedded databases, and other resources. The package
-    * will be initialized with the provided metadata and can immediately accept content.
-    */
-   "create-package": {
-      parameters: {
-         query?: {
-            /**
-             * @description When true, automatically loads any existing build manifest
-             * for the package so materialized table references resolve immediately.
-             * Defaults to false.
-             */
-            autoLoadManifest?: boolean;
-         };
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      requestBody: {
-         content: {
-            "application/json": components["schemas"]["Package"];
-         };
-      };
-      responses: {
-         /** @description Returns the package created */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Package"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         500: components["responses"]["InternalServerError"];
-         501: components["responses"]["NotImplemented"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Get package details and metadata
-    * @description Retrieves detailed information about a specific package, including its models, notebooks,
-    * databases, and metadata. The reload parameter can be used to refresh the package state
-    * from disk before returning the information. The versionId parameter allows access to
-    * specific package versions.
-    */
-   "get-package": {
-      parameters: {
-         query?: {
-            /** @description Version identifier for the package */
-            versionId?: components["schemas"]["VersionIdPattern"];
-            /** @description Load / reload the package before returning result */
-            reload?: boolean;
-         };
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Package name */
-            packageName: string;
-         };
-      };
-      responses: {
-         /** @description Package details and metadata */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Package"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         501: components["responses"]["NotImplemented"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Delete a package
-    * @description Permanently deletes a package and all its associated resources including models,
-    * notebooks, databases, and metadata. This operation cannot be undone, so use with caution.
-    * The package must exist and be accessible for deletion.
-    */
-   "delete-package": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the package */
-            packageName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description Returns the package deleted */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Package"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         501: components["responses"]["NotImplemented"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Update package configuration
-    * @description Updates the configuration and metadata of an existing package. This allows you to
-    * modify package settings, update the description, change the location, or update other
-    * package-level properties. The package must exist and be accessible.
-    */
-   "update-package": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the package */
-            packageName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      requestBody: {
-         content: {
-            "application/json": components["schemas"]["Package"];
-         };
-      };
-      responses: {
-         /** @description Returns the package updated */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Package"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         501: components["responses"]["NotImplemented"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * List package models
-    * @description Retrieves a list of all Malloy models within the specified package. Each model entry
-    * includes the relative path, package name, and any compilation errors. This endpoint
-    * is useful for discovering available models and checking their status.
-    */
-   "list-models": {
-      parameters: {
-         query?: {
-            /** @description Version identifier for the package */
-            versionId?: components["schemas"]["VersionIdPattern"];
-         };
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the package */
-            packageName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description A list of models in the package */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Model"][];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         501: components["responses"]["NotImplemented"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Get compiled Malloy model
-    * @description Retrieves a compiled Malloy model with its source information, queries, and metadata.
-    * The model is compiled using the specified version of the Malloy compiler. This endpoint
-    * provides access to the model's structure, sources, and named queries for use in applications.
-    */
-   "get-model": {
-      parameters: {
-         query?: {
-            /** @description Version identifier for the package */
-            versionId?: components["schemas"]["VersionIdPattern"];
-         };
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the package */
-            packageName: string;
-            /** @description Path to the model within the package */
-            path: components["schemas"]["PathPattern"];
-         };
-      };
-      responses: {
-         /** @description Compiled Malloy model */
-         200: {
-            content: {
-               "application/json": components["schemas"]["CompiledModel"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         424: components["responses"]["ModelCompilationError"];
-         500: components["responses"]["InternalServerError"];
-         501: components["responses"]["NotImplemented"];
-      };
-   };
-   /**
-    * Execute Malloy query
-    * @description Executes a Malloy query against a model and returns the results. The query can be specified
-    * as a raw Malloy query string or by referencing a named query within the model. This endpoint
-    * supports both ad-hoc queries and predefined model queries, making it flexible for various
-    * use cases including data exploration, reporting, and application integration.
-    */
-   "execute-query-model": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the package */
-            packageName: components["schemas"]["VersionIdPattern"];
-            /** @description Path to the model within the package */
-            path: components["schemas"]["PathPattern"];
-         };
-      };
-      requestBody: {
-         content: {
-            "application/json": components["schemas"]["QueryRequest"];
-         };
-      };
-      responses: {
-         /** @description Query execution results */
-         200: {
-            content: {
-               "application/json": components["schemas"]["QueryResult"];
-            };
-         };
-         400: components["responses"]["BadRequest"];
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         501: components["responses"]["NotImplemented"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Compile Malloy source code
-    * @description Compiles Malloy source code in the context of a specific model file.
-    * The submitted source is appended to the full model content, giving it
-    * access to all sources, imports, and queries defined in the model.
-    * Relative imports resolve correctly against sibling model files.
-    * Returns compilation status and any problems (errors or warnings) found.
-    */
-   "compile-model-source": {
-      parameters: {
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the package */
-            packageName: string;
-            /** @description Path to the model within the package (used to resolve relative imports) */
-            path: components["schemas"]["PathPattern"];
-         };
-      };
-      requestBody: {
-         content: {
-            "application/json": components["schemas"]["CompileRequest"];
-         };
-      };
-      responses: {
-         /** @description Compilation result with status and any problems */
-         200: {
-            content: {
-               "application/json": components["schemas"]["CompileResult"];
-            };
-         };
-         400: components["responses"]["BadRequest"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * List package notebooks
-    * @description Retrieves a list of all Malloy notebooks within the specified package. Each notebook entry
-    * includes the relative path, package name, and any compilation errors. This endpoint
-    * is useful for discovering available notebooks and checking their status.
-    */
-   "list-notebooks": {
-      parameters: {
-         query?: {
-            /** @description Version identifier for the package */
-            versionId?: components["schemas"]["VersionIdPattern"];
-         };
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the package */
-            packageName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description A list of models in the package */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Notebook"][];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         501: components["responses"]["NotImplemented"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Get Malloy notebook cells
-    * @description Retrieves a Malloy notebook with its raw cell contents (markdown and code).
-    * Cell execution should be done separately via the execute-notebook-cell endpoint.
-    */
-   "get-notebook": {
-      parameters: {
-         query?: {
-            /** @description Version identifier for the package */
-            versionId?: components["schemas"]["VersionIdPattern"];
-         };
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the package */
-            packageName: string;
-            /** @description Path to notebook within the package. */
-            path: string;
-         };
-      };
-      responses: {
-         /** @description A Malloy notebook with raw cell contents. */
-         200: {
-            content: {
-               "application/json": components["schemas"]["RawNotebook"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         501: components["responses"]["NotImplemented"];
-      };
-   };
-   /**
-    * Execute a specific notebook cell
-    * @description Executes a specific cell in a Malloy notebook by index. For code cells, this compiles
-    * and runs the Malloy code, returning query results and any new sources defined.
-    * For markdown cells, this simply returns the cell content.
-    */
-   "execute-notebook-cell": {
-      parameters: {
-         query?: {
-            /** @description Version identifier for the package */
-            versionId?: components["schemas"]["VersionIdPattern"];
-            /** @description JSON-encoded filter parameter values keyed by filter name */
-            filter_params?: string;
-            /** @description When true, skip filter injection entirely */
-            bypass_filters?: "true" | "false";
-         };
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the package */
-            packageName: string;
-            /** @description Path to notebook within the package */
-            path: string;
-            /** @description Index of the cell to execute (0-based) */
-            cellIndex: number;
-         };
-      };
-      responses: {
-         /** @description Cell execution result */
-         200: {
-            content: {
-               "application/json": components["schemas"]["NotebookCellResult"];
-            };
-         };
-         400: components["responses"]["BadRequest"];
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         501: components["responses"]["NotImplemented"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * List embedded databases
-    * @description Retrieves a list of all embedded databases within the specified package. These are typically
-    * DuckDB databases stored as .parquet files that provide local data storage for the package.
-    * Each database entry includes metadata about the database structure and content.
-    */
-   "list-databases": {
-      parameters: {
-         query?: {
-            /** @description Version identifier for the package */
-            versionId?: components["schemas"]["VersionIdPattern"];
-         };
-         path: {
-            /** @description Name of the environment */
-            environmentName: components["schemas"]["IdentifierPattern"];
-            /** @description Name of the package */
-            packageName: components["schemas"]["IdentifierPattern"];
-         };
-      };
-      responses: {
-         /** @description A list of embedded databases in the package */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Database"][];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         501: components["responses"]["NotImplemented"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Test database connection configuration
-    * @description Validates a database connection configuration without adding it to any environment.
-    * This endpoint allows you to test connection parameters, credentials, and network
-    * connectivity before committing the connection to an environment. Useful for troubleshooting
-    * connection issues and validating configurations during setup.
-    */
-   "test-connection-configuration": {
-      requestBody: {
-         content: {
-            "application/json": components["schemas"]["Connection"];
-         };
-      };
-      responses: {
-         /** @description Connection test result */
-         200: {
-            content: {
-               "application/json": components["schemas"]["ConnectionStatus"];
-            };
-         };
-         400: components["responses"]["BadRequest"];
-         401: components["responses"]["Unauthorized"];
-         404: components["responses"]["NotFound"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Get watch mode status
-    * @description Retrieves the current status of the file watching system. This includes whether watch mode
-    * is enabled, which environment is being watched, and the path being monitored. Useful for
-    * monitoring the development workflow and ensuring file changes are being detected.
-    */
-   "get-watch-status": {
-      responses: {
-         /** @description The current watch mode status. */
-         200: {
-            content: {
-               "application/json": components["schemas"]["WatchStatus"];
-            };
-         };
-         401: components["responses"]["Unauthorized"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Start file watching
-    * @description Initiates file watching for the specified environment. This enables real-time monitoring of
-    * file changes within the environment directory, allowing for automatic reloading and updates
-    * during development. Only one environment can be watched at a time.
-    */
-   "start-watching": {
-      requestBody: {
-         content: {
-            "application/json": components["schemas"]["StartWatchRequest"];
-         };
-      };
-      responses: {
-         /** @description Watch mode started successfully. */
-         200: {
-            content: never;
-         };
-         401: components["responses"]["Unauthorized"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * Stop file watching
-    * @description Stops the current file watching session. This disables real-time monitoring of file changes
-    * and releases system resources. Use this when development is complete or when switching
-    * to a different environment.
-    */
-   "stop-watching": {
-      responses: {
-         /** @description Watch mode stopped successfully. */
-         200: {
-            content: never;
-         };
-         401: components["responses"]["Unauthorized"];
-         500: components["responses"]["InternalServerError"];
-         503: components["responses"]["ServiceUnavailable"];
-      };
-   };
-   /**
-    * List materializations for a package
-    * @description Returns the materialization history for the package, ordered by most recent first.
-    */
-   "list-materializations": {
-      parameters: {
-         query?: {
-            /** @description Maximum number of materializations to return */
-            limit?: number;
-            /** @description Number of materializations to skip */
-            offset?: number;
-         };
-         path: {
-            environmentName: components["parameters"]["environmentName"];
-            packageName: components["parameters"]["packageName"];
-         };
-      };
-      responses: {
-         /** @description List of materializations */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Materialization"][];
-            };
-         };
-         404: components["responses"]["NotFound"];
-      };
-   };
-   /**
-    * Create a materialization
-    * @description Creates a new materialization in PENDING state for all persist sources across all
-    * models in the package. Use POST .../materializations/{materializationId}?action=start to begin execution.
-    */
-   "create-materialization": {
-      parameters: {
-         path: {
-            environmentName: components["parameters"]["environmentName"];
-            packageName: components["parameters"]["packageName"];
-         };
-      };
-      requestBody?: {
-         content: {
-            "application/json": components["schemas"]["CreateMaterializationRequest"];
-         };
-      };
-      responses: {
-         /** @description Materialization created */
-         201: {
-            content: {
-               "application/json": components["schemas"]["Materialization"];
-            };
-         };
-         404: components["responses"]["NotFound"];
-         /** @description Package already has an active materialization */
-         409: {
-            content: {
-               "application/json": components["schemas"]["Error"];
-            };
-         };
-      };
-   };
-   /** Get a specific materialization */
-   "get-materialization": {
-      parameters: {
-         path: {
-            environmentName: components["parameters"]["environmentName"];
-            packageName: components["parameters"]["packageName"];
-            materializationId: components["parameters"]["materializationId"];
-         };
-      };
-      responses: {
-         /** @description Materialization details */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Materialization"];
-            };
-         };
-         404: components["responses"]["NotFound"];
-      };
-   };
-   /**
-    * Perform an action on a materialization
-    * @description Performs an action on a materialization. The action is specified via
-    * the `action` query parameter:
-    *   * `start` - Transitions a PENDING materialization to RUNNING and begins execution in the background. Returns 202.
-    *   * `stop` - Cancels a PENDING or RUNNING materialization. Returns 200.
-    */
-   "materialization-action": {
-      parameters: {
-         query: {
-            /** @description Action to perform on the materialization */
-            action: "start" | "stop";
-         };
-         path: {
-            environmentName: components["parameters"]["environmentName"];
-            packageName: components["parameters"]["packageName"];
-            materializationId: components["parameters"]["materializationId"];
-         };
-      };
-      responses: {
-         /** @description Materialization cancelled (action=stop) */
-         200: {
-            content: {
-               "application/json": components["schemas"]["Materialization"];
-            };
-         };
-         /** @description Materialization started (action=start) */
-         202: {
-            content: {
-               "application/json": components["schemas"]["Materialization"];
-            };
-         };
-         400: components["responses"]["BadRequest"];
-         404: components["responses"]["NotFound"];
-         /** @description Materialization cannot transition to the requested state */
-         409: {
-            content: {
-               "application/json": components["schemas"]["Error"];
-            };
-         };
-      };
-   };
-   /**
-    * Delete a materialization
-    * @description Deletes a terminal (SUCCESS, FAILED, or CANCELLED) materialization record.
-    */
-   "delete-materialization": {
-      parameters: {
-         path: {
-            environmentName: components["parameters"]["environmentName"];
-            packageName: components["parameters"]["packageName"];
-            materializationId: components["parameters"]["materializationId"];
-         };
-      };
-      responses: {
-         /** @description Materialization deleted */
-         204: {
-            content: never;
-         };
-         404: components["responses"]["NotFound"];
-         /** @description Materialization cannot be deleted (PENDING or RUNNING) */
-         409: {
-            content: {
-               "application/json": components["schemas"]["Error"];
-            };
-         };
-      };
-   };
-   /**
-    * Get the build manifest for a package
-    * @description Returns the current build manifest containing buildId-to-tableName mappings
-    * for all materialized sources in the package.
-    */
-   "get-manifest": {
-      parameters: {
-         path: {
-            environmentName: components["parameters"]["environmentName"];
-            packageName: components["parameters"]["packageName"];
-         };
-      };
-      responses: {
-         /** @description Build manifest */
-         200: {
-            content: {
-               "application/json": components["schemas"]["BuildManifest"];
-            };
-         };
-         404: components["responses"]["NotFound"];
-      };
-   };
-   /**
-    * Perform an action on the package manifest
-    * @description Performs an action on the package manifest. The action is specified via
-    * the `action` query parameter:
-    *   * `reload` - Reads the build manifest from the shared store (DuckLake
-    *     in orchestrated mode, local DuckDB in standalone mode) and recompiles
-    *     every model in the package so subsequent queries resolve persisted
-    *     sources to their materialized tables. Intended for orchestrated
-    *     workers that did not themselves run the build; the endpoint does
-    *     not write anything *into* storage.
-    */
-   "manifest-action": {
-      parameters: {
-         query: {
-            /** @description Action to perform on the manifest */
-            action: "reload";
-         };
-         path: {
-            environmentName: components["parameters"]["environmentName"];
-            packageName: components["parameters"]["packageName"];
-         };
-      };
-      responses: {
-         /** @description Manifest loaded */
-         200: {
-            content: {
-               "application/json": components["schemas"]["BuildManifest"];
-            };
-         };
-         400: components["responses"]["BadRequest"];
-         404: components["responses"]["NotFound"];
-      };
-   };
+
+  /**
+   * Get server status and health information
+   * @description Returns the current status of the Malloy Publisher server, including initialization state,
+   * available environments, and server timestamp. This endpoint is useful for health checks and
+   * monitoring server availability.
+   */
+  "get-status": {
+    responses: {
+      /** @description Returns server status */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ServerStatus"];
+        };
+      };
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * List all available environments
+   * @description Retrieves a list of all environments currently hosted on this Malloy Publisher server.
+   * Each environment contains metadata about its packages, connections, and configuration.
+   * This endpoint is typically used to discover available environments and their basic information.
+   */
+  "list-environments": {
+    responses: {
+      /** @description A list of all available environments */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Environment"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Create a new environment
+   * @description Creates a new Malloy environment with the specified configuration. An environment serves as a
+   * container for packages, connections, and other resources. The environment will be initialized
+   * with the provided metadata and can immediately accept packages and connections.
+   */
+  "create-environment": {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Environment"];
+      };
+    };
+    responses: {
+      /** @description Returns the environment created */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Environment"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Get environment details and metadata
+   * @description Retrieves detailed information about a specific environment, including its packages,
+   * connections, configuration, and metadata. The reload parameter can be used to
+   * refresh the environment state from disk before returning the information.
+   */
+  "get-environment": {
+    parameters: {
+      query?: {
+        /** @description Load / reload the environment before returning result */
+        reload?: boolean;
+      };
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description Environment details and metadata */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Environment"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Delete an environment
+   * @description Permanently deletes an environment and all its associated resources including packages,
+   * connections, and metadata. This operation cannot be undone, so use with caution.
+   * The environment must exist and be accessible for deletion.
+   */
+  "delete-environment": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description Returns the environment deleted */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Environment"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Update environment configuration
+   * @description Updates the configuration and metadata of an existing environment. This allows you to
+   * modify environment settings, update the README, change the location, or update other
+   * environment-level properties. The environment must exist and be accessible.
+   */
+  "update-environment": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Environment"];
+      };
+    };
+    responses: {
+      /** @description Returns the environment updated */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Environment"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * List environment database connections
+   * @description Retrieves a list of all database connections configured for the specified environment.
+   * Each connection includes its configuration, type, and status information. This endpoint
+   * is useful for discovering available data sources within an environment.
+   */
+  "list-connections": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description A list of database connections in the environment */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Connection"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Get connection details
+   * @description Retrieves detailed information about a specific database connection within an environment.
+   * This includes connection configuration, credentials (if accessible), and metadata.
+   * Useful for inspecting connection settings and troubleshooting connectivity issues.
+   */
+  "get-connection": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description Connection details and configuration */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Connection"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Create a new database connection
+   * @description Creates a new database connection in the specified environment.
+   */
+  "create-connection": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Connection"];
+      };
+    };
+    responses: {
+      /** @description Connection created successfully */
+      201: {
+        content: {
+          "application/json": {
+            message?: string;
+          };
+        };
+      };
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      /** @description Connection already exists */
+      409: {
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Delete a database connection
+   * @description Permanently deletes a database connection from the environment.
+   */
+  "delete-connection": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection to delete */
+        connectionName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description Connection deleted successfully */
+      200: {
+        content: {
+          "application/json": {
+            message?: string;
+          };
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Update an existing database connection
+   * @description Updates the configuration of an existing database connection.
+   */
+  "update-connection": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection to update */
+        connectionName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          postgresConnection?: components["schemas"]["PostgresConnection"];
+          mysqlConnection?: components["schemas"]["MysqlConnection"];
+          bigqueryConnection?: components["schemas"]["BigqueryConnection"];
+          snowflakeConnection?: components["schemas"]["SnowflakeConnection"];
+          duckdbConnection?: components["schemas"]["DuckdbConnection"];
+          motherduckConnection?: components["schemas"]["MotherDuckConnection"];
+          trinoConnection?: components["schemas"]["TrinoConnection"];
+          databricksConnection?: components["schemas"]["DatabricksConnection"];
+          ducklakeConnection?: components["schemas"]["DucklakeConnection"];
+        };
+      };
+    };
+    responses: {
+      /** @description Connection updated successfully */
+      200: {
+        content: {
+          "application/json": {
+            message?: string;
+          };
+        };
+      };
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * List database schemas
+   * @description Retrieves a list of all schemas (databases) available in the specified connection.
+   * Each schema includes metadata such as name, description, and whether it's the default schema.
+   * This endpoint is useful for exploring the database structure and discovering available data sources.
+   */
+  "list-schemas": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description A list of schemas available in the connection with metadata */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Schema"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * List tables in database
+   * @description Retrieves a list of all tables and views available in the specified database schema.
+   * This endpoint is useful for discovering available data sources and exploring the database
+   * structure. The schema must exist in the connection for this operation to succeed.
+   */
+  "list-tables": {
+    parameters: {
+      query?: {
+        /**
+         * @description List of table names to filter results. When provided, only returns metadata
+         * for the specified tables. When omitted, returns all tables in the schema.
+         */
+        tableNames?: string[];
+      };
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the schema */
+        schemaName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description A list of table names available in the specified schema */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Table"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Get table details from database
+   * @description Retrieves a table from the specified database schema.
+   * This endpoint is useful for discovering available data sources and exploring the database
+   * structure. The schema must exist in the connection for this operation to succeed.
+   * The tablePath is the full path to the table, including the schema name.
+   */
+  "get-table": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the schema */
+        schemaName: components["schemas"]["IdentifierPattern"];
+        /** @description Full path to the table */
+        tablePath: components["schemas"]["PathPattern"];
+      };
+    };
+    responses: {
+      /** @description Table information */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Table"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Get SQL source (deprecated)
+   * @deprecated
+   * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
+   * Use the POST version instead for better security and functionality.
+   *
+   * Creates a Malloy source from a SQL statement using the specified connection.
+   * The SQL statement is executed to generate a source definition that can be used in Malloy models.
+   */
+  "get-sqlsource": {
+    parameters: {
+      query?: {
+        /** @description SQL statement */
+        sqlStatement?: string;
+      };
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description SQL source information */
+      200: {
+        content: {
+          "application/json": components["schemas"]["SqlSource"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Create SQL source from statement
+   * @description Creates a Malloy source from a SQL statement using the specified database connection.
+   * The SQL statement is executed to generate a source definition that can be used in Malloy models.
+   */
+  "post-sqlsource": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    /** @description SQL statement to fetch the SQL source */
+    requestBody: {
+      content: {
+        "application/json": {
+          sqlStatement?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description SQL source information */
+      200: {
+        content: {
+          "application/json": components["schemas"]["SqlSource"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Execute SQL query
+   * @description Executes a SQL statement against the specified database connection and returns the results.
+   * The results include data, metadata, and execution information.
+   */
+  "post-querydata": {
+    parameters: {
+      query?: {
+        /**
+         * @deprecated
+         * @description Options (deprecated; pass in body instead)
+         */
+        options?: string;
+      };
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    /** @description SQL statement to execute */
+    requestBody: {
+      content: {
+        "application/json": {
+          sqlStatement?: string;
+          /** @description Options */
+          options?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Query execution results */
+      200: {
+        content: {
+          "application/json": components["schemas"]["QueryData"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Create temporary table
+   * @description Creates a temporary table from a SQL statement using the specified database connection.
+   * Temporary tables are useful for storing intermediate results during complex queries and data processing workflows.
+   */
+  "post-temporarytable": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    /** @description SQL statement to create the temporary table */
+    requestBody: {
+      content: {
+        "application/json": {
+          sqlStatement?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Temporary table information */
+      200: {
+        content: {
+          "application/json": components["schemas"]["TemporaryTable"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Create temporary table (deprecated)
+   * @deprecated
+   * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
+   * Use the POST version instead for better security and functionality.
+   *
+   * Creates a temporary table from a SQL statement using the specified connection.
+   * Temporary tables are useful for storing intermediate results during complex queries.
+   */
+  "get-temporarytable": {
+    parameters: {
+      query?: {
+        /** @description SQL statement */
+        sqlStatement?: string;
+      };
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description Temporary table information */
+      200: {
+        content: {
+          "application/json": components["schemas"]["TemporaryTable"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Execute SQL query (deprecated)
+   * @deprecated
+   * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
+   * Use the POST version instead for better security and functionality.
+   *
+   * Executes a SQL statement against the specified database connection and returns the results.
+   * The query results include data, metadata, and execution information.
+   */
+  "get-querydata": {
+    parameters: {
+      query?: {
+        /** @description SQL statement */
+        sqlStatement?: string;
+        /** @description Options */
+        options?: string;
+      };
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description Query execution results */
+      200: {
+        content: {
+          "application/json": components["schemas"]["QueryData"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+    };
+  };
+  /**
+   * List database schemas (per-package)
+   * @description Retrieves a list of all schemas (databases) available in the specified
+   * connection, resolved in the context of the named package. Required for
+   * `connectionName="duckdb"`, which is per-package; works for any other
+   * connection name as well (resolution falls through to the environment).
+   */
+  "list-schemas-in-package": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the package whose connection context to use */
+        packageName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description A list of schemas available in the connection with metadata */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Schema"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * List tables in database (per-package)
+   * @description Retrieves a list of all tables and views available in the specified
+   * database schema, resolved in the context of the named package.
+   */
+  "list-tables-in-package": {
+    parameters: {
+      query?: {
+        /**
+         * @description List of table names to filter results. When provided, only returns metadata
+         * for the specified tables. When omitted, returns all tables in the schema.
+         */
+        tableNames?: string[];
+      };
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the package whose connection context to use */
+        packageName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the schema */
+        schemaName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description A list of table names available in the specified schema */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Table"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Get table details from database (per-package)
+   * @description Retrieves a table from the specified database schema, resolved in
+   * the context of the named package.
+   */
+  "get-table-in-package": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the package whose connection context to use */
+        packageName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the schema */
+        schemaName: components["schemas"]["IdentifierPattern"];
+        /** @description Full path to the table */
+        tablePath: components["schemas"]["PathPattern"];
+      };
+    };
+    responses: {
+      /** @description Table information */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Table"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Get SQL source (per-package, deprecated)
+   * @deprecated
+   * @description **DEPRECATED**: Use the POST version instead.
+   *
+   * Creates a Malloy source from a SQL statement using the specified
+   * connection, resolved in the context of the named package.
+   */
+  "get-sqlsource-in-package": {
+    parameters: {
+      query?: {
+        /** @description SQL statement */
+        sqlStatement?: string;
+      };
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the package whose connection context to use */
+        packageName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description SQL source information */
+      200: {
+        content: {
+          "application/json": components["schemas"]["SqlSource"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Create SQL source from statement (per-package)
+   * @description Creates a Malloy source from a SQL statement using the specified
+   * connection, resolved in the context of the named package.
+   */
+  "post-sqlsource-in-package": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the package whose connection context to use */
+        packageName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    /** @description SQL statement to fetch the SQL source */
+    requestBody: {
+      content: {
+        "application/json": {
+          sqlStatement?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description SQL source information */
+      200: {
+        content: {
+          "application/json": components["schemas"]["SqlSource"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Execute SQL query (per-package)
+   * @description Executes a SQL statement against the specified database connection,
+   * resolved in the context of the named package, and returns the results.
+   */
+  "post-querydata-in-package": {
+    parameters: {
+      query?: {
+        /**
+         * @deprecated
+         * @description Options (deprecated; pass in body instead)
+         */
+        options?: string;
+      };
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the package whose connection context to use */
+        packageName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    /** @description SQL statement to execute */
+    requestBody: {
+      content: {
+        "application/json": {
+          sqlStatement?: string;
+          /** @description Options */
+          options?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Query execution results */
+      200: {
+        content: {
+          "application/json": components["schemas"]["QueryData"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Create temporary table (per-package)
+   * @description Creates a temporary table from a SQL statement using the specified
+   * database connection, resolved in the context of the named package.
+   */
+  "post-temporarytable-in-package": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the package whose connection context to use */
+        packageName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    /** @description SQL statement to create the temporary table */
+    requestBody: {
+      content: {
+        "application/json": {
+          sqlStatement?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Temporary table information */
+      200: {
+        content: {
+          "application/json": components["schemas"]["TemporaryTable"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Create temporary table (per-package, deprecated)
+   * @deprecated
+   * @description **DEPRECATED**: Use the POST version instead.
+   *
+   * Creates a temporary table from a SQL statement using the specified
+   * connection, resolved in the context of the named package.
+   */
+  "get-temporarytable-in-package": {
+    parameters: {
+      query?: {
+        /** @description SQL statement */
+        sqlStatement?: string;
+      };
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the package whose connection context to use */
+        packageName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description Temporary table information */
+      200: {
+        content: {
+          "application/json": components["schemas"]["TemporaryTable"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Execute SQL query (per-package, deprecated)
+   * @deprecated
+   * @description **DEPRECATED**: Use the POST version instead.
+   *
+   * Executes a SQL statement against the specified database connection,
+   * resolved in the context of the named package, and returns the results.
+   */
+  "get-querydata-in-package": {
+    parameters: {
+      query?: {
+        /** @description SQL statement */
+        sqlStatement?: string;
+        /** @description Options */
+        options?: string;
+      };
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the package whose connection context to use */
+        packageName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the connection */
+        connectionName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description Query execution results */
+      200: {
+        content: {
+          "application/json": components["schemas"]["QueryData"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+    };
+  };
+  /**
+   * List environment packages
+   * @description Retrieves a list of all Malloy packages within the specified environment. Each package
+   * contains models, notebooks, databases, and other resources. This endpoint is useful
+   * for discovering available packages and their basic metadata.
+   */
+  "list-packages": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description A list of all packages in the environment */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Package"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      500: components["responses"]["InternalServerError"];
+      501: components["responses"]["NotImplemented"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Create a new package
+   * @description Creates a new Malloy package within the specified environment. A package serves as a
+   * container for models, notebooks, embedded databases, and other resources. The package
+   * will be initialized with the provided metadata and can immediately accept content.
+   */
+  "create-package": {
+    parameters: {
+      query?: {
+        /**
+         * @description When true, automatically loads any existing build manifest
+         * for the package so materialized table references resolve immediately.
+         * Defaults to false.
+         */
+        autoLoadManifest?: boolean;
+      };
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Package"];
+      };
+    };
+    responses: {
+      /** @description Returns the package created */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Package"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      500: components["responses"]["InternalServerError"];
+      501: components["responses"]["NotImplemented"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Get package details and metadata
+   * @description Retrieves detailed information about a specific package, including its models, notebooks,
+   * databases, and metadata. The reload parameter can be used to refresh the package state
+   * from disk before returning the information. The versionId parameter allows access to
+   * specific package versions.
+   */
+  "get-package": {
+    parameters: {
+      query?: {
+        /** @description Version identifier for the package */
+        versionId?: components["schemas"]["VersionIdPattern"];
+        /** @description Load / reload the package before returning result */
+        reload?: boolean;
+      };
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Package name */
+        packageName: string;
+      };
+    };
+    responses: {
+      /** @description Package details and metadata */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Package"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      501: components["responses"]["NotImplemented"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Delete a package
+   * @description Permanently deletes a package and all its associated resources including models,
+   * notebooks, databases, and metadata. This operation cannot be undone, so use with caution.
+   * The package must exist and be accessible for deletion.
+   */
+  "delete-package": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the package */
+        packageName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description Returns the package deleted */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Package"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      501: components["responses"]["NotImplemented"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Update package configuration
+   * @description Updates the configuration and metadata of an existing package. This allows you to
+   * modify package settings, update the description, change the location, or update other
+   * package-level properties. The package must exist and be accessible.
+   */
+  "update-package": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the package */
+        packageName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Package"];
+      };
+    };
+    responses: {
+      /** @description Returns the package updated */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Package"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      501: components["responses"]["NotImplemented"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * List package models
+   * @description Retrieves a list of all Malloy models within the specified package. Each model entry
+   * includes the relative path, package name, and any compilation errors. This endpoint
+   * is useful for discovering available models and checking their status.
+   */
+  "list-models": {
+    parameters: {
+      query?: {
+        /** @description Version identifier for the package */
+        versionId?: components["schemas"]["VersionIdPattern"];
+      };
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the package */
+        packageName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description A list of models in the package */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Model"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      501: components["responses"]["NotImplemented"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Get compiled Malloy model
+   * @description Retrieves a compiled Malloy model with its source information, queries, and metadata.
+   * The model is compiled using the specified version of the Malloy compiler. This endpoint
+   * provides access to the model's structure, sources, and named queries for use in applications.
+   */
+  "get-model": {
+    parameters: {
+      query?: {
+        /** @description Version identifier for the package */
+        versionId?: components["schemas"]["VersionIdPattern"];
+      };
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the package */
+        packageName: string;
+        /** @description Path to the model within the package */
+        path: components["schemas"]["PathPattern"];
+      };
+    };
+    responses: {
+      /** @description Compiled Malloy model */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CompiledModel"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      424: components["responses"]["ModelCompilationError"];
+      500: components["responses"]["InternalServerError"];
+      501: components["responses"]["NotImplemented"];
+    };
+  };
+  /**
+   * Execute Malloy query
+   * @description Executes a Malloy query against a model and returns the results. The query can be specified
+   * as a raw Malloy query string or by referencing a named query within the model. This endpoint
+   * supports both ad-hoc queries and predefined model queries, making it flexible for various
+   * use cases including data exploration, reporting, and application integration.
+   */
+  "execute-query-model": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the package */
+        packageName: components["schemas"]["VersionIdPattern"];
+        /** @description Path to the model within the package */
+        path: components["schemas"]["PathPattern"];
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["QueryRequest"];
+      };
+    };
+    responses: {
+      /** @description Query execution results */
+      200: {
+        content: {
+          "application/json": components["schemas"]["QueryResult"];
+        };
+      };
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      501: components["responses"]["NotImplemented"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Compile Malloy source code
+   * @description Compiles Malloy source code in the context of a specific model file.
+   * The submitted source is appended to the full model content, giving it
+   * access to all sources, imports, and queries defined in the model.
+   * Relative imports resolve correctly against sibling model files.
+   * Returns compilation status and any problems (errors or warnings) found.
+   */
+  "compile-model-source": {
+    parameters: {
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the package */
+        packageName: string;
+        /** @description Path to the model within the package (used to resolve relative imports) */
+        path: components["schemas"]["PathPattern"];
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CompileRequest"];
+      };
+    };
+    responses: {
+      /** @description Compilation result with status and any problems */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CompileResult"];
+        };
+      };
+      400: components["responses"]["BadRequest"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * List package notebooks
+   * @description Retrieves a list of all Malloy notebooks within the specified package. Each notebook entry
+   * includes the relative path, package name, and any compilation errors. This endpoint
+   * is useful for discovering available notebooks and checking their status.
+   */
+  "list-notebooks": {
+    parameters: {
+      query?: {
+        /** @description Version identifier for the package */
+        versionId?: components["schemas"]["VersionIdPattern"];
+      };
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the package */
+        packageName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description A list of models in the package */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Notebook"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      501: components["responses"]["NotImplemented"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Get Malloy notebook cells
+   * @description Retrieves a Malloy notebook with its raw cell contents (markdown and code).
+   * Cell execution should be done separately via the execute-notebook-cell endpoint.
+   */
+  "get-notebook": {
+    parameters: {
+      query?: {
+        /** @description Version identifier for the package */
+        versionId?: components["schemas"]["VersionIdPattern"];
+      };
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the package */
+        packageName: string;
+        /** @description Path to notebook within the package. */
+        path: string;
+      };
+    };
+    responses: {
+      /** @description A Malloy notebook with raw cell contents. */
+      200: {
+        content: {
+          "application/json": components["schemas"]["RawNotebook"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      501: components["responses"]["NotImplemented"];
+    };
+  };
+  /**
+   * Execute a specific notebook cell
+   * @description Executes a specific cell in a Malloy notebook by index. For code cells, this compiles
+   * and runs the Malloy code, returning query results and any new sources defined.
+   * For markdown cells, this simply returns the cell content.
+   */
+  "execute-notebook-cell": {
+    parameters: {
+      query?: {
+        /** @description Version identifier for the package */
+        versionId?: components["schemas"]["VersionIdPattern"];
+        /** @description JSON-encoded filter parameter values keyed by filter name */
+        filter_params?: string;
+        /** @description When true, skip filter injection entirely */
+        bypass_filters?: "true" | "false";
+      };
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the package */
+        packageName: string;
+        /** @description Path to notebook within the package */
+        path: string;
+        /** @description Index of the cell to execute (0-based) */
+        cellIndex: number;
+      };
+    };
+    responses: {
+      /** @description Cell execution result */
+      200: {
+        content: {
+          "application/json": components["schemas"]["NotebookCellResult"];
+        };
+      };
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      501: components["responses"]["NotImplemented"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * List embedded databases
+   * @description Retrieves a list of all embedded databases within the specified package. These are typically
+   * DuckDB databases stored as .parquet files that provide local data storage for the package.
+   * Each database entry includes metadata about the database structure and content.
+   */
+  "list-databases": {
+    parameters: {
+      query?: {
+        /** @description Version identifier for the package */
+        versionId?: components["schemas"]["VersionIdPattern"];
+      };
+      path: {
+        /** @description Name of the environment */
+        environmentName: components["schemas"]["IdentifierPattern"];
+        /** @description Name of the package */
+        packageName: components["schemas"]["IdentifierPattern"];
+      };
+    };
+    responses: {
+      /** @description A list of embedded databases in the package */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Database"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      501: components["responses"]["NotImplemented"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Test database connection configuration
+   * @description Validates a database connection configuration without adding it to any environment.
+   * This endpoint allows you to test connection parameters, credentials, and network
+   * connectivity before committing the connection to an environment. Useful for troubleshooting
+   * connection issues and validating configurations during setup.
+   */
+  "test-connection-configuration": {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Connection"];
+      };
+    };
+    responses: {
+      /** @description Connection test result */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ConnectionStatus"];
+        };
+      };
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Get watch mode status
+   * @description Retrieves the current status of the file watching system. This includes whether watch mode
+   * is enabled, which environment is being watched, and the path being monitored. Useful for
+   * monitoring the development workflow and ensuring file changes are being detected.
+   */
+  "get-watch-status": {
+    responses: {
+      /** @description The current watch mode status. */
+      200: {
+        content: {
+          "application/json": components["schemas"]["WatchStatus"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Start file watching
+   * @description Initiates file watching for the specified environment. This enables real-time monitoring of
+   * file changes within the environment directory, allowing for automatic reloading and updates
+   * during development. Only one environment can be watched at a time.
+   */
+  "start-watching": {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["StartWatchRequest"];
+      };
+    };
+    responses: {
+      /** @description Watch mode started successfully. */
+      200: {
+        content: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * Stop file watching
+   * @description Stops the current file watching session. This disables real-time monitoring of file changes
+   * and releases system resources. Use this when development is complete or when switching
+   * to a different environment.
+   */
+  "stop-watching": {
+    responses: {
+      /** @description Watch mode stopped successfully. */
+      200: {
+        content: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      500: components["responses"]["InternalServerError"];
+      503: components["responses"]["ServiceUnavailable"];
+    };
+  };
+  /**
+   * List materializations for a package
+   * @description Returns the materialization history for the package, ordered by most recent first.
+   */
+  "list-materializations": {
+    parameters: {
+      query?: {
+        /** @description Maximum number of materializations to return */
+        limit?: number;
+        /** @description Number of materializations to skip */
+        offset?: number;
+      };
+      path: {
+        environmentName: components["parameters"]["environmentName"];
+        packageName: components["parameters"]["packageName"];
+      };
+    };
+    responses: {
+      /** @description List of materializations */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Materialization"][];
+        };
+      };
+      404: components["responses"]["NotFound"];
+    };
+  };
+  /**
+   * Create a materialization
+   * @description Creates a new materialization in PENDING state for all persist sources across all
+   * models in the package. Use POST .../materializations/{materializationId}?action=start to begin execution.
+   */
+  "create-materialization": {
+    parameters: {
+      path: {
+        environmentName: components["parameters"]["environmentName"];
+        packageName: components["parameters"]["packageName"];
+      };
+    };
+    requestBody?: {
+      content: {
+        "application/json": components["schemas"]["CreateMaterializationRequest"];
+      };
+    };
+    responses: {
+      /** @description Materialization created */
+      201: {
+        content: {
+          "application/json": components["schemas"]["Materialization"];
+        };
+      };
+      404: components["responses"]["NotFound"];
+      /** @description Package already has an active materialization */
+      409: {
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
+  /** Get a specific materialization */
+  "get-materialization": {
+    parameters: {
+      path: {
+        environmentName: components["parameters"]["environmentName"];
+        packageName: components["parameters"]["packageName"];
+        materializationId: components["parameters"]["materializationId"];
+      };
+    };
+    responses: {
+      /** @description Materialization details */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Materialization"];
+        };
+      };
+      404: components["responses"]["NotFound"];
+    };
+  };
+  /**
+   * Perform an action on a materialization
+   * @description Performs an action on a materialization. The action is specified via
+   * the `action` query parameter:
+   *   * `start` - Transitions a PENDING materialization to RUNNING and begins execution in the background. Returns 202.
+   *   * `stop` - Cancels a PENDING or RUNNING materialization. Returns 200.
+   */
+  "materialization-action": {
+    parameters: {
+      query: {
+        /** @description Action to perform on the materialization */
+        action: "start" | "stop";
+      };
+      path: {
+        environmentName: components["parameters"]["environmentName"];
+        packageName: components["parameters"]["packageName"];
+        materializationId: components["parameters"]["materializationId"];
+      };
+    };
+    responses: {
+      /** @description Materialization cancelled (action=stop) */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Materialization"];
+        };
+      };
+      /** @description Materialization started (action=start) */
+      202: {
+        content: {
+          "application/json": components["schemas"]["Materialization"];
+        };
+      };
+      400: components["responses"]["BadRequest"];
+      404: components["responses"]["NotFound"];
+      /** @description Materialization cannot transition to the requested state */
+      409: {
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
+  /**
+   * Delete a materialization
+   * @description Deletes a terminal (SUCCESS, FAILED, or CANCELLED) materialization record.
+   */
+  "delete-materialization": {
+    parameters: {
+      path: {
+        environmentName: components["parameters"]["environmentName"];
+        packageName: components["parameters"]["packageName"];
+        materializationId: components["parameters"]["materializationId"];
+      };
+    };
+    responses: {
+      /** @description Materialization deleted */
+      204: {
+        content: never;
+      };
+      404: components["responses"]["NotFound"];
+      /** @description Materialization cannot be deleted (PENDING or RUNNING) */
+      409: {
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
+  /**
+   * Get the build manifest for a package
+   * @description Returns the current build manifest containing buildId-to-tableName mappings
+   * for all materialized sources in the package.
+   */
+  "get-manifest": {
+    parameters: {
+      path: {
+        environmentName: components["parameters"]["environmentName"];
+        packageName: components["parameters"]["packageName"];
+      };
+    };
+    responses: {
+      /** @description Build manifest */
+      200: {
+        content: {
+          "application/json": components["schemas"]["BuildManifest"];
+        };
+      };
+      404: components["responses"]["NotFound"];
+    };
+  };
+  /**
+   * Perform an action on the package manifest
+   * @description Performs an action on the package manifest. The action is specified via
+   * the `action` query parameter:
+   *   * `reload` - Reads the build manifest from the shared store (DuckLake
+   *     in orchestrated mode, local DuckDB in standalone mode) and recompiles
+   *     every model in the package so subsequent queries resolve persisted
+   *     sources to their materialized tables. Intended for orchestrated
+   *     workers that did not themselves run the build; the endpoint does
+   *     not write anything *into* storage.
+   */
+  "manifest-action": {
+    parameters: {
+      query: {
+        /** @description Action to perform on the manifest */
+        action: "reload";
+      };
+      path: {
+        environmentName: components["parameters"]["environmentName"];
+        packageName: components["parameters"]["packageName"];
+      };
+    };
+    responses: {
+      /** @description Manifest loaded */
+      200: {
+        content: {
+          "application/json": components["schemas"]["BuildManifest"];
+        };
+      };
+      400: components["responses"]["BadRequest"];
+      404: components["responses"]["NotFound"];
+    };
+  };
 }

--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -3,1192 +3,1697 @@
  * Do not make direct changes to the file.
  */
 
-
 export interface paths {
-  "/status": {
-    /**
-     * Get server status and health information
-     * @description Returns the current status of the Malloy Publisher server, including initialization state,
-     * available environments, and server timestamp. This endpoint is useful for health checks and
-     * monitoring server availability.
-     */
-    get: operations["get-status"];
-  };
-  "/environments": {
-    /**
-     * List all available environments
-     * @description Retrieves a list of all environments currently hosted on this Malloy Publisher server.
-     * Each environment contains metadata about its packages, connections, and configuration.
-     * This endpoint is typically used to discover available environments and their basic information.
-     */
-    get: operations["list-environments"];
-    /**
-     * Create a new environment
-     * @description Creates a new Malloy environment with the specified configuration. An environment serves as a
-     * container for packages, connections, and other resources. The environment will be initialized
-     * with the provided metadata and can immediately accept packages and connections.
-     */
-    post: operations["create-environment"];
-  };
-  "/environments/{environmentName}": {
-    /**
-     * Get environment details and metadata
-     * @description Retrieves detailed information about a specific environment, including its packages,
-     * connections, configuration, and metadata. The reload parameter can be used to
-     * refresh the environment state from disk before returning the information.
-     */
-    get: operations["get-environment"];
-    /**
-     * Delete an environment
-     * @description Permanently deletes an environment and all its associated resources including packages,
-     * connections, and metadata. This operation cannot be undone, so use with caution.
-     * The environment must exist and be accessible for deletion.
-     */
-    delete: operations["delete-environment"];
-    /**
-     * Update environment configuration
-     * @description Updates the configuration and metadata of an existing environment. This allows you to
-     * modify environment settings, update the README, change the location, or update other
-     * environment-level properties. The environment must exist and be accessible.
-     */
-    patch: operations["update-environment"];
-  };
-  "/environments/{environmentName}/connections": {
-    /**
-     * List environment database connections
-     * @description Retrieves a list of all database connections configured for the specified environment.
-     * Each connection includes its configuration, type, and status information. This endpoint
-     * is useful for discovering available data sources within an environment.
-     */
-    get: operations["list-connections"];
-  };
-  "/environments/{environmentName}/connections/{connectionName}": {
-    /**
-     * Get connection details
-     * @description Retrieves detailed information about a specific database connection within an environment.
-     * This includes connection configuration, credentials (if accessible), and metadata.
-     * Useful for inspecting connection settings and troubleshooting connectivity issues.
-     */
-    get: operations["get-connection"];
-    /**
-     * Create a new database connection
-     * @description Creates a new database connection in the specified environment.
-     */
-    post: operations["create-connection"];
-    /**
-     * Delete a database connection
-     * @description Permanently deletes a database connection from the environment.
-     */
-    delete: operations["delete-connection"];
-    /**
-     * Update an existing database connection
-     * @description Updates the configuration of an existing database connection.
-     */
-    patch: operations["update-connection"];
-  };
-  "/environments/{environmentName}/connections/{connectionName}/schemas": {
-    /**
-     * List database schemas
-     * @description Retrieves a list of all schemas (databases) available in the specified connection.
-     * Each schema includes metadata such as name, description, and whether it's the default schema.
-     * This endpoint is useful for exploring the database structure and discovering available data sources.
-     */
-    get: operations["list-schemas"];
-  };
-  "/environments/{environmentName}/connections/{connectionName}/schemas/{schemaName}/tables": {
-    /**
-     * List tables in database
-     * @description Retrieves a list of all tables and views available in the specified database schema.
-     * This endpoint is useful for discovering available data sources and exploring the database
-     * structure. The schema must exist in the connection for this operation to succeed.
-     */
-    get: operations["list-tables"];
-  };
-  "/environments/{environmentName}/connections/{connectionName}/schemas/{schemaName}/tables/{tablePath}": {
-    /**
-     * Get table details from database
-     * @description Retrieves a table from the specified database schema.
-     * This endpoint is useful for discovering available data sources and exploring the database
-     * structure. The schema must exist in the connection for this operation to succeed.
-     * The tablePath is the full path to the table, including the schema name.
-     */
-    get: operations["get-table"];
-  };
-  "/environments/{environmentName}/connections/{connectionName}/sqlSource": {
-    /**
-     * Get SQL source (deprecated)
-     * @deprecated
-     * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
-     * Use the POST version instead for better security and functionality.
-     *
-     * Creates a Malloy source from a SQL statement using the specified connection.
-     * The SQL statement is executed to generate a source definition that can be used in Malloy models.
-     */
-    get: operations["get-sqlsource"];
-    /**
-     * Create SQL source from statement
-     * @description Creates a Malloy source from a SQL statement using the specified database connection.
-     * The SQL statement is executed to generate a source definition that can be used in Malloy models.
-     */
-    post: operations["post-sqlsource"];
-  };
-  "/environments/{environmentName}/connections/{connectionName}/sqlQuery": {
-    /**
-     * Execute SQL query
-     * @description Executes a SQL statement against the specified database connection and returns the results.
-     * The results include data, metadata, and execution information.
-     */
-    post: operations["post-querydata"];
-  };
-  "/environments/{environmentName}/connections/{connectionName}/sqlTemporaryTable": {
-    /**
-     * Create temporary table
-     * @description Creates a temporary table from a SQL statement using the specified database connection.
-     * Temporary tables are useful for storing intermediate results during complex queries and data processing workflows.
-     */
-    post: operations["post-temporarytable"];
-  };
-  "/environments/{environmentName}/connections/{connectionName}/temporaryTable": {
-    /**
-     * Create temporary table (deprecated)
-     * @deprecated
-     * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
-     * Use the POST version instead for better security and functionality.
-     *
-     * Creates a temporary table from a SQL statement using the specified connection.
-     * Temporary tables are useful for storing intermediate results during complex queries.
-     */
-    get: operations["get-temporarytable"];
-  };
-  "/environments/{environmentName}/connections/{connectionName}/queryData": {
-    /**
-     * Execute SQL query (deprecated)
-     * @deprecated
-     * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
-     * Use the POST version instead for better security and functionality.
-     *
-     * Executes a SQL statement against the specified database connection and returns the results.
-     * The query results include data, metadata, and execution information.
-     */
-    get: operations["get-querydata"];
-  };
-  "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/schemas": {
-    /**
-     * List database schemas (per-package)
-     * @description Retrieves a list of all schemas (databases) available in the specified
-     * connection, resolved in the context of the named package. Required for
-     * `connectionName="duckdb"`, which is per-package; works for any other
-     * connection name as well (resolution falls through to the environment).
-     */
-    get: operations["list-schemas-in-package"];
-  };
-  "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/schemas/{schemaName}/tables": {
-    /**
-     * List tables in database (per-package)
-     * @description Retrieves a list of all tables and views available in the specified
-     * database schema, resolved in the context of the named package.
-     */
-    get: operations["list-tables-in-package"];
-  };
-  "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/schemas/{schemaName}/tables/{tablePath}": {
-    /**
-     * Get table details from database (per-package)
-     * @description Retrieves a table from the specified database schema, resolved in
-     * the context of the named package.
-     */
-    get: operations["get-table-in-package"];
-  };
-  "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/sqlSource": {
-    /**
-     * Get SQL source (per-package, deprecated)
-     * @deprecated
-     * @description **DEPRECATED**: Use the POST version instead.
-     *
-     * Creates a Malloy source from a SQL statement using the specified
-     * connection, resolved in the context of the named package.
-     */
-    get: operations["get-sqlsource-in-package"];
-    /**
-     * Create SQL source from statement (per-package)
-     * @description Creates a Malloy source from a SQL statement using the specified
-     * connection, resolved in the context of the named package.
-     */
-    post: operations["post-sqlsource-in-package"];
-  };
-  "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/sqlQuery": {
-    /**
-     * Execute SQL query (per-package)
-     * @description Executes a SQL statement against the specified database connection,
-     * resolved in the context of the named package, and returns the results.
-     */
-    post: operations["post-querydata-in-package"];
-  };
-  "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/sqlTemporaryTable": {
-    /**
-     * Create temporary table (per-package)
-     * @description Creates a temporary table from a SQL statement using the specified
-     * database connection, resolved in the context of the named package.
-     */
-    post: operations["post-temporarytable-in-package"];
-  };
-  "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/temporaryTable": {
-    /**
-     * Create temporary table (per-package, deprecated)
-     * @deprecated
-     * @description **DEPRECATED**: Use the POST version instead.
-     *
-     * Creates a temporary table from a SQL statement using the specified
-     * connection, resolved in the context of the named package.
-     */
-    get: operations["get-temporarytable-in-package"];
-  };
-  "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/queryData": {
-    /**
-     * Execute SQL query (per-package, deprecated)
-     * @deprecated
-     * @description **DEPRECATED**: Use the POST version instead.
-     *
-     * Executes a SQL statement against the specified database connection,
-     * resolved in the context of the named package, and returns the results.
-     */
-    get: operations["get-querydata-in-package"];
-  };
-  "/environments/{environmentName}/packages": {
-    /**
-     * List environment packages
-     * @description Retrieves a list of all Malloy packages within the specified environment. Each package
-     * contains models, notebooks, databases, and other resources. This endpoint is useful
-     * for discovering available packages and their basic metadata.
-     */
-    get: operations["list-packages"];
-    /**
-     * Create a new package
-     * @description Creates a new Malloy package within the specified environment. A package serves as a
-     * container for models, notebooks, embedded databases, and other resources. The package
-     * will be initialized with the provided metadata and can immediately accept content.
-     */
-    post: operations["create-package"];
-  };
-  "/environments/{environmentName}/packages/{packageName}": {
-    /**
-     * Get package details and metadata
-     * @description Retrieves detailed information about a specific package, including its models, notebooks,
-     * databases, and metadata. The reload parameter can be used to refresh the package state
-     * from disk before returning the information. The versionId parameter allows access to
-     * specific package versions.
-     */
-    get: operations["get-package"];
-    /**
-     * Delete a package
-     * @description Permanently deletes a package and all its associated resources including models,
-     * notebooks, databases, and metadata. This operation cannot be undone, so use with caution.
-     * The package must exist and be accessible for deletion.
-     */
-    delete: operations["delete-package"];
-    /**
-     * Update package configuration
-     * @description Updates the configuration and metadata of an existing package. This allows you to
-     * modify package settings, update the description, change the location, or update other
-     * package-level properties. The package must exist and be accessible.
-     */
-    patch: operations["update-package"];
-  };
-  "/environments/{environmentName}/packages/{packageName}/models": {
-    /**
-     * List package models
-     * @description Retrieves a list of all Malloy models within the specified package. Each model entry
-     * includes the relative path, package name, and any compilation errors. This endpoint
-     * is useful for discovering available models and checking their status.
-     */
-    get: operations["list-models"];
-  };
-  "/environments/{environmentName}/packages/{packageName}/models/{path}": {
-    /**
-     * Get compiled Malloy model
-     * @description Retrieves a compiled Malloy model with its source information, queries, and metadata.
-     * The model is compiled using the specified version of the Malloy compiler. This endpoint
-     * provides access to the model's structure, sources, and named queries for use in applications.
-     */
-    get: operations["get-model"];
-  };
-  "/environments/{environmentName}/packages/{packageName}/models/{path}/query": {
-    /**
-     * Execute Malloy query
-     * @description Executes a Malloy query against a model and returns the results. The query can be specified
-     * as a raw Malloy query string or by referencing a named query within the model. This endpoint
-     * supports both ad-hoc queries and predefined model queries, making it flexible for various
-     * use cases including data exploration, reporting, and application integration.
-     */
-    post: operations["execute-query-model"];
-  };
-  "/environments/{environmentName}/packages/{packageName}/models/{path}/compile": {
-    /**
-     * Compile Malloy source code
-     * @description Compiles Malloy source code in the context of a specific model file.
-     * The submitted source is appended to the full model content, giving it
-     * access to all sources, imports, and queries defined in the model.
-     * Relative imports resolve correctly against sibling model files.
-     * Returns compilation status and any problems (errors or warnings) found.
-     */
-    post: operations["compile-model-source"];
-  };
-  "/environments/{environmentName}/packages/{packageName}/notebooks": {
-    /**
-     * List package notebooks
-     * @description Retrieves a list of all Malloy notebooks within the specified package. Each notebook entry
-     * includes the relative path, package name, and any compilation errors. This endpoint
-     * is useful for discovering available notebooks and checking their status.
-     */
-    get: operations["list-notebooks"];
-  };
-  "/environments/{environmentName}/packages/{packageName}/notebooks/{path}": {
-    /**
-     * Get Malloy notebook cells
-     * @description Retrieves a Malloy notebook with its raw cell contents (markdown and code).
-     * Cell execution should be done separately via the execute-notebook-cell endpoint.
-     */
-    get: operations["get-notebook"];
-  };
-  "/environments/{environmentName}/packages/{packageName}/notebooks/{path}/cells/{cellIndex}": {
-    /**
-     * Execute a specific notebook cell
-     * @description Executes a specific cell in a Malloy notebook by index. For code cells, this compiles
-     * and runs the Malloy code, returning query results and any new sources defined.
-     * For markdown cells, this simply returns the cell content.
-     */
-    get: operations["execute-notebook-cell"];
-  };
-  "/environments/{environmentName}/packages/{packageName}/databases": {
-    /**
-     * List embedded databases
-     * @description Retrieves a list of all embedded databases within the specified package. These are typically
-     * DuckDB databases stored as .parquet files that provide local data storage for the package.
-     * Each database entry includes metadata about the database structure and content.
-     */
-    get: operations["list-databases"];
-  };
-  "/connections/test": {
-    /**
-     * Test database connection configuration
-     * @description Validates a database connection configuration without adding it to any environment.
-     * This endpoint allows you to test connection parameters, credentials, and network
-     * connectivity before committing the connection to an environment. Useful for troubleshooting
-     * connection issues and validating configurations during setup.
-     */
-    post: operations["test-connection-configuration"];
-  };
-  "/watch-mode/status": {
-    /**
-     * Get watch mode status
-     * @description Retrieves the current status of the file watching system. This includes whether watch mode
-     * is enabled, which environment is being watched, and the path being monitored. Useful for
-     * monitoring the development workflow and ensuring file changes are being detected.
-     */
-    get: operations["get-watch-status"];
-  };
-  "/watch-mode/start": {
-    /**
-     * Start file watching
-     * @description Initiates file watching for the specified environment. This enables real-time monitoring of
-     * file changes within the environment directory, allowing for automatic reloading and updates
-     * during development. Only one environment can be watched at a time.
-     */
-    post: operations["start-watching"];
-  };
-  "/watch-mode/stop": {
-    /**
-     * Stop file watching
-     * @description Stops the current file watching session. This disables real-time monitoring of file changes
-     * and releases system resources. Use this when development is complete or when switching
-     * to a different environment.
-     */
-    post: operations["stop-watching"];
-  };
-  "/environments/{environmentName}/packages/{packageName}/materializations": {
-    /**
-     * List materializations for a package
-     * @description Returns the materialization history for the package, ordered by most recent first.
-     */
-    get: operations["list-materializations"];
-    /**
-     * Create a materialization
-     * @description Creates a new materialization in PENDING state for all persist sources across all
-     * models in the package. Use POST .../materializations/{materializationId}?action=start to begin execution.
-     */
-    post: operations["create-materialization"];
-  };
-  "/environments/{environmentName}/packages/{packageName}/materializations/{materializationId}": {
-    /** Get a specific materialization */
-    get: operations["get-materialization"];
-    /**
-     * Perform an action on a materialization
-     * @description Performs an action on a materialization. The action is specified via
-     * the `action` query parameter:
-     *   * `start` - Transitions a PENDING materialization to RUNNING and begins execution in the background. Returns 202.
-     *   * `stop` - Cancels a PENDING or RUNNING materialization. Returns 200.
-     */
-    post: operations["materialization-action"];
-    /**
-     * Delete a materialization
-     * @description Deletes a terminal (SUCCESS, FAILED, or CANCELLED) materialization record.
-     */
-    delete: operations["delete-materialization"];
-  };
-  "/environments/{environmentName}/packages/{packageName}/manifest": {
-    /**
-     * Get the build manifest for a package
-     * @description Returns the current build manifest containing buildId-to-tableName mappings
-     * for all materialized sources in the package.
-     */
-    get: operations["get-manifest"];
-    /**
-     * Perform an action on the package manifest
-     * @description Performs an action on the package manifest. The action is specified via
-     * the `action` query parameter:
-     *   * `reload` - Reads the build manifest from the shared store (DuckLake
-     *     in orchestrated mode, local DuckDB in standalone mode) and recompiles
-     *     every model in the package so subsequent queries resolve persisted
-     *     sources to their materialized tables. Intended for orchestrated
-     *     workers that did not themselves run the build; the endpoint does
-     *     not write anything *into* storage.
-     */
-    post: operations["manifest-action"];
-  };
+   "/status": {
+      /**
+       * Get server status and health information
+       * @description Returns the current status of the Malloy Publisher server, including initialization state,
+       * available environments, and server timestamp. This endpoint is useful for health checks and
+       * monitoring server availability.
+       */
+      get: operations["get-status"];
+   };
+   "/environments": {
+      /**
+       * List all available environments
+       * @description Retrieves a list of all environments currently hosted on this Malloy Publisher server.
+       * Each environment contains metadata about its packages, connections, and configuration.
+       * This endpoint is typically used to discover available environments and their basic information.
+       */
+      get: operations["list-environments"];
+      /**
+       * Create a new environment
+       * @description Creates a new Malloy environment with the specified configuration. An environment serves as a
+       * container for packages, connections, and other resources. The environment will be initialized
+       * with the provided metadata and can immediately accept packages and connections.
+       */
+      post: operations["create-environment"];
+   };
+   "/environments/{environmentName}": {
+      /**
+       * Get environment details and metadata
+       * @description Retrieves detailed information about a specific environment, including its packages,
+       * connections, configuration, and metadata. The reload parameter can be used to
+       * refresh the environment state from disk before returning the information.
+       */
+      get: operations["get-environment"];
+      /**
+       * Delete an environment
+       * @description Permanently deletes an environment and all its associated resources including packages,
+       * connections, and metadata. This operation cannot be undone, so use with caution.
+       * The environment must exist and be accessible for deletion.
+       */
+      delete: operations["delete-environment"];
+      /**
+       * Update environment configuration
+       * @description Updates the configuration and metadata of an existing environment. This allows you to
+       * modify environment settings, update the README, change the location, or update other
+       * environment-level properties. The environment must exist and be accessible.
+       */
+      patch: operations["update-environment"];
+   };
+   "/environments/{environmentName}/connections": {
+      /**
+       * List environment database connections
+       * @description Retrieves a list of all database connections configured for the specified environment.
+       * Each connection includes its configuration, type, and status information. This endpoint
+       * is useful for discovering available data sources within an environment.
+       */
+      get: operations["list-connections"];
+   };
+   "/environments/{environmentName}/connections/{connectionName}": {
+      /**
+       * Get connection details
+       * @description Retrieves detailed information about a specific database connection within an environment.
+       * This includes connection configuration, credentials (if accessible), and metadata.
+       * Useful for inspecting connection settings and troubleshooting connectivity issues.
+       */
+      get: operations["get-connection"];
+      /**
+       * Create a new database connection
+       * @description Creates a new database connection in the specified environment.
+       */
+      post: operations["create-connection"];
+      /**
+       * Delete a database connection
+       * @description Permanently deletes a database connection from the environment.
+       */
+      delete: operations["delete-connection"];
+      /**
+       * Update an existing database connection
+       * @description Updates the configuration of an existing database connection.
+       */
+      patch: operations["update-connection"];
+   };
+   "/environments/{environmentName}/connections/{connectionName}/schemas": {
+      /**
+       * List database schemas
+       * @description Retrieves a list of all schemas (databases) available in the specified connection.
+       * Each schema includes metadata such as name, description, and whether it's the default schema.
+       * This endpoint is useful for exploring the database structure and discovering available data sources.
+       */
+      get: operations["list-schemas"];
+   };
+   "/environments/{environmentName}/connections/{connectionName}/schemas/{schemaName}/tables": {
+      /**
+       * List tables in database
+       * @description Retrieves a list of all tables and views available in the specified database schema.
+       * This endpoint is useful for discovering available data sources and exploring the database
+       * structure. The schema must exist in the connection for this operation to succeed.
+       */
+      get: operations["list-tables"];
+   };
+   "/environments/{environmentName}/connections/{connectionName}/schemas/{schemaName}/tables/{tablePath}": {
+      /**
+       * Get table details from database
+       * @description Retrieves a table from the specified database schema.
+       * This endpoint is useful for discovering available data sources and exploring the database
+       * structure. The schema must exist in the connection for this operation to succeed.
+       * The tablePath is the full path to the table, including the schema name.
+       */
+      get: operations["get-table"];
+   };
+   "/environments/{environmentName}/connections/{connectionName}/sqlSource": {
+      /**
+       * Get SQL source (deprecated)
+       * @deprecated
+       * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
+       * Use the POST version instead for better security and functionality.
+       *
+       * Creates a Malloy source from a SQL statement using the specified connection.
+       * The SQL statement is executed to generate a source definition that can be used in Malloy models.
+       */
+      get: operations["get-sqlsource"];
+      /**
+       * Create SQL source from statement
+       * @description Creates a Malloy source from a SQL statement using the specified database connection.
+       * The SQL statement is executed to generate a source definition that can be used in Malloy models.
+       */
+      post: operations["post-sqlsource"];
+   };
+   "/environments/{environmentName}/connections/{connectionName}/sqlQuery": {
+      /**
+       * Execute SQL query
+       * @description Executes a SQL statement against the specified database connection and returns the results.
+       * The results include data, metadata, and execution information.
+       */
+      post: operations["post-querydata"];
+   };
+   "/environments/{environmentName}/connections/{connectionName}/sqlTemporaryTable": {
+      /**
+       * Create temporary table
+       * @description Creates a temporary table from a SQL statement using the specified database connection.
+       * Temporary tables are useful for storing intermediate results during complex queries and data processing workflows.
+       */
+      post: operations["post-temporarytable"];
+   };
+   "/environments/{environmentName}/connections/{connectionName}/temporaryTable": {
+      /**
+       * Create temporary table (deprecated)
+       * @deprecated
+       * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
+       * Use the POST version instead for better security and functionality.
+       *
+       * Creates a temporary table from a SQL statement using the specified connection.
+       * Temporary tables are useful for storing intermediate results during complex queries.
+       */
+      get: operations["get-temporarytable"];
+   };
+   "/environments/{environmentName}/connections/{connectionName}/queryData": {
+      /**
+       * Execute SQL query (deprecated)
+       * @deprecated
+       * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
+       * Use the POST version instead for better security and functionality.
+       *
+       * Executes a SQL statement against the specified database connection and returns the results.
+       * The query results include data, metadata, and execution information.
+       */
+      get: operations["get-querydata"];
+   };
+   "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/schemas": {
+      /**
+       * List database schemas (per-package)
+       * @description Retrieves a list of all schemas (databases) available in the specified
+       * connection, resolved in the context of the named package. Required for
+       * `connectionName="duckdb"`, which is per-package; works for any other
+       * connection name as well (resolution falls through to the environment).
+       */
+      get: operations["list-schemas-in-package"];
+   };
+   "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/schemas/{schemaName}/tables": {
+      /**
+       * List tables in database (per-package)
+       * @description Retrieves a list of all tables and views available in the specified
+       * database schema, resolved in the context of the named package.
+       */
+      get: operations["list-tables-in-package"];
+   };
+   "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/schemas/{schemaName}/tables/{tablePath}": {
+      /**
+       * Get table details from database (per-package)
+       * @description Retrieves a table from the specified database schema, resolved in
+       * the context of the named package.
+       */
+      get: operations["get-table-in-package"];
+   };
+   "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/sqlSource": {
+      /**
+       * Get SQL source (per-package, deprecated)
+       * @deprecated
+       * @description **DEPRECATED**: Use the POST version instead.
+       *
+       * Creates a Malloy source from a SQL statement using the specified
+       * connection, resolved in the context of the named package.
+       */
+      get: operations["get-sqlsource-in-package"];
+      /**
+       * Create SQL source from statement (per-package)
+       * @description Creates a Malloy source from a SQL statement using the specified
+       * connection, resolved in the context of the named package.
+       */
+      post: operations["post-sqlsource-in-package"];
+   };
+   "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/sqlQuery": {
+      /**
+       * Execute SQL query (per-package)
+       * @description Executes a SQL statement against the specified database connection,
+       * resolved in the context of the named package, and returns the results.
+       */
+      post: operations["post-querydata-in-package"];
+   };
+   "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/sqlTemporaryTable": {
+      /**
+       * Create temporary table (per-package)
+       * @description Creates a temporary table from a SQL statement using the specified
+       * database connection, resolved in the context of the named package.
+       */
+      post: operations["post-temporarytable-in-package"];
+   };
+   "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/temporaryTable": {
+      /**
+       * Create temporary table (per-package, deprecated)
+       * @deprecated
+       * @description **DEPRECATED**: Use the POST version instead.
+       *
+       * Creates a temporary table from a SQL statement using the specified
+       * connection, resolved in the context of the named package.
+       */
+      get: operations["get-temporarytable-in-package"];
+   };
+   "/environments/{environmentName}/packages/{packageName}/connections/{connectionName}/queryData": {
+      /**
+       * Execute SQL query (per-package, deprecated)
+       * @deprecated
+       * @description **DEPRECATED**: Use the POST version instead.
+       *
+       * Executes a SQL statement against the specified database connection,
+       * resolved in the context of the named package, and returns the results.
+       */
+      get: operations["get-querydata-in-package"];
+   };
+   "/environments/{environmentName}/packages": {
+      /**
+       * List environment packages
+       * @description Retrieves a list of all Malloy packages within the specified environment. Each package
+       * contains models, notebooks, databases, and other resources. This endpoint is useful
+       * for discovering available packages and their basic metadata.
+       */
+      get: operations["list-packages"];
+      /**
+       * Create a new package
+       * @description Creates a new Malloy package within the specified environment. A package serves as a
+       * container for models, notebooks, embedded databases, and other resources. The package
+       * will be initialized with the provided metadata and can immediately accept content.
+       */
+      post: operations["create-package"];
+   };
+   "/environments/{environmentName}/packages/{packageName}": {
+      /**
+       * Get package details and metadata
+       * @description Retrieves detailed information about a specific package, including its models, notebooks,
+       * databases, and metadata. The reload parameter can be used to refresh the package state
+       * from disk before returning the information. The versionId parameter allows access to
+       * specific package versions.
+       */
+      get: operations["get-package"];
+      /**
+       * Delete a package
+       * @description Permanently deletes a package and all its associated resources including models,
+       * notebooks, databases, and metadata. This operation cannot be undone, so use with caution.
+       * The package must exist and be accessible for deletion.
+       */
+      delete: operations["delete-package"];
+      /**
+       * Update package configuration
+       * @description Updates the configuration and metadata of an existing package. This allows you to
+       * modify package settings, update the description, change the location, or update other
+       * package-level properties. The package must exist and be accessible.
+       */
+      patch: operations["update-package"];
+   };
+   "/environments/{environmentName}/packages/{packageName}/models": {
+      /**
+       * List package models
+       * @description Retrieves a list of all Malloy models within the specified package. Each model entry
+       * includes the relative path, package name, and any compilation errors. This endpoint
+       * is useful for discovering available models and checking their status.
+       */
+      get: operations["list-models"];
+   };
+   "/environments/{environmentName}/packages/{packageName}/models/{path}": {
+      /**
+       * Get compiled Malloy model
+       * @description Retrieves a compiled Malloy model with its source information, queries, and metadata.
+       * The model is compiled using the specified version of the Malloy compiler. This endpoint
+       * provides access to the model's structure, sources, and named queries for use in applications.
+       */
+      get: operations["get-model"];
+   };
+   "/environments/{environmentName}/packages/{packageName}/models/{path}/query": {
+      /**
+       * Execute Malloy query
+       * @description Executes a Malloy query against a model and returns the results. The query can be specified
+       * as a raw Malloy query string or by referencing a named query within the model. This endpoint
+       * supports both ad-hoc queries and predefined model queries, making it flexible for various
+       * use cases including data exploration, reporting, and application integration.
+       */
+      post: operations["execute-query-model"];
+   };
+   "/environments/{environmentName}/packages/{packageName}/models/{path}/compile": {
+      /**
+       * Compile Malloy source code
+       * @description Compiles Malloy source code in the context of a specific model file.
+       * The submitted source is appended to the full model content, giving it
+       * access to all sources, imports, and queries defined in the model.
+       * Relative imports resolve correctly against sibling model files.
+       * Returns compilation status and any problems (errors or warnings) found.
+       */
+      post: operations["compile-model-source"];
+   };
+   "/environments/{environmentName}/packages/{packageName}/notebooks": {
+      /**
+       * List package notebooks
+       * @description Retrieves a list of all Malloy notebooks within the specified package. Each notebook entry
+       * includes the relative path, package name, and any compilation errors. This endpoint
+       * is useful for discovering available notebooks and checking their status.
+       */
+      get: operations["list-notebooks"];
+   };
+   "/environments/{environmentName}/packages/{packageName}/notebooks/{path}": {
+      /**
+       * Get Malloy notebook cells
+       * @description Retrieves a Malloy notebook with its raw cell contents (markdown and code).
+       * Cell execution should be done separately via the execute-notebook-cell endpoint.
+       */
+      get: operations["get-notebook"];
+   };
+   "/environments/{environmentName}/packages/{packageName}/notebooks/{path}/cells/{cellIndex}": {
+      /**
+       * Execute a specific notebook cell
+       * @description Executes a specific cell in a Malloy notebook by index. For code cells, this compiles
+       * and runs the Malloy code, returning query results and any new sources defined.
+       * For markdown cells, this simply returns the cell content.
+       */
+      get: operations["execute-notebook-cell"];
+   };
+   "/environments/{environmentName}/packages/{packageName}/databases": {
+      /**
+       * List embedded databases
+       * @description Retrieves a list of all embedded databases within the specified package. These are typically
+       * DuckDB databases stored as .parquet files that provide local data storage for the package.
+       * Each database entry includes metadata about the database structure and content.
+       */
+      get: operations["list-databases"];
+   };
+   "/connections/test": {
+      /**
+       * Test database connection configuration
+       * @description Validates a database connection configuration without adding it to any environment.
+       * This endpoint allows you to test connection parameters, credentials, and network
+       * connectivity before committing the connection to an environment. Useful for troubleshooting
+       * connection issues and validating configurations during setup.
+       */
+      post: operations["test-connection-configuration"];
+   };
+   "/watch-mode/status": {
+      /**
+       * Get watch mode status
+       * @description Retrieves the current status of the file watching system. This includes whether watch mode
+       * is enabled, which environment is being watched, and the path being monitored. Useful for
+       * monitoring the development workflow and ensuring file changes are being detected.
+       */
+      get: operations["get-watch-status"];
+   };
+   "/watch-mode/start": {
+      /**
+       * Start file watching
+       * @description Initiates file watching for the specified environment. This enables real-time monitoring of
+       * file changes within the environment directory, allowing for automatic reloading and updates
+       * during development. Only one environment can be watched at a time.
+       */
+      post: operations["start-watching"];
+   };
+   "/watch-mode/stop": {
+      /**
+       * Stop file watching
+       * @description Stops the current file watching session. This disables real-time monitoring of file changes
+       * and releases system resources. Use this when development is complete or when switching
+       * to a different environment.
+       */
+      post: operations["stop-watching"];
+   };
+   "/environments/{environmentName}/packages/{packageName}/materializations": {
+      /**
+       * List materializations for a package
+       * @description Returns the materialization history for the package, ordered by most recent first.
+       */
+      get: operations["list-materializations"];
+      /**
+       * Create a materialization
+       * @description Creates a new materialization in PENDING state for all persist sources across all
+       * models in the package. Use POST .../materializations/{materializationId}?action=start to begin execution.
+       */
+      post: operations["create-materialization"];
+   };
+   "/environments/{environmentName}/packages/{packageName}/materializations/{materializationId}": {
+      /** Get a specific materialization */
+      get: operations["get-materialization"];
+      /**
+       * Perform an action on a materialization
+       * @description Performs an action on a materialization. The action is specified via
+       * the `action` query parameter:
+       *   * `start` - Transitions a PENDING materialization to RUNNING and begins execution in the background. Returns 202.
+       *   * `stop` - Cancels a PENDING or RUNNING materialization. Returns 200.
+       */
+      post: operations["materialization-action"];
+      /**
+       * Delete a materialization
+       * @description Deletes a terminal (SUCCESS, FAILED, or CANCELLED) materialization record.
+       */
+      delete: operations["delete-materialization"];
+   };
+   "/environments/{environmentName}/packages/{packageName}/manifest": {
+      /**
+       * Get the build manifest for a package
+       * @description Returns the current build manifest containing buildId-to-tableName mappings
+       * for all materialized sources in the package.
+       */
+      get: operations["get-manifest"];
+      /**
+       * Perform an action on the package manifest
+       * @description Performs an action on the package manifest. The action is specified via
+       * the `action` query parameter:
+       *   * `reload` - Reads the build manifest from the shared store (DuckLake
+       *     in orchestrated mode, local DuckDB in standalone mode) and recompiles
+       *     every model in the package so subsequent queries resolve persisted
+       *     sources to their materialized tables. Intended for orchestrated
+       *     workers that did not themselves run the build; the endpoint does
+       *     not write anything *into* storage.
+       */
+      post: operations["manifest-action"];
+   };
 }
 
 export type webhooks = Record<string, never>;
 
 export interface components {
-  schemas: {
-    /** @description Standard identifier pattern for resource names */
-    IdentifierPattern: string;
-    /** @description Version identifier pattern supporting dots and dashes */
-    VersionIdPattern: string;
-    /** @description Path pattern supporting slashes, dots, and dashes */
-    PathPattern: string;
-    /** @description Current server status and health information */
-    ServerStatus: {
-      /** @description Unix timestamp of the status check */
-      timestamp?: number;
-      /** @description List of available environments */
-      environments?: components["schemas"]["Environment"][];
-      /** @description Whether the server is fully initialized and ready to serve requests */
-      initialized?: boolean;
-      /**
-       * @description Status of the server; initializing when the server is loading environments, packages and connections, serving when the server is initialized and ready to serve requests, degraded when initialization completed but one or more environments failed to load (the surviving environments are served; see failedEnvironments), and draining when the server is going to shut down
-       * @enum {string}
-       */
-      operationalState?: "initializing" | "serving" | "degraded" | "draining";
-      /** @description Environments that failed to initialize. Present only when operationalState is "degraded". Healthy environments are listed under "environments". */
-      failedEnvironments?: {
-          /** @description Environment name as declared in publisher.config.json */
-          name: string;
-          /** @description Error message from the initialization failure */
-          error: string;
-        }[];
-      /** @description Whether the server configuration is frozen (read-only mode). When true, all mutation operations are disabled. */
-      frozenConfig?: boolean;
-    };
-    /** @description Represents a Malloy environment containing packages, connections, and other resources */
-    Environment: {
-      /** @description Resource path to the environment */
-      resource?: string;
-      /** @description Environment name */
-      name?: string;
-      /** @description Environment README content */
-      readme?: string;
-      /** @description Environment location, can be an absolute path or URI (e.g. github, s3, gcs, etc.) */
-      location?: string;
-      /** @description List of database connections configured for this environment */
-      connections?: components["schemas"]["Connection"][];
-      /** @description List of Malloy packages in this environment */
-      packages?: components["schemas"]["Package"][];
-      /** @description Optional DuckLake-backed storage for materialization manifests (orchestrated mode). When set, manifests are stored in a shared DuckLake catalog instead of the local DuckDB database. */
-      materializationStorage?: {
-        /** @description PostgreSQL connection URL for the DuckLake catalog metadata store */
-        catalogUrl?: string;
-        /** @description Cloud storage path (s3:// or gs://) for DuckLake data files */
-        dataPath?: string;
-      } | null;
-    };
-    /** @description Represents a Malloy package containing models, notebooks, and embedded databases */
-    Package: {
-      /** @description Resource path to the package */
-      resource?: string;
-      /** @description Package name */
-      name?: string;
-      /** @description Package description */
-      description?: string;
-      /** @description Package location, can be an absolute path or URI (e.g. github, s3, gcs, etc.) */
-      location?: string;
-    };
-    /** @description Malloy model metadata and status information */
-    Model: {
-      /** @description Resource path to the model */
-      resource?: string;
-      /** @description Name of the package containing this model */
-      packageName?: string;
-      /** @description Relative path to the model file within its package directory */
-      path?: string;
-      /** @description Error message if the model failed to compile or load */
-      error?: string;
-    };
-    /** @description Malloy notebook metadata and status information */
-    Notebook: {
-      /** @description Resource path to the notebook */
-      resource?: string;
-      /** @description Name of the package containing this notebook */
-      packageName?: string;
-      /** @description Relative path to the notebook file within its package directory */
-      path?: string;
-      /** @description Error message if the notebook failed to compile or load */
-      error?: string;
-    };
-    /** @description Raw Malloy notebook with unexecuted cell contents */
-    RawNotebook: {
-      /** @description Resource path to the notebook */
-      resource?: string;
-      /** @description Name of the package containing this notebook */
-      packageName?: string;
-      /** @description Relative path to the notebook file within its package directory */
-      path?: string;
-      /** @description Version of the Malloy compiler used to generate the notebook data */
-      malloyVersion?: string;
-      /** @description Array of notebook cells containing raw markdown and code content */
-      notebookCells?: components["schemas"]["NotebookCell"][];
-      /** @description Array of file-level (##) annotations attached to the notebook */
-      annotations?: string[];
-      /** @description Sources defined in the notebook's model */
-      sources?: components["schemas"]["Source"][];
-    };
-    /** @description Compiled Malloy model with sources, queries, and metadata */
-    CompiledModel: {
-      /** @description Resource path to the model */
-      resource?: string;
-      /** @description Name of the package containing this model */
-      packageName?: string;
-      /** @description Relative path to the model file within its package directory */
-      path?: string;
-      /** @description Version of the Malloy compiler used to generate the model data */
-      malloyVersion?: string;
-      /** @description JSON string containing model metadata and structure information */
-      modelInfo?: string;
-      /** @description Array of JSON strings containing source information for each data source */
-      sourceInfos?: string[];
-      /** @description Array of named queries defined in the model */
-      queries?: components["schemas"]["Query"][];
-      /** @description Sources defined in this model */
-      sources?: components["schemas"]["Source"][];
-    };
-    /** @description Named model view definition */
-    View: {
-      /** @description Name of the view */
-      name?: string;
-      /** @description Annotations attached to the view */
-      annotations?: string[];
-    };
-    /** @description Named model query definition */
-    Query: {
-      /** @description Name of the query */
-      name?: string;
-      /** @description Name of the source this query operates on */
-      sourceName?: string;
-      /** @description Annotations attached to the query */
-      annotations?: string[];
-    };
-    /** @description A filter declared via */
-    Filter: {
-      /** @description Display name of the filter */
-      name?: string;
-      /** @description Dimension this filter targets */
-      dimension?: string;
-      /**
-       * @description Comparator type
-       * @enum {string}
-       */
-      type?: "equal" | "in" | "like" | "greater_than" | "less_than";
-      /** @description Whether this filter is hidden from users */
-      implicit?: boolean;
-      /** @description Whether a value must be provided */
-      required?: boolean;
-      /** @description Malloy data type of the dimension (e.g. string, number, boolean, date, timestamp) */
-      dimensionType?: string;
-    };
-    /** @description A Malloy source defined in a model */
-    Source: {
-      /** @description Name of the source */
-      name?: string;
-      /** @description Annotations attached to the source */
-      annotations?: string[];
-      /** @description Views defined in this source */
-      views?: components["schemas"]["View"][];
-      /** @description Filters declared on this source via */
-      filters?: components["schemas"]["Filter"][];
-    };
-    /** @description Request body for executing a Malloy query */
-    QueryRequest: {
-      /** @description Query string to execute on the model. If the query parameter is set, the queryName parameter must be empty. */
-      query?: string;
-      /** @description Name of the source in the model to use for queryName, search, and topValue requests. */
-      sourceName?: string;
-      /** @description Name of a query to execute on a source in the model. Requires the sourceName parameter is set. If the queryName parameter is set, the query parameter must be empty. */
-      queryName?: string;
-      /**
-       * @description If true, returns a simple JSON array of row objects in the form {"columnName": value}. If false (default), returns the full Malloy result with type metadata for rendering.
-       * @default false
-       */
-      compactJson?: boolean;
-      /** @description Version ID */
-      versionId?: string;
-      /** @description Filter parameter values keyed by filter name. Used with sources that declare \#(filter) annotations. Each value is either a string or an array of strings. */
-      filterParams?: {
-        [key: string]: unknown;
+   schemas: {
+      /** @description Standard identifier pattern for resource names */
+      IdentifierPattern: string;
+      /** @description Version identifier pattern supporting dots and dashes */
+      VersionIdPattern: string;
+      /** @description Path pattern supporting slashes, dots, and dashes */
+      PathPattern: string;
+      /** @description Current server status and health information */
+      ServerStatus: {
+         /** @description Unix timestamp of the status check */
+         timestamp?: number;
+         /** @description List of available environments */
+         environments?: components["schemas"]["Environment"][];
+         /** @description Whether the server is fully initialized and ready to serve requests */
+         initialized?: boolean;
+         /**
+          * @description Status of the server; initializing when the server is loading environments, packages and connections, serving when the server is initialized and ready to serve requests, degraded when initialization completed but one or more environments failed to load (the surviving environments are served; see failedEnvironments), and draining when the server is going to shut down
+          * @enum {string}
+          */
+         operationalState?:
+            | "initializing"
+            | "serving"
+            | "degraded"
+            | "draining";
+         /** @description Environments that failed to initialize. Present only when operationalState is "degraded". Healthy environments are listed under "environments". */
+         failedEnvironments?: {
+            /** @description Environment name as declared in publisher.config.json */
+            name: string;
+            /** @description Error message from the initialization failure */
+            error: string;
+         }[];
+         /** @description Whether the server configuration is frozen (read-only mode). When true, all mutation operations are disabled. */
+         frozenConfig?: boolean;
       };
-      /**
-       * @description When true, skip server-side \#(filter) injection entirely.
-       * @default false
-       */
-      bypassFilters?: boolean;
-      /** @description Per-query given values that override model defaults. Keys are given names declared in the model's `given:` block. Values must match the declared type (string, number, boolean, date, etc.). See Malloy givens documentation for accepted value shapes. */
-      givens?: {
-        [key: string]: unknown;
+      /** @description Represents a Malloy environment containing packages, connections, and other resources */
+      Environment: {
+         /** @description Resource path to the environment */
+         resource?: string;
+         /** @description Environment name */
+         name?: string;
+         /** @description Environment README content */
+         readme?: string;
+         /** @description Environment location, can be an absolute path or URI (e.g. github, s3, gcs, etc.) */
+         location?: string;
+         /** @description List of database connections configured for this environment */
+         connections?: components["schemas"]["Connection"][];
+         /** @description List of Malloy packages in this environment */
+         packages?: components["schemas"]["Package"][];
+         /** @description Optional DuckLake-backed storage for materialization manifests (orchestrated mode). When set, manifests are stored in a shared DuckLake catalog instead of the local DuckDB database. */
+         materializationStorage?: {
+            /** @description PostgreSQL connection URL for the DuckLake catalog metadata store */
+            catalogUrl?: string;
+            /** @description Cloud storage path (s3:// or gs://) for DuckLake data files */
+            dataPath?: string;
+         } | null;
       };
-    };
-    /** @description Individual cell within a Malloy notebook */
-    NotebookCell: {
-      /**
-       * @description Type of notebook cell
-       * @enum {string}
-       */
-      type?: "markdown" | "code";
-      /** @description Text contents of the notebook cell (either markdown or Malloy code) */
-      text?: string;
-      /** @description Array of JSON strings containing SourceInfo objects made available in this cell */
-      newSources?: string[];
-      /** @description JSON string containing QueryInfo object for the query in this cell (if the cell contains a query) */
-      queryInfo?: string;
-    };
-    /** @description Result of executing a notebook cell */
-    NotebookCellResult: {
-      /**
-       * @description Type of notebook cell
-       * @enum {string}
-       */
-      type?: "markdown" | "code";
-      /** @description Text contents of the notebook cell */
-      text?: string;
-      /** @description JSON string containing the execution result for this cell */
-      result?: string;
-      /** @description Array of JSON strings containing SourceInfo objects made available in this cell */
-      newSources?: string[];
-    };
-    /** @description Results from executing a Malloy query */
-    QueryResult: {
-      /** @description JSON string containing the query results, metadata, and execution information */
-      result?: string;
-      /** @description Resource path to the query result */
-      resource?: string;
-      /** @description Render tag validation messages (errors, warnings) detected during query preparation */
-      renderLogs?: components["schemas"]["LogMessage"][];
-    };
-    /** @description A log message from render tag validation */
-    LogMessage: {
-      /** @description URL of the source file related to this message */
-      url?: string;
-      /** @description Source location range for this message */
-      range?: {
-        start?: {
-          line?: number;
-          character?: number;
-        };
-        end?: {
-          line?: number;
-          character?: number;
-        };
+      /** @description Represents a Malloy package containing models, notebooks, and embedded databases */
+      Package: {
+         /** @description Resource path to the package */
+         resource?: string;
+         /** @description Package name */
+         name?: string;
+         /** @description Package description */
+         description?: string;
+         /** @description Package location, can be an absolute path or URI (e.g. github, s3, gcs, etc.) */
+         location?: string;
       };
-      /**
-       * @description Severity level of the log message
-       * @enum {string}
-       */
-      severity?: "debug" | "info" | "warn" | "error";
-      /** @description Human-readable log message */
-      message?: string;
-    };
-    /** @description Embedded database within a Malloy package */
-    Database: {
-      /** @description Resource path to the database */
-      resource?: string;
-      /** @description Relative path to the database file within its package directory */
-      path?: string;
-      info?: components["schemas"]["TableDescription"];
-      /**
-       * @description Type of embedded database
-       * @enum {string}
-       */
-      type?: "embedded" | "materialized";
-    };
-    /** @description A schema name in a Connection. */
-    Schema: {
-      /** @description Name of the schema */
-      name?: string;
-      /** @description Description of the schema */
-      description?: string;
-      /** @description Whether this schema is the default schema */
-      isDefault?: boolean;
-      /** @description Whether this schema is hidden */
-      isHidden?: boolean;
-    };
-    /** @description Database connection configuration and metadata */
-    Connection: {
-      /** @description Resource path to the connection */
-      resource?: string;
-      /** @description Name of the connection */
-      name?: string;
-      /**
-       * @description Type of database connection
-       * @enum {string}
-       */
-      type?: "postgres" | "bigquery" | "snowflake" | "trino" | "databricks" | "mysql" | "duckdb" | "motherduck" | "ducklake";
-      attributes?: components["schemas"]["ConnectionAttributes"];
-      postgresConnection?: components["schemas"]["PostgresConnection"];
-      bigqueryConnection?: components["schemas"]["BigqueryConnection"];
-      snowflakeConnection?: components["schemas"]["SnowflakeConnection"];
-      trinoConnection?: components["schemas"]["TrinoConnection"];
-      databricksConnection?: components["schemas"]["DatabricksConnection"];
-      mysqlConnection?: components["schemas"]["MysqlConnection"];
-      duckdbConnection?: components["schemas"]["DuckdbConnection"];
-      motherduckConnection?: components["schemas"]["MotherDuckConnection"];
-      ducklakeConnection?: components["schemas"]["DucklakeConnection"];
-    };
-    /** @description Connection capabilities and configuration attributes */
-    ConnectionAttributes: {
-      /** @description SQL dialect name for the connection */
-      dialectName?: string;
-      /** @description Whether the connection uses connection pooling */
-      isPool?: boolean;
-      /** @description Whether the connection supports persistent storage operations */
-      canPersist?: boolean;
-      /** @description Whether the connection supports streaming query results */
-      canStream?: boolean;
-    };
-    /** @description PostgreSQL database connection configuration */
-    PostgresConnection: {
-      /** @description PostgreSQL server hostname or IP address */
-      host?: string;
-      /** @description PostgreSQL server port number */
-      port?: number;
-      /** @description Name of the PostgreSQL database */
-      databaseName?: string;
-      /** @description PostgreSQL username for authentication */
-      userName?: string;
-      /** @description PostgreSQL password for authentication */
-      password?: string;
-      /** @description Complete PostgreSQL connection string (alternative to individual parameters) */
-      connectionString?: string;
-    };
-    /** @description MySQL database connection configuration */
-    MysqlConnection: {
-      /** @description MySQL server hostname or IP address */
-      host?: string;
-      /** @description MySQL server port number */
-      port?: number;
-      /** @description Name of the MySQL database */
-      database?: string;
-      /** @description MySQL username for authentication */
-      user?: string;
-      /** @description MySQL password for authentication */
-      password?: string;
-    };
-    /** @description Google Cloud Storage connection configuration for DuckDB */
-    GCSConnection: {
-      /** @description GCS HMAC access key ID */
-      keyId: string;
-      /** @description GCS HMAC secret key */
-      secret: string;
-    };
-    /** @description AWS S3 connection configuration for DuckDB */
-    S3Connection: {
-      /** @description AWS access key ID */
-      accessKeyId: string;
-      /** @description AWS secret access key */
-      secretAccessKey: string;
-      /**
-       * @description AWS region (e.g., us-east-1)
-       * @default us-east-1
-       */
-      region?: string;
-      /** @description Custom S3-compatible endpoint URL (optional, for MinIO, etc.) */
-      endpoint?: string;
-      /** @description AWS session token for temporary credentials (optional) */
-      sessionToken?: string;
-    };
-    /** @description Azure Data Lake Storage (ADLS Gen2) / Blob Storage connection configuration Supports https://, http://, abfss://, and az:// URL schemes. */
-    AzureConnection: {
-      /**
-       * @description Authentication method for Azure Storage
-       * @enum {string}
-       */
-      authType: "service_principal" | "sas_token";
-      /** @description Full SAS URL including token; required for sas_token auth. Supports single file, directory glob (*.ext), or recursive (**) patterns. Example: https://account.blob.core.windows.net/container/path/*.parquet?sp=rl&st=... */
-      sasUrl?: string;
-      /** @description Azure AD tenant ID (required for service_principal) */
-      tenantId?: string;
-      /** @description Azure AD application (client) ID (required for service_principal) */
-      clientId?: string;
-      /** @description Azure AD client secret (required for service_principal) */
-      clientSecret?: string;
-      /** @description Azure Storage account name (required for service_principal) */
-      accountName?: string;
-      /** @description Azure file URL to query; required for service_principal auth. Supports single file, directory glob (*.ext), or recursive (**) patterns. Example: https://account.blob.core.windows.net/container/path/** */
-      fileUrl?: string;
-    };
-    /** @description DuckLake lakehouse connection configuration */
-    DucklakeConnection: {
-      /** @description Data storage connection configuration (S3 or GCS) */
-      storage: {
-        /** @description URL of the storage bucket (e.g. s3://my-bucket/path or gs://my-bucket/path) */
-        bucketUrl: string;
-        /** @description AWS S3 connection configuration for data storage */
-        s3Connection?: components["schemas"]["S3Connection"];
-        /** @description Google Cloud Storage connection configuration for data storage */
-        gcsConnection?: components["schemas"]["GCSConnection"];
+      /** @description Malloy model metadata and status information */
+      Model: {
+         /** @description Resource path to the model */
+         resource?: string;
+         /** @description Name of the package containing this model */
+         packageName?: string;
+         /** @description Relative path to the model file within its package directory */
+         path?: string;
+         /** @description Error message if the model failed to compile or load */
+         error?: string;
       };
-      /** @description Catalog metadata connection configuration */
-      catalog: {
-        /** @description PostgreSQL connection for DuckLake metadata catalog */
-        postgresConnection: components["schemas"]["PostgresConnection"];
+      /** @description Malloy notebook metadata and status information */
+      Notebook: {
+         /** @description Resource path to the notebook */
+         resource?: string;
+         /** @description Name of the package containing this notebook */
+         packageName?: string;
+         /** @description Relative path to the notebook file within its package directory */
+         path?: string;
+         /** @description Error message if the notebook failed to compile or load */
+         error?: string;
       };
-    };
-    /** @description Google BigQuery database connection configuration */
-    BigqueryConnection: {
-      /** @description Default BigQuery project ID for queries */
-      defaultProjectId?: string;
-      /** @description BigQuery project ID for billing purposes */
-      billingProjectId?: string;
-      /** @description BigQuery dataset location/region */
-      location?: string;
-      /** @description JSON string containing Google Cloud service account credentials */
-      serviceAccountKeyJson?: string;
-      /** @description Maximum bytes to bill for query execution (prevents runaway costs) */
-      maximumBytesBilled?: string;
-      /** @description Query timeout in milliseconds */
-      queryTimeoutMilliseconds?: string;
-    };
-    /** @description Snowflake database connection configuration */
-    SnowflakeConnection: {
-      /** @description Snowflake account identifier */
-      account?: string;
-      /** @description Snowflake username for authentication */
-      username?: string;
-      /** @description Snowflake password for authentication */
-      password?: string;
-      /** @description Snowflake private key for authentication */
-      privateKey?: string;
-      /** @description Passphrase for the Snowflake private key */
-      privateKeyPass?: string;
-      /** @description Snowflake warehouse name */
-      warehouse?: string;
-      /** @description Snowflake database name */
-      database?: string;
-      /** @description Snowflake schema name */
-      schema?: string;
-      /** @description Snowflake role name */
-      role?: string;
-      /** @description Query response timeout in milliseconds */
-      responseTimeoutMilliseconds?: number;
-    };
-    /** @description Trino database connection configuration */
-    TrinoConnection: {
-      /** @description Trino server hostname or IP address */
-      server?: string;
-      /** @description Trino server port number */
-      port?: number;
-      /** @description Trino catalog name */
-      catalog?: string;
-      /** @description Trino schema name */
-      schema?: string;
-      /** @description Trino username for authentication */
-      user?: string;
-      /** @description Trino password for authentication */
-      password?: string;
-      /** @description Peaka API key for authentication with Peaka-hosted Trino clusters */
-      peakaKey?: string;
-    };
-    /** @description Databricks SQL warehouse connection configuration */
-    DatabricksConnection: {
-      /** @description Databricks workspace host (e.g. dbc-xxxxxxxx-xxxx.cloud.databricks.com) */
-      host?: string;
-      /** @description SQL warehouse HTTP path (e.g. /sql/1.0/warehouses/<warehouse-id>) */
-      path?: string;
-      /** @description Personal access token for authentication */
-      token?: string;
-      /** @description OAuth M2M client ID (service principal) */
-      oauthClientId?: string;
-      /** @description OAuth M2M client secret (service principal) */
-      oauthClientSecret?: string;
-      /** @description Default Unity Catalog to use for queries */
-      defaultCatalog?: string;
-      /** @description Default schema to use for queries */
-      defaultSchema?: string;
-      /** @description SQL statements to run when the connection is established */
-      setupSQL?: string;
-    };
-    /** @description MotherDuck database connection configuration */
-    MotherDuckConnection: {
-      /** @description MotherDuck access token */
-      accessToken?: string;
-      /** @description MotherDuck database name */
-      database?: string;
-    };
-    /** @description DuckDB database connection configuration. Publisher intentionally exposes only data-source intent here. Database files, working directories, filesystem/network policy, extension loading, setup SQL, temp directories, and resource knobs are owned by Publisher so environment configs cannot widen deployment policy through low-level DuckDB settings. */
-    DuckdbConnection: {
-      attachedDatabases?: components["schemas"]["AttachedDatabase"][];
-    };
-    /** @description Attached DuckDB database */
-    AttachedDatabase: {
-      /** @example test_connection, _connection, test_connection_1 */
-      name?: string;
-      /**
-       * @description Type of database connection
-       * @enum {string}
-       */
-      type?: "bigquery" | "snowflake" | "postgres" | "gcs" | "s3" | "azure";
-      attributes?: components["schemas"]["ConnectionAttributes"];
-      bigqueryConnection?: components["schemas"]["BigqueryConnection"];
-      snowflakeConnection?: components["schemas"]["SnowflakeConnection"];
-      postgresConnection?: components["schemas"]["PostgresConnection"];
-      gcsConnection?: components["schemas"]["GCSConnection"];
-      s3Connection?: components["schemas"]["S3Connection"];
-      azureConnection?: components["schemas"]["AzureConnection"];
-    };
-    SqlSource: {
-      /** @description Resource path to the sql source. */
-      resource?: string;
-      source?: string;
-    };
-    Table: {
-      /** @description Resource path to the table. */
-      resource?: string;
-      /** @description Table source as a JSON string. */
-      source?: string;
-      /** @description Table fields */
-      columns?: components["schemas"]["Column"][];
-    };
-    /** @deprecated */
-    TableSource: {
-      /** @description Resource path to the table source. */
-      resource?: string;
-      source?: string;
-      /** @description Table fields */
-      columns?: components["schemas"]["Column"][];
-    };
-    TemporaryTable: {
-      /** @description Resource path to the temporary table. */
-      resource?: string;
-      table?: string;
-    };
-    QueryData: {
-      /** @description Resource path to the query data. */
-      resource?: string;
-      data?: string;
-    };
-    /** @description Standard error response format */
-    Error: {
-      /** @description Human-readable error message describing what went wrong */
-      message: string;
-      /** @description Additional error details or context */
-      details?: string;
-    };
-    /** @description Database column definition */
-    Column: {
-      /** @description Name of the column */
-      name?: string;
-      /** @description Data type of the column */
-      type?: string;
-    };
-    /** @description Database table structure and metadata */
-    TableDescription: {
-      /** @description Name of the table */
-      name?: string;
-      /** @description Number of rows in the table */
-      rowCount?: number;
-      /** @description List of columns in the table */
-      columns?: components["schemas"]["Column"][];
-    };
-    /** @description Current file watching status and configuration */
-    WatchStatus: {
-      /** @description Whether file watching is currently active */
-      enabled: boolean;
-      /** @description Name of the environment being watched for file changes */
+      /** @description Raw Malloy notebook with unexecuted cell contents */
+      RawNotebook: {
+         /** @description Resource path to the notebook */
+         resource?: string;
+         /** @description Name of the package containing this notebook */
+         packageName?: string;
+         /** @description Relative path to the notebook file within its package directory */
+         path?: string;
+         /** @description Version of the Malloy compiler used to generate the notebook data */
+         malloyVersion?: string;
+         /** @description Array of notebook cells containing raw markdown and code content */
+         notebookCells?: components["schemas"]["NotebookCell"][];
+         /** @description Array of file-level (##) annotations attached to the notebook */
+         annotations?: string[];
+         /** @description Sources defined in the notebook's model */
+         sources?: components["schemas"]["Source"][];
+      };
+      /** @description Compiled Malloy model with sources, queries, and metadata */
+      CompiledModel: {
+         /** @description Resource path to the model */
+         resource?: string;
+         /** @description Name of the package containing this model */
+         packageName?: string;
+         /** @description Relative path to the model file within its package directory */
+         path?: string;
+         /** @description Version of the Malloy compiler used to generate the model data */
+         malloyVersion?: string;
+         /** @description JSON string containing model metadata and structure information */
+         modelInfo?: string;
+         /** @description Array of JSON strings containing source information for each data source */
+         sourceInfos?: string[];
+         /** @description Array of named queries defined in the model */
+         queries?: components["schemas"]["Query"][];
+         /** @description Sources defined in this model */
+         sources?: components["schemas"]["Source"][];
+      };
+      /** @description Named model view definition */
+      View: {
+         /** @description Name of the view */
+         name?: string;
+         /** @description Annotations attached to the view */
+         annotations?: string[];
+      };
+      /** @description Named model query definition */
+      Query: {
+         /** @description Name of the query */
+         name?: string;
+         /** @description Name of the source this query operates on */
+         sourceName?: string;
+         /** @description Annotations attached to the query */
+         annotations?: string[];
+      };
+      /** @description A filter declared via */
+      Filter: {
+         /** @description Display name of the filter */
+         name?: string;
+         /** @description Dimension this filter targets */
+         dimension?: string;
+         /**
+          * @description Comparator type
+          * @enum {string}
+          */
+         type?: "equal" | "in" | "like" | "greater_than" | "less_than";
+         /** @description Whether this filter is hidden from users */
+         implicit?: boolean;
+         /** @description Whether a value must be provided */
+         required?: boolean;
+         /** @description Malloy data type of the dimension (e.g. string, number, boolean, date, timestamp) */
+         dimensionType?: string;
+      };
+      /** @description A Malloy source defined in a model */
+      Source: {
+         /** @description Name of the source */
+         name?: string;
+         /** @description Annotations attached to the source */
+         annotations?: string[];
+         /** @description Views defined in this source */
+         views?: components["schemas"]["View"][];
+         /** @description Filters declared on this source via */
+         filters?: components["schemas"]["Filter"][];
+      };
+      /** @description Request body for executing a Malloy query */
+      QueryRequest: {
+         /** @description Query string to execute on the model. If the query parameter is set, the queryName parameter must be empty. */
+         query?: string;
+         /** @description Name of the source in the model to use for queryName, search, and topValue requests. */
+         sourceName?: string;
+         /** @description Name of a query to execute on a source in the model. Requires the sourceName parameter is set. If the queryName parameter is set, the query parameter must be empty. */
+         queryName?: string;
+         /**
+          * @description If true, returns a simple JSON array of row objects in the form {"columnName": value}. If false (default), returns the full Malloy result with type metadata for rendering.
+          * @default false
+          */
+         compactJson?: boolean;
+         /** @description Version ID */
+         versionId?: string;
+         /** @description Filter parameter values keyed by filter name. Used with sources that declare \#(filter) annotations. Each value is either a string or an array of strings. */
+         filterParams?: {
+            [key: string]: unknown;
+         };
+         /**
+          * @description When true, skip server-side \#(filter) injection entirely.
+          * @default false
+          */
+         bypassFilters?: boolean;
+         /** @description Per-query given values that override model defaults. Keys are given names declared in the model's `given:` block. Values must match the declared type (string, number, boolean, date, etc.). See Malloy givens documentation for accepted value shapes. */
+         givens?: {
+            [key: string]: unknown;
+         };
+      };
+      /** @description Individual cell within a Malloy notebook */
+      NotebookCell: {
+         /**
+          * @description Type of notebook cell
+          * @enum {string}
+          */
+         type?: "markdown" | "code";
+         /** @description Text contents of the notebook cell (either markdown or Malloy code) */
+         text?: string;
+         /** @description Array of JSON strings containing SourceInfo objects made available in this cell */
+         newSources?: string[];
+         /** @description JSON string containing QueryInfo object for the query in this cell (if the cell contains a query) */
+         queryInfo?: string;
+      };
+      /** @description Result of executing a notebook cell */
+      NotebookCellResult: {
+         /**
+          * @description Type of notebook cell
+          * @enum {string}
+          */
+         type?: "markdown" | "code";
+         /** @description Text contents of the notebook cell */
+         text?: string;
+         /** @description JSON string containing the execution result for this cell */
+         result?: string;
+         /** @description Array of JSON strings containing SourceInfo objects made available in this cell */
+         newSources?: string[];
+      };
+      /** @description Results from executing a Malloy query */
+      QueryResult: {
+         /** @description JSON string containing the query results, metadata, and execution information */
+         result?: string;
+         /** @description Resource path to the query result */
+         resource?: string;
+         /** @description Render tag validation messages (errors, warnings) detected during query preparation */
+         renderLogs?: components["schemas"]["LogMessage"][];
+      };
+      /** @description A log message from render tag validation */
+      LogMessage: {
+         /** @description URL of the source file related to this message */
+         url?: string;
+         /** @description Source location range for this message */
+         range?: {
+            start?: {
+               line?: number;
+               character?: number;
+            };
+            end?: {
+               line?: number;
+               character?: number;
+            };
+         };
+         /**
+          * @description Severity level of the log message
+          * @enum {string}
+          */
+         severity?: "debug" | "info" | "warn" | "error";
+         /** @description Human-readable log message */
+         message?: string;
+      };
+      /** @description Embedded database within a Malloy package */
+      Database: {
+         /** @description Resource path to the database */
+         resource?: string;
+         /** @description Relative path to the database file within its package directory */
+         path?: string;
+         info?: components["schemas"]["TableDescription"];
+         /**
+          * @description Type of embedded database
+          * @enum {string}
+          */
+         type?: "embedded" | "materialized";
+      };
+      /** @description A schema name in a Connection. */
+      Schema: {
+         /** @description Name of the schema */
+         name?: string;
+         /** @description Description of the schema */
+         description?: string;
+         /** @description Whether this schema is the default schema */
+         isDefault?: boolean;
+         /** @description Whether this schema is hidden */
+         isHidden?: boolean;
+      };
+      /** @description Database connection configuration and metadata */
+      Connection: {
+         /** @description Resource path to the connection */
+         resource?: string;
+         /** @description Name of the connection */
+         name?: string;
+         /**
+          * @description Type of database connection
+          * @enum {string}
+          */
+         type?:
+            | "postgres"
+            | "bigquery"
+            | "snowflake"
+            | "trino"
+            | "databricks"
+            | "mysql"
+            | "duckdb"
+            | "motherduck"
+            | "ducklake";
+         attributes?: components["schemas"]["ConnectionAttributes"];
+         postgresConnection?: components["schemas"]["PostgresConnection"];
+         bigqueryConnection?: components["schemas"]["BigqueryConnection"];
+         snowflakeConnection?: components["schemas"]["SnowflakeConnection"];
+         trinoConnection?: components["schemas"]["TrinoConnection"];
+         databricksConnection?: components["schemas"]["DatabricksConnection"];
+         mysqlConnection?: components["schemas"]["MysqlConnection"];
+         duckdbConnection?: components["schemas"]["DuckdbConnection"];
+         motherduckConnection?: components["schemas"]["MotherDuckConnection"];
+         ducklakeConnection?: components["schemas"]["DucklakeConnection"];
+      };
+      /** @description Connection capabilities and configuration attributes */
+      ConnectionAttributes: {
+         /** @description SQL dialect name for the connection */
+         dialectName?: string;
+         /** @description Whether the connection uses connection pooling */
+         isPool?: boolean;
+         /** @description Whether the connection supports persistent storage operations */
+         canPersist?: boolean;
+         /** @description Whether the connection supports streaming query results */
+         canStream?: boolean;
+      };
+      /** @description PostgreSQL database connection configuration */
+      PostgresConnection: {
+         /** @description PostgreSQL server hostname or IP address */
+         host?: string;
+         /** @description PostgreSQL server port number */
+         port?: number;
+         /** @description Name of the PostgreSQL database */
+         databaseName?: string;
+         /** @description PostgreSQL username for authentication */
+         userName?: string;
+         /** @description PostgreSQL password for authentication */
+         password?: string;
+         /** @description Complete PostgreSQL connection string (alternative to individual parameters) */
+         connectionString?: string;
+      };
+      /** @description MySQL database connection configuration */
+      MysqlConnection: {
+         /** @description MySQL server hostname or IP address */
+         host?: string;
+         /** @description MySQL server port number */
+         port?: number;
+         /** @description Name of the MySQL database */
+         database?: string;
+         /** @description MySQL username for authentication */
+         user?: string;
+         /** @description MySQL password for authentication */
+         password?: string;
+      };
+      /** @description Google Cloud Storage connection configuration for DuckDB */
+      GCSConnection: {
+         /** @description GCS HMAC access key ID */
+         keyId: string;
+         /** @description GCS HMAC secret key */
+         secret: string;
+      };
+      /** @description AWS S3 connection configuration for DuckDB */
+      S3Connection: {
+         /** @description AWS access key ID */
+         accessKeyId: string;
+         /** @description AWS secret access key */
+         secretAccessKey: string;
+         /**
+          * @description AWS region (e.g., us-east-1)
+          * @default us-east-1
+          */
+         region?: string;
+         /** @description Custom S3-compatible endpoint URL (optional, for MinIO, etc.) */
+         endpoint?: string;
+         /** @description AWS session token for temporary credentials (optional) */
+         sessionToken?: string;
+      };
+      /** @description Azure Data Lake Storage (ADLS Gen2) / Blob Storage connection configuration Supports https://, http://, abfss://, and az:// URL schemes. */
+      AzureConnection: {
+         /**
+          * @description Authentication method for Azure Storage
+          * @enum {string}
+          */
+         authType: "service_principal" | "sas_token";
+         /** @description Full SAS URL including token; required for sas_token auth. Supports single file, directory glob (*.ext), or recursive (**) patterns. Example: https://account.blob.core.windows.net/container/path/*.parquet?sp=rl&st=... */
+         sasUrl?: string;
+         /** @description Azure AD tenant ID (required for service_principal) */
+         tenantId?: string;
+         /** @description Azure AD application (client) ID (required for service_principal) */
+         clientId?: string;
+         /** @description Azure AD client secret (required for service_principal) */
+         clientSecret?: string;
+         /** @description Azure Storage account name (required for service_principal) */
+         accountName?: string;
+         /** @description Azure file URL to query; required for service_principal auth. Supports single file, directory glob (*.ext), or recursive (**) patterns. Example: https://account.blob.core.windows.net/container/path/** */
+         fileUrl?: string;
+      };
+      /** @description DuckLake lakehouse connection configuration */
+      DucklakeConnection: {
+         /** @description Data storage connection configuration (S3 or GCS) */
+         storage: {
+            /** @description URL of the storage bucket (e.g. s3://my-bucket/path or gs://my-bucket/path) */
+            bucketUrl: string;
+            /** @description AWS S3 connection configuration for data storage */
+            s3Connection?: components["schemas"]["S3Connection"];
+            /** @description Google Cloud Storage connection configuration for data storage */
+            gcsConnection?: components["schemas"]["GCSConnection"];
+         };
+         /** @description Catalog metadata connection configuration */
+         catalog: {
+            /** @description PostgreSQL connection for DuckLake metadata catalog */
+            postgresConnection: components["schemas"]["PostgresConnection"];
+         };
+         /** @description Raw Malloy notebook with unexecuted cell contents */
+         RawNotebook: {
+            /** @description Resource path to the notebook */
+            resource?: string;
+            /** @description Name of the package containing this notebook */
+            packageName?: string;
+            /** @description Relative path to the notebook file within its package directory */
+            path?: string;
+            /** @description Version of the Malloy compiler used to generate the notebook data */
+            malloyVersion?: string;
+            /** @description Array of notebook cells containing raw markdown and code content */
+            notebookCells?: components["schemas"]["NotebookCell"][];
+            /** @description Array of file-level (##) annotations attached to the notebook */
+            annotations?: string[];
+            /** @description Sources defined in the notebook's model */
+            sources?: components["schemas"]["Source"][];
+         };
+         /** @description Compiled Malloy model with sources, queries, and metadata */
+         CompiledModel: {
+            /** @description Resource path to the model */
+            resource?: string;
+            /** @description Name of the package containing this model */
+            packageName?: string;
+            /** @description Relative path to the model file within its package directory */
+            path?: string;
+            /** @description Version of the Malloy compiler used to generate the model data */
+            malloyVersion?: string;
+            /** @description JSON string containing model metadata and structure information */
+            modelInfo?: string;
+            /** @description Array of JSON strings containing source information for each data source */
+            sourceInfos?: string[];
+            /** @description Array of named queries defined in the model */
+            queries?: components["schemas"]["Query"][];
+            /** @description Sources defined in this model */
+            sources?: components["schemas"]["Source"][];
+         };
+         /** @description Named model view definition */
+         View: {
+            /** @description Name of the view */
+            name?: string;
+            /** @description Annotations attached to the view */
+            annotations?: string[];
+         };
+         /** @description Named model query definition */
+         Query: {
+            /** @description Name of the query */
+            name?: string;
+            /** @description Name of the source this query operates on */
+            sourceName?: string;
+            /** @description Annotations attached to the query */
+            annotations?: string[];
+         };
+         /** @description A filter declared via */
+         Filter: {
+            /** @description Display name of the filter */
+            name?: string;
+            /** @description Dimension this filter targets */
+            dimension?: string;
+            /**
+             * @description Comparator type
+             * @enum {string}
+             */
+            type?: "equal" | "in" | "like" | "greater_than" | "less_than";
+            /** @description Whether this filter is hidden from users */
+            implicit?: boolean;
+            /** @description Whether a value must be provided */
+            required?: boolean;
+            /** @description Malloy data type of the dimension (e.g. string, number, boolean, date, timestamp) */
+            dimensionType?: string;
+         };
+         /** @description A Malloy source defined in a model */
+         Source: {
+            /** @description Name of the source */
+            name?: string;
+            /** @description Annotations attached to the source */
+            annotations?: string[];
+            /** @description Views defined in this source */
+            views?: components["schemas"]["View"][];
+            /** @description Filters declared on this source via */
+            filters?: components["schemas"]["Filter"][];
+         };
+         /** @description Request body for executing a Malloy query */
+         QueryRequest: {
+            /** @description Query string to execute on the model. If the query parameter is set, the queryName parameter must be empty. */
+            query?: string;
+            /** @description Name of the source in the model to use for queryName, search, and topValue requests. */
+            sourceName?: string;
+            /** @description Name of a query to execute on a source in the model. Requires the sourceName parameter is set. If the queryName parameter is set, the query parameter must be empty. */
+            queryName?: string;
+            /**
+             * @description If true, returns a simple JSON array of row objects in the form {"columnName": value}. If false (default), returns the full Malloy result with type metadata for rendering.
+             * @default false
+             */
+            compactJson?: boolean;
+            /** @description Version ID */
+            versionId?: string;
+            /** @description Filter parameter values keyed by filter name. Used with sources that declare \#(filter) annotations. Each value is either a string or an array of strings. */
+            filterParams?: {
+               [key: string]: unknown;
+            };
+            /**
+             * @description When true, skip server-side \#(filter) injection entirely.
+             * @default false
+             */
+            bypassFilters?: boolean;
+            /** @description Per-query given values that override model defaults. Keys are given names declared in the model's `given:` block. Values must match the declared type (string, number, boolean, date, etc.). See Malloy givens documentation for accepted value shapes. */
+            givens?: {
+               [key: string]: unknown;
+            };
+         };
+         /** @description Individual cell within a Malloy notebook */
+         NotebookCell: {
+            /**
+             * @description Type of notebook cell
+             * @enum {string}
+             */
+            type?: "markdown" | "code";
+            /** @description Text contents of the notebook cell (either markdown or Malloy code) */
+            text?: string;
+            /** @description Array of JSON strings containing SourceInfo objects made available in this cell */
+            newSources?: string[];
+            /** @description JSON string containing QueryInfo object for the query in this cell (if the cell contains a query) */
+            queryInfo?: string;
+         };
+         /** @description Result of executing a notebook cell */
+         NotebookCellResult: {
+            /**
+             * @description Type of notebook cell
+             * @enum {string}
+             */
+            type?: "markdown" | "code";
+            /** @description Text contents of the notebook cell */
+            text?: string;
+            /** @description JSON string containing the execution result for this cell */
+            result?: string;
+            /** @description Array of JSON strings containing SourceInfo objects made available in this cell */
+            newSources?: string[];
+         };
+         /** @description Results from executing a Malloy query */
+         QueryResult: {
+            /** @description JSON string containing the query results, metadata, and execution information */
+            result?: string;
+            /** @description Resource path to the query result */
+            resource?: string;
+            /** @description Render tag validation messages (errors, warnings) detected during query preparation */
+            renderLogs?: components["schemas"]["LogMessage"][];
+         };
+         /** @description A log message from render tag validation */
+         LogMessage: {
+            /** @description URL of the source file related to this message */
+            url?: string;
+            /** @description Source location range for this message */
+            range?: {
+               start?: {
+                  line?: number;
+                  character?: number;
+               };
+               end?: {
+                  line?: number;
+                  character?: number;
+               };
+            };
+            /**
+             * @description Severity level of the log message
+             * @enum {string}
+             */
+            severity?: "debug" | "info" | "warn" | "error";
+            /** @description Human-readable log message */
+            message?: string;
+         };
+         /** @description Embedded database within a Malloy package */
+         Database: {
+            /** @description Resource path to the database */
+            resource?: string;
+            /** @description Relative path to the database file within its package directory */
+            path?: string;
+            info?: components["schemas"]["TableDescription"];
+            /**
+             * @description Type of embedded database
+             * @enum {string}
+             */
+            type?: "embedded" | "materialized";
+         };
+         /** @description A schema name in a Connection. */
+         Schema: {
+            /** @description Name of the schema */
+            name?: string;
+            /** @description Description of the schema */
+            description?: string;
+            /** @description Whether this schema is the default schema */
+            isDefault?: boolean;
+            /** @description Whether this schema is hidden */
+            isHidden?: boolean;
+         };
+         /** @description Database connection configuration and metadata */
+         Connection: {
+            /** @description Resource path to the connection */
+            resource?: string;
+            /** @description Name of the connection */
+            name?: string;
+            /**
+             * @description Type of database connection
+             * @enum {string}
+             */
+            type?:
+               | "postgres"
+               | "bigquery"
+               | "snowflake"
+               | "trino"
+               | "databricks"
+               | "mysql"
+               | "duckdb"
+               | "motherduck"
+               | "ducklake";
+            attributes?: components["schemas"]["ConnectionAttributes"];
+            postgresConnection?: components["schemas"]["PostgresConnection"];
+            bigqueryConnection?: components["schemas"]["BigqueryConnection"];
+            snowflakeConnection?: components["schemas"]["SnowflakeConnection"];
+            trinoConnection?: components["schemas"]["TrinoConnection"];
+            databricksConnection?: components["schemas"]["DatabricksConnection"];
+            mysqlConnection?: components["schemas"]["MysqlConnection"];
+            duckdbConnection?: components["schemas"]["DuckdbConnection"];
+            motherduckConnection?: components["schemas"]["MotherDuckConnection"];
+            ducklakeConnection?: components["schemas"]["DucklakeConnection"];
+         };
+         /** @description Connection capabilities and configuration attributes */
+         ConnectionAttributes: {
+            /** @description SQL dialect name for the connection */
+            dialectName?: string;
+            /** @description Whether the connection uses connection pooling */
+            isPool?: boolean;
+            /** @description Whether the connection supports persistent storage operations */
+            canPersist?: boolean;
+            /** @description Whether the connection supports streaming query results */
+            canStream?: boolean;
+         };
+         /** @description PostgreSQL database connection configuration */
+         PostgresConnection: {
+            /** @description PostgreSQL server hostname or IP address */
+            host?: string;
+            /** @description PostgreSQL server port number */
+            port?: number;
+            /** @description Name of the PostgreSQL database */
+            databaseName?: string;
+            /** @description PostgreSQL username for authentication */
+            userName?: string;
+            /** @description PostgreSQL password for authentication */
+            password?: string;
+            /** @description Complete PostgreSQL connection string (alternative to individual parameters) */
+            connectionString?: string;
+         };
+         /** @description MySQL database connection configuration */
+         MysqlConnection: {
+            /** @description MySQL server hostname or IP address */
+            host?: string;
+            /** @description MySQL server port number */
+            port?: number;
+            /** @description Name of the MySQL database */
+            database?: string;
+            /** @description MySQL username for authentication */
+            user?: string;
+            /** @description MySQL password for authentication */
+            password?: string;
+         };
+         /** @description Google Cloud Storage connection configuration for DuckDB */
+         GCSConnection: {
+            /** @description GCS HMAC access key ID */
+            keyId: string;
+            /** @description GCS HMAC secret key */
+            secret: string;
+         };
+         /** @description AWS S3 connection configuration for DuckDB */
+         S3Connection: {
+            /** @description AWS access key ID */
+            accessKeyId: string;
+            /** @description AWS secret access key */
+            secretAccessKey: string;
+            /**
+             * @description AWS region (e.g., us-east-1)
+             * @default us-east-1
+             */
+            region?: string;
+            /** @description Custom S3-compatible endpoint URL (optional, for MinIO, etc.) */
+            endpoint?: string;
+            /** @description AWS session token for temporary credentials (optional) */
+            sessionToken?: string;
+         };
+         /** @description Azure Data Lake Storage (ADLS Gen2) / Blob Storage connection configuration Supports https://, http://, abfss://, and az:// URL schemes. */
+         AzureConnection: {
+            /**
+             * @description Authentication method for Azure Storage
+             * @enum {string}
+             */
+            authType: "service_principal" | "sas_token";
+            /** @description Full SAS URL including token; required for sas_token auth. Supports single file, directory glob (*.ext), or recursive (**) patterns. Example: https://account.blob.core.windows.net/container/path/*.parquet?sp=rl&st=... */
+            sasUrl?: string;
+            /** @description Azure AD tenant ID (required for service_principal) */
+            tenantId?: string;
+            /** @description Azure AD application (client) ID (required for service_principal) */
+            clientId?: string;
+            /** @description Azure AD client secret (required for service_principal) */
+            clientSecret?: string;
+            /** @description Azure Storage account name (required for service_principal) */
+            accountName?: string;
+            /** @description Azure file URL to query; required for service_principal auth. Supports single file, directory glob (*.ext), or recursive (**) patterns. Example: https://account.blob.core.windows.net/container/path/** */
+            fileUrl?: string;
+         };
+         /** @description DuckLake lakehouse connection configuration */
+         DucklakeConnection: {
+            /** @description Data storage connection configuration (S3 or GCS) */
+            storage: {
+               /** @description URL of the storage bucket (e.g. s3://my-bucket/path or gs://my-bucket/path) */
+               bucketUrl: string;
+               /** @description AWS S3 connection configuration for data storage */
+               s3Connection?: components["schemas"]["S3Connection"];
+               /** @description Google Cloud Storage connection configuration for data storage */
+               gcsConnection?: components["schemas"]["GCSConnection"];
+            };
+            /** @description Catalog metadata connection configuration */
+            catalog: {
+               /** @description PostgreSQL connection for DuckLake metadata catalog */
+               postgresConnection: components["schemas"]["PostgresConnection"];
+            };
+         };
+         /** @description Google BigQuery database connection configuration */
+         BigqueryConnection: {
+            /** @description Default BigQuery project ID for queries */
+            defaultProjectId?: string;
+            /** @description BigQuery project ID for billing purposes */
+            billingProjectId?: string;
+            /** @description BigQuery dataset location/region */
+            location?: string;
+            /** @description JSON string containing Google Cloud service account credentials */
+            serviceAccountKeyJson?: string;
+            /** @description Maximum bytes to bill for query execution (prevents runaway costs) */
+            maximumBytesBilled?: string;
+            /** @description Query timeout in milliseconds */
+            queryTimeoutMilliseconds?: string;
+         };
+         /** @description Snowflake database connection configuration */
+         SnowflakeConnection: {
+            /** @description Snowflake account identifier */
+            account?: string;
+            /** @description Snowflake username for authentication */
+            username?: string;
+            /** @description Snowflake password for authentication */
+            password?: string;
+            /** @description Snowflake private key for authentication */
+            privateKey?: string;
+            /** @description Passphrase for the Snowflake private key */
+            privateKeyPass?: string;
+            /** @description Snowflake warehouse name */
+            warehouse?: string;
+            /** @description Snowflake database name */
+            database?: string;
+            /** @description Snowflake schema name */
+            schema?: string;
+            /** @description Snowflake role name */
+            role?: string;
+            /** @description Query response timeout in milliseconds */
+            responseTimeoutMilliseconds?: number;
+         };
+         /** @description Trino database connection configuration */
+         TrinoConnection: {
+            /** @description Trino server hostname or IP address */
+            server?: string;
+            /** @description Trino server port number */
+            port?: number;
+            /** @description Trino catalog name */
+            catalog?: string;
+            /** @description Trino schema name */
+            schema?: string;
+            /** @description Trino username for authentication */
+            user?: string;
+            /** @description Trino password for authentication */
+            password?: string;
+            /** @description Peaka API key for authentication with Peaka-hosted Trino clusters */
+            peakaKey?: string;
+         };
+         /** @description Databricks SQL warehouse connection configuration */
+         DatabricksConnection: {
+            /** @description Databricks workspace host (e.g. dbc-xxxxxxxx-xxxx.cloud.databricks.com) */
+            host?: string;
+            /** @description SQL warehouse HTTP path (e.g. /sql/1.0/warehouses/<warehouse-id>) */
+            path?: string;
+            /** @description Personal access token for authentication */
+            token?: string;
+            /** @description OAuth M2M client ID (service principal) */
+            oauthClientId?: string;
+            /** @description OAuth M2M client secret (service principal) */
+            oauthClientSecret?: string;
+            /** @description Default Unity Catalog to use for queries */
+            defaultCatalog?: string;
+            /** @description Default schema to use for queries */
+            defaultSchema?: string;
+            /** @description SQL statements to run when the connection is established */
+            setupSQL?: string;
+         };
+         /** @description MotherDuck database connection configuration */
+         MotherDuckConnection: {
+            /** @description MotherDuck access token */
+            accessToken?: string;
+            /** @description MotherDuck database name */
+            database?: string;
+         };
+         /** @description DuckDB database connection configuration. Publisher intentionally exposes only data-source intent here. Database files, working directories, filesystem/network policy, extension loading, setup SQL, temp directories, and resource knobs are owned by Publisher so environment configs cannot widen deployment policy through low-level DuckDB settings. */
+         DuckdbConnection: {
+            attachedDatabases?: components["schemas"]["AttachedDatabase"][];
+         };
+         /** @description Attached DuckDB database */
+         AttachedDatabase: {
+            /** @example test_connection, _connection, test_connection_1 */
+            name?: string;
+            /**
+             * @description Type of database connection
+             * @enum {string}
+             */
+            type?:
+               | "bigquery"
+               | "snowflake"
+               | "postgres"
+               | "gcs"
+               | "s3"
+               | "azure";
+            attributes?: components["schemas"]["ConnectionAttributes"];
+            bigqueryConnection?: components["schemas"]["BigqueryConnection"];
+            snowflakeConnection?: components["schemas"]["SnowflakeConnection"];
+            postgresConnection?: components["schemas"]["PostgresConnection"];
+            gcsConnection?: components["schemas"]["GCSConnection"];
+            s3Connection?: components["schemas"]["S3Connection"];
+            azureConnection?: components["schemas"]["AzureConnection"];
+         };
+         SqlSource: {
+            /** @description Resource path to the sql source. */
+            resource?: string;
+            source?: string;
+         };
+         Table: {
+            /** @description Resource path to the table. */
+            resource?: string;
+            /** @description Table source as a JSON string. */
+            source?: string;
+            /** @description Table fields */
+            columns?: components["schemas"]["Column"][];
+         };
+         /** @deprecated */
+         TableSource: {
+            /** @description Resource path to the table source. */
+            resource?: string;
+            source?: string;
+            /** @description Table fields */
+            columns?: components["schemas"]["Column"][];
+         };
+         TemporaryTable: {
+            /** @description Resource path to the temporary table. */
+            resource?: string;
+            table?: string;
+         };
+         QueryData: {
+            /** @description Resource path to the query data. */
+            resource?: string;
+            data?: string;
+         };
+         /** @description Standard error response format */
+         Error: {
+            /** @description Human-readable error message describing what went wrong */
+            message: string;
+            /** @description Additional error details or context */
+            details?: string;
+         };
+         /** @description Database column definition */
+         Column: {
+            /** @description Name of the column */
+            name?: string;
+            /** @description Data type of the column */
+            type?: string;
+         };
+         /** @description Database table structure and metadata */
+         TableDescription: {
+            /** @description Name of the table */
+            name?: string;
+            /** @description Number of rows in the table */
+            rowCount?: number;
+            /** @description List of columns in the table */
+            columns?: components["schemas"]["Column"][];
+         };
+         /** @description Current file watching status and configuration */
+         WatchStatus: {
+            /** @description Whether file watching is currently active */
+            enabled: boolean;
+            /** @description Name of the environment being watched for file changes */
+            environmentName: string;
+            /** @description The file system path being monitored for changes, null if not watching */
+            watchingPath: string;
+         };
+         /** @description Request to start file watching for an environment */
+         StartWatchRequest: {
+            /** @description Name of the environment to start watching for file changes */
+            environmentName: string;
+         };
+         /** @description Result of testing a database connection */
+         ConnectionStatus: {
+            /**
+             * @description Connection test result status
+             * @enum {string}
+             */
+            status?: "ok" | "failed";
+            /** @description Error message if the connection test failed, null if successful */
+            errorMessage?: string;
+         };
+         /** @description Request body for compiling Malloy source code */
+         CompileRequest: {
+            /** @description Malloy source code to compile */
+            source: string;
+            /**
+             * @description If true, returns the generated SQL alongside compilation results (only available when compilation succeeds and the source contains a runnable query).
+             * @default false
+             */
+            includeSql?: boolean;
+            /** @description Per-query given values that override model defaults. Keys are given names declared in the model's `given:` block. Values must match the declared type (string, number, boolean, date, etc.). See Malloy givens documentation for accepted value shapes. */
+            givens?: {
+               [key: string]: unknown;
+            };
+         };
+         /** @description Result of a Malloy source compilation check */
+         CompileResult: {
+            /**
+             * @description Overall compilation status — "error" if any problems have error severity
+             * @enum {string}
+             */
+            status?: "success" | "error";
+            /** @description List of compilation problems (errors and warnings) */
+            problems?: components["schemas"]["CompileProblem"][];
+            /** @description Generated SQL for the compiled query. Only present when includeSql is true and compilation succeeds with a runnable query. */
+            sql?: string;
+         };
+         /** @description A compilation problem reported by the Malloy compiler */
+         CompileProblem: {
+            /** @description Human-readable problem description */
+            message?: string;
+            /**
+             * @description Severity level of the problem
+             * @enum {string}
+             */
+            severity?: "error" | "warn" | "debug";
+            /** @description Machine-readable error code */
+            code?: string;
+            /** @description Source location of the problem */
+            at?: {
+               /** @description URL of the source file */
+               url?: string;
+               /** @description Character range within the source file */
+               range?: Record<string, never>;
+            };
+         };
+         /** @description Options for creating a materialization */
+         CreateMaterializationRequest: {
+            /**
+             * @description If true, forces rebuild of all sources even if their BuildID is unchanged
+             * @default false
+             */
+            forceRefresh?: boolean;
+            /**
+             * @description If true, automatically reloads the manifest into the Malloy Runtime after a successful materialization
+             * @default false
+             */
+            autoLoadManifest?: boolean;
+         };
+         /** @description A record of a package materialization */
+         Materialization: {
+            id?: string;
+            environmentId?: string;
+            packageName?: string;
+            /** @enum {string} */
+            status?: "PENDING" | "RUNNING" | "SUCCESS" | "FAILED" | "CANCELLED";
+            /** Format: date-time */
+            startedAt?: string | null;
+            /** Format: date-time */
+            completedAt?: string | null;
+            /** @description Error message if the materialization failed */
+            error?: string | null;
+            /** @description Materialization metadata including build options, source counts, and durations */
+            metadata?: Record<string, never> | null;
+            /** Format: date-time */
+            createdAt?: string;
+            /** Format: date-time */
+            updatedAt?: string;
+         };
+         /** @description Manifest mapping BuildIDs to materialized table names */
+         BuildManifest: {
+            /** @description Map of BuildID to manifest entry */
+            entries?: {
+               [key: string]: components["schemas"]["ManifestEntry"];
+            };
+            /** @description Whether the manifest is in strict mode */
+            strict?: boolean;
+         };
+         /** @description A single entry in the build manifest */
+         ManifestEntry: {
+            /** @description Name of the materialized table */
+            tableName?: string;
+         };
+      };
+      responses: {
+         /** @description The request was malformed or cannot be performed given the current state of the system */
+         BadRequest: {
+            content: {
+               "application/json": components["schemas"]["Error"];
+            };
+         };
+         /** @description Unauthorized - authentication required */
+         Unauthorized: {
+            content: {
+               "application/json": components["schemas"]["Error"];
+            };
+         };
+         /** @description Forbidden - insufficient permissions to perform the operation */
+         Forbidden: {
+            content: {
+               "application/json": components["schemas"]["Error"];
+            };
+         };
+         /** @description The specified resource was not found */
+         NotFound: {
+            content: {
+               "application/json": components["schemas"]["Error"];
+            };
+         };
+         /** @description The server encountered an internal error */
+         InternalServerError: {
+            content: {
+               "application/json": components["schemas"]["Error"];
+            };
+         };
+         /** @description The requested operation is not implemented */
+         NotImplemented: {
+            content: {
+               "application/json": components["schemas"]["Error"];
+            };
+         };
+         /** @description Model compilation failed due to syntax or semantic errors */
+         ModelCompilationError: {
+            content: {
+               "application/json": components["schemas"]["Error"];
+            };
+         };
+         /** @description The service is temporarily unavailable, typically due to initialization, or draining state (Rolling updates, etc.) */
+         ServiceUnavailable: {
+            content: {
+               "application/json": components["schemas"]["Error"];
+            };
+         };
+      };
+      parameters: {
+         /** @description Name of the environment */
+         environmentName: string;
+         /** @description The file system path being monitored for changes, null if not watching */
+         watchingPath: string;
+      };
+      /** @description Request to start file watching for an environment */
+      StartWatchRequest: {
+         /** @description Name of the environment to start watching for file changes */
+         environmentName: string;
+      };
+      /** @description Result of testing a database connection */
+      ConnectionStatus: {
+         /**
+          * @description Connection test result status
+          * @enum {string}
+          */
+         status?: "ok" | "failed";
+         /** @description Error message if the connection test failed, null if successful */
+         errorMessage?: string;
+      };
+      /** @description Request body for compiling Malloy source code */
+      CompileRequest: {
+         /** @description Malloy source code to compile */
+         source: string;
+         /**
+          * @description If true, returns the generated SQL alongside compilation results (only available when compilation succeeds and the source contains a runnable query).
+          * @default false
+          */
+         includeSql?: boolean;
+      };
+      /** @description Result of a Malloy source compilation check */
+      CompileResult: {
+         /**
+          * @description Overall compilation status — "error" if any problems have error severity
+          * @enum {string}
+          */
+         status?: "success" | "error";
+         /** @description List of compilation problems (errors and warnings) */
+         problems?: components["schemas"]["CompileProblem"][];
+         /** @description Generated SQL for the compiled query. Only present when includeSql is true and compilation succeeds with a runnable query. */
+         sql?: string;
+      };
+      /** @description A compilation problem reported by the Malloy compiler */
+      CompileProblem: {
+         /** @description Human-readable problem description */
+         message?: string;
+         /**
+          * @description Severity level of the problem
+          * @enum {string}
+          */
+         severity?: "error" | "warn" | "debug";
+         /** @description Machine-readable error code */
+         code?: string;
+         /** @description Source location of the problem */
+         at?: {
+            /** @description URL of the source file */
+            url?: string;
+            /** @description Character range within the source file */
+            range?: Record<string, never>;
+         };
+      };
+      /** @description Options for creating a materialization */
+      CreateMaterializationRequest: {
+         /**
+          * @description If true, forces rebuild of all sources even if their BuildID is unchanged
+          * @default false
+          */
+         forceRefresh?: boolean;
+         /**
+          * @description If true, automatically reloads the manifest into the Malloy Runtime after a successful materialization
+          * @default false
+          */
+         autoLoadManifest?: boolean;
+      };
+      /** @description A record of a package materialization */
+      Materialization: {
+         id?: string;
+         environmentId?: string;
+         packageName?: string;
+         /** @enum {string} */
+         status?: "PENDING" | "RUNNING" | "SUCCESS" | "FAILED" | "CANCELLED";
+         /** Format: date-time */
+         startedAt?: string | null;
+         /** Format: date-time */
+         completedAt?: string | null;
+         /** @description Error message if the materialization failed */
+         error?: string | null;
+         /** @description Materialization metadata including build options, source counts, and durations */
+         metadata?: Record<string, never> | null;
+         /** Format: date-time */
+         createdAt?: string;
+         /** Format: date-time */
+         updatedAt?: string;
+      };
+      /** @description Manifest mapping BuildIDs to materialized table names */
+      BuildManifest: {
+         /** @description Map of BuildID to manifest entry */
+         entries?: {
+            [key: string]: components["schemas"]["ManifestEntry"];
+         };
+         /** @description Whether the manifest is in strict mode */
+         strict?: boolean;
+      };
+      /** @description A single entry in the build manifest */
+      ManifestEntry: {
+         /** @description Name of the materialized table */
+         tableName?: string;
+      };
+   };
+   responses: {
+      /** @description The request was malformed or cannot be performed given the current state of the system */
+      BadRequest: {
+         content: {
+            "application/json": components["schemas"]["Error"];
+         };
+      };
+      /** @description Unauthorized - authentication required */
+      Unauthorized: {
+         content: {
+            "application/json": components["schemas"]["Error"];
+         };
+      };
+      /** @description Forbidden - insufficient permissions to perform the operation */
+      Forbidden: {
+         content: {
+            "application/json": components["schemas"]["Error"];
+         };
+      };
+      /** @description The specified resource was not found */
+      NotFound: {
+         content: {
+            "application/json": components["schemas"]["Error"];
+         };
+      };
+      /** @description The server encountered an internal error */
+      InternalServerError: {
+         content: {
+            "application/json": components["schemas"]["Error"];
+         };
+      };
+      /** @description The requested operation is not implemented */
+      NotImplemented: {
+         content: {
+            "application/json": components["schemas"]["Error"];
+         };
+      };
+      /** @description Model compilation failed due to syntax or semantic errors */
+      ModelCompilationError: {
+         content: {
+            "application/json": components["schemas"]["Error"];
+         };
+      };
+      /** @description The service is temporarily unavailable, typically due to initialization, or draining state (Rolling updates, etc.) */
+      ServiceUnavailable: {
+         content: {
+            "application/json": components["schemas"]["Error"];
+         };
+      };
+   };
+   parameters: {
+      /** @description Name of the environment */
       environmentName: string;
-      /** @description The file system path being monitored for changes, null if not watching */
-      watchingPath: string;
-    };
-    /** @description Request to start file watching for an environment */
-    StartWatchRequest: {
-      /** @description Name of the environment to start watching for file changes */
-      environmentName: string;
-    };
-    /** @description Result of testing a database connection */
-    ConnectionStatus: {
-      /**
-       * @description Connection test result status
-       * @enum {string}
-       */
-      status?: "ok" | "failed";
-      /** @description Error message if the connection test failed, null if successful */
-      errorMessage?: string;
-    };
-    /** @description Request body for compiling Malloy source code */
-    CompileRequest: {
-      /** @description Malloy source code to compile */
-      source: string;
-      /**
-       * @description If true, returns the generated SQL alongside compilation results (only available when compilation succeeds and the source contains a runnable query).
-       * @default false
-       */
-      includeSql?: boolean;
-    };
-    /** @description Result of a Malloy source compilation check */
-    CompileResult: {
-      /**
-       * @description Overall compilation status — "error" if any problems have error severity
-       * @enum {string}
-       */
-      status?: "success" | "error";
-      /** @description List of compilation problems (errors and warnings) */
-      problems?: components["schemas"]["CompileProblem"][];
-      /** @description Generated SQL for the compiled query. Only present when includeSql is true and compilation succeeds with a runnable query. */
-      sql?: string;
-    };
-    /** @description A compilation problem reported by the Malloy compiler */
-    CompileProblem: {
-      /** @description Human-readable problem description */
-      message?: string;
-      /**
-       * @description Severity level of the problem
-       * @enum {string}
-       */
-      severity?: "error" | "warn" | "debug";
-      /** @description Machine-readable error code */
-      code?: string;
-      /** @description Source location of the problem */
-      at?: {
-        /** @description URL of the source file */
-        url?: string;
-        /** @description Character range within the source file */
-        range?: Record<string, never>;
-      };
-    };
-    /** @description Options for creating a materialization */
-    CreateMaterializationRequest: {
-      /**
-       * @description If true, forces rebuild of all sources even if their BuildID is unchanged
-       * @default false
-       */
-      forceRefresh?: boolean;
-      /**
-       * @description If true, automatically reloads the manifest into the Malloy Runtime after a successful materialization
-       * @default false
-       */
-      autoLoadManifest?: boolean;
-    };
-    /** @description A record of a package materialization */
-    Materialization: {
-      id?: string;
-      environmentId?: string;
-      packageName?: string;
-      /** @enum {string} */
-      status?: "PENDING" | "RUNNING" | "SUCCESS" | "FAILED" | "CANCELLED";
-      /** Format: date-time */
-      startedAt?: string | null;
-      /** Format: date-time */
-      completedAt?: string | null;
-      /** @description Error message if the materialization failed */
-      error?: string | null;
-      /** @description Materialization metadata including build options, source counts, and durations */
-      metadata?: Record<string, never> | null;
-      /** Format: date-time */
-      createdAt?: string;
-      /** Format: date-time */
-      updatedAt?: string;
-    };
-    /** @description Manifest mapping BuildIDs to materialized table names */
-    BuildManifest: {
-      /** @description Map of BuildID to manifest entry */
-      entries?: {
-        [key: string]: components["schemas"]["ManifestEntry"];
-      };
-      /** @description Whether the manifest is in strict mode */
-      strict?: boolean;
-    };
-    /** @description A single entry in the build manifest */
-    ManifestEntry: {
-      /** @description Name of the materialized table */
-      tableName?: string;
-    };
-  };
-  responses: {
-    /** @description The request was malformed or cannot be performed given the current state of the system */
-    BadRequest: {
-      content: {
-        "application/json": components["schemas"]["Error"];
-      };
-    };
-    /** @description Unauthorized - authentication required */
-    Unauthorized: {
-      content: {
-        "application/json": components["schemas"]["Error"];
-      };
-    };
-    /** @description Forbidden - insufficient permissions to perform the operation */
-    Forbidden: {
-      content: {
-        "application/json": components["schemas"]["Error"];
-      };
-    };
-    /** @description The specified resource was not found */
-    NotFound: {
-      content: {
-        "application/json": components["schemas"]["Error"];
-      };
-    };
-    /** @description The server encountered an internal error */
-    InternalServerError: {
-      content: {
-        "application/json": components["schemas"]["Error"];
-      };
-    };
-    /** @description The requested operation is not implemented */
-    NotImplemented: {
-      content: {
-        "application/json": components["schemas"]["Error"];
-      };
-    };
-    /** @description Model compilation failed due to syntax or semantic errors */
-    ModelCompilationError: {
-      content: {
-        "application/json": components["schemas"]["Error"];
-      };
-    };
-    /** @description The service is temporarily unavailable, typically due to initialization, or draining state (Rolling updates, etc.) */
-    ServiceUnavailable: {
-      content: {
-        "application/json": components["schemas"]["Error"];
-      };
-    };
-  };
-  parameters: {
-    /** @description Name of the environment */
-    environmentName: string;
-    /** @description Name of the package */
-    packageName: string;
-    /** @description ID of the materialization */
-    materializationId: string;
-  };
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+      /** @description Name of the package */
+      packageName: string;
+      /** @description ID of the materialization */
+      materializationId: string;
+   };
+   requestBodies: never;
+   headers: never;
+   pathItems: never;
 }
 
 export type $defs = Record<string, never>;
@@ -1196,1702 +1701,1701 @@ export type $defs = Record<string, never>;
 export type external = Record<string, never>;
 
 export interface operations {
-
-  /**
-   * Get server status and health information
-   * @description Returns the current status of the Malloy Publisher server, including initialization state,
-   * available environments, and server timestamp. This endpoint is useful for health checks and
-   * monitoring server availability.
-   */
-  "get-status": {
-    responses: {
-      /** @description Returns server status */
-      200: {
-        content: {
-          "application/json": components["schemas"]["ServerStatus"];
-        };
-      };
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * List all available environments
-   * @description Retrieves a list of all environments currently hosted on this Malloy Publisher server.
-   * Each environment contains metadata about its packages, connections, and configuration.
-   * This endpoint is typically used to discover available environments and their basic information.
-   */
-  "list-environments": {
-    responses: {
-      /** @description A list of all available environments */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Environment"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Create a new environment
-   * @description Creates a new Malloy environment with the specified configuration. An environment serves as a
-   * container for packages, connections, and other resources. The environment will be initialized
-   * with the provided metadata and can immediately accept packages and connections.
-   */
-  "create-environment": {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["Environment"];
-      };
-    };
-    responses: {
-      /** @description Returns the environment created */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Environment"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Get environment details and metadata
-   * @description Retrieves detailed information about a specific environment, including its packages,
-   * connections, configuration, and metadata. The reload parameter can be used to
-   * refresh the environment state from disk before returning the information.
-   */
-  "get-environment": {
-    parameters: {
-      query?: {
-        /** @description Load / reload the environment before returning result */
-        reload?: boolean;
-      };
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description Environment details and metadata */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Environment"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Delete an environment
-   * @description Permanently deletes an environment and all its associated resources including packages,
-   * connections, and metadata. This operation cannot be undone, so use with caution.
-   * The environment must exist and be accessible for deletion.
-   */
-  "delete-environment": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description Returns the environment deleted */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Environment"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Update environment configuration
-   * @description Updates the configuration and metadata of an existing environment. This allows you to
-   * modify environment settings, update the README, change the location, or update other
-   * environment-level properties. The environment must exist and be accessible.
-   */
-  "update-environment": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["Environment"];
-      };
-    };
-    responses: {
-      /** @description Returns the environment updated */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Environment"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * List environment database connections
-   * @description Retrieves a list of all database connections configured for the specified environment.
-   * Each connection includes its configuration, type, and status information. This endpoint
-   * is useful for discovering available data sources within an environment.
-   */
-  "list-connections": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description A list of database connections in the environment */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Connection"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Get connection details
-   * @description Retrieves detailed information about a specific database connection within an environment.
-   * This includes connection configuration, credentials (if accessible), and metadata.
-   * Useful for inspecting connection settings and troubleshooting connectivity issues.
-   */
-  "get-connection": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description Connection details and configuration */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Connection"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Create a new database connection
-   * @description Creates a new database connection in the specified environment.
-   */
-  "create-connection": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["Connection"];
-      };
-    };
-    responses: {
-      /** @description Connection created successfully */
-      201: {
-        content: {
-          "application/json": {
-            message?: string;
-          };
-        };
-      };
-      400: components["responses"]["BadRequest"];
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      /** @description Connection already exists */
-      409: {
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Delete a database connection
-   * @description Permanently deletes a database connection from the environment.
-   */
-  "delete-connection": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection to delete */
-        connectionName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description Connection deleted successfully */
-      200: {
-        content: {
-          "application/json": {
-            message?: string;
-          };
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Update an existing database connection
-   * @description Updates the configuration of an existing database connection.
-   */
-  "update-connection": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection to update */
-        connectionName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          postgresConnection?: components["schemas"]["PostgresConnection"];
-          mysqlConnection?: components["schemas"]["MysqlConnection"];
-          bigqueryConnection?: components["schemas"]["BigqueryConnection"];
-          snowflakeConnection?: components["schemas"]["SnowflakeConnection"];
-          duckdbConnection?: components["schemas"]["DuckdbConnection"];
-          motherduckConnection?: components["schemas"]["MotherDuckConnection"];
-          trinoConnection?: components["schemas"]["TrinoConnection"];
-          databricksConnection?: components["schemas"]["DatabricksConnection"];
-          ducklakeConnection?: components["schemas"]["DucklakeConnection"];
-        };
-      };
-    };
-    responses: {
-      /** @description Connection updated successfully */
-      200: {
-        content: {
-          "application/json": {
-            message?: string;
-          };
-        };
-      };
-      400: components["responses"]["BadRequest"];
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * List database schemas
-   * @description Retrieves a list of all schemas (databases) available in the specified connection.
-   * Each schema includes metadata such as name, description, and whether it's the default schema.
-   * This endpoint is useful for exploring the database structure and discovering available data sources.
-   */
-  "list-schemas": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description A list of schemas available in the connection with metadata */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Schema"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * List tables in database
-   * @description Retrieves a list of all tables and views available in the specified database schema.
-   * This endpoint is useful for discovering available data sources and exploring the database
-   * structure. The schema must exist in the connection for this operation to succeed.
-   */
-  "list-tables": {
-    parameters: {
-      query?: {
-        /**
-         * @description List of table names to filter results. When provided, only returns metadata
-         * for the specified tables. When omitted, returns all tables in the schema.
-         */
-        tableNames?: string[];
-      };
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the schema */
-        schemaName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description A list of table names available in the specified schema */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Table"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Get table details from database
-   * @description Retrieves a table from the specified database schema.
-   * This endpoint is useful for discovering available data sources and exploring the database
-   * structure. The schema must exist in the connection for this operation to succeed.
-   * The tablePath is the full path to the table, including the schema name.
-   */
-  "get-table": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the schema */
-        schemaName: components["schemas"]["IdentifierPattern"];
-        /** @description Full path to the table */
-        tablePath: components["schemas"]["PathPattern"];
-      };
-    };
-    responses: {
-      /** @description Table information */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Table"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Get SQL source (deprecated)
-   * @deprecated
-   * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
-   * Use the POST version instead for better security and functionality.
-   *
-   * Creates a Malloy source from a SQL statement using the specified connection.
-   * The SQL statement is executed to generate a source definition that can be used in Malloy models.
-   */
-  "get-sqlsource": {
-    parameters: {
-      query?: {
-        /** @description SQL statement */
-        sqlStatement?: string;
-      };
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description SQL source information */
-      200: {
-        content: {
-          "application/json": components["schemas"]["SqlSource"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Create SQL source from statement
-   * @description Creates a Malloy source from a SQL statement using the specified database connection.
-   * The SQL statement is executed to generate a source definition that can be used in Malloy models.
-   */
-  "post-sqlsource": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    /** @description SQL statement to fetch the SQL source */
-    requestBody: {
-      content: {
-        "application/json": {
-          sqlStatement?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description SQL source information */
-      200: {
-        content: {
-          "application/json": components["schemas"]["SqlSource"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Execute SQL query
-   * @description Executes a SQL statement against the specified database connection and returns the results.
-   * The results include data, metadata, and execution information.
-   */
-  "post-querydata": {
-    parameters: {
-      query?: {
-        /**
-         * @deprecated
-         * @description Options (deprecated; pass in body instead)
-         */
-        options?: string;
-      };
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    /** @description SQL statement to execute */
-    requestBody: {
-      content: {
-        "application/json": {
-          sqlStatement?: string;
-          /** @description Options */
-          options?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Query execution results */
-      200: {
-        content: {
-          "application/json": components["schemas"]["QueryData"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Create temporary table
-   * @description Creates a temporary table from a SQL statement using the specified database connection.
-   * Temporary tables are useful for storing intermediate results during complex queries and data processing workflows.
-   */
-  "post-temporarytable": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    /** @description SQL statement to create the temporary table */
-    requestBody: {
-      content: {
-        "application/json": {
-          sqlStatement?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Temporary table information */
-      200: {
-        content: {
-          "application/json": components["schemas"]["TemporaryTable"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Create temporary table (deprecated)
-   * @deprecated
-   * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
-   * Use the POST version instead for better security and functionality.
-   *
-   * Creates a temporary table from a SQL statement using the specified connection.
-   * Temporary tables are useful for storing intermediate results during complex queries.
-   */
-  "get-temporarytable": {
-    parameters: {
-      query?: {
-        /** @description SQL statement */
-        sqlStatement?: string;
-      };
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description Temporary table information */
-      200: {
-        content: {
-          "application/json": components["schemas"]["TemporaryTable"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Execute SQL query (deprecated)
-   * @deprecated
-   * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
-   * Use the POST version instead for better security and functionality.
-   *
-   * Executes a SQL statement against the specified database connection and returns the results.
-   * The query results include data, metadata, and execution information.
-   */
-  "get-querydata": {
-    parameters: {
-      query?: {
-        /** @description SQL statement */
-        sqlStatement?: string;
-        /** @description Options */
-        options?: string;
-      };
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description Query execution results */
-      200: {
-        content: {
-          "application/json": components["schemas"]["QueryData"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-    };
-  };
-  /**
-   * List database schemas (per-package)
-   * @description Retrieves a list of all schemas (databases) available in the specified
-   * connection, resolved in the context of the named package. Required for
-   * `connectionName="duckdb"`, which is per-package; works for any other
-   * connection name as well (resolution falls through to the environment).
-   */
-  "list-schemas-in-package": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the package whose connection context to use */
-        packageName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description A list of schemas available in the connection with metadata */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Schema"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * List tables in database (per-package)
-   * @description Retrieves a list of all tables and views available in the specified
-   * database schema, resolved in the context of the named package.
-   */
-  "list-tables-in-package": {
-    parameters: {
-      query?: {
-        /**
-         * @description List of table names to filter results. When provided, only returns metadata
-         * for the specified tables. When omitted, returns all tables in the schema.
-         */
-        tableNames?: string[];
-      };
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the package whose connection context to use */
-        packageName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the schema */
-        schemaName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description A list of table names available in the specified schema */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Table"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Get table details from database (per-package)
-   * @description Retrieves a table from the specified database schema, resolved in
-   * the context of the named package.
-   */
-  "get-table-in-package": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the package whose connection context to use */
-        packageName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the schema */
-        schemaName: components["schemas"]["IdentifierPattern"];
-        /** @description Full path to the table */
-        tablePath: components["schemas"]["PathPattern"];
-      };
-    };
-    responses: {
-      /** @description Table information */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Table"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Get SQL source (per-package, deprecated)
-   * @deprecated
-   * @description **DEPRECATED**: Use the POST version instead.
-   *
-   * Creates a Malloy source from a SQL statement using the specified
-   * connection, resolved in the context of the named package.
-   */
-  "get-sqlsource-in-package": {
-    parameters: {
-      query?: {
-        /** @description SQL statement */
-        sqlStatement?: string;
-      };
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the package whose connection context to use */
-        packageName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description SQL source information */
-      200: {
-        content: {
-          "application/json": components["schemas"]["SqlSource"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Create SQL source from statement (per-package)
-   * @description Creates a Malloy source from a SQL statement using the specified
-   * connection, resolved in the context of the named package.
-   */
-  "post-sqlsource-in-package": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the package whose connection context to use */
-        packageName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    /** @description SQL statement to fetch the SQL source */
-    requestBody: {
-      content: {
-        "application/json": {
-          sqlStatement?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description SQL source information */
-      200: {
-        content: {
-          "application/json": components["schemas"]["SqlSource"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Execute SQL query (per-package)
-   * @description Executes a SQL statement against the specified database connection,
-   * resolved in the context of the named package, and returns the results.
-   */
-  "post-querydata-in-package": {
-    parameters: {
-      query?: {
-        /**
-         * @deprecated
-         * @description Options (deprecated; pass in body instead)
-         */
-        options?: string;
-      };
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the package whose connection context to use */
-        packageName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    /** @description SQL statement to execute */
-    requestBody: {
-      content: {
-        "application/json": {
-          sqlStatement?: string;
-          /** @description Options */
-          options?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Query execution results */
-      200: {
-        content: {
-          "application/json": components["schemas"]["QueryData"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Create temporary table (per-package)
-   * @description Creates a temporary table from a SQL statement using the specified
-   * database connection, resolved in the context of the named package.
-   */
-  "post-temporarytable-in-package": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the package whose connection context to use */
-        packageName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    /** @description SQL statement to create the temporary table */
-    requestBody: {
-      content: {
-        "application/json": {
-          sqlStatement?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Temporary table information */
-      200: {
-        content: {
-          "application/json": components["schemas"]["TemporaryTable"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Create temporary table (per-package, deprecated)
-   * @deprecated
-   * @description **DEPRECATED**: Use the POST version instead.
-   *
-   * Creates a temporary table from a SQL statement using the specified
-   * connection, resolved in the context of the named package.
-   */
-  "get-temporarytable-in-package": {
-    parameters: {
-      query?: {
-        /** @description SQL statement */
-        sqlStatement?: string;
-      };
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the package whose connection context to use */
-        packageName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description Temporary table information */
-      200: {
-        content: {
-          "application/json": components["schemas"]["TemporaryTable"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Execute SQL query (per-package, deprecated)
-   * @deprecated
-   * @description **DEPRECATED**: Use the POST version instead.
-   *
-   * Executes a SQL statement against the specified database connection,
-   * resolved in the context of the named package, and returns the results.
-   */
-  "get-querydata-in-package": {
-    parameters: {
-      query?: {
-        /** @description SQL statement */
-        sqlStatement?: string;
-        /** @description Options */
-        options?: string;
-      };
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the package whose connection context to use */
-        packageName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the connection */
-        connectionName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description Query execution results */
-      200: {
-        content: {
-          "application/json": components["schemas"]["QueryData"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-    };
-  };
-  /**
-   * List environment packages
-   * @description Retrieves a list of all Malloy packages within the specified environment. Each package
-   * contains models, notebooks, databases, and other resources. This endpoint is useful
-   * for discovering available packages and their basic metadata.
-   */
-  "list-packages": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description A list of all packages in the environment */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Package"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      500: components["responses"]["InternalServerError"];
-      501: components["responses"]["NotImplemented"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Create a new package
-   * @description Creates a new Malloy package within the specified environment. A package serves as a
-   * container for models, notebooks, embedded databases, and other resources. The package
-   * will be initialized with the provided metadata and can immediately accept content.
-   */
-  "create-package": {
-    parameters: {
-      query?: {
-        /**
-         * @description When true, automatically loads any existing build manifest
-         * for the package so materialized table references resolve immediately.
-         * Defaults to false.
-         */
-        autoLoadManifest?: boolean;
-      };
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["Package"];
-      };
-    };
-    responses: {
-      /** @description Returns the package created */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Package"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      500: components["responses"]["InternalServerError"];
-      501: components["responses"]["NotImplemented"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Get package details and metadata
-   * @description Retrieves detailed information about a specific package, including its models, notebooks,
-   * databases, and metadata. The reload parameter can be used to refresh the package state
-   * from disk before returning the information. The versionId parameter allows access to
-   * specific package versions.
-   */
-  "get-package": {
-    parameters: {
-      query?: {
-        /** @description Version identifier for the package */
-        versionId?: components["schemas"]["VersionIdPattern"];
-        /** @description Load / reload the package before returning result */
-        reload?: boolean;
-      };
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Package name */
-        packageName: string;
-      };
-    };
-    responses: {
-      /** @description Package details and metadata */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Package"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      501: components["responses"]["NotImplemented"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Delete a package
-   * @description Permanently deletes a package and all its associated resources including models,
-   * notebooks, databases, and metadata. This operation cannot be undone, so use with caution.
-   * The package must exist and be accessible for deletion.
-   */
-  "delete-package": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the package */
-        packageName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description Returns the package deleted */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Package"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      501: components["responses"]["NotImplemented"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Update package configuration
-   * @description Updates the configuration and metadata of an existing package. This allows you to
-   * modify package settings, update the description, change the location, or update other
-   * package-level properties. The package must exist and be accessible.
-   */
-  "update-package": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the package */
-        packageName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["Package"];
-      };
-    };
-    responses: {
-      /** @description Returns the package updated */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Package"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      501: components["responses"]["NotImplemented"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * List package models
-   * @description Retrieves a list of all Malloy models within the specified package. Each model entry
-   * includes the relative path, package name, and any compilation errors. This endpoint
-   * is useful for discovering available models and checking their status.
-   */
-  "list-models": {
-    parameters: {
-      query?: {
-        /** @description Version identifier for the package */
-        versionId?: components["schemas"]["VersionIdPattern"];
-      };
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the package */
-        packageName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description A list of models in the package */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Model"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      501: components["responses"]["NotImplemented"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Get compiled Malloy model
-   * @description Retrieves a compiled Malloy model with its source information, queries, and metadata.
-   * The model is compiled using the specified version of the Malloy compiler. This endpoint
-   * provides access to the model's structure, sources, and named queries for use in applications.
-   */
-  "get-model": {
-    parameters: {
-      query?: {
-        /** @description Version identifier for the package */
-        versionId?: components["schemas"]["VersionIdPattern"];
-      };
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the package */
-        packageName: string;
-        /** @description Path to the model within the package */
-        path: components["schemas"]["PathPattern"];
-      };
-    };
-    responses: {
-      /** @description Compiled Malloy model */
-      200: {
-        content: {
-          "application/json": components["schemas"]["CompiledModel"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      424: components["responses"]["ModelCompilationError"];
-      500: components["responses"]["InternalServerError"];
-      501: components["responses"]["NotImplemented"];
-    };
-  };
-  /**
-   * Execute Malloy query
-   * @description Executes a Malloy query against a model and returns the results. The query can be specified
-   * as a raw Malloy query string or by referencing a named query within the model. This endpoint
-   * supports both ad-hoc queries and predefined model queries, making it flexible for various
-   * use cases including data exploration, reporting, and application integration.
-   */
-  "execute-query-model": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the package */
-        packageName: components["schemas"]["VersionIdPattern"];
-        /** @description Path to the model within the package */
-        path: components["schemas"]["PathPattern"];
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["QueryRequest"];
-      };
-    };
-    responses: {
-      /** @description Query execution results */
-      200: {
-        content: {
-          "application/json": components["schemas"]["QueryResult"];
-        };
-      };
-      400: components["responses"]["BadRequest"];
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      501: components["responses"]["NotImplemented"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Compile Malloy source code
-   * @description Compiles Malloy source code in the context of a specific model file.
-   * The submitted source is appended to the full model content, giving it
-   * access to all sources, imports, and queries defined in the model.
-   * Relative imports resolve correctly against sibling model files.
-   * Returns compilation status and any problems (errors or warnings) found.
-   */
-  "compile-model-source": {
-    parameters: {
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the package */
-        packageName: string;
-        /** @description Path to the model within the package (used to resolve relative imports) */
-        path: components["schemas"]["PathPattern"];
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CompileRequest"];
-      };
-    };
-    responses: {
-      /** @description Compilation result with status and any problems */
-      200: {
-        content: {
-          "application/json": components["schemas"]["CompileResult"];
-        };
-      };
-      400: components["responses"]["BadRequest"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * List package notebooks
-   * @description Retrieves a list of all Malloy notebooks within the specified package. Each notebook entry
-   * includes the relative path, package name, and any compilation errors. This endpoint
-   * is useful for discovering available notebooks and checking their status.
-   */
-  "list-notebooks": {
-    parameters: {
-      query?: {
-        /** @description Version identifier for the package */
-        versionId?: components["schemas"]["VersionIdPattern"];
-      };
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the package */
-        packageName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description A list of models in the package */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Notebook"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      501: components["responses"]["NotImplemented"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Get Malloy notebook cells
-   * @description Retrieves a Malloy notebook with its raw cell contents (markdown and code).
-   * Cell execution should be done separately via the execute-notebook-cell endpoint.
-   */
-  "get-notebook": {
-    parameters: {
-      query?: {
-        /** @description Version identifier for the package */
-        versionId?: components["schemas"]["VersionIdPattern"];
-      };
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the package */
-        packageName: string;
-        /** @description Path to notebook within the package. */
-        path: string;
-      };
-    };
-    responses: {
-      /** @description A Malloy notebook with raw cell contents. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["RawNotebook"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      501: components["responses"]["NotImplemented"];
-    };
-  };
-  /**
-   * Execute a specific notebook cell
-   * @description Executes a specific cell in a Malloy notebook by index. For code cells, this compiles
-   * and runs the Malloy code, returning query results and any new sources defined.
-   * For markdown cells, this simply returns the cell content.
-   */
-  "execute-notebook-cell": {
-    parameters: {
-      query?: {
-        /** @description Version identifier for the package */
-        versionId?: components["schemas"]["VersionIdPattern"];
-        /** @description JSON-encoded filter parameter values keyed by filter name */
-        filter_params?: string;
-        /** @description When true, skip filter injection entirely */
-        bypass_filters?: "true" | "false";
-      };
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the package */
-        packageName: string;
-        /** @description Path to notebook within the package */
-        path: string;
-        /** @description Index of the cell to execute (0-based) */
-        cellIndex: number;
-      };
-    };
-    responses: {
-      /** @description Cell execution result */
-      200: {
-        content: {
-          "application/json": components["schemas"]["NotebookCellResult"];
-        };
-      };
-      400: components["responses"]["BadRequest"];
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      501: components["responses"]["NotImplemented"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * List embedded databases
-   * @description Retrieves a list of all embedded databases within the specified package. These are typically
-   * DuckDB databases stored as .parquet files that provide local data storage for the package.
-   * Each database entry includes metadata about the database structure and content.
-   */
-  "list-databases": {
-    parameters: {
-      query?: {
-        /** @description Version identifier for the package */
-        versionId?: components["schemas"]["VersionIdPattern"];
-      };
-      path: {
-        /** @description Name of the environment */
-        environmentName: components["schemas"]["IdentifierPattern"];
-        /** @description Name of the package */
-        packageName: components["schemas"]["IdentifierPattern"];
-      };
-    };
-    responses: {
-      /** @description A list of embedded databases in the package */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Database"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      501: components["responses"]["NotImplemented"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Test database connection configuration
-   * @description Validates a database connection configuration without adding it to any environment.
-   * This endpoint allows you to test connection parameters, credentials, and network
-   * connectivity before committing the connection to an environment. Useful for troubleshooting
-   * connection issues and validating configurations during setup.
-   */
-  "test-connection-configuration": {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["Connection"];
-      };
-    };
-    responses: {
-      /** @description Connection test result */
-      200: {
-        content: {
-          "application/json": components["schemas"]["ConnectionStatus"];
-        };
-      };
-      400: components["responses"]["BadRequest"];
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Get watch mode status
-   * @description Retrieves the current status of the file watching system. This includes whether watch mode
-   * is enabled, which environment is being watched, and the path being monitored. Useful for
-   * monitoring the development workflow and ensuring file changes are being detected.
-   */
-  "get-watch-status": {
-    responses: {
-      /** @description The current watch mode status. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["WatchStatus"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Start file watching
-   * @description Initiates file watching for the specified environment. This enables real-time monitoring of
-   * file changes within the environment directory, allowing for automatic reloading and updates
-   * during development. Only one environment can be watched at a time.
-   */
-  "start-watching": {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["StartWatchRequest"];
-      };
-    };
-    responses: {
-      /** @description Watch mode started successfully. */
-      200: {
-        content: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * Stop file watching
-   * @description Stops the current file watching session. This disables real-time monitoring of file changes
-   * and releases system resources. Use this when development is complete or when switching
-   * to a different environment.
-   */
-  "stop-watching": {
-    responses: {
-      /** @description Watch mode stopped successfully. */
-      200: {
-        content: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      500: components["responses"]["InternalServerError"];
-      503: components["responses"]["ServiceUnavailable"];
-    };
-  };
-  /**
-   * List materializations for a package
-   * @description Returns the materialization history for the package, ordered by most recent first.
-   */
-  "list-materializations": {
-    parameters: {
-      query?: {
-        /** @description Maximum number of materializations to return */
-        limit?: number;
-        /** @description Number of materializations to skip */
-        offset?: number;
-      };
-      path: {
-        environmentName: components["parameters"]["environmentName"];
-        packageName: components["parameters"]["packageName"];
-      };
-    };
-    responses: {
-      /** @description List of materializations */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Materialization"][];
-        };
-      };
-      404: components["responses"]["NotFound"];
-    };
-  };
-  /**
-   * Create a materialization
-   * @description Creates a new materialization in PENDING state for all persist sources across all
-   * models in the package. Use POST .../materializations/{materializationId}?action=start to begin execution.
-   */
-  "create-materialization": {
-    parameters: {
-      path: {
-        environmentName: components["parameters"]["environmentName"];
-        packageName: components["parameters"]["packageName"];
-      };
-    };
-    requestBody?: {
-      content: {
-        "application/json": components["schemas"]["CreateMaterializationRequest"];
-      };
-    };
-    responses: {
-      /** @description Materialization created */
-      201: {
-        content: {
-          "application/json": components["schemas"]["Materialization"];
-        };
-      };
-      404: components["responses"]["NotFound"];
-      /** @description Package already has an active materialization */
-      409: {
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
-  /** Get a specific materialization */
-  "get-materialization": {
-    parameters: {
-      path: {
-        environmentName: components["parameters"]["environmentName"];
-        packageName: components["parameters"]["packageName"];
-        materializationId: components["parameters"]["materializationId"];
-      };
-    };
-    responses: {
-      /** @description Materialization details */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Materialization"];
-        };
-      };
-      404: components["responses"]["NotFound"];
-    };
-  };
-  /**
-   * Perform an action on a materialization
-   * @description Performs an action on a materialization. The action is specified via
-   * the `action` query parameter:
-   *   * `start` - Transitions a PENDING materialization to RUNNING and begins execution in the background. Returns 202.
-   *   * `stop` - Cancels a PENDING or RUNNING materialization. Returns 200.
-   */
-  "materialization-action": {
-    parameters: {
-      query: {
-        /** @description Action to perform on the materialization */
-        action: "start" | "stop";
-      };
-      path: {
-        environmentName: components["parameters"]["environmentName"];
-        packageName: components["parameters"]["packageName"];
-        materializationId: components["parameters"]["materializationId"];
-      };
-    };
-    responses: {
-      /** @description Materialization cancelled (action=stop) */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Materialization"];
-        };
-      };
-      /** @description Materialization started (action=start) */
-      202: {
-        content: {
-          "application/json": components["schemas"]["Materialization"];
-        };
-      };
-      400: components["responses"]["BadRequest"];
-      404: components["responses"]["NotFound"];
-      /** @description Materialization cannot transition to the requested state */
-      409: {
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
-  /**
-   * Delete a materialization
-   * @description Deletes a terminal (SUCCESS, FAILED, or CANCELLED) materialization record.
-   */
-  "delete-materialization": {
-    parameters: {
-      path: {
-        environmentName: components["parameters"]["environmentName"];
-        packageName: components["parameters"]["packageName"];
-        materializationId: components["parameters"]["materializationId"];
-      };
-    };
-    responses: {
-      /** @description Materialization deleted */
-      204: {
-        content: never;
-      };
-      404: components["responses"]["NotFound"];
-      /** @description Materialization cannot be deleted (PENDING or RUNNING) */
-      409: {
-        content: {
-          "application/json": components["schemas"]["Error"];
-        };
-      };
-    };
-  };
-  /**
-   * Get the build manifest for a package
-   * @description Returns the current build manifest containing buildId-to-tableName mappings
-   * for all materialized sources in the package.
-   */
-  "get-manifest": {
-    parameters: {
-      path: {
-        environmentName: components["parameters"]["environmentName"];
-        packageName: components["parameters"]["packageName"];
-      };
-    };
-    responses: {
-      /** @description Build manifest */
-      200: {
-        content: {
-          "application/json": components["schemas"]["BuildManifest"];
-        };
-      };
-      404: components["responses"]["NotFound"];
-    };
-  };
-  /**
-   * Perform an action on the package manifest
-   * @description Performs an action on the package manifest. The action is specified via
-   * the `action` query parameter:
-   *   * `reload` - Reads the build manifest from the shared store (DuckLake
-   *     in orchestrated mode, local DuckDB in standalone mode) and recompiles
-   *     every model in the package so subsequent queries resolve persisted
-   *     sources to their materialized tables. Intended for orchestrated
-   *     workers that did not themselves run the build; the endpoint does
-   *     not write anything *into* storage.
-   */
-  "manifest-action": {
-    parameters: {
-      query: {
-        /** @description Action to perform on the manifest */
-        action: "reload";
-      };
-      path: {
-        environmentName: components["parameters"]["environmentName"];
-        packageName: components["parameters"]["packageName"];
-      };
-    };
-    responses: {
-      /** @description Manifest loaded */
-      200: {
-        content: {
-          "application/json": components["schemas"]["BuildManifest"];
-        };
-      };
-      400: components["responses"]["BadRequest"];
-      404: components["responses"]["NotFound"];
-    };
-  };
+   /**
+    * Get server status and health information
+    * @description Returns the current status of the Malloy Publisher server, including initialization state,
+    * available environments, and server timestamp. This endpoint is useful for health checks and
+    * monitoring server availability.
+    */
+   "get-status": {
+      responses: {
+         /** @description Returns server status */
+         200: {
+            content: {
+               "application/json": components["schemas"]["ServerStatus"];
+            };
+         };
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * List all available environments
+    * @description Retrieves a list of all environments currently hosted on this Malloy Publisher server.
+    * Each environment contains metadata about its packages, connections, and configuration.
+    * This endpoint is typically used to discover available environments and their basic information.
+    */
+   "list-environments": {
+      responses: {
+         /** @description A list of all available environments */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Environment"][];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Create a new environment
+    * @description Creates a new Malloy environment with the specified configuration. An environment serves as a
+    * container for packages, connections, and other resources. The environment will be initialized
+    * with the provided metadata and can immediately accept packages and connections.
+    */
+   "create-environment": {
+      requestBody: {
+         content: {
+            "application/json": components["schemas"]["Environment"];
+         };
+      };
+      responses: {
+         /** @description Returns the environment created */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Environment"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Get environment details and metadata
+    * @description Retrieves detailed information about a specific environment, including its packages,
+    * connections, configuration, and metadata. The reload parameter can be used to
+    * refresh the environment state from disk before returning the information.
+    */
+   "get-environment": {
+      parameters: {
+         query?: {
+            /** @description Load / reload the environment before returning result */
+            reload?: boolean;
+         };
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description Environment details and metadata */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Environment"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Delete an environment
+    * @description Permanently deletes an environment and all its associated resources including packages,
+    * connections, and metadata. This operation cannot be undone, so use with caution.
+    * The environment must exist and be accessible for deletion.
+    */
+   "delete-environment": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description Returns the environment deleted */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Environment"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Update environment configuration
+    * @description Updates the configuration and metadata of an existing environment. This allows you to
+    * modify environment settings, update the README, change the location, or update other
+    * environment-level properties. The environment must exist and be accessible.
+    */
+   "update-environment": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      requestBody: {
+         content: {
+            "application/json": components["schemas"]["Environment"];
+         };
+      };
+      responses: {
+         /** @description Returns the environment updated */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Environment"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * List environment database connections
+    * @description Retrieves a list of all database connections configured for the specified environment.
+    * Each connection includes its configuration, type, and status information. This endpoint
+    * is useful for discovering available data sources within an environment.
+    */
+   "list-connections": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description A list of database connections in the environment */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Connection"][];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Get connection details
+    * @description Retrieves detailed information about a specific database connection within an environment.
+    * This includes connection configuration, credentials (if accessible), and metadata.
+    * Useful for inspecting connection settings and troubleshooting connectivity issues.
+    */
+   "get-connection": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description Connection details and configuration */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Connection"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Create a new database connection
+    * @description Creates a new database connection in the specified environment.
+    */
+   "create-connection": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      requestBody: {
+         content: {
+            "application/json": components["schemas"]["Connection"];
+         };
+      };
+      responses: {
+         /** @description Connection created successfully */
+         201: {
+            content: {
+               "application/json": {
+                  message?: string;
+               };
+            };
+         };
+         400: components["responses"]["BadRequest"];
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         /** @description Connection already exists */
+         409: {
+            content: {
+               "application/json": {
+                  error?: string;
+               };
+            };
+         };
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Delete a database connection
+    * @description Permanently deletes a database connection from the environment.
+    */
+   "delete-connection": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection to delete */
+            connectionName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description Connection deleted successfully */
+         200: {
+            content: {
+               "application/json": {
+                  message?: string;
+               };
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Update an existing database connection
+    * @description Updates the configuration of an existing database connection.
+    */
+   "update-connection": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection to update */
+            connectionName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      requestBody: {
+         content: {
+            "application/json": {
+               postgresConnection?: components["schemas"]["PostgresConnection"];
+               mysqlConnection?: components["schemas"]["MysqlConnection"];
+               bigqueryConnection?: components["schemas"]["BigqueryConnection"];
+               snowflakeConnection?: components["schemas"]["SnowflakeConnection"];
+               duckdbConnection?: components["schemas"]["DuckdbConnection"];
+               motherduckConnection?: components["schemas"]["MotherDuckConnection"];
+               trinoConnection?: components["schemas"]["TrinoConnection"];
+               databricksConnection?: components["schemas"]["DatabricksConnection"];
+               ducklakeConnection?: components["schemas"]["DucklakeConnection"];
+            };
+         };
+      };
+      responses: {
+         /** @description Connection updated successfully */
+         200: {
+            content: {
+               "application/json": {
+                  message?: string;
+               };
+            };
+         };
+         400: components["responses"]["BadRequest"];
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * List database schemas
+    * @description Retrieves a list of all schemas (databases) available in the specified connection.
+    * Each schema includes metadata such as name, description, and whether it's the default schema.
+    * This endpoint is useful for exploring the database structure and discovering available data sources.
+    */
+   "list-schemas": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description A list of schemas available in the connection with metadata */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Schema"][];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * List tables in database
+    * @description Retrieves a list of all tables and views available in the specified database schema.
+    * This endpoint is useful for discovering available data sources and exploring the database
+    * structure. The schema must exist in the connection for this operation to succeed.
+    */
+   "list-tables": {
+      parameters: {
+         query?: {
+            /**
+             * @description List of table names to filter results. When provided, only returns metadata
+             * for the specified tables. When omitted, returns all tables in the schema.
+             */
+            tableNames?: string[];
+         };
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the schema */
+            schemaName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description A list of table names available in the specified schema */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Table"][];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Get table details from database
+    * @description Retrieves a table from the specified database schema.
+    * This endpoint is useful for discovering available data sources and exploring the database
+    * structure. The schema must exist in the connection for this operation to succeed.
+    * The tablePath is the full path to the table, including the schema name.
+    */
+   "get-table": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the schema */
+            schemaName: components["schemas"]["IdentifierPattern"];
+            /** @description Full path to the table */
+            tablePath: components["schemas"]["PathPattern"];
+         };
+      };
+      responses: {
+         /** @description Table information */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Table"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Get SQL source (deprecated)
+    * @deprecated
+    * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
+    * Use the POST version instead for better security and functionality.
+    *
+    * Creates a Malloy source from a SQL statement using the specified connection.
+    * The SQL statement is executed to generate a source definition that can be used in Malloy models.
+    */
+   "get-sqlsource": {
+      parameters: {
+         query?: {
+            /** @description SQL statement */
+            sqlStatement?: string;
+         };
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description SQL source information */
+         200: {
+            content: {
+               "application/json": components["schemas"]["SqlSource"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Create SQL source from statement
+    * @description Creates a Malloy source from a SQL statement using the specified database connection.
+    * The SQL statement is executed to generate a source definition that can be used in Malloy models.
+    */
+   "post-sqlsource": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      /** @description SQL statement to fetch the SQL source */
+      requestBody: {
+         content: {
+            "application/json": {
+               sqlStatement?: string;
+            };
+         };
+      };
+      responses: {
+         /** @description SQL source information */
+         200: {
+            content: {
+               "application/json": components["schemas"]["SqlSource"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Execute SQL query
+    * @description Executes a SQL statement against the specified database connection and returns the results.
+    * The results include data, metadata, and execution information.
+    */
+   "post-querydata": {
+      parameters: {
+         query?: {
+            /**
+             * @deprecated
+             * @description Options (deprecated; pass in body instead)
+             */
+            options?: string;
+         };
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      /** @description SQL statement to execute */
+      requestBody: {
+         content: {
+            "application/json": {
+               sqlStatement?: string;
+               /** @description Options */
+               options?: string;
+            };
+         };
+      };
+      responses: {
+         /** @description Query execution results */
+         200: {
+            content: {
+               "application/json": components["schemas"]["QueryData"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Create temporary table
+    * @description Creates a temporary table from a SQL statement using the specified database connection.
+    * Temporary tables are useful for storing intermediate results during complex queries and data processing workflows.
+    */
+   "post-temporarytable": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      /** @description SQL statement to create the temporary table */
+      requestBody: {
+         content: {
+            "application/json": {
+               sqlStatement?: string;
+            };
+         };
+      };
+      responses: {
+         /** @description Temporary table information */
+         200: {
+            content: {
+               "application/json": components["schemas"]["TemporaryTable"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Create temporary table (deprecated)
+    * @deprecated
+    * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
+    * Use the POST version instead for better security and functionality.
+    *
+    * Creates a temporary table from a SQL statement using the specified connection.
+    * Temporary tables are useful for storing intermediate results during complex queries.
+    */
+   "get-temporarytable": {
+      parameters: {
+         query?: {
+            /** @description SQL statement */
+            sqlStatement?: string;
+         };
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description Temporary table information */
+         200: {
+            content: {
+               "application/json": components["schemas"]["TemporaryTable"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Execute SQL query (deprecated)
+    * @deprecated
+    * @description **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
+    * Use the POST version instead for better security and functionality.
+    *
+    * Executes a SQL statement against the specified database connection and returns the results.
+    * The query results include data, metadata, and execution information.
+    */
+   "get-querydata": {
+      parameters: {
+         query?: {
+            /** @description SQL statement */
+            sqlStatement?: string;
+            /** @description Options */
+            options?: string;
+         };
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description Query execution results */
+         200: {
+            content: {
+               "application/json": components["schemas"]["QueryData"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+      };
+   };
+   /**
+    * List database schemas (per-package)
+    * @description Retrieves a list of all schemas (databases) available in the specified
+    * connection, resolved in the context of the named package. Required for
+    * `connectionName="duckdb"`, which is per-package; works for any other
+    * connection name as well (resolution falls through to the environment).
+    */
+   "list-schemas-in-package": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the package whose connection context to use */
+            packageName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description A list of schemas available in the connection with metadata */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Schema"][];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * List tables in database (per-package)
+    * @description Retrieves a list of all tables and views available in the specified
+    * database schema, resolved in the context of the named package.
+    */
+   "list-tables-in-package": {
+      parameters: {
+         query?: {
+            /**
+             * @description List of table names to filter results. When provided, only returns metadata
+             * for the specified tables. When omitted, returns all tables in the schema.
+             */
+            tableNames?: string[];
+         };
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the package whose connection context to use */
+            packageName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the schema */
+            schemaName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description A list of table names available in the specified schema */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Table"][];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Get table details from database (per-package)
+    * @description Retrieves a table from the specified database schema, resolved in
+    * the context of the named package.
+    */
+   "get-table-in-package": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the package whose connection context to use */
+            packageName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the schema */
+            schemaName: components["schemas"]["IdentifierPattern"];
+            /** @description Full path to the table */
+            tablePath: components["schemas"]["PathPattern"];
+         };
+      };
+      responses: {
+         /** @description Table information */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Table"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Get SQL source (per-package, deprecated)
+    * @deprecated
+    * @description **DEPRECATED**: Use the POST version instead.
+    *
+    * Creates a Malloy source from a SQL statement using the specified
+    * connection, resolved in the context of the named package.
+    */
+   "get-sqlsource-in-package": {
+      parameters: {
+         query?: {
+            /** @description SQL statement */
+            sqlStatement?: string;
+         };
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the package whose connection context to use */
+            packageName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description SQL source information */
+         200: {
+            content: {
+               "application/json": components["schemas"]["SqlSource"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Create SQL source from statement (per-package)
+    * @description Creates a Malloy source from a SQL statement using the specified
+    * connection, resolved in the context of the named package.
+    */
+   "post-sqlsource-in-package": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the package whose connection context to use */
+            packageName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      /** @description SQL statement to fetch the SQL source */
+      requestBody: {
+         content: {
+            "application/json": {
+               sqlStatement?: string;
+            };
+         };
+      };
+      responses: {
+         /** @description SQL source information */
+         200: {
+            content: {
+               "application/json": components["schemas"]["SqlSource"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Execute SQL query (per-package)
+    * @description Executes a SQL statement against the specified database connection,
+    * resolved in the context of the named package, and returns the results.
+    */
+   "post-querydata-in-package": {
+      parameters: {
+         query?: {
+            /**
+             * @deprecated
+             * @description Options (deprecated; pass in body instead)
+             */
+            options?: string;
+         };
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the package whose connection context to use */
+            packageName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      /** @description SQL statement to execute */
+      requestBody: {
+         content: {
+            "application/json": {
+               sqlStatement?: string;
+               /** @description Options */
+               options?: string;
+            };
+         };
+      };
+      responses: {
+         /** @description Query execution results */
+         200: {
+            content: {
+               "application/json": components["schemas"]["QueryData"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Create temporary table (per-package)
+    * @description Creates a temporary table from a SQL statement using the specified
+    * database connection, resolved in the context of the named package.
+    */
+   "post-temporarytable-in-package": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the package whose connection context to use */
+            packageName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      /** @description SQL statement to create the temporary table */
+      requestBody: {
+         content: {
+            "application/json": {
+               sqlStatement?: string;
+            };
+         };
+      };
+      responses: {
+         /** @description Temporary table information */
+         200: {
+            content: {
+               "application/json": components["schemas"]["TemporaryTable"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Create temporary table (per-package, deprecated)
+    * @deprecated
+    * @description **DEPRECATED**: Use the POST version instead.
+    *
+    * Creates a temporary table from a SQL statement using the specified
+    * connection, resolved in the context of the named package.
+    */
+   "get-temporarytable-in-package": {
+      parameters: {
+         query?: {
+            /** @description SQL statement */
+            sqlStatement?: string;
+         };
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the package whose connection context to use */
+            packageName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description Temporary table information */
+         200: {
+            content: {
+               "application/json": components["schemas"]["TemporaryTable"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Execute SQL query (per-package, deprecated)
+    * @deprecated
+    * @description **DEPRECATED**: Use the POST version instead.
+    *
+    * Executes a SQL statement against the specified database connection,
+    * resolved in the context of the named package, and returns the results.
+    */
+   "get-querydata-in-package": {
+      parameters: {
+         query?: {
+            /** @description SQL statement */
+            sqlStatement?: string;
+            /** @description Options */
+            options?: string;
+         };
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the package whose connection context to use */
+            packageName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the connection */
+            connectionName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description Query execution results */
+         200: {
+            content: {
+               "application/json": components["schemas"]["QueryData"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+      };
+   };
+   /**
+    * List environment packages
+    * @description Retrieves a list of all Malloy packages within the specified environment. Each package
+    * contains models, notebooks, databases, and other resources. This endpoint is useful
+    * for discovering available packages and their basic metadata.
+    */
+   "list-packages": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description A list of all packages in the environment */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Package"][];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         500: components["responses"]["InternalServerError"];
+         501: components["responses"]["NotImplemented"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Create a new package
+    * @description Creates a new Malloy package within the specified environment. A package serves as a
+    * container for models, notebooks, embedded databases, and other resources. The package
+    * will be initialized with the provided metadata and can immediately accept content.
+    */
+   "create-package": {
+      parameters: {
+         query?: {
+            /**
+             * @description When true, automatically loads any existing build manifest
+             * for the package so materialized table references resolve immediately.
+             * Defaults to false.
+             */
+            autoLoadManifest?: boolean;
+         };
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      requestBody: {
+         content: {
+            "application/json": components["schemas"]["Package"];
+         };
+      };
+      responses: {
+         /** @description Returns the package created */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Package"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         500: components["responses"]["InternalServerError"];
+         501: components["responses"]["NotImplemented"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Get package details and metadata
+    * @description Retrieves detailed information about a specific package, including its models, notebooks,
+    * databases, and metadata. The reload parameter can be used to refresh the package state
+    * from disk before returning the information. The versionId parameter allows access to
+    * specific package versions.
+    */
+   "get-package": {
+      parameters: {
+         query?: {
+            /** @description Version identifier for the package */
+            versionId?: components["schemas"]["VersionIdPattern"];
+            /** @description Load / reload the package before returning result */
+            reload?: boolean;
+         };
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Package name */
+            packageName: string;
+         };
+      };
+      responses: {
+         /** @description Package details and metadata */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Package"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         501: components["responses"]["NotImplemented"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Delete a package
+    * @description Permanently deletes a package and all its associated resources including models,
+    * notebooks, databases, and metadata. This operation cannot be undone, so use with caution.
+    * The package must exist and be accessible for deletion.
+    */
+   "delete-package": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the package */
+            packageName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description Returns the package deleted */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Package"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         501: components["responses"]["NotImplemented"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Update package configuration
+    * @description Updates the configuration and metadata of an existing package. This allows you to
+    * modify package settings, update the description, change the location, or update other
+    * package-level properties. The package must exist and be accessible.
+    */
+   "update-package": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the package */
+            packageName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      requestBody: {
+         content: {
+            "application/json": components["schemas"]["Package"];
+         };
+      };
+      responses: {
+         /** @description Returns the package updated */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Package"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         501: components["responses"]["NotImplemented"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * List package models
+    * @description Retrieves a list of all Malloy models within the specified package. Each model entry
+    * includes the relative path, package name, and any compilation errors. This endpoint
+    * is useful for discovering available models and checking their status.
+    */
+   "list-models": {
+      parameters: {
+         query?: {
+            /** @description Version identifier for the package */
+            versionId?: components["schemas"]["VersionIdPattern"];
+         };
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the package */
+            packageName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description A list of models in the package */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Model"][];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         501: components["responses"]["NotImplemented"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Get compiled Malloy model
+    * @description Retrieves a compiled Malloy model with its source information, queries, and metadata.
+    * The model is compiled using the specified version of the Malloy compiler. This endpoint
+    * provides access to the model's structure, sources, and named queries for use in applications.
+    */
+   "get-model": {
+      parameters: {
+         query?: {
+            /** @description Version identifier for the package */
+            versionId?: components["schemas"]["VersionIdPattern"];
+         };
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the package */
+            packageName: string;
+            /** @description Path to the model within the package */
+            path: components["schemas"]["PathPattern"];
+         };
+      };
+      responses: {
+         /** @description Compiled Malloy model */
+         200: {
+            content: {
+               "application/json": components["schemas"]["CompiledModel"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         424: components["responses"]["ModelCompilationError"];
+         500: components["responses"]["InternalServerError"];
+         501: components["responses"]["NotImplemented"];
+      };
+   };
+   /**
+    * Execute Malloy query
+    * @description Executes a Malloy query against a model and returns the results. The query can be specified
+    * as a raw Malloy query string or by referencing a named query within the model. This endpoint
+    * supports both ad-hoc queries and predefined model queries, making it flexible for various
+    * use cases including data exploration, reporting, and application integration.
+    */
+   "execute-query-model": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the package */
+            packageName: components["schemas"]["VersionIdPattern"];
+            /** @description Path to the model within the package */
+            path: components["schemas"]["PathPattern"];
+         };
+      };
+      requestBody: {
+         content: {
+            "application/json": components["schemas"]["QueryRequest"];
+         };
+      };
+      responses: {
+         /** @description Query execution results */
+         200: {
+            content: {
+               "application/json": components["schemas"]["QueryResult"];
+            };
+         };
+         400: components["responses"]["BadRequest"];
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         501: components["responses"]["NotImplemented"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Compile Malloy source code
+    * @description Compiles Malloy source code in the context of a specific model file.
+    * The submitted source is appended to the full model content, giving it
+    * access to all sources, imports, and queries defined in the model.
+    * Relative imports resolve correctly against sibling model files.
+    * Returns compilation status and any problems (errors or warnings) found.
+    */
+   "compile-model-source": {
+      parameters: {
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the package */
+            packageName: string;
+            /** @description Path to the model within the package (used to resolve relative imports) */
+            path: components["schemas"]["PathPattern"];
+         };
+      };
+      requestBody: {
+         content: {
+            "application/json": components["schemas"]["CompileRequest"];
+         };
+      };
+      responses: {
+         /** @description Compilation result with status and any problems */
+         200: {
+            content: {
+               "application/json": components["schemas"]["CompileResult"];
+            };
+         };
+         400: components["responses"]["BadRequest"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * List package notebooks
+    * @description Retrieves a list of all Malloy notebooks within the specified package. Each notebook entry
+    * includes the relative path, package name, and any compilation errors. This endpoint
+    * is useful for discovering available notebooks and checking their status.
+    */
+   "list-notebooks": {
+      parameters: {
+         query?: {
+            /** @description Version identifier for the package */
+            versionId?: components["schemas"]["VersionIdPattern"];
+         };
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the package */
+            packageName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description A list of models in the package */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Notebook"][];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         501: components["responses"]["NotImplemented"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Get Malloy notebook cells
+    * @description Retrieves a Malloy notebook with its raw cell contents (markdown and code).
+    * Cell execution should be done separately via the execute-notebook-cell endpoint.
+    */
+   "get-notebook": {
+      parameters: {
+         query?: {
+            /** @description Version identifier for the package */
+            versionId?: components["schemas"]["VersionIdPattern"];
+         };
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the package */
+            packageName: string;
+            /** @description Path to notebook within the package. */
+            path: string;
+         };
+      };
+      responses: {
+         /** @description A Malloy notebook with raw cell contents. */
+         200: {
+            content: {
+               "application/json": components["schemas"]["RawNotebook"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         501: components["responses"]["NotImplemented"];
+      };
+   };
+   /**
+    * Execute a specific notebook cell
+    * @description Executes a specific cell in a Malloy notebook by index. For code cells, this compiles
+    * and runs the Malloy code, returning query results and any new sources defined.
+    * For markdown cells, this simply returns the cell content.
+    */
+   "execute-notebook-cell": {
+      parameters: {
+         query?: {
+            /** @description Version identifier for the package */
+            versionId?: components["schemas"]["VersionIdPattern"];
+            /** @description JSON-encoded filter parameter values keyed by filter name */
+            filter_params?: string;
+            /** @description When true, skip filter injection entirely */
+            bypass_filters?: "true" | "false";
+         };
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the package */
+            packageName: string;
+            /** @description Path to notebook within the package */
+            path: string;
+            /** @description Index of the cell to execute (0-based) */
+            cellIndex: number;
+         };
+      };
+      responses: {
+         /** @description Cell execution result */
+         200: {
+            content: {
+               "application/json": components["schemas"]["NotebookCellResult"];
+            };
+         };
+         400: components["responses"]["BadRequest"];
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         501: components["responses"]["NotImplemented"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * List embedded databases
+    * @description Retrieves a list of all embedded databases within the specified package. These are typically
+    * DuckDB databases stored as .parquet files that provide local data storage for the package.
+    * Each database entry includes metadata about the database structure and content.
+    */
+   "list-databases": {
+      parameters: {
+         query?: {
+            /** @description Version identifier for the package */
+            versionId?: components["schemas"]["VersionIdPattern"];
+         };
+         path: {
+            /** @description Name of the environment */
+            environmentName: components["schemas"]["IdentifierPattern"];
+            /** @description Name of the package */
+            packageName: components["schemas"]["IdentifierPattern"];
+         };
+      };
+      responses: {
+         /** @description A list of embedded databases in the package */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Database"][];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         501: components["responses"]["NotImplemented"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Test database connection configuration
+    * @description Validates a database connection configuration without adding it to any environment.
+    * This endpoint allows you to test connection parameters, credentials, and network
+    * connectivity before committing the connection to an environment. Useful for troubleshooting
+    * connection issues and validating configurations during setup.
+    */
+   "test-connection-configuration": {
+      requestBody: {
+         content: {
+            "application/json": components["schemas"]["Connection"];
+         };
+      };
+      responses: {
+         /** @description Connection test result */
+         200: {
+            content: {
+               "application/json": components["schemas"]["ConnectionStatus"];
+            };
+         };
+         400: components["responses"]["BadRequest"];
+         401: components["responses"]["Unauthorized"];
+         404: components["responses"]["NotFound"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Get watch mode status
+    * @description Retrieves the current status of the file watching system. This includes whether watch mode
+    * is enabled, which environment is being watched, and the path being monitored. Useful for
+    * monitoring the development workflow and ensuring file changes are being detected.
+    */
+   "get-watch-status": {
+      responses: {
+         /** @description The current watch mode status. */
+         200: {
+            content: {
+               "application/json": components["schemas"]["WatchStatus"];
+            };
+         };
+         401: components["responses"]["Unauthorized"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Start file watching
+    * @description Initiates file watching for the specified environment. This enables real-time monitoring of
+    * file changes within the environment directory, allowing for automatic reloading and updates
+    * during development. Only one environment can be watched at a time.
+    */
+   "start-watching": {
+      requestBody: {
+         content: {
+            "application/json": components["schemas"]["StartWatchRequest"];
+         };
+      };
+      responses: {
+         /** @description Watch mode started successfully. */
+         200: {
+            content: never;
+         };
+         401: components["responses"]["Unauthorized"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * Stop file watching
+    * @description Stops the current file watching session. This disables real-time monitoring of file changes
+    * and releases system resources. Use this when development is complete or when switching
+    * to a different environment.
+    */
+   "stop-watching": {
+      responses: {
+         /** @description Watch mode stopped successfully. */
+         200: {
+            content: never;
+         };
+         401: components["responses"]["Unauthorized"];
+         500: components["responses"]["InternalServerError"];
+         503: components["responses"]["ServiceUnavailable"];
+      };
+   };
+   /**
+    * List materializations for a package
+    * @description Returns the materialization history for the package, ordered by most recent first.
+    */
+   "list-materializations": {
+      parameters: {
+         query?: {
+            /** @description Maximum number of materializations to return */
+            limit?: number;
+            /** @description Number of materializations to skip */
+            offset?: number;
+         };
+         path: {
+            environmentName: components["parameters"]["environmentName"];
+            packageName: components["parameters"]["packageName"];
+         };
+      };
+      responses: {
+         /** @description List of materializations */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Materialization"][];
+            };
+         };
+         404: components["responses"]["NotFound"];
+      };
+   };
+   /**
+    * Create a materialization
+    * @description Creates a new materialization in PENDING state for all persist sources across all
+    * models in the package. Use POST .../materializations/{materializationId}?action=start to begin execution.
+    */
+   "create-materialization": {
+      parameters: {
+         path: {
+            environmentName: components["parameters"]["environmentName"];
+            packageName: components["parameters"]["packageName"];
+         };
+      };
+      requestBody?: {
+         content: {
+            "application/json": components["schemas"]["CreateMaterializationRequest"];
+         };
+      };
+      responses: {
+         /** @description Materialization created */
+         201: {
+            content: {
+               "application/json": components["schemas"]["Materialization"];
+            };
+         };
+         404: components["responses"]["NotFound"];
+         /** @description Package already has an active materialization */
+         409: {
+            content: {
+               "application/json": components["schemas"]["Error"];
+            };
+         };
+      };
+   };
+   /** Get a specific materialization */
+   "get-materialization": {
+      parameters: {
+         path: {
+            environmentName: components["parameters"]["environmentName"];
+            packageName: components["parameters"]["packageName"];
+            materializationId: components["parameters"]["materializationId"];
+         };
+      };
+      responses: {
+         /** @description Materialization details */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Materialization"];
+            };
+         };
+         404: components["responses"]["NotFound"];
+      };
+   };
+   /**
+    * Perform an action on a materialization
+    * @description Performs an action on a materialization. The action is specified via
+    * the `action` query parameter:
+    *   * `start` - Transitions a PENDING materialization to RUNNING and begins execution in the background. Returns 202.
+    *   * `stop` - Cancels a PENDING or RUNNING materialization. Returns 200.
+    */
+   "materialization-action": {
+      parameters: {
+         query: {
+            /** @description Action to perform on the materialization */
+            action: "start" | "stop";
+         };
+         path: {
+            environmentName: components["parameters"]["environmentName"];
+            packageName: components["parameters"]["packageName"];
+            materializationId: components["parameters"]["materializationId"];
+         };
+      };
+      responses: {
+         /** @description Materialization cancelled (action=stop) */
+         200: {
+            content: {
+               "application/json": components["schemas"]["Materialization"];
+            };
+         };
+         /** @description Materialization started (action=start) */
+         202: {
+            content: {
+               "application/json": components["schemas"]["Materialization"];
+            };
+         };
+         400: components["responses"]["BadRequest"];
+         404: components["responses"]["NotFound"];
+         /** @description Materialization cannot transition to the requested state */
+         409: {
+            content: {
+               "application/json": components["schemas"]["Error"];
+            };
+         };
+      };
+   };
+   /**
+    * Delete a materialization
+    * @description Deletes a terminal (SUCCESS, FAILED, or CANCELLED) materialization record.
+    */
+   "delete-materialization": {
+      parameters: {
+         path: {
+            environmentName: components["parameters"]["environmentName"];
+            packageName: components["parameters"]["packageName"];
+            materializationId: components["parameters"]["materializationId"];
+         };
+      };
+      responses: {
+         /** @description Materialization deleted */
+         204: {
+            content: never;
+         };
+         404: components["responses"]["NotFound"];
+         /** @description Materialization cannot be deleted (PENDING or RUNNING) */
+         409: {
+            content: {
+               "application/json": components["schemas"]["Error"];
+            };
+         };
+      };
+   };
+   /**
+    * Get the build manifest for a package
+    * @description Returns the current build manifest containing buildId-to-tableName mappings
+    * for all materialized sources in the package.
+    */
+   "get-manifest": {
+      parameters: {
+         path: {
+            environmentName: components["parameters"]["environmentName"];
+            packageName: components["parameters"]["packageName"];
+         };
+      };
+      responses: {
+         /** @description Build manifest */
+         200: {
+            content: {
+               "application/json": components["schemas"]["BuildManifest"];
+            };
+         };
+         404: components["responses"]["NotFound"];
+      };
+   };
+   /**
+    * Perform an action on the package manifest
+    * @description Performs an action on the package manifest. The action is specified via
+    * the `action` query parameter:
+    *   * `reload` - Reads the build manifest from the shared store (DuckLake
+    *     in orchestrated mode, local DuckDB in standalone mode) and recompiles
+    *     every model in the package so subsequent queries resolve persisted
+    *     sources to their materialized tables. Intended for orchestrated
+    *     workers that did not themselves run the build; the endpoint does
+    *     not write anything *into* storage.
+    */
+   "manifest-action": {
+      parameters: {
+         query: {
+            /** @description Action to perform on the manifest */
+            action: "reload";
+         };
+         path: {
+            environmentName: components["parameters"]["environmentName"];
+            packageName: components["parameters"]["packageName"];
+         };
+      };
+      responses: {
+         /** @description Manifest loaded */
+         200: {
+            content: {
+               "application/json": components["schemas"]["BuildManifest"];
+            };
+         };
+         400: components["responses"]["BadRequest"];
+         404: components["responses"]["NotFound"];
+      };
+   };
 }

--- a/packages/server/src/controller/compile.controller.ts
+++ b/packages/server/src/controller/compile.controller.ts
@@ -1,4 +1,4 @@
-import type { LogMessage } from "@malloydata/malloy";
+import type { GivenValue, LogMessage } from "@malloydata/malloy";
 import { EnvironmentStore } from "../service/environment_store";
 
 export class CompileController {
@@ -14,6 +14,7 @@ export class CompileController {
       modelName: string,
       source: string,
       includeSql: boolean = false,
+      givens?: Record<string, GivenValue>,
    ): Promise<{ status: string; problems: LogMessage[]; sql?: string }> {
       const environment = await this.environmentStore.getEnvironment(
          environmentName,
@@ -24,6 +25,7 @@ export class CompileController {
          modelName,
          source,
          includeSql,
+         givens,
       );
 
       // Determine overall status based on presence of errors

--- a/packages/server/src/controller/query.controller.ts
+++ b/packages/server/src/controller/query.controller.ts
@@ -4,6 +4,7 @@ import { API_PREFIX } from "../constants";
 import { ModelNotFoundError } from "../errors";
 import { EnvironmentStore } from "../service/environment_store";
 import type { FilterParams } from "../service/filter";
+import type { GivenValue } from "@malloydata/malloy";
 
 type ApiQuery = components["schemas"]["QueryResult"];
 
@@ -32,6 +33,7 @@ export class QueryController {
       compactJson: boolean = false,
       filterParams?: FilterParams,
       bypassFilters?: boolean,
+      givens?: Record<string, GivenValue>,
    ): Promise<ApiQuery> {
       const environment = await this.environmentStore.getEnvironment(
          environmentName,
@@ -49,6 +51,7 @@ export class QueryController {
             query,
             filterParams,
             bypassFilters,
+            givens,
          );
          const renderLogs = validateRenderTags(result);
          return {

--- a/packages/server/src/mcp/tools/execute_query_tool.ts
+++ b/packages/server/src/mcp/tools/execute_query_tool.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
+import type { GivenValue } from "@malloydata/malloy";
 import { logger } from "../../logger";
 import { EnvironmentStore } from "../../service/environment_store";
 import { getMalloyErrorDetails, type ErrorDetails } from "../error_messages";
@@ -30,6 +31,12 @@ const executeQueryShape = {
       .describe(
          "Filter parameter values keyed by filter name. Used with sources that declare #(filter) annotations.",
       ),
+   givens: z
+      .record(z.unknown())
+      .optional()
+      .describe(
+         "Per-query given values that override model defaults. Keys are given names declared in the model's given: block.",
+      ),
 };
 
 // Type inference is handled automatically by the MCP server based on the executeQueryShape
@@ -56,6 +63,7 @@ export function registerExecuteQueryTool(
             sourceName,
             queryName,
             filterParams,
+            givens,
          } = params;
 
          logger.info("[MCP Tool executeQuery] Received params:", { params });
@@ -128,6 +136,8 @@ export function registerExecuteQueryTool(
                   undefined,
                   query,
                   filterParams,
+                  undefined,
+                  givens as Record<string, GivenValue> | undefined,
                );
                const { validateRenderTags } = await import(
                   "@malloydata/render-validator"
@@ -174,6 +184,8 @@ export function registerExecuteQueryTool(
                   queryName,
                   undefined,
                   filterParams,
+                  undefined,
+                  givens as Record<string, GivenValue> | undefined,
                );
                const { validateRenderTags } = await import(
                   "@malloydata/render-validator"

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,4 +1,5 @@
 // Pre-load the instrumentation module; the instrumentation module must be loaded before the other imports.
+import type { GivenValue } from "@malloydata/malloy";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import bodyParser from "body-parser";
 import cors from "cors";
@@ -1178,6 +1179,9 @@ app.post(
                   | Record<string, string | string[]>
                   | undefined,
                req.body.bypassFilters === true ? true : undefined,
+               req.body.givens as
+                  | Record<string, GivenValue>
+                  | undefined,
             ),
          );
       } catch (error) {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1179,9 +1179,7 @@ app.post(
                   | Record<string, string | string[]>
                   | undefined,
                req.body.bypassFilters === true ? true : undefined,
-               req.body.givens as
-                  | Record<string, GivenValue>
-                  | undefined,
+               req.body.givens as Record<string, GivenValue> | undefined,
             ),
          );
       } catch (error) {
@@ -1225,6 +1223,7 @@ app.post(
             req.params.modelName,
             req.body.source,
             req.body.includeSql === true,
+            req.body.givens as Record<string, GivenValue> | undefined,
          );
          res.status(200).json(result);
       } catch (error) {

--- a/packages/server/src/service/environment.ts
+++ b/packages/server/src/service/environment.ts
@@ -1,4 +1,4 @@
-import type { LogMessage } from "@malloydata/malloy";
+import type { GivenValue, LogMessage } from "@malloydata/malloy";
 import { MalloyError, Runtime } from "@malloydata/malloy";
 import { Mutex } from "async-mutex";
 import crypto from "crypto";
@@ -238,6 +238,7 @@ export class Environment {
       modelName: string,
       source: string,
       includeSql: boolean = false,
+      givens?: Record<string, GivenValue>,
    ): Promise<{ problems: LogMessage[]; sql?: string }> {
       assertSafePackageName(packageName);
       assertSafeRelativeModelPath(modelName);
@@ -308,7 +309,7 @@ export class Environment {
             if (includeSql) {
                try {
                   const queryMaterializer = modelMaterializer.loadFinalQuery();
-                  sql = await queryMaterializer.getSQL();
+                  sql = await queryMaterializer.getSQL({ givens });
                } catch {
                   // Source may not contain a runnable query (e.g. only source definitions),
                   // in which case we simply omit the sql field.

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -3,6 +3,7 @@ import {
    API,
    Connection,
    FixedConnectionMap,
+   GivenValue,
    isSourceDef,
    MalloyConfig,
    MalloyError,
@@ -342,6 +343,7 @@ export class Model {
       query?: string,
       filterParams?: FilterParams,
       bypassFilters?: boolean,
+      givens?: Record<string, GivenValue>,
    ): Promise<{
       result: Malloy.Result;
       compactResult: QueryData;
@@ -442,7 +444,7 @@ export class Model {
 
       let queryResults;
       try {
-         queryResults = await runnable.run({ rowLimit });
+         queryResults = await runnable.run({ rowLimit, givens });
       } catch (error) {
          // Record error metrics
          const errorEndTime = performance.now();


### PR DESCRIPTION
Grafted from #744 — original work by @adamribaudo-ff.

Closes #744.

### Why a graft

PR #744 was BEHIND main and "Allow edits from maintainers" wasn't enabled, so the head branch on `form-function-co/malloy-publisher` couldn't be updated from this side. Rather than block on a branch update, the 5 original commits are cherry-picked here onto a fresh branch from current main. Authors are preserved on every commit (`Adam Ribaudo <aribaudo@form-function.co>`).

Since all commits in this PR share the same author, GitHub's squash-author-preservation rule will keep @adamribaudo-ff as the Author of the resulting squash commit on main.

### Verification (carried over from #744 review)

- `bun run build:server` — green
- `bun run test:server` — unit 389 / integration 165, 0 fail
- Smoke test against a `given: target_code :: string is 'WN'` model on the `faa` sample:
  - `POST /…/compile` with `givens` → substituted literal lands in returned SQL (`WN`, `AA`)
  - `POST /…/query` with and without `givens` → correct row back; default applied when omitted
  - MCP `malloy_executeQuery` with and without `givens` → same (`WN`, `AA`, `DL`)

Composition with the legacy `#(filter)` path is intact: `model.ts` passes `givens` to `runnable.run` unconditionally and the existing filter-clause injection block is untouched. `bypassFilters` correctly scopes only to the legacy path.

### Notes
- One pre-existing behavior worth flagging (not introduced by this PR): when `includeSql: true` is requested on a model whose given has neither a default nor a supplied value, `getSQL` throws and is swallowed by the existing try/catch at `environment.ts:251`, so the caller sees `status: success` with no `sql` field. Worth a follow-up to distinguish "no runnable query" from "unsatisfied given" in the compile response.
- The 3 formatter cleanup commits from #744 are preserved, but produce the same prettier-config drift that's recurred across several recent regen rounds on `api.ts`. Not something to fix here.