### PR TITLE
perf(server): reuse the package's duckdb connection across database probes

### DIFF
--- a/packages/server/src/service/package.spec.ts
+++ b/packages/server/src/service/package.spec.ts
@@ -1,3 +1,5 @@
+import { DuckDBConnection } from "@malloydata/db-duckdb";
+import "@malloydata/db-duckdb/native";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { Stats } from "fs";
 import fs from "fs/promises";
@@ -340,10 +342,18 @@ describe("service/package", () => {
          it("should return the size of the database file", async () => {
             sinon.stub(fs, "stat").resolves({ size: 13 } as Stats);
 
+            // `getDatabaseInfo` now requires the caller to pass in the
+            // shared DuckDB connection (resolved once by `readDatabases`
+            // off the package's MalloyConfig). For this isolated unit
+            // test we mint a fresh ephemeral one — production paths
+            // reuse a single connection per package via `Package.create`.
+            const conn = new DuckDBConnection("duckdb");
+
             // @ts-expect-error Accessing private static method for testing
             const info = await Package.getDatabaseInfo(
                testPackageDirectory,
                "database.csv",
+               conn,
             );
 
             expect(info).toEqual({

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -1,7 +1,6 @@
 import * as fs from "fs/promises";
 import * as path from "path";
 
-import { DuckDBConnection } from "@malloydata/db-duckdb";
 import "@malloydata/db-duckdb/native";
 import {
    Connection,
@@ -104,19 +103,40 @@ export class Package {
          });
          packageConfig.resource = `${API_PREFIX}/environments/${environmentName}/packages/${packageName}`;
 
-         const databases = await Package.readDatabases(packagePath);
-         const databasesTime = performance.now();
-         logger.info("Databases read completed", {
-            packageName,
-            databaseCount: databases.length,
-            duration: formatDuration(databasesTime - packageConfigTime),
-         });
+         // Build the MalloyConfig before reading databases so we can
+         // reuse the package's single in-memory duckdb connection for
+         // both the per-database schema probes and the model compiles
+         // that follow. The previous order allocated a fresh
+         // `new DuckDBConnection("duckdb")` per `.parquet`/`.csv` file
+         // inside `readDatabases`, then a separate one inside the
+         // package's MalloyConfig for the models — N+1 native handles
+         // (and N+1 native init / extension-load / memory-pool setups)
+         // for what is really one ephemeral :memory: database the
+         // package never escapes. Consolidating to one connection keeps
+         // package-load time and main-thread CPU proportional to the
+         // package's contents rather than to its database-file count.
          const malloyConfig = Package.buildPackageMalloyConfig(
             packagePath,
             typeof environmentMalloyConfig === "function"
                ? environmentMalloyConfig
                : () => Package.toMalloyConfig(environmentMalloyConfig),
          );
+         const malloyConfigTime = performance.now();
+         logger.info("Package MalloyConfig built", {
+            packageName,
+            duration: formatDuration(malloyConfigTime - packageConfigTime),
+         });
+
+         const databases = await Package.readDatabases(
+            packagePath,
+            malloyConfig,
+         );
+         const databasesTime = performance.now();
+         logger.info("Databases read completed", {
+            packageName,
+            databaseCount: databases.length,
+            duration: formatDuration(databasesTime - malloyConfigTime),
+         });
 
          const models = await Package.loadModels(
             packageName,
@@ -429,22 +449,30 @@ export class Package {
 
    private static async readDatabases(
       packagePath: string,
+      malloyConfig: MalloyConfig,
    ): Promise<ApiDatabase[]> {
+      const databasePaths = await Package.getDatabasePaths(packagePath);
+      if (databasePaths.length === 0) {
+         return [];
+      }
+      // Resolve the package's duckdb connection ONCE and reuse it for
+      // every schema/row-count probe in this package. Malloy caches the
+      // materialized connection on the MalloyConfig so the same instance
+      // will be returned to model compiles later in `Package.create`.
+      // This is the substantive optimization over the previous code:
+      // we go from `databasePaths.length` separate DuckDBConnections
+      // (each doing its own native init + extension load) to one.
+      const conn = await malloyConfig.connections.lookupConnection("duckdb");
       return await Promise.all(
-         (await Package.getDatabasePaths(packagePath)).map(
-            async (databasePath) => {
-               const databaseInfo = await Package.getDatabaseInfo(
-                  packagePath,
-                  databasePath,
-               );
-
-               return {
-                  path: databasePath,
-                  info: databaseInfo,
-                  type: "embedded",
-               };
-            },
-         ),
+         databasePaths.map(async (databasePath) => ({
+            path: databasePath,
+            info: await Package.getDatabaseInfo(
+               packagePath,
+               databasePath,
+               conn,
+            ),
+            type: "embedded" as const,
+         })),
       );
    }
 
@@ -465,15 +493,20 @@ export class Package {
    private static async getDatabaseInfo(
       packagePath: string,
       databasePath: string,
+      conn: Connection,
    ): Promise<ApiTableDescription> {
       const fullPath = path.join(packagePath, databasePath);
 
       // Create a DuckDB source then:
       // 1. Load the model and get the table schema from model
       // 2. Run a query to get the row count from the table
+      // ConnectionRuntime is cheap (just a wrapper), and creating one
+      // per call keeps each probe's compile state isolated. The
+      // expensive piece — the underlying DuckDBConnection — is shared
+      // across all probes via `conn` (resolved once in readDatabases).
       const runtime = new ConnectionRuntime({
          urlReader: new EmptyURLReader(),
-         connections: [new DuckDBConnection("duckdb")],
+         connections: [conn],
       });
       // Normalize path to use forward slashes for cross-platform compatibility
       // DuckDB on Windows supports forward slashes, and this avoids escaping issues


### PR DESCRIPTION
## Summary

`Package.readDatabases` was allocating a brand-new `DuckDBConnection("duckdb")` per `.parquet`/`.csv` file in the package — typically wrapped in `Promise.all` so all those connections came up together during `Package.create`. For a package with N data files we ended up with **N+1 native DuckDB handles**: N transient ones inside `getDatabaseInfo` plus one materialized later from the package's `MalloyConfig` for model compiles.

Each of those N transient connections does its own native init, extension load, and in-memory database setup before serving exactly one ``SELECT count(*) FROM 'file.parquet'``-equivalent query. That's main-thread CPU and main-thread `malloc`s proportional to the database-file count — directly relevant to the liveness probe failures we've been hunting on data-heavy packages.

## Change

Reorder `Package.create` so the package's `MalloyConfig` is built **before** `readDatabases`, resolve its `duckdb` connection once via `malloyConfig.connections.lookupConnection("duckdb")`, and thread that single connection through `readDatabases` → `getDatabaseInfo`. The model compiles that follow share the same MalloyConfig, so Malloy hands them the cached instance — **total DuckDB connections per package drops from N+1 to 1**.

```diff
- const databases = await Package.readDatabases(packagePath);
- ...
- const malloyConfig = Package.buildPackageMalloyConfig(...);
+ const malloyConfig = Package.buildPackageMalloyConfig(...);
+ const databases = await Package.readDatabases(packagePath, malloyConfig);

  private static async readDatabases(
    packagePath: string,
+   malloyConfig: MalloyConfig,
  ) {
+   const conn = await malloyConfig.connections.lookupConnection("duckdb");
    return Promise.all(paths.map(p => getDatabaseInfo(packagePath, p, conn)));
  }
```

## Why this PR can stand alone

This is independent of #767 (compile worker pool) and the recently-merged #771 (async unzip). It's a pure structural optimization — no behavior change in the response shape (\`{ name, rowCount, columns }\`), no new env vars, no kill switch. The reordering is internal to \`Package.create\`; the public surface is unchanged.

## What this fixes

- **N×native-init CPU on the main thread** of \`Package.create\`. On a package with 50 data files, that was 50 round trips through DuckDB native init + extension load + memory-pool setup before the first model could even compile. Now it's one.
- **N×file-handle and memory-pool allocations** that didn't survive past \`Package.create\`.
- **A pre-existing connection leak**: the N transient connections in \`getDatabaseInfo\` were created but never \`.close()\`d. One leftover connection still rides along with the Package's MalloyConfig (intentional, bounded by Package lifetime).

## What this does NOT fix

The two \`runtime.loadModel(snippet).getModel()\` Malloy compiles still run on the main thread per database file. That's a separate problem — this PR only addresses the native-connection cost. The Malloy-compile cost will be addressed in a follow-up.

## Test plan

- [x] \`tsc --noEmit\` clean.
- [x] \`eslint\` clean.
- [x] \`bun test src/service/package.spec.ts\` — 8/8 pass (existing \`getDatabaseInfo\` test updated to pass an ephemeral connection, since the production caller now supplies the shared one).
- [x] \`bun test src/\` — 471 pass, 15 pre-existing failures from \`#768\`'s \`monitorEventLoopDelay\` not implemented in bun's test runtime, **all unrelated to this PR** (reproduces on clean \`origin/main\`).
- [ ] Reviewer: spot-check on a real data-heavy package; new log line \`Package MalloyConfig built\` appears before \`Databases read completed\` to confirm the reorder.

## Reviewer notes

- \`Package.create\` now emits an extra timing log line (\`Package MalloyConfig built\`) between the existing \`Package config read completed\` and \`Databases read completed\` lines so we can see in production where the time actually goes.
- The unused \`DuckDBConnection\` value import is dropped; the side-effect \`import "@malloydata/db-duckdb/native"\` is kept so the \`{ is: "duckdb" }\` factory still registers with Malloy's connection registry.

Made with [Cursor](https://cursor.com)