### PR TITLE
feat(server): export event-loop-lag metrics

### DIFF
--- a/packages/server/src/instrumentation.ts
+++ b/packages/server/src/instrumentation.ts
@@ -1,3 +1,4 @@
+import { monitorEventLoopDelay } from "node:perf_hooks";
 import { metrics } from "@opentelemetry/api";
 import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-proto";
@@ -115,6 +116,52 @@ const httpRequestDuration = meter.createHistogram(
 const httpRequestCount = meter.createCounter("http_server_requests_total", {
    description: "Total number of HTTP requests",
 });
+
+// Event-loop-delay metrics. A blocked event loop is the only way the
+// /health/liveness probe (a pure synchronous 200 handler) can fail under K8s,
+// so we surface p50/p99/max so an operator can correlate liveness restarts
+// with sustained event-loop pressure (large Malloy compiles, GC, etc.).
+const eventLoopHistogram = monitorEventLoopDelay({ resolution: 20 });
+eventLoopHistogram.enable();
+
+const eventLoopLagP50 = meter.createObservableGauge(
+   "publisher_event_loop_lag_p50_ms",
+   {
+      description: "Event loop delay p50 since the last scrape, in milliseconds",
+      unit: "ms",
+   },
+);
+const eventLoopLagP99 = meter.createObservableGauge(
+   "publisher_event_loop_lag_p99_ms",
+   {
+      description: "Event loop delay p99 since the last scrape, in milliseconds",
+      unit: "ms",
+   },
+);
+const eventLoopLagMax = meter.createObservableGauge(
+   "publisher_event_loop_lag_max_ms",
+   {
+      description: "Event loop delay max since the last scrape, in milliseconds",
+      unit: "ms",
+   },
+);
+
+// Sample all three in one batch so the histogram reset can't race the reads.
+meter.addBatchObservableCallback(
+   (observableResult) => {
+      observableResult.observe(
+         eventLoopLagP50,
+         eventLoopHistogram.percentile(50) / 1e6,
+      );
+      observableResult.observe(
+         eventLoopLagP99,
+         eventLoopHistogram.percentile(99) / 1e6,
+      );
+      observableResult.observe(eventLoopLagMax, eventLoopHistogram.max / 1e6);
+      eventLoopHistogram.reset();
+   },
+   [eventLoopLagP50, eventLoopLagP99, eventLoopLagMax],
+);
 
 const IGNORED_PATHS = new Set([
    "/health",

--- a/packages/server/src/instrumentation.ts
+++ b/packages/server/src/instrumentation.ts
@@ -127,21 +127,24 @@ eventLoopHistogram.enable();
 const eventLoopLagP50 = meter.createObservableGauge(
    "publisher_event_loop_lag_p50_ms",
    {
-      description: "Event loop delay p50 since the last scrape, in milliseconds",
+      description:
+         "Event loop delay p50 since the last scrape, in milliseconds",
       unit: "ms",
    },
 );
 const eventLoopLagP99 = meter.createObservableGauge(
    "publisher_event_loop_lag_p99_ms",
    {
-      description: "Event loop delay p99 since the last scrape, in milliseconds",
+      description:
+         "Event loop delay p99 since the last scrape, in milliseconds",
       unit: "ms",
    },
 );
 const eventLoopLagMax = meter.createObservableGauge(
    "publisher_event_loop_lag_max_ms",
    {
-      description: "Event loop delay max since the last scrape, in milliseconds",
+      description:
+         "Event loop delay max since the last scrape, in milliseconds",
       unit: "ms",
    },
 );


### PR DESCRIPTION
## Summary
- Adds `publisher_event_loop_lag_{p50,p99,max}_ms` observable gauges populated from `node:perf_hooks.monitorEventLoopDelay()`, sampled in a single `addBatchObservableCallback` so the histogram `reset()` can't race the `percentile()` / `max` reads.
- K8s liveness hits `/health/liveness` ([`health.ts:207`](packages/server/src/health.ts#L207)) — a pure 200 handler doing no I/O. The only way it fails is the event loop itself being blocked from running it, but we don't surface any signal that distinguishes a stalled loop from an OOMKill or app crash. These metrics fill that gap.
- Observation-only — no behavior change. Lays the groundwork for deciding whether the more expensive Malloy-compile-off-the-main-thread work is actually warranted in production.

Healthy idle Bun: <2ms p99. Anything >1000ms p99 means a single tick parked the loop long enough to risk the 3-5s probe timeout (AWS / GCP terraform).

## Test plan
- [x] **Local — gauges present in `/metrics`**
  ```
  publisher_event_loop_lag_p50_ms{otel_scope_name="publisher"} 1.008127
  publisher_event_loop_lag_p99_ms{otel_scope_name="publisher"} 2.254847
  publisher_event_loop_lag_max_ms{otel_scope_name="publisher"} 2.6018
  ```
- [x] **Standalone — gauges spike under a deliberate 500ms CPU block, then reset cleanly**
  | phase | p50_ms | p99_ms | max_ms |
  |---|---|---|---|
  | idle-baseline | 0.728 | 1.252 | 1.252 |
  | after 500ms tight CPU loop | 1.008 | **493.879** | **493.818** |
  | after `.reset()` + idle | 1.005 | 1.010 | 1.010 |

  The 500ms block registered as a single ~493ms tick at p99/max, exactly as designed. The reset returned the next window to baseline, so each Prometheus scrape gets a fresh sample.
- [x] **Live server — wired metric reacts to a burst against `/api/v0/status`**
  | scrape | p50_ms | p99_ms | max_ms |
  |---|---|---|---|
  | before 500-req burst | 1.008 | 2.228 | 2.932 |
  | after 500-req burst | 0.364 | **17.416** | **17.404** |

  Confirms the batch observable callback fires on every scrape, samples all three gauges from a single histogram state, then resets so the next window is clean. (p50 actually dropped post-burst because the new window had relatively more idle ticks once the storm passed; that's the expected behavior of a per-scrape histogram.)
- [x] **Codex review** (`/codex review --base main`) — 0 `[P1]`/`[P2]` findings; codex independently verified the histogram-reset semantics with its own node one-liner.

## Follow-up (not in this PR)
- Plot `publisher_event_loop_lag_p99_ms` against K8s pod restart events to confirm whether compile bursts (or something else) are actually parking the loop long enough to fail liveness. The answer drives whether to invest in the larger compile-off-thread refactor.