### PR TITLE
feat(server): require a package-load worker pool to serve packages

### DIFF
--- a/packages/server/build.ts
+++ b/packages/server/build.ts
@@ -5,7 +5,15 @@ fs.rmSync("./dist", { recursive: true, force: true });
 fs.mkdirSync("./dist");
 
 await build({
-   entrypoints: ["./src/server.ts", "./src/instrumentation.ts"],
+   // package_load_worker.ts is bundled as a SEPARATE entrypoint so it
+   // can be loaded by `new Worker(...)` at runtime. It must NOT be
+   // inlined into server.mjs (workers can't share module state with
+   // the parent process — they get their own JS realm).
+   entrypoints: [
+      "./src/server.ts",
+      "./src/instrumentation.ts",
+      "./src/package_load/package_load_worker.ts",
+   ],
    outdir: "./dist",
    target: "node",
    format: "esm",
@@ -48,6 +56,27 @@ fs.copyFileSync(
 // Rename ESM outputs to .mjs so both Node and Bun can execute them
 fs.renameSync("./dist/server.js", "./dist/server.mjs");
 fs.renameSync("./dist/instrumentation.js", "./dist/instrumentation.mjs");
+// Bun emits package_load_worker into its source-relative subdir;
+// flatten so package_load_pool.ts's `resolveWorkerScript()` finds it
+// as a sibling of server.mjs. The path layout match is intentional —
+// keep these two in sync or the worker pool throws at boot (the
+// in-process fallback was removed; missing worker = no service).
+if (fs.existsSync("./dist/package_load/package_load_worker.js")) {
+   fs.renameSync(
+      "./dist/package_load/package_load_worker.js",
+      "./dist/package_load_worker.mjs",
+   );
+   try {
+      fs.rmdirSync("./dist/package_load");
+   } catch {
+      /* directory may be non-empty if Bun produced sourcemaps; leave it */
+   }
+} else if (fs.existsSync("./dist/package_load_worker.js")) {
+   fs.renameSync(
+      "./dist/package_load_worker.js",
+      "./dist/package_load_worker.mjs",
+   );
+}
 
 // Add shebang to server.mjs for npx/bunx compatibility
 const serverJsPath = "./dist/server.mjs";

--- a/packages/server/src/health.ts
+++ b/packages/server/src/health.ts
@@ -143,6 +143,21 @@ export async function performGracefulShutdownAfterDrain(
       /* do nothing */
    }
 
+   try {
+      // Drain in-flight compiles and terminate worker_threads before
+      // we exit so a slow compile doesn't leave orphan worker
+      // processes. Lazy-imported to avoid pulling the pool module
+      // into the health.ts dep graph for tests that don't exercise
+      // the compile path.
+      const { getPackageLoadPool } = await import(
+         "./package_load/package_load_pool"
+      );
+      await getPackageLoadPool().shutdown();
+      logger.info("Package-load worker pool shut down");
+   } catch (_error) {
+      /* do nothing */
+   }
+
    if (shutdownGracefulCloseTimeoutSeconds > 0) {
       logger.info(
          `Waiting ${shutdownGracefulCloseTimeoutSeconds} seconds after server close before exit...`,

--- a/packages/server/src/package_load/package_load_pool.spec.ts
+++ b/packages/server/src/package_load/package_load_pool.spec.ts
@@ -1,0 +1,252 @@
+/**
+ * Unit + light integration tests for the PackageLoadPool.
+ *
+ * The pool runs real `worker_threads` workers under the hood. These
+ * tests intentionally exercise that path so we catch regressions in
+ * RPC routing, queueing, lifecycle, and error propagation that
+ * wouldn't surface in a pure mock.
+ *
+ * Pool reuse strategy
+ * -------------------
+ * The "real worker" tests share a single `PackageLoadPool` across
+ * cases via Bun's `beforeAll`/`afterAll`. The worker itself owns no
+ * native handles (all duckdb work runs on the main thread); we still
+ * share to keep per-test overhead low and to match the production
+ * deployment, where the pool spawns workers up-front and reuses them.
+ */
+import {
+   afterAll,
+   afterEach,
+   beforeAll,
+   beforeEach,
+   describe,
+   expect,
+   it,
+} from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+   PackageLoadPool,
+   __setPackageLoadPoolForTests,
+   getPackageLoadWorkerCount,
+} from "./package_load_pool";
+
+// ──────────────────────────────────────────────────────────────────────
+// getPackageLoadWorkerCount — env var parsing
+// ──────────────────────────────────────────────────────────────────────
+
+describe("getPackageLoadWorkerCount", () => {
+   const ORIGINAL = process.env.PACKAGE_LOAD_WORKERS;
+
+   afterEach(() => {
+      if (ORIGINAL === undefined) {
+         delete process.env.PACKAGE_LOAD_WORKERS;
+      } else {
+         process.env.PACKAGE_LOAD_WORKERS = ORIGINAL;
+      }
+   });
+
+   it("defaults to 1 worker when env unset", () => {
+      delete process.env.PACKAGE_LOAD_WORKERS;
+      expect(getPackageLoadWorkerCount()).toBe(1);
+   });
+
+   it("throws when env value is non-numeric", () => {
+      process.env.PACKAGE_LOAD_WORKERS = "not-a-number";
+      expect(() => getPackageLoadWorkerCount()).toThrow(/positive integer/);
+   });
+
+   it("throws when env value is negative", () => {
+      process.env.PACKAGE_LOAD_WORKERS = "-2";
+      expect(() => getPackageLoadWorkerCount()).toThrow(/positive integer/);
+   });
+
+   it("throws when env value is 0 (no in-process fallback)", () => {
+      process.env.PACKAGE_LOAD_WORKERS = "0";
+      expect(() => getPackageLoadWorkerCount()).toThrow(/positive integer/);
+   });
+
+   it("honors positive overrides", () => {
+      process.env.PACKAGE_LOAD_WORKERS = "4";
+      expect(getPackageLoadWorkerCount()).toBe(4);
+   });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// PackageLoadPool constructor validation
+// ──────────────────────────────────────────────────────────────────────
+
+describe("PackageLoadPool constructor", () => {
+   it("throws when maxWorkers is 0", () => {
+      expect(() => new PackageLoadPool(0)).toThrow(/maxWorkers >= 1/);
+   });
+
+   it("throws when maxWorkers is negative", () => {
+      expect(() => new PackageLoadPool(-1)).toThrow(/maxWorkers >= 1/);
+   });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// PackageLoadPool — real worker loads a package
+//
+// One shared pool across the describe; each test gets its own temp
+// package directory and its own DuckDB connection.
+// ──────────────────────────────────────────────────────────────────────
+
+describe("PackageLoadPool (real worker)", () => {
+   let pool: PackageLoadPool;
+   let tempDir: string;
+
+   beforeAll(() => {
+      pool = new PackageLoadPool(1);
+   });
+
+   afterAll(async () => {
+      await pool.shutdown();
+      await __setPackageLoadPoolForTests(null);
+   });
+
+   beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "publisher-compile-"));
+   });
+
+   afterEach(() => {
+      if (tempDir) {
+         fs.rmSync(tempDir, { recursive: true, force: true });
+         tempDir = "";
+      }
+   });
+
+   function writeManifest(dir: string, name = "pkg"): void {
+      fs.writeFileSync(
+         path.join(dir, "publisher.json"),
+         JSON.stringify({ name, description: "test package" }),
+      );
+   }
+
+   async function buildConfig(): Promise<{
+      malloyConfig: import("@malloydata/malloy").MalloyConfig;
+      duckdb: { close: () => Promise<void> };
+   }> {
+      const { MalloyConfig, FixedConnectionMap } = await import(
+         "@malloydata/malloy"
+      );
+      const { DuckDBConnection } = await import("@malloydata/db-duckdb");
+      const duckdb = new DuckDBConnection("duckdb", ":memory:");
+      const connections = new FixedConnectionMap(
+         new Map([["duckdb", duckdb]]),
+         "duckdb",
+      );
+      const malloyConfig = new MalloyConfig({ connections: {} });
+      malloyConfig.wrapConnections(() => connections);
+      return { malloyConfig, duckdb };
+   }
+
+   it("loads a trivial single-model package and returns a hydratable modelDef", async () => {
+      writeManifest(tempDir);
+      fs.writeFileSync(
+         path.join(tempDir, "trivial.malloy"),
+         `source: nums is duckdb.sql("select 1 as a, 2 as b") extend {
+  measure: total is a.sum()
+}`,
+      );
+
+      const { malloyConfig, duckdb } = await buildConfig();
+      try {
+         const outcome = await pool.loadPackage({
+            packagePath: tempDir,
+            packageName: "pkg",
+            malloyConfig,
+            defaultConnectionName: "duckdb",
+         });
+
+         expect(outcome.packageMetadata.name).toBe("pkg");
+         expect(outcome.models).toHaveLength(1);
+         const m = outcome.models[0];
+         expect(m.modelPath).toBe("trivial.malloy");
+         expect(m.modelType).toBe("model");
+         expect(m.compilationError).toBeUndefined();
+         expect(m.modelDef).toBeDefined();
+         expect(Array.isArray(m.sources)).toBe(true);
+         expect(outcome.loadDurationMs).toBeGreaterThan(0);
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("propagates a per-model compile failure in-band (not as a rejected Promise)", async () => {
+      writeManifest(tempDir);
+      fs.writeFileSync(
+         path.join(tempDir, "broken.malloy"),
+         `source: bad is duckdb.sql("select 1 as a") extend {
+  measure: oops is THIS_FUNC_DOES_NOT_EXIST(a)
+}`,
+      );
+
+      const { malloyConfig, duckdb } = await buildConfig();
+      try {
+         const outcome = await pool.loadPackage({
+            packagePath: tempDir,
+            packageName: "pkg",
+            malloyConfig,
+            defaultConnectionName: "duckdb",
+         });
+         expect(outcome.models).toHaveLength(1);
+         const m = outcome.models[0];
+         expect(m.compilationError).toBeDefined();
+         expect(m.modelDef).toBeUndefined();
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("ignores embedded csv/parquet files (database probing is a main-thread concern)", async () => {
+      // The worker is pure-CPU: it reads the manifest and compiles
+      // .malloy files only. Database probing stays on the main thread
+      // (Package.readDatabases) so the worker doesn't need to dlopen
+      // duckdb-native. Verify that dropping a .csv next to the model
+      // doesn't crash the worker and doesn't show up in the result.
+      writeManifest(tempDir);
+      fs.writeFileSync(path.join(tempDir, "rows.csv"), "a,b\n1,2\n3,4\n5,6\n");
+      fs.writeFileSync(
+         path.join(tempDir, "trivial.malloy"),
+         `source: nums is duckdb.sql("select 1 as a") extend {\n  measure: total is a.sum()\n}`,
+      );
+
+      const { malloyConfig, duckdb } = await buildConfig();
+      try {
+         const outcome = await pool.loadPackage({
+            packagePath: tempDir,
+            packageName: "pkg",
+            malloyConfig,
+            defaultConnectionName: "duckdb",
+         });
+         expect(outcome.models).toHaveLength(1);
+         expect(outcome.models[0].compilationError).toBeUndefined();
+      } finally {
+         await duckdb.close();
+      }
+   });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// PackageLoadPool — shutdown rejects new submissions
+// Separate describe so the shutdown doesn't poison the shared pool above.
+// ──────────────────────────────────────────────────────────────────────
+
+describe("PackageLoadPool (shutdown)", () => {
+   it("rejects loadPackage() after shutdown()", async () => {
+      const { MalloyConfig } = await import("@malloydata/malloy");
+      const pool = new PackageLoadPool(1);
+      await pool.shutdown();
+      await expect(
+         pool.loadPackage({
+            packagePath: "/tmp/nowhere",
+            packageName: "nowhere",
+            malloyConfig: new MalloyConfig({ connections: {} }),
+            defaultConnectionName: "duckdb",
+         }),
+      ).rejects.toThrow("shutting down");
+   });
+});

--- a/packages/server/src/package_load/package_load_pool.ts
+++ b/packages/server/src/package_load/package_load_pool.ts
@@ -1,0 +1,920 @@
+/**
+ * Main-thread half of the package-load worker pool.
+ *
+ * Why this exists: Malloy compile is pure JavaScript that runs on the
+ * V8 main event loop. A large package can hold the loop for many
+ * seconds — long enough to time out the Kubernetes `/health/liveness`
+ * probe (timeout=5s, see worker/main.tf) and trigger a pod restart in
+ * the middle of an otherwise routine package load. This pool moves the
+ * CPU-bound bulk of `Package.create` (manifest read, every
+ * `.malloy`/`.malloynb` compile) into `worker_threads` workers, leaving
+ * the main loop free to serve `/health/liveness` and other API traffic.
+ *
+ * Public surface
+ * --------------
+ *   getPackageLoadPool()       — lazy singleton; respects PACKAGE_LOAD_WORKERS
+ *   pool.loadPackage({...})    — submit one package for off-thread load
+ *   pool.shutdown()            — graceful drain (called from health.ts)
+ *
+ * The pool is REQUIRED. There is no in-process compile fallback —
+ * `PACKAGE_LOAD_WORKERS=0` throws at boot. Running Malloy compile on
+ * the main event loop is what tripped the K8s liveness probe in the
+ * first place; we don't want a knob that re-enables that. Pool-
+ * infrastructure failures (worker crash, job timeout, pool shutting
+ * down) reject `loadPackage()`; `Package.loadViaWorker` then rewraps
+ * them as `ServiceUnavailableError` so the HTTP layer responds 503.
+ *
+ * Concurrency model
+ * -----------------
+ *   - Workers are spawned lazily on first use, up to N (configurable
+ *     via PACKAGE_LOAD_WORKERS).
+ *   - Each worker emits {type:'ready'} once its module has initialized;
+ *     the pool waits for that before dispatching to a newly-spawned
+ *     worker.
+ *   - **Per-worker active job cap = 1.** Compile is CPU-bound and
+ *     doesn't multiplex meaningfully inside a single event loop, so
+ *     loading two large packages on the same worker just doubles each
+ *     of their latencies rather than overlapping their work. Excess
+ *     jobs queue at the pool layer and pick a worker the moment one
+ *     becomes idle.
+ *   - Schema/URL/connection-metadata RPCs from a worker back to the
+ *     main thread (over MessagePort) are not counted against the
+ *     active-job cap — they're sub-RPCs of the worker's currently
+ *     active load-package job.
+ *
+ * Failure modes
+ * -------------
+ *   - **Worker spawn fails.** `pw.ready` rejects on `worker.error`,
+ *     `worker.exit`, or after `WORKER_SPAWN_TIMEOUT_MS`. Pending jobs
+ *     waiting on that worker get a clean rejection and are re-queued
+ *     to whichever worker becomes available next.
+ *   - **Worker dies mid-job.** `worker.exit` fails every in-flight job
+ *     on that worker; the pool prunes the dead worker, and the next
+ *     `loadPackage()` lazily respawns up to `maxWorkers`.
+ *   - **Job timeout.** `PACKAGE_LOAD_JOB_TIMEOUT_MS` (default 120s) caps a
+ *     single package load. On timeout we **terminate the worker** and
+ *     reject the caller — we do not silently fall back, and we do not
+ *     leave a zombie compile burning CPU on the worker (that's the
+ *     exact scenario PR-#767's job-timeout-without-terminate had).
+ *
+ * Schema-fetch RPC routing
+ * ------------------------
+ *   When a worker proxies `fetchSchemaForTables` (or other connection
+ *   metadata calls) back to the main thread, the message includes a
+ *   `jobId`. The pool keeps a `jobId → JobContext` map so it knows
+ *   which live `MalloyConfig` to dispatch the request against. The
+ *   mapping is installed when the job is submitted and removed when
+ *   it resolves.
+ */
+import type {
+   Annotation,
+   FetchSchemaOptions,
+   InfoConnection,
+   LookupConnection,
+   MalloyConfig,
+   ModelDef,
+   SQLSourceDef,
+   TableSourceDef,
+} from "@malloydata/malloy";
+import * as Malloy from "@malloydata/malloy-interfaces";
+import { Worker } from "node:worker_threads";
+import { dirname, join } from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+
+import { ModelCompilationError } from "../errors";
+import { logger } from "../logger";
+import type {
+   ConnectionMetadataRequest,
+   ConnectionMetadataResponse,
+   LoadPackageError,
+   LoadPackageRequest,
+   LoadPackageResult,
+   MainToWorkerMessage,
+   ReadUrlRequest,
+   ReadUrlResponse,
+   RpcErrorResponse,
+   SchemaForSqlRequest,
+   SchemaForSqlResponse,
+   SchemaForTablesRequest,
+   SchemaForTablesResponse,
+   SerializedError,
+   SerializedModel,
+   WorkerToMainMessage,
+} from "./protocol";
+
+// ──────────────────────────────────────────────────────────────────────
+// Configuration
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns the configured worker pool size. The pool is REQUIRED — no
+ * in-process fallback exists. Defaults to 1 worker when the env var
+ * is unset; throws when set to 0 or to a non-positive / non-numeric
+ * value so we fail fast at boot rather than silently degrading.
+ *
+ * Operators set `PACKAGE_LOAD_WORKERS=N` (N ≥ 1) to tune the pool
+ * size for their workload. Setting it to 0 to "disable" the pool is
+ * unsupported by design — running Malloy compile on the main event
+ * loop is what tripped the K8s liveness probe in the first place
+ * and we don't want a config knob that re-enables that footgun.
+ */
+export function getPackageLoadWorkerCount(): number {
+   const raw = process.env.PACKAGE_LOAD_WORKERS;
+   if (raw === undefined) return 1;
+   const parsed = Number.parseInt(raw, 10);
+   if (!Number.isFinite(parsed) || parsed < 1) {
+      throw new Error(
+         `PACKAGE_LOAD_WORKERS must be a positive integer (got ${JSON.stringify(raw)}). ` +
+            `Refusing to start without a package-load worker pool.`,
+      );
+   }
+   return parsed;
+}
+
+/**
+ * Wall-clock cap for a single load-package job. If a worker hangs we
+ * don't want to leak a Promise forever. Twice the K8s liveness
+ * threshold (5s × 15 fails = 75s) gives comfortable margin against
+ * false timeouts during cold starts while still failing fast on real
+ * hangs. Overridable via `PACKAGE_LOAD_JOB_TIMEOUT_MS`.
+ */
+const PACKAGE_LOAD_JOB_TIMEOUT_MS = (() => {
+   const raw = process.env.PACKAGE_LOAD_JOB_TIMEOUT_MS;
+   if (raw === undefined) return 120_000;
+   const parsed = Number.parseInt(raw, 10);
+   if (!Number.isFinite(parsed) || parsed <= 0) return 120_000;
+   return parsed;
+})();
+
+/**
+ * How long a freshly-spawned worker has to send its `ready` handshake.
+ * If the worker can't load its bundle (missing `package_load_worker.mjs`,
+ * native module init failure, etc.), this fires and the pool fails
+ * the pending jobs on that worker without waiting forever. Distinct
+ * from the per-job timeout so a slow-to-start worker doesn't poison
+ * the job timeout budget.
+ */
+const WORKER_SPAWN_TIMEOUT_MS = 30_000;
+
+// ──────────────────────────────────────────────────────────────────────
+// Internal types
+// ──────────────────────────────────────────────────────────────────────
+
+interface JobContext {
+   jobId: string;
+   pw: PoolWorker;
+   connections: LookupConnection<InfoConnection>;
+   urlReader: PackageLoadUrlReader;
+   resolve: (result: LoadPackageResult) => void;
+   reject: (err: Error) => void;
+   timeout: ReturnType<typeof setTimeout>;
+}
+
+interface QueuedJob {
+   request: LoadPackageJob;
+   resolve: (result: LoadPackageOutcome) => void;
+   reject: (err: Error) => void;
+}
+
+interface PoolWorker {
+   id: number;
+   worker: Worker;
+   ready: Promise<void>;
+   inFlight: Set<string>; // job ids — capped at 1 by per-worker active job rule
+   exited: boolean;
+}
+
+/**
+ * Minimal URL-reader shape the pool dispatches to. Intentionally
+ * narrower than Malloy's `URLReader` (which can also return
+ * `{contents, invalidationKey}`) — the pool only needs the string
+ * payload to forward back to the worker.
+ */
+export interface PackageLoadUrlReader {
+   readURL(
+      url: URL,
+   ): Promise<string | { contents: string; invalidationKey?: unknown }>;
+}
+
+export interface LoadPackageJob {
+   packagePath: string;
+   packageName: string;
+   /**
+    * The live MalloyConfig. We don't ship it across the worker
+    * boundary; we hold it on the main side and answer the worker's
+    * proxy RPCs (for non-duckdb connections) against
+    * `config.connections`. The worker has its own DuckDB connection
+    * for embedded-database probes.
+    */
+   malloyConfig: MalloyConfig;
+   /** Default connection name (passed verbatim to the worker). */
+   defaultConnectionName: string | null;
+   /** Custom URLReader for non-file:// imports; falls back to fs in the worker. */
+   urlReader?: PackageLoadUrlReader;
+   /** Optional buildManifest passed through to Malloy Runtime. */
+   buildManifest?: unknown;
+}
+
+/**
+ * Adapter result the pool surfaces to callers. Same wire shape as
+ * `LoadPackageResult` but with the heavy `modelDef` / `sourceInfos`
+ * fields restored to their Malloy types so the consumer (currently
+ * `Package.createViaWorker`) doesn't need to repeat the cast at
+ * every call site. The protocol module uses `unknown` for these so
+ * it stays decoupled from the full Malloy type surface; this is
+ * where we re-tighten.
+ *
+ * `filterMap` stays as the wire array; `Model.fromSerialized` will
+ * rebuild a `Map` on demand. Keeping it array-shaped here means we
+ * don't allocate a Map for models the caller never looks at.
+ */
+export interface LoadPackageOutcome {
+   packageMetadata: { name?: string; description?: string };
+   models: Array<
+      Omit<SerializedModel, "modelDef" | "sourceInfos"> & {
+         modelDef?: ModelDef;
+         sourceInfos?: Malloy.SourceInfo[];
+      }
+   >;
+   loadDurationMs: number;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Path to the bundled worker script
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Locate the worker entrypoint. In production builds it's bundled to
+ * `dist/package_load_worker.mjs` next to `server.mjs`. In dev
+ * (bun --watch) the source `.ts` next to this file loads directly —
+ * Bun supports `new Worker(<ts-url>)`. The .ts fallback also keeps
+ * `bun test` working without a build step.
+ *
+ * Uses `pathToFileURL` rather than a `file://${path}` template so the
+ * URL stays valid on Windows, where absolute paths look like
+ * `D:\foo\bar` (template form would yield `file://D:\foo\bar`, which
+ * parses as host `D:` rather than a path).
+ */
+function resolveWorkerScript(): URL {
+   const thisFile = fileURLToPath(import.meta.url);
+   const thisDir = dirname(thisFile);
+   const distCandidate = join(thisDir, "package_load_worker.mjs");
+   if (thisFile.endsWith(".mjs") || thisFile.endsWith(".js")) {
+      return pathToFileURL(distCandidate);
+   }
+   const tsCandidate = join(thisDir, "package_load_worker.ts");
+   return pathToFileURL(tsCandidate);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// The pool
+// ──────────────────────────────────────────────────────────────────────
+
+export class PackageLoadPool {
+   private readonly workers: PoolWorker[] = [];
+   private readonly queue: QueuedJob[] = [];
+   private readonly jobs = new Map<string, JobContext>();
+   private readonly maxWorkers: number;
+   private nextWorkerId = 0;
+   private nextJobId = 0;
+   private shuttingDown = false;
+   private readonly workerScript: URL;
+
+   constructor(maxWorkers: number, workerScript?: URL) {
+      if (!Number.isFinite(maxWorkers) || maxWorkers < 1) {
+         throw new Error(
+            `PackageLoadPool requires maxWorkers >= 1 (got ${maxWorkers}). ` +
+               `The in-process compile fallback was removed in favour of a hard ` +
+               `dependency on the worker pool; see getPackageLoadWorkerCount().`,
+         );
+      }
+      this.maxWorkers = maxWorkers;
+      this.workerScript = workerScript ?? resolveWorkerScript();
+   }
+
+   get size(): number {
+      return this.workers.filter((w) => !w.exited).length;
+   }
+
+   /**
+    * Submit a package for off-thread load. Returns when the worker
+    * has produced a {@link LoadPackageOutcome}. Per-package compile
+    * failures are surfaced **inside** the outcome (as
+    * `model.compilationError`), not as a rejected Promise — the
+    * Promise only rejects for whole-package errors (manifest missing,
+    * worker crash, RPC timeout, etc.) so the caller can distinguish
+    * "this package is broken; tell the user" from "the worker pool
+    * itself failed and we have a bigger problem".
+    */
+   async loadPackage(request: LoadPackageJob): Promise<LoadPackageOutcome> {
+      if (this.shuttingDown) {
+         throw new Error("PackageLoadPool is shutting down");
+      }
+      return new Promise<LoadPackageOutcome>((resolve, reject) => {
+         this.queue.push({ request, resolve, reject });
+         this.tryDispatch();
+      });
+   }
+
+   /**
+    * Drain every in-flight job and terminate the workers. Safe to
+    * call multiple times. Awaits each worker's `exit` event.
+    */
+   async shutdown(): Promise<void> {
+      if (this.shuttingDown) return;
+      this.shuttingDown = true;
+      // Fail any queued jobs that never got dispatched.
+      const queued = this.queue.splice(0, this.queue.length);
+      for (const qj of queued) {
+         qj.reject(new Error("PackageLoadPool: shutdown before dispatch"));
+      }
+      const exits = this.workers.map(
+         (pw) =>
+            new Promise<void>((resolve) => {
+               if (pw.exited) {
+                  resolve();
+                  return;
+               }
+               pw.worker.once("exit", () => resolve());
+               const msg: { type: "shutdown" } = { type: "shutdown" };
+               pw.worker.postMessage(msg);
+               // Hard ceiling — if a worker won't exit, terminate it.
+               setTimeout(() => {
+                  if (!pw.exited) {
+                     void pw.worker.terminate().finally(() => resolve());
+                  }
+               }, 10_000);
+            }),
+      );
+      await Promise.all(exits);
+   }
+
+   // ────────────────────────────────────────────────────────────────
+   // Internals: dispatch / queue
+   // ────────────────────────────────────────────────────────────────
+
+   /**
+    * Greedy dispatcher: keep draining the queue while there's both
+    * a queued job and an available worker. Called from `loadPackage`
+    * (on submit) and from job completion / worker exit (to give the
+    * next job a worker that just freed up).
+    */
+   private tryDispatch(): void {
+      if (this.shuttingDown) return;
+      while (this.queue.length > 0) {
+         const worker = this.findIdleOrSpawnable();
+         if (!worker) return; // saturated; wait for a job to finish
+         const qj = this.queue.shift();
+         if (!qj) return;
+         void this.dispatchToWorker(worker, qj);
+      }
+   }
+
+   /**
+    * Return an idle worker, or spawn a new one if we're below
+    * `maxWorkers`. With per-worker active=1, "idle" means
+    * `inFlight.size === 0`. Returns null when the pool is saturated.
+    */
+   private findIdleOrSpawnable(): PoolWorker | null {
+      const alive = this.workers.filter((w) => !w.exited);
+      const idle = alive.find((w) => w.inFlight.size === 0);
+      if (idle) return idle;
+      if (alive.length < this.maxWorkers) {
+         const pw = this.spawnWorker();
+         this.workers.push(pw);
+         return pw;
+      }
+      return null;
+   }
+
+   private async dispatchToWorker(
+      pw: PoolWorker,
+      qj: QueuedJob,
+   ): Promise<void> {
+      try {
+         await pw.ready;
+      } catch (err) {
+         // Spawn failed; this worker is dead. Reject this job and
+         // try the next queued one — a different worker may already
+         // be alive, or `findIdleOrSpawnable` will lazily spawn one.
+         qj.reject(err as Error);
+         this.tryDispatch();
+         return;
+      }
+
+      this.nextJobId += 1;
+      const jobId = `job-${this.nextJobId}`;
+
+      const timeout = setTimeout(() => {
+         this.handleJobTimeout(pw, jobId, qj.request.packagePath);
+      }, PACKAGE_LOAD_JOB_TIMEOUT_MS);
+
+      this.jobs.set(jobId, {
+         jobId,
+         pw,
+         connections: qj.request.malloyConfig.connections,
+         urlReader: qj.request.urlReader ?? defaultUrlReader,
+         resolve: (result) => {
+            clearTimeout(timeout);
+            qj.resolve(adaptResult(result));
+         },
+         reject: (err) => {
+            clearTimeout(timeout);
+            qj.reject(err);
+         },
+         timeout,
+      });
+
+      // Register inFlight BEFORE postMessage so the next concurrent
+      // dispatcher pass sees this worker as busy (fixes Sha-Bang #1's
+      // 4/1 skew where simultaneous callers all tiebreak to alive[0]).
+      pw.inFlight.add(jobId);
+
+      const message: LoadPackageRequest = {
+         type: "load-package",
+         requestId: jobId,
+         packagePath: qj.request.packagePath,
+         packageName: qj.request.packageName,
+         defaultConnectionName: qj.request.defaultConnectionName,
+         buildManifest: qj.request.buildManifest,
+      };
+      pw.worker.postMessage(message);
+   }
+
+   /**
+    * On job timeout we DON'T silently fall back — that lets the
+    * worker keep burning CPU on the doomed compile while the caller
+    * also re-runs it on the main thread (the exact 2× CPU situation
+    * the pool exists to avoid). Instead: terminate the worker,
+    * reject the caller, and let the next call respawn lazily.
+    */
+   private handleJobTimeout(
+      pw: PoolWorker,
+      jobId: string,
+      packagePath: string,
+   ): void {
+      logger.error(
+         `PackageLoadPool: job ${jobId} (${packagePath}) timed out after ${PACKAGE_LOAD_JOB_TIMEOUT_MS}ms; terminating worker #${pw.id}`,
+      );
+      this.failJob(
+         jobId,
+         new Error(
+            `Package-load worker timed out after ${PACKAGE_LOAD_JOB_TIMEOUT_MS}ms (package=${packagePath})`,
+         ),
+      );
+      void pw.worker.terminate();
+      // The exit handler will mark the worker exited, fail any
+      // residual jobs on it, and trigger tryDispatch.
+   }
+
+   private spawnWorker(): PoolWorker {
+      this.nextWorkerId += 1;
+      const id = this.nextWorkerId;
+      logger.info(
+         `PackageLoadPool: spawning worker #${id} (script=${this.workerScript.toString()})`,
+      );
+      const worker = new Worker(this.workerScript, {
+         name: `malloy-package-load-worker-${id}`,
+      });
+
+      let readyResolve!: () => void;
+      let readyReject!: (err: Error) => void;
+      let readySettled = false;
+      const ready = new Promise<void>((resolve, reject) => {
+         readyResolve = () => {
+            if (readySettled) return;
+            readySettled = true;
+            resolve();
+         };
+         readyReject = (err: Error) => {
+            if (readySettled) return;
+            readySettled = true;
+            reject(err);
+         };
+      });
+      // Silence unhandled-rejection on `ready` itself — every caller
+      // that consumes it (via dispatchToWorker) handles rejection
+      // explicitly, but Node still tracks the original promise.
+      ready.catch(() => {});
+
+      const spawnTimer = setTimeout(() => {
+         readyReject(
+            new Error(
+               `Package-load worker #${id} failed to become ready within ${WORKER_SPAWN_TIMEOUT_MS}ms`,
+            ),
+         );
+         void worker.terminate();
+      }, WORKER_SPAWN_TIMEOUT_MS);
+
+      const pw: PoolWorker = {
+         id,
+         worker,
+         ready,
+         inFlight: new Set(),
+         exited: false,
+      };
+
+      worker.on("message", (msg: WorkerToMainMessage) => {
+         this.handleWorkerMessage(pw, msg, readyResolve, spawnTimer);
+      });
+
+      worker.on("error", (err) => {
+         logger.error(`PackageLoadPool: worker #${id} errored`, {
+            error: err,
+         });
+         clearTimeout(spawnTimer);
+         readyReject(err);
+      });
+
+      worker.on("exit", (code) => {
+         pw.exited = true;
+         clearTimeout(spawnTimer);
+         readyReject(
+            new Error(
+               `Package-load worker #${id} exited before becoming ready (code=${code})`,
+            ),
+         );
+         logger.warn(
+            `PackageLoadPool: worker #${id} exited (code=${code}, inFlight=${pw.inFlight.size})`,
+         );
+         // Fail any jobs that were running on this worker so callers
+         // don't strand waiting for a result that will never come.
+         for (const jobId of Array.from(pw.inFlight)) {
+            this.failJob(
+               jobId,
+               new Error(
+                  `Package-load worker #${id} exited unexpectedly (code=${code})`,
+               ),
+            );
+         }
+         pw.inFlight.clear();
+         // Prune the dead worker so size accounting is honest and
+         // the next dispatch will see a free slot to respawn into.
+         const idx = this.workers.indexOf(pw);
+         if (idx >= 0) this.workers.splice(idx, 1);
+         // Give queued jobs a chance to dispatch elsewhere.
+         this.tryDispatch();
+      });
+
+      return pw;
+   }
+
+   // ────────────────────────────────────────────────────────────────
+   // Internals: message dispatch
+   // ────────────────────────────────────────────────────────────────
+
+   private handleWorkerMessage(
+      pw: PoolWorker,
+      msg: WorkerToMainMessage,
+      markReady: () => void,
+      spawnTimer: ReturnType<typeof setTimeout>,
+   ): void {
+      switch (msg.type) {
+         case "ready":
+            clearTimeout(spawnTimer);
+            markReady();
+            return;
+         case "load-package-result":
+            this.completeJob(pw, msg);
+            return;
+         case "load-package-error":
+            this.errorJob(pw, msg);
+            return;
+         case "connection-metadata":
+            void this.handleConnectionMetadata(pw, msg);
+            return;
+         case "schema-for-tables":
+            void this.handleSchemaForTables(pw, msg);
+            return;
+         case "schema-for-sql":
+            void this.handleSchemaForSql(pw, msg);
+            return;
+         case "read-url":
+            void this.handleReadUrl(pw, msg);
+            return;
+         default: {
+            const exhaustive: never = msg;
+            void exhaustive;
+            return;
+         }
+      }
+   }
+
+   private completeJob(pw: PoolWorker, msg: LoadPackageResult): void {
+      const ctx = this.jobs.get(msg.requestId);
+      if (!ctx) return;
+      this.jobs.delete(msg.requestId);
+      pw.inFlight.delete(msg.requestId);
+      ctx.resolve(msg);
+      // Worker is idle now — give it the next queued job (if any).
+      this.tryDispatch();
+   }
+
+   private errorJob(pw: PoolWorker, msg: LoadPackageError): void {
+      const ctx = this.jobs.get(msg.requestId);
+      if (!ctx) return;
+      this.jobs.delete(msg.requestId);
+      pw.inFlight.delete(msg.requestId);
+      ctx.reject(deserializeError(msg.error));
+      this.tryDispatch();
+   }
+
+   /** Fail a job out-of-band (timeout, worker exit). */
+   private failJob(jobId: string, error: Error): void {
+      const ctx = this.jobs.get(jobId);
+      if (!ctx) return;
+      this.jobs.delete(jobId);
+      ctx.pw.inFlight.delete(jobId);
+      ctx.reject(error);
+   }
+
+   private async handleConnectionMetadata(
+      pw: PoolWorker,
+      msg: ConnectionMetadataRequest,
+   ): Promise<void> {
+      const ctx = this.jobs.get(msg.jobId);
+      const reply = (
+         response: ConnectionMetadataResponse | RpcErrorResponse,
+      ): void => {
+         pw.worker.postMessage(response as MainToWorkerMessage);
+      };
+      if (!ctx) {
+         reply({
+            type: "rpc-error",
+            requestId: msg.requestId,
+            ok: false,
+            error: { name: "Error", message: `Unknown jobId ${msg.jobId}` },
+         });
+         return;
+      }
+      try {
+         const conn = await ctx.connections.lookupConnection(
+            msg.connectionName,
+         );
+         reply({
+            type: "connection-metadata-response",
+            requestId: msg.requestId,
+            ok: true,
+            metadata: {
+               name: msg.connectionName,
+               dialectName: conn.dialectName,
+               digest:
+                  typeof conn.getDigest === "function"
+                     ? conn.getDigest()
+                     : msg.connectionName,
+            },
+         });
+      } catch (error) {
+         reply({
+            type: "rpc-error",
+            requestId: msg.requestId,
+            ok: false,
+            error: serializeError(error),
+         });
+      }
+   }
+
+   private async handleSchemaForTables(
+      pw: PoolWorker,
+      msg: SchemaForTablesRequest,
+   ): Promise<void> {
+      const ctx = this.jobs.get(msg.jobId);
+      const reply = (
+         response: SchemaForTablesResponse | RpcErrorResponse,
+      ): void => {
+         pw.worker.postMessage(response as MainToWorkerMessage);
+      };
+      if (!ctx) {
+         reply({
+            type: "rpc-error",
+            requestId: msg.requestId,
+            ok: false,
+            error: { name: "Error", message: `Unknown jobId ${msg.jobId}` },
+         });
+         return;
+      }
+      try {
+         const conn = await ctx.connections.lookupConnection(
+            msg.connectionName,
+         );
+         const result = await conn.fetchSchemaForTables(
+            msg.tables,
+            buildFetchOptions(msg.options),
+         );
+         reply({
+            type: "schema-for-tables-response",
+            requestId: msg.requestId,
+            ok: true,
+            schemas: result.schemas as Record<string, TableSourceDef>,
+            errors: result.errors,
+         });
+      } catch (error) {
+         reply({
+            type: "rpc-error",
+            requestId: msg.requestId,
+            ok: false,
+            error: serializeError(error),
+         });
+      }
+   }
+
+   private async handleSchemaForSql(
+      pw: PoolWorker,
+      msg: SchemaForSqlRequest,
+   ): Promise<void> {
+      const ctx = this.jobs.get(msg.jobId);
+      const reply = (
+         response: SchemaForSqlResponse | RpcErrorResponse,
+      ): void => {
+         pw.worker.postMessage(response as MainToWorkerMessage);
+      };
+      if (!ctx) {
+         reply({
+            type: "rpc-error",
+            requestId: msg.requestId,
+            ok: false,
+            error: { name: "Error", message: `Unknown jobId ${msg.jobId}` },
+         });
+         return;
+      }
+      try {
+         const conn = await ctx.connections.lookupConnection(
+            msg.connectionName,
+         );
+         const result = await conn.fetchSchemaForSQLStruct(
+            msg.sentence as Parameters<
+               InfoConnection["fetchSchemaForSQLStruct"]
+            >[0],
+            buildFetchOptions(msg.options),
+         );
+         if (result.error !== undefined) {
+            reply({
+               type: "schema-for-sql-response",
+               requestId: msg.requestId,
+               ok: true,
+               error: result.error,
+            });
+         } else {
+            reply({
+               type: "schema-for-sql-response",
+               requestId: msg.requestId,
+               ok: true,
+               structDef: result.structDef as SQLSourceDef,
+            });
+         }
+      } catch (error) {
+         reply({
+            type: "rpc-error",
+            requestId: msg.requestId,
+            ok: false,
+            error: serializeError(error),
+         });
+      }
+   }
+
+   private async handleReadUrl(
+      pw: PoolWorker,
+      msg: ReadUrlRequest,
+   ): Promise<void> {
+      const ctx = this.jobs.get(msg.jobId);
+      const reply = (response: ReadUrlResponse | RpcErrorResponse): void => {
+         pw.worker.postMessage(response as MainToWorkerMessage);
+      };
+      if (!ctx) {
+         reply({
+            type: "rpc-error",
+            requestId: msg.requestId,
+            ok: false,
+            error: { name: "Error", message: `Unknown jobId ${msg.jobId}` },
+         });
+         return;
+      }
+      try {
+         const raw = await ctx.urlReader.readURL(new URL(msg.url));
+         const contents = typeof raw === "string" ? raw : raw.contents;
+         reply({
+            type: "read-url-response",
+            requestId: msg.requestId,
+            ok: true,
+            contents,
+         });
+      } catch (error) {
+         reply({
+            type: "rpc-error",
+            requestId: msg.requestId,
+            ok: false,
+            error: serializeError(error),
+         });
+      }
+   }
+}
+
+function buildFetchOptions(options: {
+   refreshTimestamp?: number;
+   modelAnnotation?: Annotation;
+}): FetchSchemaOptions {
+   const out: FetchSchemaOptions = {};
+   if (options.refreshTimestamp !== undefined) {
+      out.refreshTimestamp = options.refreshTimestamp;
+   }
+   if (options.modelAnnotation !== undefined) {
+      out.modelAnnotation = options.modelAnnotation;
+   }
+   return out;
+}
+
+/**
+ * Hydrate the wire-typed serialized model fields back into their
+ * full Malloy types. Cheap (one pass, no copy); `filterMap` is
+ * deliberately left as the wire array — `Model.fromSerialized`
+ * rebuilds the `Map` lazily for the models it actually uses.
+ */
+function adaptResult(result: LoadPackageResult): LoadPackageOutcome {
+   return {
+      packageMetadata: result.packageMetadata,
+      models: result.models.map((m) => ({
+         ...m,
+         modelDef: m.modelDef as ModelDef | undefined,
+         sourceInfos: m.sourceInfos as Malloy.SourceInfo[] | undefined,
+      })),
+      loadDurationMs: result.loadDurationMs,
+   };
+}
+
+function serializeError(error: unknown): SerializedError {
+   if (error instanceof Error) {
+      return {
+         name: error.name,
+         message: error.message,
+         stack: error.stack,
+      };
+   }
+   return { name: "Error", message: String(error) };
+}
+
+/**
+ * Reconstitute an Error from a serialized payload. When the original
+ * was a Malloy compile error we re-wrap as `ModelCompilationError` so
+ * downstream `instanceof` checks (which decide e.g. HTTP 424 vs 500)
+ * keep firing across the worker boundary.
+ */
+export function deserializeError(serialized: SerializedError): Error {
+   const err = new Error(serialized.message);
+   err.name = serialized.name;
+   if (serialized.stack) err.stack = serialized.stack;
+   if (serialized.malloyProblems) {
+      (err as unknown as { problems: unknown }).problems =
+         serialized.malloyProblems;
+   }
+   if (serialized.isCompilationError) {
+      // ModelCompilationError's ctor expects a MalloyError-shaped
+      // input but only reads `.message` at runtime. Cast through to
+      // satisfy the nominal type without losing data.
+      const wrapped = new ModelCompilationError(
+         err as unknown as ConstructorParameters<
+            typeof ModelCompilationError
+         >[0],
+      );
+      if (serialized.stack) wrapped.stack = serialized.stack;
+      return wrapped;
+   }
+   return err;
+}
+
+const defaultUrlReader = {
+   readURL: async (url: URL): Promise<string> => {
+      const { promises: fs } = await import("fs");
+      const { fileURLToPath } = await import("url");
+      const filePath =
+         url.protocol === "file:" ? fileURLToPath(url) : url.toString();
+      return fs.readFile(filePath, "utf8");
+   },
+};
+
+// ──────────────────────────────────────────────────────────────────────
+// Singleton accessor
+// ──────────────────────────────────────────────────────────────────────
+
+let singleton: PackageLoadPool | null = null;
+
+export function getPackageLoadPool(): PackageLoadPool {
+   if (singleton === null) {
+      const n = getPackageLoadWorkerCount();
+      singleton = new PackageLoadPool(n);
+      logger.info(
+         `Malloy package-load worker pool enabled (size=${n}). ` +
+            `Override with PACKAGE_LOAD_WORKERS=N (N >= 1).`,
+      );
+   }
+   return singleton;
+}
+
+/** Test-only: replace the singleton (and shut down the previous one). */
+export async function __setPackageLoadPoolForTests(
+   pool: PackageLoadPool | null,
+): Promise<void> {
+   if (singleton && singleton !== pool) {
+      await singleton.shutdown();
+   }
+   singleton = pool;
+}

--- a/packages/server/src/package_load/package_load_worker.ts
+++ b/packages/server/src/package_load/package_load_worker.ts
@@ -1,0 +1,980 @@
+/**
+ * Package-load worker entry point.
+ *
+ * Runs inside a worker_threads `Worker`. Owns **no native connection
+ * state of any kind** — every connection lookup, schema fetch, SQL
+ * block schema, and non-file URL read is proxied back to the main
+ * thread via correlated RPC messages. The worker is intentionally
+ * pure-CPU: only Malloy parser / type-checker / IR-builder runs here.
+ *
+ * Why no DuckDB in the worker?
+ * ----------------------------
+ * DuckDB's native bindings cannot be safely loaded into more than one
+ * isolate of the same Node/Bun process (we hit Bun crash 0x20131 when
+ * the worker isolate and the main isolate both `dlopen` duckdb-native).
+ * Even if Bun fixes that, holding a duckdb handle in the worker
+ * duplicates the in-memory DB state and adds native-module load
+ * latency to every worker spawn. Database probing (`readDatabases`)
+ * stays on the main thread where it can reuse the package's existing
+ * DuckDB connection (see PR #772).
+ *
+ * Boundary
+ * --------
+ *   1. Worker: read `publisher.json` (package manifest).
+ *   2. Worker: compile every `.malloy` and `.malloynb` via Malloy.
+ *      All `lookupConnection(name)` / schema-fetch calls Malloy makes
+ *      during compile are proxied to the main thread's live
+ *      connection pool over RPC.
+ *   3. Worker: for each model, capture the structured-clonable fields
+ *      the main-thread `Model` constructor needs: `modelDef`,
+ *      `sourceInfos`, `sources`, `queries`, `filterMap`, `givens`,
+ *      dataStyles, plus per-cell `modelDef` + `queryDef` for
+ *      notebooks (so per-cell materializers / runnables can be
+ *      hydrated on the main thread via `Runtime._loadModelFromModelDef`
+ *      / `ModelMaterializer._loadQueryFromQueryDef` — no recompile).
+ *   4. Main thread: probe embedded `.parquet` / `.csv` databases
+ *      against the package's existing DuckDB connection.
+ *
+ * Per-model compile failures are returned in-band on
+ * `SerializedModel.compilationError`; the rest of the package keeps
+ * loading. Whole-package failures (e.g. manifest missing) come back
+ * as `LoadPackageError`.
+ *
+ * Bundled separately by `build.ts` as `dist/package_load_worker.mjs`
+ * so `new Worker(...)` can load it without dragging in the entire
+ * server module graph.
+ */
+import {
+   contextOverlay,
+   type Annotation,
+   type BuildManifestEntry,
+   type Connection,
+   type FetchSchemaOptions,
+   type LookupConnection,
+   MalloyConfig,
+   MalloyError,
+   type ModelDef,
+   type ModelMaterializer,
+   modelDefToModelInfo,
+   type NamedModelObject,
+   type NamedQueryDef,
+   type Query,
+   Runtime,
+   type SQLSourceDef,
+   type SQLSourceRequest,
+   type StructDef,
+   type TableSourceDef,
+   type TurtleDef,
+   isSourceDef,
+} from "@malloydata/malloy";
+import * as Malloy from "@malloydata/malloy-interfaces";
+import {
+   MalloySQLParser,
+   MalloySQLStatementType,
+} from "@malloydata/malloy-sql";
+import * as fs from "fs";
+import * as path from "path";
+import { parentPort, threadId } from "node:worker_threads";
+import recursive from "recursive-readdir";
+import { fileURLToPath, pathToFileURL } from "url";
+
+import {
+   MODEL_FILE_SUFFIX,
+   NOTEBOOK_FILE_SUFFIX,
+   PACKAGE_MANIFEST_NAME,
+} from "../constants";
+import { HackyDataStylesAccumulator } from "../data_styles";
+import { parseFilters, type FilterDefinition } from "../service/filter";
+import {
+   malloyGivenToApi,
+   type MalloyGiven,
+   type MalloyGivenApi,
+} from "../service/given";
+import { ignoreDotfiles } from "../utils";
+import type {
+   ConnectionMetadata,
+   ConnectionMetadataRequest,
+   ConnectionMetadataResponse,
+   LoadPackageError,
+   LoadPackageRequest,
+   LoadPackageResult,
+   MainToWorkerMessage,
+   ReadUrlRequest,
+   ReadUrlResponse,
+   SchemaForSqlRequest,
+   SchemaForSqlResponse,
+   SchemaForTablesRequest,
+   SchemaForTablesResponse,
+   SerializedError,
+   SerializedModel,
+   SerializedNotebookCell,
+} from "./protocol";
+
+if (!parentPort) {
+   throw new Error(
+      "package_load_worker.ts must be loaded inside a worker_threads Worker",
+   );
+}
+
+const port = parentPort;
+
+// ──────────────────────────────────────────────────────────────────────
+// RPC plumbing for worker → main calls
+// ──────────────────────────────────────────────────────────────────────
+
+let nextRpcId = 0;
+const pendingRpc = new Map<
+   string,
+   { resolve: (value: unknown) => void; reject: (err: Error) => void }
+>();
+
+function newRpcId(): string {
+   nextRpcId += 1;
+   return `w${threadId}-rpc-${nextRpcId}`;
+}
+
+function callMain<T>(send: (requestId: string) => void): Promise<T> {
+   const requestId = newRpcId();
+   return new Promise<T>((resolve, reject) => {
+      pendingRpc.set(requestId, {
+         resolve: (value) => resolve(value as T),
+         reject,
+      });
+      send(requestId);
+   });
+}
+
+function dispatchMainResponse(message: MainToWorkerMessage): void {
+   if (
+      message.type === "schema-for-tables-response" ||
+      message.type === "schema-for-sql-response" ||
+      message.type === "read-url-response" ||
+      message.type === "connection-metadata-response"
+   ) {
+      const pending = pendingRpc.get(message.requestId);
+      if (!pending) return;
+      pendingRpc.delete(message.requestId);
+      pending.resolve(message);
+      return;
+   }
+   if (message.type === "rpc-error") {
+      const pending = pendingRpc.get(message.requestId);
+      if (!pending) return;
+      pendingRpc.delete(message.requestId);
+      pending.reject(deserializeError(message.error));
+      return;
+   }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Proxy connection: stand-in for non-duckdb connections at compile time
+// ──────────────────────────────────────────────────────────────────────
+
+class ProxyConnection {
+   public readonly name: string;
+   public readonly dialectName: string;
+   private readonly digest: string;
+   private readonly jobId: string;
+
+   constructor(metadata: ConnectionMetadata, jobId: string) {
+      this.name = metadata.name;
+      this.dialectName = metadata.dialectName;
+      this.digest = metadata.digest;
+      this.jobId = jobId;
+   }
+
+   getDigest(): string {
+      return this.digest;
+   }
+
+   async fetchSchemaForTables(
+      tables: Record<string, string>,
+      options: FetchSchemaOptions,
+   ): Promise<{
+      schemas: Record<string, TableSourceDef>;
+      errors: Record<string, string>;
+   }> {
+      const response = await callMain<SchemaForTablesResponse>((requestId) => {
+         const req: SchemaForTablesRequest = {
+            type: "schema-for-tables",
+            requestId,
+            jobId: this.jobId,
+            connectionName: this.name,
+            tables,
+            options: serializeFetchOptions(options),
+         };
+         port.postMessage(req);
+      });
+      return { schemas: response.schemas, errors: response.errors };
+   }
+
+   async fetchSchemaForSQLStruct(
+      sentence: SQLSourceRequest,
+      options: FetchSchemaOptions,
+   ): Promise<
+      | { structDef: SQLSourceDef; error?: undefined }
+      | { error: string; structDef?: undefined }
+   > {
+      const response = await callMain<SchemaForSqlResponse>((requestId) => {
+         const req: SchemaForSqlRequest = {
+            type: "schema-for-sql",
+            requestId,
+            jobId: this.jobId,
+            connectionName: this.name,
+            sentence: sentence as unknown,
+            options: serializeFetchOptions(options),
+         };
+         port.postMessage(req);
+      });
+      if (response.error !== undefined) return { error: response.error };
+      if (response.structDef === undefined) {
+         return { error: "Empty SQL schema response from main thread" };
+      }
+      return { structDef: response.structDef };
+   }
+
+   // Compile path never calls these on a non-duckdb connection (the
+   // worker doesn't execute non-duckdb SQL). We throw rather than no-op
+   // so a misrouted call surfaces loudly.
+   async runSQL(): Promise<never> {
+      throw new Error(
+         `ProxyConnection(${this.name}): runSQL is not available in package-load workers`,
+      );
+   }
+   isPool(): false {
+      return false;
+   }
+   canPersist(): false {
+      return false;
+   }
+   canStream(): false {
+      return false;
+   }
+   async close(): Promise<void> {
+      /* no-op */
+   }
+   async idle(): Promise<void> {
+      /* no-op */
+   }
+   async estimateQueryCost(): Promise<never> {
+      throw new Error(
+         `ProxyConnection(${this.name}): estimateQueryCost not available in package-load workers`,
+      );
+   }
+   async fetchMetadata(): Promise<Record<string, unknown>> {
+      return {};
+   }
+   async fetchTableMetadata(): Promise<Record<string, unknown>> {
+      return {};
+   }
+}
+
+function serializeFetchOptions(options: FetchSchemaOptions): {
+   refreshTimestamp?: number;
+   modelAnnotation?: Annotation;
+} {
+   const out: { refreshTimestamp?: number; modelAnnotation?: Annotation } = {};
+   if (options.refreshTimestamp !== undefined) {
+      out.refreshTimestamp = options.refreshTimestamp;
+   }
+   if (options.modelAnnotation !== undefined) {
+      out.modelAnnotation = options.modelAnnotation;
+   }
+   return out;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// URLReader: file:// → fs; everything else proxies to main thread
+// ──────────────────────────────────────────────────────────────────────
+
+function makeWorkerUrlReader(jobId: string): {
+   readURL: (url: URL) => Promise<string>;
+} {
+   return {
+      readURL: async (url: URL): Promise<string> => {
+         if (url.protocol === "file:") {
+            const filePath = fileURLToPath(url);
+            return fs.promises.readFile(filePath, "utf8");
+         }
+         const response = await callMain<ReadUrlResponse>((requestId) => {
+            const req: ReadUrlRequest = {
+               type: "read-url",
+               requestId,
+               jobId,
+               url: url.toString(),
+            };
+            port.postMessage(req);
+         });
+         return response.contents;
+      },
+   };
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// MalloyConfig assembly inside the worker
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Build the package's MalloyConfig inside the worker. Every
+ * connection name — including `"duckdb"` — resolves to a
+ * {@link ProxyConnection} that RPCs schema fetches back to the main
+ * thread. The worker never holds a native connection handle, which
+ * keeps it pure-CPU and avoids dlopen'ing duckdb in a second isolate.
+ *
+ * Concurrent `lookupConnection(name)` calls for the same name are
+ * deduped via `inflight` — Malloy's compile pipeline can fan out
+ * many schema fetches that all hit `lookupConnection` before any
+ * resolve, and we don't want to N-multiply the metadata RPC.
+ */
+function buildWorkerMalloyConfig(job: LoadPackageRequest): MalloyConfig {
+   const proxies = new Map<string, ProxyConnection>();
+   const inflight = new Map<string, Promise<ProxyConnection>>();
+
+   const config = new MalloyConfig(
+      { connections: {} },
+      { config: contextOverlay({ rootDirectory: job.packagePath }) },
+   );
+   config.wrapConnections(
+      (_base: LookupConnection<Connection>): LookupConnection<Connection> => ({
+         lookupConnection: async (name?: string): Promise<Connection> => {
+            const effectiveName = name ?? job.defaultConnectionName ?? "duckdb";
+            const cached = proxies.get(effectiveName);
+            if (cached) return cached as unknown as Connection;
+            let pending = inflight.get(effectiveName);
+            if (!pending) {
+               pending = (async () => {
+                  const response = await callMain<ConnectionMetadataResponse>(
+                     (requestId) => {
+                        const req: ConnectionMetadataRequest = {
+                           type: "connection-metadata",
+                           requestId,
+                           jobId: job.requestId,
+                           connectionName: effectiveName,
+                        };
+                        port.postMessage(req);
+                     },
+                  );
+                  const proxy = new ProxyConnection(
+                     response.metadata,
+                     job.requestId,
+                  );
+                  proxies.set(effectiveName, proxy);
+                  inflight.delete(effectiveName);
+                  return proxy;
+               })();
+               inflight.set(effectiveName, pending);
+            }
+            return (await pending) as unknown as Connection;
+         },
+      }),
+   );
+   return config;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Filesystem helpers (replicated from service/package.ts so the worker
+// stays decoupled from the main-thread service module graph)
+// ──────────────────────────────────────────────────────────────────────
+
+async function readPackageMetadata(
+   packagePath: string,
+): Promise<{ name?: string; description?: string }> {
+   const manifestPath = path.join(packagePath, PACKAGE_MANIFEST_NAME);
+   const contents = await fs.promises.readFile(manifestPath, "utf8");
+   const parsed = JSON.parse(contents) as {
+      name?: string;
+      description?: string;
+   };
+   return { name: parsed.name, description: parsed.description };
+}
+
+async function listPackageFiles(packagePath: string): Promise<string[]> {
+   const files = await recursive(packagePath, [ignoreDotfiles]);
+   return files.map((full: string) =>
+      path.relative(packagePath, full).replace(/\\/g, "/"),
+   );
+}
+
+function filterModelPaths(allRelative: string[]): string[] {
+   return allRelative.filter(
+      (p) => p.endsWith(MODEL_FILE_SUFFIX) || p.endsWith(NOTEBOOK_FILE_SUFFIX),
+   );
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Model compile (mirrors service/model.ts but produces SerializedModel)
+// ──────────────────────────────────────────────────────────────────────
+
+interface ApiSourceWire {
+   name: string;
+   annotations?: string[];
+   views?: { name: string; annotations?: string[] }[];
+   filters?: unknown[];
+   givens?: unknown[];
+}
+interface ApiQueryWire {
+   name: string;
+   sourceName?: string;
+   annotations?: string[];
+}
+type ApiGivenWire = MalloyGivenApi;
+
+async function collectImportedSourceInfos(
+   modelDef: ModelDef,
+   runtime: Runtime,
+   importBaseURL: URL,
+): Promise<{
+   sourceInfos: Malloy.SourceInfo[];
+   importedNames: Set<string>;
+}> {
+   const sourceInfos: Malloy.SourceInfo[] = [];
+   const importedNames = new Set<string>();
+   const imports = modelDef.imports ?? [];
+   for (const importLocation of imports) {
+      try {
+         const modelString = await runtime.urlReader.readURL(
+            new URL(importLocation.importURL),
+         );
+         const importedModelDef = (
+            await runtime
+               .loadModel(modelString as string, { importBaseURL })
+               .getModel()
+         )._modelDef;
+         const importedInfo = modelDefToModelInfo(importedModelDef);
+         const importedSources = importedInfo.entries.filter(
+            (entry) => entry.kind === "source",
+         ) as Malloy.SourceInfo[];
+         for (const source of importedSources) {
+            if (!importedNames.has(source.name)) {
+               sourceInfos.push(source);
+               importedNames.add(source.name);
+            }
+         }
+      } catch {
+         // Best-effort, matches the in-process Model.create behaviour
+         // of warning-and-skipping when an import can't be loaded.
+      }
+   }
+   return { sourceInfos, importedNames };
+}
+
+function appendLocalSourceInfos(
+   modelDef: ModelDef,
+   target: Malloy.SourceInfo[],
+   importedNames: Set<string>,
+): void {
+   const localInfo = modelDefToModelInfo(modelDef);
+   const localSources = localInfo.entries.filter(
+      (entry) => entry.kind === "source",
+   ) as Malloy.SourceInfo[];
+   for (const source of localSources) {
+      if (!importedNames.has(source.name)) target.push(source);
+   }
+}
+
+function extractSources(
+   modelPath: string,
+   modelDef: ModelDef,
+   givens: ApiGivenWire[] | undefined,
+): { sources: ApiSourceWire[]; filterMap: Map<string, FilterDefinition[]> } {
+   const filterMap = new Map<string, FilterDefinition[]>();
+   const sources: ApiSourceWire[] = Object.values(modelDef.contents)
+      .filter((obj) => isSourceDef(obj))
+      .map((sourceObj) => {
+         const sourceName =
+            (sourceObj as StructDef).as || (sourceObj as StructDef).name;
+         const annotations = (sourceObj as StructDef).annotation?.blockNotes
+            ?.filter((note) => note.at.url.includes(modelPath))
+            .map((note) => note.text);
+
+         const collected: string[][] = [];
+         let cur: Annotation | undefined = (sourceObj as StructDef).annotation;
+         while (cur) {
+            if (cur.blockNotes) {
+               collected.push(cur.blockNotes.map((note) => note.text));
+            }
+            cur = cur.inherits;
+         }
+         const allAnnotations = collected.reverse().flat();
+         let filters: unknown[] | undefined;
+         if (allAnnotations.length > 0) {
+            try {
+               const parsed = parseFilters(allAnnotations);
+               if (parsed.length > 0) {
+                  filterMap.set(sourceName, parsed);
+                  const fields = (sourceObj as StructDef).fields;
+                  filters = parsed.map((f) => {
+                     const field = fields.find(
+                        (fd) => (fd.as || fd.name) === f.dimension,
+                     );
+                     return {
+                        name: f.name,
+                        dimension: f.dimension,
+                        type: f.type,
+                        implicit: f.implicit,
+                        required: f.required,
+                        dimensionType: field?.type as string | undefined,
+                     };
+                  });
+               }
+            } catch {
+               /* parse errors are warnings; matches in-process */
+            }
+         }
+
+         const views = (sourceObj as StructDef).fields
+            .filter((f) => f.type === "turtle")
+            .filter((turtle) =>
+               (turtle as TurtleDef).pipeline
+                  .map((stage) => stage.type)
+                  .every((type) => type === "reduce"),
+            )
+            .map((turtle) => ({
+               name: turtle.as || turtle.name,
+               annotations: turtle?.annotation?.blockNotes
+                  ?.filter((note) => note.at.url.includes(modelPath))
+                  .map((note) => note.text),
+            }));
+
+         return {
+            name: sourceName,
+            annotations,
+            views,
+            filters,
+            givens,
+         } as ApiSourceWire;
+      });
+
+   return { sources, filterMap };
+}
+
+function extractQueries(modelPath: string, modelDef: ModelDef): ApiQueryWire[] {
+   const isNamedQuery = (obj: NamedModelObject): obj is NamedQueryDef =>
+      obj.type === "query";
+   return Object.values(modelDef.contents)
+      .filter(isNamedQuery)
+      .map((q) => ({
+         name: q.as || q.name,
+         sourceName: typeof q.structRef === "string" ? q.structRef : undefined,
+         annotations: q?.annotation?.blockNotes
+            ?.filter((note: { at: { url: string } }) =>
+               note.at.url.includes(modelPath),
+            )
+            .map((note: { text: string }) => note.text),
+      }));
+}
+
+function buildRuntimeForModel(
+   job: LoadPackageRequest,
+   malloyConfig: MalloyConfig,
+   jobId: string,
+): { runtime: Runtime; urlReader: HackyDataStylesAccumulator } {
+   const urlReader = new HackyDataStylesAccumulator(makeWorkerUrlReader(jobId));
+   const runtime = new Runtime({
+      urlReader,
+      config: malloyConfig,
+      buildManifest:
+         job.buildManifest !== undefined && job.buildManifest !== null
+            ? {
+                 entries: job.buildManifest as Record<
+                    string,
+                    BuildManifestEntry
+                 >,
+                 strict: false,
+              }
+            : undefined,
+   });
+   return { runtime, urlReader };
+}
+
+async function compileMalloyModel(
+   job: LoadPackageRequest,
+   malloyConfig: MalloyConfig,
+   modelPath: string,
+): Promise<SerializedModel> {
+   const compileStart = performance.now();
+   const fullPath = path.join(job.packagePath, modelPath);
+   // `pathToFileURL` produces a valid URL on every platform; the
+   // naïve `file://${fullPath}` template parses host=`D:` on Windows.
+   const modelURL = pathToFileURL(fullPath);
+   const importBaseURL = new URL(".", modelURL);
+
+   const { runtime, urlReader } = buildRuntimeForModel(
+      job,
+      malloyConfig,
+      job.requestId,
+   );
+   const mm = runtime.loadModel(modelURL, { importBaseURL });
+   const compiled = await mm.getModel();
+   const modelDef = compiled._modelDef;
+
+   const malloyGivens = Array.from(compiled.givens.values());
+   const givens =
+      malloyGivens.length > 0
+         ? malloyGivens.map((g) => malloyGivenToApi(g as MalloyGiven))
+         : undefined;
+
+   const { sourceInfos, importedNames } = await collectImportedSourceInfos(
+      modelDef,
+      runtime,
+      importBaseURL,
+   );
+   appendLocalSourceInfos(modelDef, sourceInfos, importedNames);
+
+   const { sources, filterMap } = extractSources(modelPath, modelDef, givens);
+   const queries = extractQueries(modelPath, modelDef);
+
+   return {
+      modelPath,
+      modelType: "model",
+      modelDef,
+      modelInfo: modelDefToModelInfo(modelDef),
+      sourceInfos,
+      sources,
+      queries,
+      filterMap: Array.from(filterMap.entries()),
+      givens,
+      dataStyles: urlReader.getHackyAccumulatedDataStyles(),
+      compileDurationMs: performance.now() - compileStart,
+   };
+}
+
+async function compileNotebookModel(
+   job: LoadPackageRequest,
+   malloyConfig: MalloyConfig,
+   modelPath: string,
+): Promise<SerializedModel> {
+   const compileStart = performance.now();
+   const fullPath = path.join(job.packagePath, modelPath);
+   // See compileMalloyModel above: `pathToFileURL` is the only
+   // cross-platform way to build a file URL from an OS path.
+   const modelURL = pathToFileURL(fullPath);
+   const importBaseURL = new URL(".", modelURL);
+
+   const { runtime, urlReader } = buildRuntimeForModel(
+      job,
+      malloyConfig,
+      job.requestId,
+   );
+
+   const fileContents = await fs.promises.readFile(modelURL, "utf8");
+   const parse = MalloySQLParser.parse(fileContents, modelPath);
+
+   // Build the extendModel chain synchronously so per-cell materializers
+   // line up with statement order. Matches the in-process flow in
+   // Model.getNotebookModelMaterializer.
+   let mm: ModelMaterializer | undefined;
+   const perCellMM: (ModelMaterializer | undefined)[] = parse.statements.map(
+      (stmt) => {
+         if (stmt.type === MalloySQLStatementType.MALLOY) {
+            mm =
+               mm === undefined
+                  ? runtime.loadModel(stmt.text, { importBaseURL })
+                  : mm.extendModel(stmt.text, { importBaseURL });
+         }
+         return mm;
+      },
+   );
+
+   const oldImports: string[] = [];
+   const oldSources: Record<string, Malloy.SourceInfo> = {};
+   const notebookCells: SerializedNotebookCell[] = [];
+   for (let i = 0; i < parse.statements.length; i++) {
+      const stmt = parse.statements[i];
+      if (stmt.type === MalloySQLStatementType.MARKDOWN) {
+         notebookCells.push({ type: "markdown", text: stmt.text });
+         continue;
+      }
+      if (stmt.type !== MalloySQLStatementType.MALLOY) continue;
+
+      const localMM = perCellMM[i];
+      if (!localMM) {
+         // Shouldn't happen for a MALLOY statement, but guard rather
+         // than crash a whole notebook compile on one corrupt cell.
+         continue;
+      }
+      const currentModelDef = (await localMM.getModel())._modelDef;
+
+      // newSources via the import chain — mirrors in-process logic.
+      let newSources: Malloy.SourceInfo[] = [];
+      const newImports = currentModelDef.imports?.slice(oldImports.length);
+      if (newImports) {
+         for (const importLocation of newImports) {
+            try {
+               const modelString = await runtime.urlReader.readURL(
+                  new URL(importLocation.importURL),
+               );
+               const importModel = (
+                  await runtime
+                     .loadModel(modelString as string, { importBaseURL })
+                     .getModel()
+               )._modelDef;
+               const importInfo = modelDefToModelInfo(importModel);
+               newSources = importInfo.entries
+                  .filter((e) => e.kind === "source")
+                  .filter(
+                     (s) => !(s.name in oldSources),
+                  ) as Malloy.SourceInfo[];
+               oldImports.push(importLocation.importURL.toString());
+            } catch {
+               // Same best-effort policy as the in-process path.
+            }
+         }
+      }
+      const currentInfo = modelDefToModelInfo(currentModelDef);
+      newSources = newSources.concat(
+         currentInfo.entries
+            .filter((e) => e.kind === "source")
+            .filter((s) => !(s.name in oldSources)) as Malloy.SourceInfo[],
+      );
+      for (const s of newSources) oldSources[s.name] = s;
+
+      // Capture the per-cell final-query queryDef so the main thread can
+      // hydrate a QueryMaterializer via
+      // `ModelMaterializer._loadQueryFromQueryDef` without a recompile.
+      const runnable = localMM.loadFinalQuery();
+      let cellQueryDef: Query | undefined;
+      let queryInfo: Malloy.QueryInfo | undefined;
+      try {
+         const prepared = await runnable.getPreparedQuery();
+         cellQueryDef = prepared._query;
+         const queryName =
+            (prepared._query as NamedQueryDef).as ||
+            (prepared._query as NamedQueryDef).name;
+         const anonymous =
+            currentInfo.anonymous_queries[
+               currentInfo.anonymous_queries.length - 1
+            ];
+         if (anonymous) {
+            queryInfo = {
+               name: queryName,
+               schema: anonymous.schema,
+               annotations: anonymous.annotations,
+               definition: anonymous.definition,
+               code: anonymous.code,
+               location: anonymous.location,
+            } as Malloy.QueryInfo;
+         }
+      } catch {
+         // Some cells (source-only) have no final query; that's fine.
+      }
+
+      notebookCells.push({
+         type: "code",
+         text: stmt.text,
+         cellModelDef: currentModelDef,
+         cellQueryDef,
+         newSources,
+         queryInfo,
+      });
+   }
+
+   // Aggregate (notebook-level) artifacts — derived from the final mm
+   // if any MALLOY statements were present. If the notebook is all
+   // markdown, modelDef stays undefined and the main thread treats
+   // this as a notebook with no compiled content.
+   let finalModelDef: ModelDef | undefined;
+   let finalSources: ApiSourceWire[] | undefined;
+   let finalQueries: ApiQueryWire[] | undefined;
+   let finalSourceInfos: Malloy.SourceInfo[] | undefined;
+   let finalFilterMap: Map<string, FilterDefinition[]> | undefined;
+   let finalGivens: ApiGivenWire[] | undefined;
+   if (mm) {
+      const compiled = await mm.getModel();
+      finalModelDef = compiled._modelDef;
+      const malloyGivens = Array.from(compiled.givens.values());
+      finalGivens =
+         malloyGivens.length > 0
+            ? malloyGivens.map((g) => malloyGivenToApi(g as MalloyGiven))
+            : undefined;
+      const collected = await collectImportedSourceInfos(
+         finalModelDef,
+         runtime,
+         importBaseURL,
+      );
+      appendLocalSourceInfos(
+         finalModelDef,
+         collected.sourceInfos,
+         collected.importedNames,
+      );
+      finalSourceInfos = collected.sourceInfos;
+      const extracted = extractSources(modelPath, finalModelDef, finalGivens);
+      finalSources = extracted.sources;
+      finalFilterMap = extracted.filterMap;
+      finalQueries = extractQueries(modelPath, finalModelDef);
+   }
+
+   return {
+      modelPath,
+      modelType: "notebook",
+      modelDef: finalModelDef,
+      modelInfo: finalModelDef ? modelDefToModelInfo(finalModelDef) : undefined,
+      sourceInfos: finalSourceInfos,
+      sources: finalSources,
+      queries: finalQueries,
+      filterMap: finalFilterMap
+         ? Array.from(finalFilterMap.entries())
+         : undefined,
+      givens: finalGivens,
+      notebookCells,
+      dataStyles: urlReader.getHackyAccumulatedDataStyles(),
+      compileDurationMs: performance.now() - compileStart,
+   };
+}
+
+async function compileOneModel(
+   job: LoadPackageRequest,
+   malloyConfig: MalloyConfig,
+   modelPath: string,
+): Promise<SerializedModel> {
+   try {
+      if (modelPath.endsWith(MODEL_FILE_SUFFIX)) {
+         return await compileMalloyModel(job, malloyConfig, modelPath);
+      }
+      if (modelPath.endsWith(NOTEBOOK_FILE_SUFFIX)) {
+         return await compileNotebookModel(job, malloyConfig, modelPath);
+      }
+      return {
+         modelPath,
+         modelType: "model",
+         compilationError: {
+            name: "Error",
+            message: `Unknown model file suffix: ${modelPath}`,
+         },
+      };
+   } catch (error) {
+      const modelType: SerializedModel["modelType"] = modelPath.endsWith(
+         NOTEBOOK_FILE_SUFFIX,
+      )
+         ? "notebook"
+         : "model";
+      return {
+         modelPath,
+         modelType,
+         compilationError: serializeError(error),
+      };
+   }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// The actual load-package job
+// ──────────────────────────────────────────────────────────────────────
+
+async function loadPackage(
+   job: LoadPackageRequest,
+): Promise<LoadPackageResult> {
+   const loadStart = performance.now();
+
+   const packageMetadata = await readPackageMetadata(job.packagePath);
+   const malloyConfig = buildWorkerMalloyConfig(job);
+
+   const allFiles = await listPackageFiles(job.packagePath);
+   const modelPaths = filterModelPaths(allFiles);
+   const models = await Promise.all(
+      modelPaths.map((modelPath) =>
+         compileOneModel(job, malloyConfig, modelPath),
+      ),
+   );
+
+   return {
+      type: "load-package-result",
+      requestId: job.requestId,
+      packageMetadata,
+      models,
+      loadDurationMs: performance.now() - loadStart,
+   };
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Error serialization
+// ──────────────────────────────────────────────────────────────────────
+
+function serializeError(error: unknown): SerializedError {
+   if (error instanceof MalloyError) {
+      return {
+         name: error.name,
+         message: error.message,
+         stack: error.stack,
+         malloyProblems: error.problems as unknown[],
+         isCompilationError: true,
+      };
+   }
+   if (error instanceof Error) {
+      return {
+         name: error.name,
+         message: error.message,
+         stack: error.stack,
+      };
+   }
+   return { name: "Error", message: String(error) };
+}
+
+function deserializeError(serialized: SerializedError): Error {
+   const err = new Error(serialized.message);
+   err.name = serialized.name;
+   if (serialized.stack) err.stack = serialized.stack;
+   return err;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Message dispatcher
+// ──────────────────────────────────────────────────────────────────────
+
+let shuttingDown = false;
+const inFlightJobs = new Set<string>();
+
+port.on("message", (message: MainToWorkerMessage) => {
+   if (message.type === "shutdown") {
+      shuttingDown = true;
+      maybeExit();
+      return;
+   }
+   if (message.type === "load-package") {
+      if (shuttingDown) {
+         const errMsg: LoadPackageError = {
+            type: "load-package-error",
+            requestId: message.requestId,
+            error: {
+               name: "ShuttingDown",
+               message: "Package-load worker is shutting down",
+            },
+         };
+         port.postMessage(errMsg);
+         return;
+      }
+      inFlightJobs.add(message.requestId);
+      void runJob(message);
+      return;
+   }
+   dispatchMainResponse(message);
+});
+
+async function runJob(job: LoadPackageRequest): Promise<void> {
+   try {
+      const result = await loadPackage(job);
+      port.postMessage(result);
+   } catch (error) {
+      const errMsg: LoadPackageError = {
+         type: "load-package-error",
+         requestId: job.requestId,
+         error: serializeError(error),
+      };
+      port.postMessage(errMsg);
+   } finally {
+      inFlightJobs.delete(job.requestId);
+      maybeExit();
+   }
+}
+
+function maybeExit(): void {
+   if (shuttingDown && inFlightJobs.size === 0 && pendingRpc.size === 0) {
+      // Give the postMessage queue a tick to flush before exit so the
+      // last result actually reaches the parent.
+      setImmediate(() => process.exit(0));
+   }
+}
+
+// Announce readiness — the pool waits for this before dispatching jobs
+// to a newly-spawned worker so we don't race the worker's module-init
+// time.
+port.postMessage({ type: "ready" });

--- a/packages/server/src/package_load/protocol.ts
+++ b/packages/server/src/package_load/protocol.ts
@@ -1,0 +1,336 @@
+/**
+ * Wire protocol between the main thread (`PackageLoadPool`) and a
+ * package-load worker thread.
+ *
+ * Boundary
+ * --------
+ * The worker performs the **CPU-bound bulk of `Package.create`** off
+ * the main event loop:
+ *
+ *   1. Read `publisher.config.json` (cheap, but already on the worker
+ *      side of the boundary so the main thread isn't blocked).
+ *   2. Compile every `.malloy` / `.malloynb` (the Malloy parser,
+ *      type-checker, and IR-builder — the dominant CPU cost).
+ *   3. Return a structured-clonable POJO carrying every `modelDef`,
+ *      `sourceInfos`, dataStyles, etc. that the main thread needs to
+ *      reconstitute a live `Package`.
+ *
+ * Embedded database probing (`.parquet` / `.csv` schema + row count)
+ * stays on the main thread — it reuses the package's existing DuckDB
+ * connection (PR #772) and the probe queries are async-IO-bound, not
+ * CPU-bound. Keeping all native-DB handles on the main thread also
+ * sidesteps Bun crash 0x20131 where duckdb-native cannot be loaded
+ * into more than one isolate of the same process.
+ *
+ * The main thread reconstitutes by:
+ *   - Building a fresh `MalloyConfig` against its own connection pool
+ *     (live native handles can't cross the worker boundary).
+ *   - Lazy-hydrating each model's `ModelMaterializer` from `modelDef`
+ *     via `Runtime._loadModelFromModelDef` on first query — NO
+ *     recompile. This is what closes the loop on PR #767's original
+ *     "first-query recompile on main thread" gap.
+ *
+ * Per-model compile failures are returned in-band on
+ * `SerializedModel.compilationError` so a single bad model doesn't
+ * abort the rest of the package load. The main thread decides
+ * whether/when to surface as a fatal `Package.create` error (today
+ * it throws on the first error; `Package.reloadAllModels` keeps the
+ * failed models as placeholders in the package's model map).
+ *
+ * Whole-package failures (manifest missing, FS errors, worker
+ * crashes) come back as `LoadPackageError`. The pool main-thread
+ * half (`PackageLoadPool.loadPackage`) rejects with a deserialised
+ * Error; `Package.loadViaWorker` then rewraps any non-compile
+ * failure as `ServiceUnavailableError` so the HTTP layer responds
+ * 503 (transient, retryable) — there is no in-process fallback.
+ *
+ * Direction summary
+ * -----------------
+ *   main  ──▶ worker:  LoadPackageRequest         (start)
+ *   worker ──▶ main:   LoadPackageResult          (success)
+ *   worker ──▶ main:   LoadPackageError           (whole-package failure)
+ *
+ *   worker ──▶ main:   ConnectionMetadataRequest  (proxy non-duckdb lookups)
+ *   worker ──▶ main:   SchemaForTablesRequest     (proxy schema fetch)
+ *   worker ──▶ main:   SchemaForSqlRequest        (proxy SQL block schema)
+ *   worker ──▶ main:   ReadUrlRequest             (proxy non-file URL reads)
+ *   main  ──▶ worker:  *Response                  (correlated by requestId)
+ *
+ *   main  ──▶ worker:  ShutdownRequest            (graceful drain)
+ *   worker ──▶ main:   ReadyMessage               (post-init handshake)
+ *
+ * The protocol uses plain structured-clonable POJOs so the
+ * `postMessage` transfer goes through V8's structured clone — much
+ * cheaper than `JSON.stringify` for the multi-MB modelDef payloads.
+ */
+
+import type {
+   Annotation,
+   SQLSourceDef,
+   TableSourceDef,
+} from "@malloydata/malloy";
+
+// ──────────────────────────────────────────────────────────────────────
+// Direction: main ──▶ worker (load-package job)
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Connection metadata the worker needs to construct a stub
+ * `InfoConnection`. Resolved lazily — the worker asks the main thread
+ * on the first `lookupConnection(name)` call (see
+ * {@link ConnectionMetadataRequest}). We don't ship the full list
+ * upfront because Malloy only references connections by name as it
+ * encounters `<connection>.table('...')` / `<connection>.sql('...')`
+ * inside the model.
+ */
+export interface ConnectionMetadata {
+   name: string;
+   dialectName: string;
+   digest: string;
+}
+
+export interface LoadPackageRequest {
+   type: "load-package";
+   requestId: string;
+   /** Absolute path to the package directory on disk. */
+   packagePath: string;
+   /** Logical package name (used in metric labels + log fields). */
+   packageName: string;
+   /**
+    * Default connection name (passed verbatim to the worker; today
+    * always `"duckdb"` for embedded packages, but kept configurable
+    * to mirror Malloy's own surface).
+    */
+   defaultConnectionName: string | null;
+   /** Optional row-build manifest passed through to Malloy Runtime. */
+   buildManifest?: unknown;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Direction: worker ──▶ main (load-package result)
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Wire shape for one compiled model in the package. Mirrors the
+ * data a main-thread `Model` constructor needs without holding a
+ * `ModelMaterializer` reference (that binds to live native
+ * connection handles and can't cross the worker boundary).
+ *
+ * `compilationError` is set when this single model failed to
+ * compile but the rest of the package is fine; the main thread
+ * decides whether to abort `Package.create`.
+ */
+export interface SerializedModel {
+   /** Path relative to the package root, forward-slash normalized. */
+   modelPath: string;
+   modelType: "model" | "notebook";
+   /** Set when the model compiled successfully. Wire-typed as
+    *  `unknown` so the protocol module doesn't drag in the full
+    *  Malloy type surface; cast to `ModelDef` on receipt. */
+   modelDef?: unknown;
+   /**
+    * Precomputed `modelDefToModelInfo(modelDef)`. Shipped from the
+    * worker so the main-thread `Model` constructor doesn't pay the
+    * derivation cost on every package load and every subsequent
+    * `getModel()` / `getNotebook()` API hit can stringify a cached
+    * object instead of recomputing.
+    */
+   modelInfo?: unknown;
+   sourceInfos?: unknown[];
+   sources?: unknown[];
+   queries?: unknown[];
+   filterMap?: Array<[string, unknown[]]>;
+   givens?: unknown[];
+   /** Notebook (.malloynb) only — per-cell pre-extracted info. */
+   notebookCells?: SerializedNotebookCell[];
+   /** Accumulated dataStyles from sibling `.styles.json` files. */
+   dataStyles?: unknown;
+   /** Wall-clock ms spent compiling this single model in the worker. */
+   compileDurationMs?: number;
+   /** Set when the model failed to compile. */
+   compilationError?: SerializedError;
+}
+
+export interface SerializedNotebookCell {
+   type: "code" | "markdown";
+   /** Raw cell text. */
+   text: string;
+   /**
+    * Per-cell ModelDef captured at the cell's point in the
+    * `extendModel` chain. The main thread hydrates a per-cell
+    * `ModelMaterializer` from this via
+    * `Runtime._loadModelFromModelDef`, so cell-level filter
+    * refinement can compile new queries against the correct scope
+    * without ever recompiling the .malloynb itself.
+    */
+   cellModelDef?: unknown;
+   /**
+    * The final-query QueryDef for this cell, captured during the
+    * worker's compile. Main thread hydrates a `QueryMaterializer`
+    * via `ModelMaterializer._loadQueryFromQueryDef` — no recompile.
+    */
+   cellQueryDef?: unknown;
+   newSources?: unknown[];
+   queryInfo?: unknown;
+}
+
+export interface LoadPackageResult {
+   type: "load-package-result";
+   requestId: string;
+   packageMetadata: { name?: string; description?: string };
+   models: SerializedModel[];
+   /** Wall-clock ms inside the worker for the full package load. */
+   loadDurationMs: number;
+}
+
+export interface LoadPackageError {
+   type: "load-package-error";
+   requestId: string;
+   error: SerializedError;
+}
+
+/**
+ * Error wire-shape. We cannot transfer `Error` instances directly
+ * across `postMessage` cleanly (Bun/Node behaviour diverges on stack
+ * propagation), so we ship a structured payload and reconstitute on
+ * the main thread.
+ */
+export interface SerializedError {
+   name: string;
+   message: string;
+   stack?: string;
+   /** Set when the error originated as a Malloy `MalloyError`. */
+   malloyProblems?: unknown[];
+   /** Set when the error originated as `ModelCompilationError`. */
+   isCompilationError?: boolean;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Direction: worker ──▶ main (proxy connection metadata)
+// ──────────────────────────────────────────────────────────────────────
+
+export interface ConnectionMetadataRequest {
+   type: "connection-metadata";
+   requestId: string;
+   jobId: string;
+   connectionName: string;
+}
+
+export interface ConnectionMetadataResponse {
+   type: "connection-metadata-response";
+   requestId: string;
+   ok: true;
+   metadata: ConnectionMetadata;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Direction: worker ──▶ main (proxy schema fetches for non-duckdb)
+// ──────────────────────────────────────────────────────────────────────
+
+export interface SchemaForTablesRequest {
+   type: "schema-for-tables";
+   requestId: string;
+   /** Job this RPC belongs to (so main routes to the right config). */
+   jobId: string;
+   connectionName: string;
+   tables: Record<string, string>;
+   options: {
+      refreshTimestamp?: number;
+      modelAnnotation?: Annotation;
+   };
+}
+
+export interface SchemaForTablesResponse {
+   type: "schema-for-tables-response";
+   requestId: string;
+   ok: true;
+   schemas: Record<string, TableSourceDef>;
+   errors: Record<string, string>;
+}
+
+export interface SchemaForSqlRequest {
+   type: "schema-for-sql";
+   requestId: string;
+   jobId: string;
+   connectionName: string;
+   sentence: unknown;
+   options: {
+      refreshTimestamp?: number;
+      modelAnnotation?: Annotation;
+   };
+}
+
+export interface SchemaForSqlResponse {
+   type: "schema-for-sql-response";
+   requestId: string;
+   ok: true;
+   structDef?: SQLSourceDef;
+   error?: string;
+}
+
+export interface RpcErrorResponse {
+   type: "rpc-error";
+   requestId: string;
+   ok: false;
+   error: SerializedError;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Direction: worker ──▶ main (file read for non-file URLs)
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Workers read most files directly via `fs` (they share the host's
+ * filesystem namespace). This RPC exists for the rare case where the
+ * package URL reader has host-specific behaviour (e.g. virtual files,
+ * remote URLs) — we delegate back to the main thread's URL reader so
+ * compile semantics stay identical to the in-process path.
+ */
+export interface ReadUrlRequest {
+   type: "read-url";
+   requestId: string;
+   jobId: string;
+   url: string;
+}
+
+export interface ReadUrlResponse {
+   type: "read-url-response";
+   requestId: string;
+   ok: true;
+   contents: string;
+   invalidationKey?: string | number | null;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Lifecycle
+// ──────────────────────────────────────────────────────────────────────
+
+export interface ShutdownRequest {
+   type: "shutdown";
+}
+
+export interface ReadyMessage {
+   type: "ready";
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Union types for routing
+// ──────────────────────────────────────────────────────────────────────
+
+export type MainToWorkerMessage =
+   | LoadPackageRequest
+   | ConnectionMetadataResponse
+   | SchemaForTablesResponse
+   | SchemaForSqlResponse
+   | ReadUrlResponse
+   | RpcErrorResponse
+   | ShutdownRequest;
+
+export type WorkerToMainMessage =
+   | LoadPackageResult
+   | LoadPackageError
+   | ConnectionMetadataRequest
+   | SchemaForTablesRequest
+   | SchemaForSqlRequest
+   | ReadUrlRequest
+   | ReadyMessage;

--- a/packages/server/src/query_param_utils.ts
+++ b/packages/server/src/query_param_utils.ts
@@ -1,0 +1,18 @@
+/**
+ * Express query-param normalization helpers.
+ *
+ * Kept in a standalone file (no transitive imports) so unit specs can
+ * exercise them without dragging in `server.ts` — which transitively
+ * constructs `EnvironmentStore` and kicks off an async storage init
+ * (clone of `malloy-samples`, package downloads, ...). When that init
+ * runs in a `bun test` process it races the test runner's exit and
+ * leaves a partially-populated `publisher_data/` on disk, which the
+ * next process (integration tests) then trips over.
+ */
+
+/** Normalize an Express query param into a string[] or undefined. */
+export function normalizeQueryArray(value: unknown): string[] | undefined {
+   if (value === undefined || value === null) return undefined;
+   if (Array.isArray(value)) return value.map(String);
+   return [String(value)];
+}

--- a/packages/server/src/server-old.ts
+++ b/packages/server/src/server-old.ts
@@ -41,7 +41,7 @@ import {
    NotImplementedError,
 } from "./errors";
 import { logger } from "./logger";
-import { normalizeQueryArray } from "./server";
+import { normalizeQueryArray } from "./query_param_utils";
 import { EnvironmentStore } from "./service/environment_store";
 
 const LEGACY_API_PREFIX = "/api/v0";

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -42,14 +42,10 @@ import { registerLegacyRoutes } from "./server-old";
 import { EnvironmentStore } from "./service/environment_store";
 import { ManifestService } from "./service/manifest_service";
 import { MaterializationService } from "./service/materialization_service";
+import { normalizeQueryArray } from "./query_param_utils";
 import { PackageMemoryGovernor } from "./service/package_memory_governor";
 
-/** Normalize an Express query param into a string[] or undefined. */
-export function normalizeQueryArray(value: unknown): string[] | undefined {
-   if (value === undefined || value === null) return undefined;
-   if (Array.isArray(value)) return value.map(String);
-   return [String(value)];
-}
+export { normalizeQueryArray } from "./query_param_utils";
 
 // Parse command line arguments
 function parseArgs() {
@@ -123,10 +119,12 @@ function parseArgs() {
    // Zero-config invocation (`npx @malloy-publisher/server`) opts in to
    // the bundled DuckDB-only sample config so the Quick Start works
    // without any flags. Any explicit --server_root or --config disables
-   // this — the user told us where to look. Skip in NODE_ENV=test so
-   // specs that import this module for utility helpers (e.g.
-   // db_utils.spec.ts -> normalizeQueryArray) don't get the bundled
-   // default leaked into their EnvironmentStore construction.
+   // this — the user told us where to look. Skip in NODE_ENV=test as a
+   // belt-and-suspenders so any spec that ends up evaluating this
+   // module doesn't accidentally pin the EnvironmentStore to the
+   // bundled malloy-samples config; query-param helpers have been
+   // moved to `./query_param_utils` precisely so unit specs no longer
+   // need to import this module at all.
    if (!sawServerRoot && !sawConfig && process.env.NODE_ENV !== "test") {
       process.env.PUBLISHER_USE_BUNDLED_DEFAULT = "true";
    }
@@ -1446,6 +1444,18 @@ app.use(
       res.status(status).json(json);
    },
 );
+
+// Eagerly construct the package-load worker pool so we fail fast at
+// boot if PACKAGE_LOAD_WORKERS is misconfigured (e.g. set to 0, the
+// removed in-process fallback). Surfacing the bad config here is much
+// friendlier than surfacing it on the first package load, which could
+// be hours after start.
+{
+   const { getPackageLoadPool } = await import(
+      "./package_load/package_load_pool"
+   );
+   getPackageLoadPool();
+}
 
 const mainServer = http.createServer({ maxHeaderSize: 262144 }, app);
 

--- a/packages/server/src/service/db_utils.spec.ts
+++ b/packages/server/src/service/db_utils.spec.ts
@@ -12,7 +12,7 @@ mock.module("@google-cloud/bigquery", () => ({
 }));
 
 import { Connection } from "@malloydata/malloy";
-import { normalizeQueryArray } from "../server";
+import { normalizeQueryArray } from "../query_param_utils";
 import {
    extractErrorDataFromError,
    getSchemasForConnection,

--- a/packages/server/src/service/given.ts
+++ b/packages/server/src/service/given.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared utilities for surfacing Malloy `Given` declarations on
+ * compiled models.
+ *
+ * The Malloy SDK's `Given` class is declared in
+ * `@malloydata/malloy/dist/api/foundation/core.d.ts` but is not
+ * re-exported from the package root, so we duck-type against the
+ * surface we actually use and don't pull in the private type.
+ *
+ * Lives here so both the main-thread `Model` constructor and the
+ * package-load worker can use the same conversion. The worker
+ * imports this file directly (it's pure TypeScript with no native
+ * deps, so it's safe to bundle into the worker entry).
+ */
+
+/**
+ * Duck-typed shape of a Malloy SDK `Given` instance (the value type
+ * of `Model.givens`).
+ */
+export interface MalloyGiven {
+   readonly name: string;
+   readonly type: { type: string; filterType?: string };
+   getTaglines(prefix?: RegExp): string[];
+}
+
+/**
+ * Wire/API shape of a given. Structurally identical to the
+ * `components["schemas"]["Given"]` shape from the OpenAPI spec —
+ * callers can cast freely.
+ */
+export interface MalloyGivenApi {
+   name: string;
+   type: string;
+   annotations?: string[];
+}
+
+/**
+ * Convert a Malloy SDK `Given` to the wire/API shape.
+ *
+ * Two fields are deliberately not surfaced:
+ *
+ * - `location` — Malloy's `DocumentLocation.url` is an absolute
+ *   `file://` path on the publisher's filesystem. Surfacing it
+ *   would leak the OS user, install directory, and internal
+ *   layout. Existing `Filter` introspection does not expose
+ *   location either; matching that floor. A future PR can add a
+ *   sanitised package-relative path if a client needs it.
+ *
+ * - `default` / `defaultText` — Malloy's API only exposes the
+ *   parsed `ConstantExpr` AST, not a rendered source string.
+ *   Rendering it here would duplicate the Malloy printer. Add
+ *   when Malloy surfaces a stringified accessor.
+ *
+ * `annotations` is restricted to `#(...)` declaration annotations
+ * (the caller-facing kind, e.g. `#(doc)`). `getTaglines()` with no
+ * prefix would also return `##` doc-comment lines and the
+ * model-level `##!` pragma, which aren't part of the given's
+ * surface contract.
+ *
+ * Type rendering: `GivenTypeDef` is typed as `AtomicTypeDef |
+ * FilterExpressionParamTypeDef`, but Malloy's grammar only emits
+ * the scalar parameter types (`string` | `number` | `boolean` |
+ * `date` | `timestamp` | `timestamptz` | `filter expression` |
+ * `error`) for given declarations today. If the grammar expands
+ * to allow array or record givens, the bare `type.type`
+ * discriminator (`'array'`, `'record'`) will land in the wire
+ * response with no element info — revisit when that happens.
+ */
+export function malloyGivenToApi(given: MalloyGiven): MalloyGivenApi {
+   const type = given.type;
+   const renderedType =
+      type.type === "filter expression"
+         ? `filter<${type.filterType}>`
+         : type.type;
+   return {
+      name: given.name,
+      type: renderedType,
+      annotations: given.getTaglines(/^#\(/),
+   };
+}

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -29,6 +29,11 @@ import * as fs from "fs/promises";
 import { createRequire } from "module";
 import * as path from "path";
 import { components } from "../api";
+import { deserializeError } from "../package_load/package_load_pool";
+import type {
+   SerializedModel,
+   SerializedNotebookCell,
+} from "../package_load/protocol";
 import {
    MODEL_FILE_SUFFIX,
    NOTEBOOK_FILE_SUFFIX,
@@ -51,6 +56,7 @@ import {
    type FilterDefinition,
    type FilterParams,
 } from "./filter";
+import { malloyGivenToApi, type MalloyGiven } from "./given";
 
 type ApiCompiledModel = components["schemas"]["CompiledModel"];
 type ApiNotebookCell = components["schemas"]["NotebookCell"];
@@ -74,61 +80,6 @@ const MALLOY_VERSION = (
 
 export type ModelType = "model" | "notebook";
 type ModelConnectionInput = MalloyConfig | Map<string, Connection>;
-
-/**
- * Structural type for a Malloy SDK `Given` instance (the value type of
- * `Model.givens`). The `Given` class is declared in
- * `@malloydata/malloy/dist/api/foundation/core.d.ts` but is not re-exported
- * from the package root, so we duck-type against the surface we use rather
- * than importing it.
- */
-interface MalloyGiven {
-   readonly name: string;
-   readonly type: { type: string; filterType?: string };
-   getTaglines(prefix?: RegExp): string[];
-}
-
-/**
- * Convert a Malloy SDK `Given` (returned from `Model.givens`) to the wire
- * shape declared in `api-doc.yaml`. Two fields are deliberately not surfaced:
- *
- * - `location` — Malloy's `DocumentLocation.url` is an absolute `file://`
- *   path on the publisher's filesystem. Surfacing it would leak the OS user,
- *   install directory, and internal layout. Existing `Filter` introspection
- *   does not expose location either; matching that floor. A future PR can
- *   add a sanitized package-relative path if a client needs it.
- *
- * - `default` / `defaultText` — Malloy's API only exposes the parsed
- *   `ConstantExpr` AST, not a rendered source string. Rendering it here
- *   would duplicate the Malloy printer. Add when Malloy surfaces a
- *   stringified accessor.
- *
- * `annotations` is restricted to `#(...)` declaration annotations (the
- * caller-facing kind, e.g. `#(doc)`). `getTaglines()` with no prefix would
- * also return `##` doc-comment lines and the model-level `##!` pragma,
- * which aren't part of the given's surface contract.
- *
- * Type rendering: `GivenTypeDef` is typed as `AtomicTypeDef |
- * FilterExpressionParamTypeDef`, but Malloy's grammar only emits the
- * scalar parameter types (`string` | `number` | `boolean` | `date` |
- * `timestamp` | `timestamptz` | `filter expression` | `error`) for
- * given declarations today. If the grammar expands to allow array or
- * record givens, the bare `type.type` discriminator (`'array'`,
- * `'record'`) will land in the wire response with no element info —
- * revisit when that happens.
- */
-function malloyGivenToApi(given: MalloyGiven): ApiGiven {
-   const type = given.type;
-   const renderedType =
-      type.type === "filter expression"
-         ? `filter<${type.filterType}>`
-         : type.type;
-   return {
-      name: given.name,
-      type: renderedType,
-      annotations: given.getTaglines(/^#\(/),
-   };
-}
 
 interface RunnableNotebookCell {
    type: "code" | "markdown";
@@ -183,6 +134,15 @@ export class Model {
       compilationError: MalloyError | Error | undefined,
       filterMap?: Map<string, FilterDefinition[]>,
       givens?: ApiGiven[],
+      /**
+       * Precomputed `modelDefToModelInfo(modelDef)`. The package-load
+       * worker emits it as part of `SerializedModel` so we don't
+       * re-derive it on every package load. Callers that build a
+       * `Model` from a raw `modelDef` (e.g. test fixtures via
+       * `Model.create`) can omit this and let the constructor
+       * derive it lazily.
+       */
+      modelInfo?: Malloy.ModelInfo,
    ) {
       this.packageName = packageName;
       this.modelPath = modelPath;
@@ -197,9 +157,9 @@ export class Model {
       this.compilationError = compilationError;
       this.filterMap = filterMap ?? new Map();
       this.givens = givens;
-      this.modelInfo = this.modelDef
-         ? modelDefToModelInfo(this.modelDef)
-         : undefined;
+      this.modelInfo =
+         modelInfo ??
+         (this.modelDef ? modelDefToModelInfo(this.modelDef) : undefined);
    }
 
    /**
@@ -221,6 +181,15 @@ export class Model {
       return runMatch?.[1] ?? arrowMatch?.[1];
    }
 
+   /**
+    * Compile a single model in-process. Kept as a library entry point
+    * for test fixtures and any future caller that needs an ad-hoc
+    * `Model` from a `.malloy` / `.malloynb` file. Production package
+    * loads (`Package.create`) and reloads (`Package.reloadAllModels`)
+    * route through the package-load worker pool and dispatch through
+    * {@link Model.fromSerialized} instead — neither calls this on the
+    * main thread.
+    */
    public static async create(
       packageName: string,
       packagePath: string,
@@ -258,10 +227,12 @@ export class Model {
             modelDef = compiledModel._modelDef;
             // Malloy's `Model.givens` already collapses inheritance from imports
             // and applies any `finalizeGivens` runtime config. Just read it.
-            const malloyGivens = Array.from(compiledModel.givens.values());
+            const malloyGivens = Array.from(
+               compiledModel.givens.values(),
+            ) as MalloyGiven[];
             givens =
                malloyGivens.length > 0
-                  ? malloyGivens.map(malloyGivenToApi)
+                  ? (malloyGivens.map(malloyGivenToApi) as ApiGiven[])
                   : undefined;
             const sourceResult = Model.getSources(modelPath, modelDef, givens);
             sources = sourceResult.sources;
@@ -357,6 +328,123 @@ export class Model {
          );
       }
    }
+
+   /**
+    * Construct a `Model` from a worker-compiled `SerializedModel`. All
+    * the heavy compile work (parse, type check, IR build, sourceInfo
+    * extraction, per-cell notebook compile) already ran inside a
+    * `worker_threads` worker; this factory just rewraps the wire data
+    * into a live `Model`.
+    *
+    * Hydrates the `ModelMaterializer` (and, for notebooks, the
+    * per-cell materializers + runnables) **eagerly** via
+    * `Runtime._loadModelFromModelDef` /
+    * `ModelMaterializer._loadQueryFromQueryDef`. These are constant-time
+    * wraps around the worker's pre-compiled `modelDef` / `queryDef` —
+    * no parse, no type-check, no schema fetch — so doing it here at
+    * package-load time costs microseconds per model and keeps the
+    * resulting `Model` interchangeable with one produced by
+    * `Model.create` (no lazy-init branches in the hot path).
+    */
+   public static fromSerialized(
+      packageName: string,
+      _packagePath: string,
+      malloyConfig: ModelConnectionInput,
+      data: SerializedModel,
+   ): Model {
+      const modelDef = data.modelDef as ModelDef | undefined;
+      const modelInfo = data.modelInfo as Malloy.ModelInfo | undefined;
+      const dataStyles = (data.dataStyles ?? {}) as DataStyles;
+      const sources = data.sources as ApiSource[] | undefined;
+      const queries = data.queries as ApiQuery[] | undefined;
+      const sourceInfos = data.sourceInfos as Malloy.SourceInfo[] | undefined;
+      const givens = data.givens as ApiGiven[] | undefined;
+      const filterMap = data.filterMap
+         ? new Map(data.filterMap as Array<[string, FilterDefinition[]]>)
+         : undefined;
+
+      // No modelDef → either an empty notebook (no MALLOY statements)
+      // or a corrupt worker payload. Build a Model with no materializer;
+      // downstream getQueryResults / executeNotebookCell will throw a
+      // clean BadRequestError if a caller tries to run a query. We
+      // still preserve markdown cells for an all-markdown notebook so
+      // `getNotebook()` can serve raw text.
+      if (!modelDef) {
+         return new Model(
+            packageName,
+            data.modelPath,
+            dataStyles,
+            data.modelType,
+            undefined,
+            undefined,
+            sources,
+            queries,
+            sourceInfos,
+            data.modelType === "notebook"
+               ? hydrateMarkdownOnlyCells(data.notebookCells)
+               : undefined,
+            undefined,
+            filterMap,
+            givens,
+            modelInfo,
+         );
+      }
+
+      const runtime = makeHydrationRuntime(malloyConfig);
+      const modelMaterializer = runtime._loadModelFromModelDef(modelDef);
+      const runnableNotebookCells =
+         data.modelType === "notebook"
+            ? hydrateNotebookCells(runtime, data.notebookCells)
+            : undefined;
+
+      return new Model(
+         packageName,
+         data.modelPath,
+         dataStyles,
+         data.modelType,
+         modelMaterializer,
+         modelDef,
+         sources,
+         queries,
+         sourceInfos,
+         runnableNotebookCells,
+         undefined, // compilationError
+         filterMap,
+         givens,
+         modelInfo,
+      );
+   }
+
+   /**
+    * Build a Model representing a compilation failure (no modelDef,
+    * no materializer). Matches the shape `Model.create` returns when
+    * it catches a `MalloyError`, so the rest of the system handles
+    * both paths uniformly (the iteration loop in `Package.create`
+    * reads `compilationError` via a structural cast).
+    */
+   public static fromCompilationError(
+      packageName: string,
+      modelPath: string,
+      modelType: ModelType,
+      error: Error,
+   ): Model {
+      return new Model(
+         packageName,
+         modelPath,
+         {} as DataStyles,
+         modelType,
+         undefined,
+         undefined,
+         undefined,
+         undefined,
+         undefined,
+         undefined,
+         error,
+      );
+   }
+
+   /** Look up the deserialized error helper for callers (e.g. Package.create). */
+   public static deserializeCompilationError = deserializeError;
 
    public getPath(): string {
       return this.modelPath;
@@ -576,9 +664,10 @@ export class Model {
          malloyVersion: MALLOY_VERSION,
          dataStyles: JSON.stringify(this.dataStyles),
          modelDef: JSON.stringify(this.modelDef),
-         modelInfo: JSON.stringify(
-            this.modelDef ? modelDefToModelInfo(this.modelDef) : {},
-         ),
+         // `this.modelInfo` is precomputed once at construction (either
+         // by the worker or in the Model.create constructor); don't
+         // re-run `modelDefToModelInfo` on every API hit.
+         modelInfo: JSON.stringify(this.modelInfo ?? {}),
          sourceInfos: this.getSourceInfos()?.map((sourceInfo) =>
             JSON.stringify(sourceInfo),
          ),
@@ -630,9 +719,7 @@ export class Model {
          packageName: this.packageName,
          modelPath: this.modelPath,
          malloyVersion: MALLOY_VERSION,
-         modelInfo: JSON.stringify(
-            this.modelDef ? modelDefToModelInfo(this.modelDef) : {},
-         ),
+         modelInfo: JSON.stringify(this.modelInfo ?? {}),
          sources: this.modelDef && this.sources,
          queries: this.modelDef && this.queries,
          annotations: allAnnotations,
@@ -1151,4 +1238,104 @@ export class Model {
          );
       }
    }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Helpers for hydrating worker-compiled models on the main thread
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Minimal subset of `Runtime` we use here. The `_` methods are
+ * marked `@internal` in Malloy but are the only API for constructing
+ * a materializer / query materializer from an existing `modelDef` /
+ * queryDef — the public `loadModel(url)` path always recompiles.
+ */
+type HydrationRuntime = Runtime & {
+   _loadModelFromModelDef(modelDef: ModelDef): ModelMaterializer;
+};
+type HydrationMaterializer = ModelMaterializer & {
+   _loadQueryFromQueryDef(query: unknown): QueryMaterializer;
+};
+
+function makeHydrationRuntime(
+   malloyConfig: ModelConnectionInput,
+): HydrationRuntime {
+   const urlReader = new HackyDataStylesAccumulator(URL_READER);
+   const config =
+      malloyConfig instanceof MalloyConfig
+         ? malloyConfig
+         : (() => {
+              const c = new MalloyConfig({ connections: {} });
+              c.wrapConnections(
+                 () => new FixedConnectionMap(malloyConfig, "duckdb"),
+              );
+              return c;
+           })();
+   return new Runtime({ urlReader, config }) as HydrationRuntime;
+}
+
+/**
+ * Build the live `RunnableNotebookCell[]` from worker-emitted
+ * per-cell data. Each MALLOY cell is hydrated via
+ * `Runtime._loadModelFromModelDef` (for the cell's scope) and
+ * `ModelMaterializer._loadQueryFromQueryDef` (for the cell's
+ * runnable) — no recompile.
+ */
+function hydrateNotebookCells(
+   runtime: HydrationRuntime,
+   notebookCells: SerializedNotebookCell[] | undefined,
+): RunnableNotebookCell[] {
+   if (!notebookCells) return [];
+   return notebookCells.map((sc): RunnableNotebookCell => {
+      if (sc.type === "markdown") {
+         return { type: "markdown", text: sc.text };
+      }
+      const cellModelDef = sc.cellModelDef as ModelDef | undefined;
+      let modelMaterializer: ModelMaterializer | undefined;
+      let runnable: QueryMaterializer | undefined;
+      if (cellModelDef) {
+         modelMaterializer = runtime._loadModelFromModelDef(cellModelDef);
+         if (sc.cellQueryDef !== undefined) {
+            try {
+               runnable = (
+                  modelMaterializer as HydrationMaterializer
+               )._loadQueryFromQueryDef(sc.cellQueryDef);
+            } catch (error) {
+               // Hydration shouldn't fail for a queryDef the worker
+               // already prepared, but if Malloy's internal shape
+               // drifts we'd rather drop the runnable than crash the
+               // whole notebook. The cell remains markdown-runnable.
+               logger.warn("Failed to hydrate notebook cell queryDef", {
+                  error,
+               });
+            }
+         }
+      }
+      return {
+         type: "code",
+         text: sc.text,
+         runnable,
+         modelMaterializer,
+         newSources: sc.newSources as Malloy.SourceInfo[] | undefined,
+         queryInfo: sc.queryInfo as Malloy.QueryInfo | undefined,
+      };
+   });
+}
+
+/**
+ * For an all-markdown notebook (no MALLOY statements → no
+ * `modelDef`), we still want to preserve the cell list so
+ * `getNotebook()` can serve raw text. This skips materializer
+ * hydration (there's nothing to hydrate) and returns markdown-only
+ * cells.
+ */
+function hydrateMarkdownOnlyCells(
+   notebookCells: SerializedNotebookCell[] | undefined,
+): RunnableNotebookCell[] | undefined {
+   if (!notebookCells) return undefined;
+   return notebookCells.map((sc): RunnableNotebookCell => {
+      if (sc.type === "markdown") return { type: "markdown", text: sc.text };
+      // A code cell without a hydratable scope — surface text only.
+      return { type: "code", text: sc.text };
+   });
 }

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -9,18 +9,24 @@ import {
    EmptyURLReader,
    FixedConnectionMap,
    MalloyConfig,
+   MalloyError,
    SourceDef,
 } from "@malloydata/malloy";
 import { metrics } from "@opentelemetry/api";
 import recursive from "recursive-readdir";
 import { components } from "../api";
+import { getPackageLoadPool } from "../package_load/package_load_pool";
 import {
    API_PREFIX,
    MODEL_FILE_SUFFIX,
    NOTEBOOK_FILE_SUFFIX,
    PACKAGE_MANIFEST_NAME,
 } from "../constants";
-import { PackageNotFoundError } from "../errors";
+import {
+   ModelCompilationError,
+   PackageNotFoundError,
+   ServiceUnavailableError,
+} from "../errors";
 import { formatDuration, logger } from "../logger";
 import { BuildManifest } from "../storage/DatabaseInterface";
 import { ignoreDotfiles } from "../utils";
@@ -93,113 +99,42 @@ export class Package {
       });
 
       try {
-         const packageConfig = await Package.readPackageConfig(packagePath);
-         const packageConfigTime = performance.now();
-         logger.info("Package config read completed", {
-            packageName,
-            duration: formatDuration(
-               packageConfigTime - manifestValidationTime,
-            ),
-         });
-         packageConfig.resource = `${API_PREFIX}/environments/${environmentName}/packages/${packageName}`;
-
-         // Build the MalloyConfig before reading databases so we can
-         // reuse the package's single in-memory duckdb connection for
-         // both the per-database schema probes and the model compiles
-         // that follow. The previous order allocated a fresh
-         // `new DuckDBConnection("duckdb")` per `.parquet`/`.csv` file
-         // inside `readDatabases`, then a separate one inside the
-         // package's MalloyConfig for the models — N+1 native handles
-         // (and N+1 native init / extension-load / memory-pool setups)
-         // for what is really one ephemeral :memory: database the
-         // package never escapes. Consolidating to one connection keeps
-         // package-load time and main-thread CPU proportional to the
-         // package's contents rather than to its database-file count.
+         // The MalloyConfig is always built on the main thread — it
+         // owns the live native connection handles the package needs
+         // to *serve queries* after load (workers can't share native
+         // handles across the V8 isolate boundary). The worker proxies
+         // non-duckdb connection lookups back through this MalloyConfig
+         // during compile.
          const malloyConfig = Package.buildPackageMalloyConfig(
             packagePath,
             typeof environmentMalloyConfig === "function"
                ? environmentMalloyConfig
                : () => Package.toMalloyConfig(environmentMalloyConfig),
          );
-         const malloyConfigTime = performance.now();
-         logger.info("Package MalloyConfig built", {
-            packageName,
-            duration: formatDuration(malloyConfigTime - packageConfigTime),
-         });
 
-         const databases = await Package.readDatabases(
-            packagePath,
-            malloyConfig,
-         );
-         const databasesTime = performance.now();
-         logger.info("Databases read completed", {
-            packageName,
-            databaseCount: databases.length,
-            duration: formatDuration(databasesTime - malloyConfigTime),
-         });
-
-         const models = await Package.loadModels(
-            packageName,
-            packagePath,
-            malloyConfig,
-         );
-         const modelsTime = performance.now();
-         logger.info("Models loaded", {
-            packageName,
-            modelCount: models.size,
-            duration: formatDuration(modelsTime - databasesTime),
-         });
-         for (const [modelPath, model] of models.entries()) {
-            const maybeModel = model as unknown as {
-               compilationError?: unknown;
-            };
-            if (maybeModel.compilationError) {
-               const err = maybeModel.compilationError;
-               const message =
-                  err instanceof Error
-                     ? err.message
-                     : `Unknown compilation error in ${modelPath}`;
-
-               logger.error("Model compilation failed", {
-                  packageName,
-                  modelPath,
-                  error: message,
-               });
-
-               this.packageLoadHistogram.record(performance.now() - startTime, {
-                  malloy_package_name: packageName,
-                  status: "compilation_error",
-               });
-               throw err;
-            }
-         }
-         const endTime = performance.now();
-         const executionTime = endTime - startTime;
-         this.packageLoadHistogram.record(executionTime, {
-            malloy_package_name: packageName,
-            status: "success",
-         });
-         logger.info(`Successfully loaded package ${packageName}`, {
-            packageName,
-            duration: formatDuration(executionTime),
-         });
-         return new Package(
+         return await Package.loadViaWorker(
             environmentName,
             packageName,
             packagePath,
-            packageConfig,
-            databases,
-            models,
             malloyConfig,
+            startTime,
+            manifestValidationTime,
          );
       } catch (error) {
          logger.error(`Error loading package ${packageName}`, { error });
          console.error(error);
          const endTime = performance.now();
          const executionTime = endTime - startTime;
+         const status =
+            error instanceof ModelCompilationError ||
+            error instanceof MalloyError
+               ? "compilation_error"
+               : error instanceof ServiceUnavailableError
+                 ? "pool_unavailable"
+                 : "error";
          this.packageLoadHistogram.record(executionTime, {
             malloy_package_name: packageName,
-            status: "error",
+            status,
          });
          // Clean up package directory on failure
          try {
@@ -215,6 +150,141 @@ export class Package {
          }
          throw error;
       }
+   }
+
+   /**
+    * Load the package via the package-load worker pool. The worker
+    * performs the CPU-bound bulk of the load off-thread (manifest
+    * read, every `.malloy` / `.malloynb` compile) and ships back a
+    * structured-clonable `LoadPackageOutcome`. Database probes
+    * (`.parquet` / `.csv`) run on the main thread, in parallel with
+    * the worker compile, against the package's existing DuckDB
+    * connection — they're async-IO-bound and don't compete with the
+    * worker for CPU.
+    *
+    * Pool-infrastructure failures (worker crash, RPC timeout, pool
+    * shutting down) are rewrapped as `ServiceUnavailableError` so
+    * the HTTP layer responds 503 (transient, retryable). Real compile
+    * errors (`MalloyError` / `ModelCompilationError`) propagate
+    * unchanged so they keep their 4xx mapping.
+    */
+   private static async loadViaWorker(
+      environmentName: string,
+      packageName: string,
+      packagePath: string,
+      malloyConfig: MalloyConfig,
+      startTime: number,
+      manifestValidationTime: number,
+   ): Promise<Package> {
+      const pool = getPackageLoadPool();
+      const dispatchTime = performance.now();
+      // Submit the worker job and run database probing on the main
+      // thread in parallel. We isolate the worker-job promise inside
+      // a wrapper so we can map pool-infrastructure failures (worker
+      // crash, RPC timeout, pool shutting down) to a 503 without
+      // accidentally re-mapping `readDatabases`'s own errors.
+      const workerOutcome = pool
+         .loadPackage({
+            packagePath,
+            packageName,
+            malloyConfig,
+            defaultConnectionName: "duckdb",
+         })
+         .catch((err: unknown) => {
+            // Compile errors surface in-band via
+            // `LoadPackageOutcome.models[i].compilationError`; if the
+            // pool itself rejects, it's an infra-side failure
+            // (shutting down, worker spawn failed, worker crashed,
+            // RPC timeout) and the client should retry. Real Malloy
+            // compile errors deserialised by the pool still carry
+            // their MalloyError / ModelCompilationError identity —
+            // let those bubble untouched so they keep their 4xx
+            // mapping in `errors.ts`.
+            const realError =
+               err instanceof Error
+                  ? err
+                  : new Error(
+                       `Package-load worker pool failure: ${String(err)}`,
+                    );
+            if (
+               realError instanceof MalloyError ||
+               realError instanceof ModelCompilationError
+            ) {
+               throw realError;
+            }
+            throw new ServiceUnavailableError(
+               `Package-load worker pool unavailable: ${realError.message}`,
+            );
+         });
+      const [outcome, databases] = await Promise.all([
+         workerOutcome,
+         Package.readDatabases(packagePath, malloyConfig),
+      ]);
+      const workerDoneTime = performance.now();
+      logger.info("Package load via worker pool completed", {
+         packageName,
+         manifestValidationMs: dispatchTime - manifestValidationTime,
+         workerDurationMs: outcome.loadDurationMs,
+         dispatchOverheadMs:
+            workerDoneTime - dispatchTime - outcome.loadDurationMs,
+         modelCount: outcome.models.length,
+         databaseCount: databases.length,
+      });
+
+      // Override the manifest-derived resource URI — the worker only
+      // returns name/description from publisher.json, but the rest of
+      // the API surface expects a `resource` field too.
+      const packageConfig: ApiPackage = {
+         name: outcome.packageMetadata.name,
+         description: outcome.packageMetadata.description,
+         resource: `${API_PREFIX}/environments/${environmentName}/packages/${packageName}`,
+      };
+
+      // Build live `Model`s from worker output. Any per-model compile
+      // failure aborts the load — matches the historical behaviour of
+      // `Package.create` failing the whole package on the first model
+      // error. (`Package.reloadAllModels` keeps the failed-model
+      // placeholders instead; that branch goes through a different
+      // hydration path.)
+      const models = new Map<string, Model>();
+      for (const sm of outcome.models) {
+         if (sm.compilationError) {
+            const err = Model.deserializeCompilationError(sm.compilationError);
+            logger.error("Model compilation failed", {
+               packageName,
+               modelPath: sm.modelPath,
+               error: err.message,
+            });
+            // The outer catch in Package.create records the metric +
+            // cleans the package directory.
+            throw err;
+         }
+         models.set(
+            sm.modelPath,
+            Model.fromSerialized(packageName, packagePath, malloyConfig, sm),
+         );
+      }
+
+      const endTime = performance.now();
+      const executionTime = endTime - startTime;
+      this.packageLoadHistogram.record(executionTime, {
+         malloy_package_name: packageName,
+         status: "success",
+      });
+      logger.info(`Successfully loaded package ${packageName}`, {
+         packageName,
+         duration: formatDuration(executionTime),
+      });
+
+      return new Package(
+         environmentName,
+         packageName,
+         packagePath,
+         packageConfig,
+         databases,
+         models,
+         malloyConfig,
+      );
    }
 
    public getPackageName(): string {
@@ -251,6 +321,21 @@ export class Package {
       return Array.from(this.models.keys());
    }
 
+   /**
+    * Re-compile every model in the package against a new build
+    * manifest (called after a materialization build commits new
+    * physicalised tables). Runs through the package-load worker pool
+    * — same off-main-thread compile path as initial `Package.create`
+    * — so a reload of a large package can't block the K8s liveness
+    * probe.
+    *
+    * Unlike `Package.create`, a per-model compile failure here does
+    * NOT abort the reload: we keep the failed model as a placeholder
+    * (`Model.fromCompilationError`) in `this.models`, matching the
+    * historical reload semantics. Whole-pool failures (worker crash,
+    * timeout, pool shutting down) propagate as `ServiceUnavailableError`
+    * — the caller (manifest service) decides how to retry.
+    */
    public async reloadAllModels(
       buildManifest: BuildManifest["entries"],
    ): Promise<void> {
@@ -260,20 +345,62 @@ export class Package {
          modelCount: modelPaths.length,
          manifestEntryCount: Object.keys(buildManifest).length,
       });
-      const reloaded = await Promise.all(
-         modelPaths.map((modelPath) =>
-            Model.create(
-               this.packageName,
-               this.packagePath,
-               modelPath,
-               this.malloyConfig,
-               { buildManifest },
-            ),
-         ),
-      );
+
+      const pool = getPackageLoadPool();
+      let outcome;
+      try {
+         outcome = await pool.loadPackage({
+            packagePath: this.packagePath,
+            packageName: this.packageName,
+            malloyConfig: this.malloyConfig,
+            defaultConnectionName: "duckdb",
+            buildManifest,
+         });
+      } catch (err) {
+         const realError =
+            err instanceof Error
+               ? err
+               : new Error(`Package-load worker pool failure: ${String(err)}`);
+         if (
+            realError instanceof MalloyError ||
+            realError instanceof ModelCompilationError
+         ) {
+            throw realError;
+         }
+         throw new ServiceUnavailableError(
+            `Package-load worker pool unavailable: ${realError.message}`,
+         );
+      }
+
       const nextModels = new Map<string, Model>();
-      for (const model of reloaded) {
-         nextModels.set(model.getPath(), model);
+      for (const sm of outcome.models) {
+         if (sm.compilationError) {
+            const err = Model.deserializeCompilationError(sm.compilationError);
+            logger.warn("Model compilation failed during reload", {
+               packageName: this.packageName,
+               modelPath: sm.modelPath,
+               error: err.message,
+            });
+            nextModels.set(
+               sm.modelPath,
+               Model.fromCompilationError(
+                  this.packageName,
+                  sm.modelPath,
+                  sm.modelType,
+                  err,
+               ),
+            );
+         } else {
+            nextModels.set(
+               sm.modelPath,
+               Model.fromSerialized(
+                  this.packageName,
+                  this.packagePath,
+                  this.malloyConfig,
+                  sm,
+               ),
+            );
+         }
       }
       this.models = nextModels;
    }
@@ -336,20 +463,6 @@ export class Package {
       );
    }
 
-   private static async loadModels(
-      packageName: string,
-      packagePath: string,
-      malloyConfig: MalloyConfig,
-   ): Promise<Map<string, Model>> {
-      const modelPaths = await Package.getModelPaths(packagePath);
-      const models = await Promise.all(
-         modelPaths.map((modelPath) =>
-            Model.create(packageName, packagePath, modelPath, malloyConfig),
-         ),
-      );
-      return new Map(models.map((model) => [model.getPath(), model]));
-   }
-
    private static buildPackageMalloyConfig(
       packagePath: string,
       getEnvironmentMalloyConfig: () => MalloyConfig,
@@ -399,27 +512,6 @@ export class Package {
       return malloyConfig;
    }
 
-   private static async getModelPaths(packagePath: string): Promise<string[]> {
-      let files = undefined;
-      try {
-         files = await recursive(packagePath, [ignoreDotfiles]);
-      } catch (error) {
-         logger.error(error);
-         throw new PackageNotFoundError(
-            `Package config for ${packagePath} does not exist.`,
-         );
-      }
-      return files
-         .map((fullPath: string) => {
-            return path.relative(packagePath, fullPath).replace(/\\/g, "/");
-         })
-         .filter(
-            (modelPath: string) =>
-               modelPath.endsWith(MODEL_FILE_SUFFIX) ||
-               modelPath.endsWith(NOTEBOOK_FILE_SUFFIX),
-         );
-   }
-
    private static async validatePackageManifestExistsOrThrowError(
       packagePath: string,
    ) {
@@ -432,19 +524,6 @@ export class Package {
             `Package manifest for ${packagePath} does not exist.`,
          );
       }
-   }
-
-   private static async readPackageConfig(
-      packagePath: string,
-   ): Promise<ApiPackage> {
-      const packageConfigPath = path.join(packagePath, PACKAGE_MANIFEST_NAME);
-      const packageConfigContents = await fs.readFile(packageConfigPath);
-      // TODO: Validate package manifest.  Define manifest type in public API.
-      const packageManifest = JSON.parse(packageConfigContents.toString());
-      return {
-         name: packageManifest.name,
-         description: packageManifest.description,
-      };
    }
 
    private static async readDatabases(

--- a/packages/server/src/service/package_worker_path.spec.ts
+++ b/packages/server/src/service/package_worker_path.spec.ts
@@ -1,0 +1,196 @@
+/**
+ * Integration test: exercise `Package.create` with the package-load
+ * worker pool enabled (PACKAGE_LOAD_WORKERS=1).
+ *
+ * Validates that the worker-load path:
+ *   - reads the manifest, probes embedded databases, and compiles
+ *     every model in a single off-thread job
+ *   - produces a live `Package` whose `Model`s have populated
+ *     `modelDef` / `sources` / `queries`
+ *   - hydrates the `ModelMaterializer` from `modelDef` on first
+ *     query (no recompile) — verified end-to-end by running a
+ *     query through the resulting Model and getting a result
+ *
+ * Kept separate from `package.spec.ts` so the existing tests keep
+ * running on the in-process path without paying worker startup cost.
+ *
+ * Pool reuse strategy: one `PackageLoadPool` shared across all
+ * cases in this file. Spawning a fresh worker per test crashes Bun
+ * (segfault) because DuckDB's native bindings don't tolerate being
+ * loaded concurrently into multiple worker isolates of the same Bun
+ * process. Production uses one pool; this matches.
+ */
+import {
+   afterAll,
+   afterEach,
+   beforeAll,
+   beforeEach,
+   describe,
+   expect,
+   it,
+} from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+   PackageLoadPool,
+   __setPackageLoadPoolForTests,
+} from "../package_load/package_load_pool";
+import { Package } from "./package";
+
+const ORIGINAL_ENV = process.env.PACKAGE_LOAD_WORKERS;
+
+describe("Package.create via worker pool", () => {
+   let tempDir: string;
+   let pool: PackageLoadPool;
+
+   beforeAll(async () => {
+      process.env.PACKAGE_LOAD_WORKERS = "1";
+      pool = new PackageLoadPool(1);
+      // Wire our pool into the module-level singleton so Package.create
+      // picks it up via getPackageLoadPool().
+      await __setPackageLoadPoolForTests(pool);
+   });
+
+   afterAll(async () => {
+      await __setPackageLoadPoolForTests(null);
+      if (ORIGINAL_ENV === undefined) {
+         delete process.env.PACKAGE_LOAD_WORKERS;
+      } else {
+         process.env.PACKAGE_LOAD_WORKERS = ORIGINAL_ENV;
+      }
+   });
+
+   beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "publisher-pkg-worker-"));
+   });
+
+   afterEach(() => {
+      if (tempDir) {
+         // tempDir gets wiped by Package.create on failure (it's the
+         // staging-cleanup path); ignore ENOENT here.
+         try {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+         } catch {
+            /* already gone */
+         }
+         tempDir = "";
+      }
+   });
+
+   async function makeMalloyConfig(): Promise<{
+      malloyConfig: import("@malloydata/malloy").MalloyConfig;
+      duckdb: { close: () => Promise<void> };
+   }> {
+      const { MalloyConfig, FixedConnectionMap } = await import(
+         "@malloydata/malloy"
+      );
+      const { DuckDBConnection } = await import("@malloydata/db-duckdb");
+      const duckdb = new DuckDBConnection("duckdb", ":memory:");
+      const connections = new FixedConnectionMap(
+         new Map([["duckdb", duckdb]]),
+         "duckdb",
+      );
+      const malloyConfig = new MalloyConfig({ connections: {} });
+      malloyConfig.wrapConnections(() => connections);
+      return { malloyConfig, duckdb };
+   }
+
+   function writeManifest(): void {
+      fs.writeFileSync(
+         path.join(tempDir, "publisher.json"),
+         JSON.stringify({ name: "pkg", description: "test package" }),
+      );
+   }
+
+   it("loads a package end-to-end and serves a query through the hydrated materializer", async () => {
+      writeManifest();
+      // Define `total_v` as a *view* on the source so the query
+      // builder's `run: nums -> total_v` form resolves. (Top-level
+      // queries take the `run: total_q` form — orthogonal path that
+      // the in-process tests already cover.)
+      fs.writeFileSync(
+         path.join(tempDir, "trivial.malloy"),
+         `source: nums is duckdb.sql("select 1 as a, 2 as b") extend {
+  measure: total is a.sum()
+  view: total_v is { aggregate: total }
+}`,
+      );
+
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         expect(pkg).toBeInstanceOf(Package);
+         expect(pkg.getModelPaths()).toEqual(["trivial.malloy"]);
+
+         const model = pkg.getModel("trivial.malloy");
+         expect(model).toBeDefined();
+         const apiModel = (await model!.getModel()) as {
+            modelDef?: string;
+            sources?: { name?: string }[];
+         };
+         expect(apiModel.modelDef).toBeDefined();
+         expect(apiModel.sources?.[0]?.name).toBe("nums");
+
+         // First query against the package — hydrates the
+         // ModelMaterializer from the worker's modelDef without a
+         // recompile, then runs the SQL against the *main thread's*
+         // DuckDB connection (the only one with the in-memory `nums`
+         // source loaded via duckdb.sql()).
+         const { result } = await model!.getQueryResults(
+            "nums",
+            "total_v",
+            undefined,
+         );
+         expect(result.data).toBeDefined();
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("propagates a per-model compile failure as a thrown error from Package.create", async () => {
+      writeManifest();
+      fs.writeFileSync(
+         path.join(tempDir, "broken.malloy"),
+         `source: bad is duckdb.sql("select 1 as a") extend {
+  measure: oops is THIS_FUNC_DOES_NOT_EXIST(a)
+}`,
+      );
+
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         await expect(
+            Package.create("env", "pkg", tempDir, malloyConfig),
+         ).rejects.toBeInstanceOf(Error);
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   // NB: kept last in this describe — swapping the singleton for a
+   // pre-shutdown pool also tears down the shared `pool` (the swap
+   // implementation shuts down the outgoing singleton). Subsequent
+   // tests in this describe would see a dead pool. afterAll only
+   // resets the singleton to null, so this is safe at the tail.
+   it("rewraps pool-infrastructure failures as ServiceUnavailableError (HTTP 503)", async () => {
+      writeManifest();
+      fs.writeFileSync(
+         path.join(tempDir, "trivial.malloy"),
+         `source: nums is duckdb.sql("select 1 as a")`,
+      );
+
+      const deadPool = new PackageLoadPool(1);
+      await deadPool.shutdown();
+      await __setPackageLoadPoolForTests(deadPool);
+
+      const { ServiceUnavailableError } = await import("../errors");
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         await expect(
+            Package.create("env", "pkg", tempDir, malloyConfig),
+         ).rejects.toBeInstanceOf(ServiceUnavailableError);
+      } finally {
+         await duckdb.close();
+      }
+   });
+});


### PR DESCRIPTION
## Summary

The Kubernetes liveness probe on `/health/liveness` was timing out for multi-second package loads because Malloy compile is pure JavaScript running on V8's main event loop. PR #767's first cut moved only per-file `.malloy`/`.malloynb` compile to workers; the rest of `Package.create` — manifest read, source/query extraction, and the first-query rehydration that still recompiled on the main thread — could still blow the probe budget on a large package. **Plus**, `Package.reloadAllModels` (the post-build manifest reload path) was still compiling on the main thread.

This refactor makes the worker pool a **hard dependency** and routes both load and reload through it, leaving no main-thread compile in the production hot path:

- **`package_load_pool.ts`** (renamed from `compile_pool.ts`) drives a `PackageLoadPool` of N `worker_threads` workers. `PACKAGE_LOAD_WORKERS` must be a positive integer; defaults to 1 when unset. Setting it to **0** — the old in-process fallback — **throws at boot**. There is no fallback path. Running Malloy compile on the main event loop is what tripped the probe in the first place; we don't want a knob that re-enables that footgun. The env var was renamed from `MALLOY_COMPILE_WORKERS` to match the new "package load" framing (the worker drives the whole load, not just compile).
- **`package_load_worker.ts`** (renamed from `compile_worker.ts`) reads `publisher.json`, compiles every `.malloy`/`.malloynb` model in the package, **precomputes `modelDefToModelInfo(modelDef)`**, and ships back a structured-clonable `LoadPackageOutcome` with every `modelDef`, `modelInfo`, `sourceInfos`, `sources`, `queries`, `filterMap`, `givens`, dataStyles, and per-cell notebook payload the main thread needs to reconstitute a live `Package`. The worker owns **zero** native handles — every `lookupConnection`, schema fetch, SQL-block schema, and non-`file://` URL read proxies back to the main thread's live connection pool over RPC.
- Embedded `.parquet`/`.csv` probes stay on the main thread (`Package.readDatabases`), which already reuses the package's shared DuckDB connection (#772). Probes run in parallel with the worker compile via `Promise.all`, so wall-clock latency is unchanged for `.parquet`-heavy packages while keeping all native-DB `dlopen` on the main isolate (sidesteps Bun crash 0x20131 where `duckdb-native` can't be loaded into a second isolate).
- **`Package.loadViaWorker` rewraps pool-infrastructure failures** (worker crash, RPC timeout, pool shutting down) as `ServiceUnavailableError`, which the HTTP error mapper translates to **503 Service Unavailable** — transient, retryable — instead of an opaque 500. Real compile errors (`MalloyError` / `ModelCompilationError`) keep their existing 4xx mapping.
- **`Package.reloadAllModels` now also goes through the pool.** Previously the last main-thread compile in the prod hot path: a manifest reload on a large package could block the event loop the same way the initial load did. Reload semantics keep the historical "failed models become placeholders in the map" behaviour (unlike the initial load, which aborts on first compile error). Same 503 mapping for pool-infra failures.
- **`Model.fromSerialized`** eagerly hydrates a `ModelMaterializer` (and per-cell runnables for notebooks) from the worker's pre-compiled `modelDef` / `queryDef` via `Runtime._loadModelFromModelDef` / `ModelMaterializer._loadQueryFromQueryDef`. These are constant-time wraps, **not recompiles** — first-query latency no longer pays a recompile and the resulting `Model` is interchangeable with one from `Model.create`. Worker-emitted `modelInfo` is threaded through too, so `getStandardModel()` / `getNotebookModel()` no longer recompute `modelDefToModelInfo` on every API hit.
- `PackageLoadPool` folds in queue + per-worker active-job cap (= 1), ready/exit handling, separate spawn vs job timeouts, and terminate-worker-on-timeout (no zombie compile burning CPU after the caller rejects). The wall-clock timeout knob is also renamed: `PACKAGE_LOAD_JOB_TIMEOUT_MS`.
- `server.ts` eagerly constructs the pool at startup so a bad `PACKAGE_LOAD_WORKERS` value fails the boot rather than surfacing on the first package load.
- New `service/given.ts` centralises the `MalloyGiven` duck-typed shape and the `malloyGivenToApi` conversion so the main-thread `Model` and the worker share one source of truth instead of drift-prone copies on each side.

## Operator-visible config

| Env var | Behaviour |
| --- | --- |
| `PACKAGE_LOAD_WORKERS` | Positive int (default `1`). `0` / negative / non-numeric → publisher refuses to boot. |
| `PACKAGE_LOAD_JOB_TIMEOUT_MS` | Wall-clock cap per worker load job (default `120000`). Worker is terminated on timeout. |

The matching terraform change to rename `MALLOY_COMPILE_WORKERS` → `PACKAGE_LOAD_WORKERS` in `~/infrastructure` is staged but lives in the infra repo (separate PR).

**Sizing note:** if your operator profile expects concurrent package load + reload (e.g. a manifest build commits while a fresh package is also being loaded), bump `PACKAGE_LOAD_WORKERS` to 2 so the two jobs don't queue against each other.

## Test plan

- [x] `package_load_pool.spec.ts` — env-var validation, constructor validation, real-worker load (single-model package), in-band per-model compile error, csv ignored by worker (probing is main-thread), shutdown rejects new jobs.
- [x] `package_worker_path.spec.ts` — integration: `Package.create` on the worker path produces a live `Package`, first-query hydration runs without a recompile, per-model compile failures throw out of `Package.create`, **pool-infrastructure failures throw `ServiceUnavailableError` (HTTP 503)**.
- [x] `package.spec.ts` — pre-existing in-process integration tests still pass against the worker path (assertions are over `Package`'s externally-visible behaviour, not the path).
- [x] `manifest_service.spec.ts` — `reloadAllModels` callers still pass (manifest service stubs the package, so reload-path changes are invisible to it).
- [x] `tsc --noEmit`, `eslint`, `bun test src` — 14 failures match `origin/main` and are unrelated (Bun's `monitorEventLoopDelay` from PR #768 isn't implemented in Bun's test runtime).

## Follow-ups (out of scope)

- `materialization_service.ts:721` still calls `Model.getModelRuntime(...) → runtime.loadModel(...).getModel()` on the main thread to read `##! experimental.persistence` tags. That's a separate compile-on-main-thread spot, lower priority because it runs only on the explicit build trigger. Route through the pool in a follow-up.
