### PR TITLE
feat(server): row + byte caps on ad-hoc connection SQL + model-query paths (subsumes #780)

### DIFF
--- a/packages/server/src/config.spec.ts
+++ b/packages/server/src/config.spec.ts
@@ -1214,3 +1214,55 @@ describe("getMaxQueryRows", () => {
       expect(() => getMaxQueryRows()).toThrow();
    });
 });
+
+describe("getMaxResponseBytes", () => {
+   beforeEach(() => {
+      delete process.env.PUBLISHER_MAX_RESPONSE_BYTES;
+   });
+   afterEach(() => {
+      delete process.env.PUBLISHER_MAX_RESPONSE_BYTES;
+   });
+
+   it("returns DEFAULT_MAX_RESPONSE_BYTES when the env var is unset", async () => {
+      const { getMaxResponseBytes } = await import("./config");
+      const { DEFAULT_MAX_RESPONSE_BYTES } = await import("./constants");
+      expect(getMaxResponseBytes()).toBe(DEFAULT_MAX_RESPONSE_BYTES);
+   });
+
+   it("returns DEFAULT_MAX_RESPONSE_BYTES when the env var is empty", async () => {
+      process.env.PUBLISHER_MAX_RESPONSE_BYTES = "";
+      const { getMaxResponseBytes } = await import("./config");
+      const { DEFAULT_MAX_RESPONSE_BYTES } = await import("./constants");
+      expect(getMaxResponseBytes()).toBe(DEFAULT_MAX_RESPONSE_BYTES);
+   });
+
+   it("returns the override when the env var is set", async () => {
+      process.env.PUBLISHER_MAX_RESPONSE_BYTES = "1048576";
+      const { getMaxResponseBytes } = await import("./config");
+      expect(getMaxResponseBytes()).toBe(1048576);
+   });
+
+   it("accepts 0 (used to opt out of byte cap)", async () => {
+      process.env.PUBLISHER_MAX_RESPONSE_BYTES = "0";
+      const { getMaxResponseBytes } = await import("./config");
+      expect(getMaxResponseBytes()).toBe(0);
+   });
+
+   it("rejects a negative override", async () => {
+      process.env.PUBLISHER_MAX_RESPONSE_BYTES = "-1";
+      const { getMaxResponseBytes } = await import("./config");
+      expect(() => getMaxResponseBytes()).toThrow();
+   });
+
+   it("rejects a non-integer override", async () => {
+      process.env.PUBLISHER_MAX_RESPONSE_BYTES = "1.5";
+      const { getMaxResponseBytes } = await import("./config");
+      expect(() => getMaxResponseBytes()).toThrow();
+   });
+
+   it("rejects a non-numeric override", async () => {
+      process.env.PUBLISHER_MAX_RESPONSE_BYTES = "big";
+      const { getMaxResponseBytes } = await import("./config");
+      expect(() => getMaxResponseBytes()).toThrow();
+   });
+});

--- a/packages/server/src/config.spec.ts
+++ b/packages/server/src/config.spec.ts
@@ -1266,3 +1266,55 @@ describe("getMaxResponseBytes", () => {
       expect(() => getMaxResponseBytes()).toThrow();
    });
 });
+
+describe("getDefaultQueryRowLimit", () => {
+   beforeEach(() => {
+      delete process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT;
+   });
+   afterEach(() => {
+      delete process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT;
+   });
+
+   it("returns DEFAULT_QUERY_ROW_LIMIT when the env var is unset", async () => {
+      const { getDefaultQueryRowLimit } = await import("./config");
+      const { DEFAULT_QUERY_ROW_LIMIT } = await import("./constants");
+      expect(getDefaultQueryRowLimit()).toBe(DEFAULT_QUERY_ROW_LIMIT);
+   });
+
+   it("returns DEFAULT_QUERY_ROW_LIMIT when the env var is empty", async () => {
+      process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT = "";
+      const { getDefaultQueryRowLimit } = await import("./config");
+      const { DEFAULT_QUERY_ROW_LIMIT } = await import("./constants");
+      expect(getDefaultQueryRowLimit()).toBe(DEFAULT_QUERY_ROW_LIMIT);
+   });
+
+   it("returns the override when the env var is set", async () => {
+      process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT = "250";
+      const { getDefaultQueryRowLimit } = await import("./config");
+      expect(getDefaultQueryRowLimit()).toBe(250);
+   });
+
+   it("rejects 0 (a default of 'zero rows' is always a misconfiguration)", async () => {
+      process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT = "0";
+      const { getDefaultQueryRowLimit } = await import("./config");
+      expect(() => getDefaultQueryRowLimit()).toThrow();
+   });
+
+   it("rejects a negative override", async () => {
+      process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT = "-1";
+      const { getDefaultQueryRowLimit } = await import("./config");
+      expect(() => getDefaultQueryRowLimit()).toThrow();
+   });
+
+   it("rejects a non-integer override", async () => {
+      process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT = "1.5";
+      const { getDefaultQueryRowLimit } = await import("./config");
+      expect(() => getDefaultQueryRowLimit()).toThrow();
+   });
+
+   it("rejects a non-numeric override", async () => {
+      process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT = "lots";
+      const { getDefaultQueryRowLimit } = await import("./config");
+      expect(() => getDefaultQueryRowLimit()).toThrow();
+   });
+});

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -6,6 +6,7 @@ import {
    API_PREFIX,
    DEFAULT_MAX_QUERY_ROWS,
    DEFAULT_MAX_RESPONSE_BYTES,
+   DEFAULT_QUERY_ROW_LIMIT,
    PUBLISHER_CONFIG_NAME,
 } from "./constants";
 import { logger } from "./logger";
@@ -272,6 +273,30 @@ export const getMaxResponseBytes = (): number => {
    if (raw < 0) {
       throw new Error(
          `PUBLISHER_MAX_RESPONSE_BYTES must be a non-negative integer (got ${raw})`,
+      );
+   }
+   return raw;
+};
+
+/**
+ * Resolve the default row limit applied to Malloy model queries
+ * (the `runnable.run` path used by `getQueryResults` and notebook
+ * cell execution) when the user's query doesn't carry its own
+ * `LIMIT`. Reads `PUBLISHER_DEFAULT_QUERY_ROW_LIMIT`; falls back to
+ * {@link DEFAULT_QUERY_ROW_LIMIT} when unset or empty.
+ *
+ * Unlike {@link getMaxQueryRows}, `0` is rejected — a default of
+ * "return zero rows" is almost certainly a misconfiguration (it
+ * would silently break every notebook), and the operator probably
+ * wanted `PUBLISHER_MAX_QUERY_ROWS=0` to opt out of the *hard cap*
+ * instead. Loud failure surfaces the typo at startup.
+ */
+export const getDefaultQueryRowLimit = (): number => {
+   const raw = parseIntEnv("PUBLISHER_DEFAULT_QUERY_ROW_LIMIT");
+   if (raw === undefined) return DEFAULT_QUERY_ROW_LIMIT;
+   if (raw <= 0) {
+      throw new Error(
+         `PUBLISHER_DEFAULT_QUERY_ROW_LIMIT must be a positive integer (got ${raw})`,
       );
    }
    return raw;

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -5,6 +5,7 @@ import { components } from "./api";
 import {
    API_PREFIX,
    DEFAULT_MAX_QUERY_ROWS,
+   DEFAULT_MAX_RESPONSE_BYTES,
    PUBLISHER_CONFIG_NAME,
 } from "./constants";
 import { logger } from "./logger";
@@ -248,6 +249,29 @@ export const getMaxQueryRows = (): number => {
    if (raw < 0) {
       throw new Error(
          `PUBLISHER_MAX_QUERY_ROWS must be a non-negative integer (got ${raw})`,
+      );
+   }
+   return raw;
+};
+
+/**
+ * Resolve the byte cap applied to ad-hoc connection SQL responses
+ * when the underlying connection implements `StreamingConnection`.
+ * Reads `PUBLISHER_MAX_RESPONSE_BYTES`; falls back to
+ * {@link DEFAULT_MAX_RESPONSE_BYTES} when unset or empty.
+ *
+ * Mirrors {@link getMaxQueryRows}'s loud-failure semantics: throws
+ * at startup on malformed input so a typo in a k8s manifest surfaces
+ * immediately. A value of `0` is accepted and disables the byte cap
+ * entirely; use it only when you intend to rely on the row cap alone
+ * (e.g. for benchmarking).
+ */
+export const getMaxResponseBytes = (): number => {
+   const raw = parseIntEnv("PUBLISHER_MAX_RESPONSE_BYTES");
+   if (raw === undefined) return DEFAULT_MAX_RESPONSE_BYTES;
+   if (raw < 0) {
+      throw new Error(
+         `PUBLISHER_MAX_RESPONSE_BYTES must be a non-negative integer (got ${raw})`,
       );
    }
    return raw;

--- a/packages/server/src/constants.ts
+++ b/packages/server/src/constants.ts
@@ -5,7 +5,24 @@ export const PUBLISHER_CONFIG_NAME = "publisher.config.json";
 export const PACKAGE_MANIFEST_NAME = "publisher.json";
 export const MODEL_FILE_SUFFIX = ".malloy";
 export const NOTEBOOK_FILE_SUFFIX = ".malloynb";
-export const ROW_LIMIT = 1000;
+/**
+ * Default row cap applied to Malloy model queries (the `runnable.run`
+ * path used by `getQueryResults` and notebook cell execution) when
+ * the user's query doesn't carry its own `LIMIT`. Override at startup
+ * via `PUBLISHER_DEFAULT_QUERY_ROW_LIMIT`.
+ *
+ * This is *the default*, not a hard ceiling. A Malloy query that
+ * carries `LIMIT 50000` overrides this. The hard ceiling is
+ * {@link DEFAULT_MAX_QUERY_ROWS} (env-tuned via
+ * `PUBLISHER_MAX_QUERY_ROWS`), which the model-query path now also
+ * enforces — preventing a user `LIMIT 10000000` from blowing up the
+ * process.
+ *
+ * Tuned conservatively (1000) because notebook UIs typically render
+ * tabular previews; operators who need larger ad-hoc exports can
+ * raise it.
+ */
+export const DEFAULT_QUERY_ROW_LIMIT = 1000;
 /**
  * Maximum number of rows the ad-hoc connection SQL endpoints
  * (`/environments/.../connections/.../sqlQuery` and the deprecated

--- a/packages/server/src/constants.ts
+++ b/packages/server/src/constants.ts
@@ -20,5 +20,25 @@ export const ROW_LIMIT = 1000;
  * Step 2 byte budget.
  */
 export const DEFAULT_MAX_QUERY_ROWS = 100_000;
+/**
+ * Maximum aggregate JSON-serialized byte size of an ad-hoc
+ * connection SQL response before failing with HTTP 413. Override at
+ * startup via `PUBLISHER_MAX_RESPONSE_BYTES`.
+ *
+ * This is the actual memory bound: row count alone is a poor proxy
+ * for memory pressure because a single 10 MB JSON column blows past
+ * the 100k-row cap's safe envelope. Enforced only when the
+ * underlying connection implements `StreamingConnection` (Postgres,
+ * DuckDB, ...) since byte counting requires iterating row-at-a-time
+ * — on non-streaming connections the driver has already buffered
+ * the whole result by the time we see it, so client-side byte
+ * counting gains nothing.
+ *
+ * 50 MB picked as a middle ground: comfortably accommodates wide
+ * exploratory results (50k rows × 1 KB, or 5k rows × 10 KB) while
+ * keeping a single pod able to serve a handful of concurrent
+ * requests under a typical 1-2 GB memory budget.
+ */
+export const DEFAULT_MAX_RESPONSE_BYTES = 50_000_000;
 export const TEMP_DIR_PATH = os.tmpdir();
 export const PUBLISHER_DATA_DIR = "publisher_data";

--- a/packages/server/src/controller/connection.controller.spec.ts
+++ b/packages/server/src/controller/connection.controller.spec.ts
@@ -1,4 +1,9 @@
-import type { Connection } from "@malloydata/malloy";
+import type {
+   Connection,
+   QueryRecord,
+   RunSQLOptions,
+   StreamingConnection,
+} from "@malloydata/malloy";
 import { afterEach, describe, expect, it } from "bun:test";
 import sinon from "sinon";
 
@@ -315,5 +320,236 @@ describe("ConnectionController.getConnectionQueryData row cap", () => {
          ),
       ).rejects.toBeInstanceOf(BadRequestError);
       expect(runSQL.called).toBe(false);
+   });
+});
+
+/**
+ * Tests for the streaming branch of
+ * {@link ConnectionController.getConnectionQueryData}. When the
+ * connection implements `canStream`, the controller routes through
+ * `streamSqlWithBudget` so the byte cap can fire mid-stream. The
+ * row cap is still enforced via `RunSQLOptions.rowLimit = cap+1` on
+ * the way in, plus an overflow check on the way out (same sentinel
+ * pattern as the non-streaming path).
+ */
+describe("ConnectionController.getConnectionQueryData streaming", () => {
+   const originalRowsEnv = process.env.PUBLISHER_MAX_QUERY_ROWS;
+   const originalBytesEnv = process.env.PUBLISHER_MAX_RESPONSE_BYTES;
+
+   afterEach(() => {
+      sinon.restore();
+      if (originalRowsEnv === undefined) {
+         delete process.env.PUBLISHER_MAX_QUERY_ROWS;
+      } else {
+         process.env.PUBLISHER_MAX_QUERY_ROWS = originalRowsEnv;
+      }
+      if (originalBytesEnv === undefined) {
+         delete process.env.PUBLISHER_MAX_RESPONSE_BYTES;
+      } else {
+         process.env.PUBLISHER_MAX_RESPONSE_BYTES = originalBytesEnv;
+      }
+   });
+
+   /**
+    * Build a controller backed by a fake `StreamingConnection`.
+    * `seenSql` and `seenOptions` let tests assert the controller
+    * passed the SQL straight through and forwarded the budget-derived
+    * `rowLimit` to the driver.
+    */
+   function buildStreamingController(opts: {
+      rows: QueryRecord[];
+      honorRowLimit?: boolean;
+   }): {
+      controller: ConnectionController;
+      seenSql: { value: string | undefined };
+      seenOptions: { value: RunSQLOptions | undefined };
+   } {
+      const { rows, honorRowLimit = true } = opts;
+      const seenSql = { value: undefined as string | undefined };
+      const seenOptions = { value: undefined as RunSQLOptions | undefined };
+      const fakeConnection = {
+         canStream(): true {
+            return true;
+         },
+         async *runSQLStream(
+            sql: string,
+            options?: RunSQLOptions,
+         ): AsyncIterableIterator<QueryRecord> {
+            seenSql.value = sql;
+            seenOptions.value = options;
+            const limit =
+               honorRowLimit && typeof options?.rowLimit === "number"
+                  ? options.rowLimit
+                  : rows.length;
+            for (let i = 0; i < Math.min(rows.length, limit); i += 1) {
+               yield rows[i];
+            }
+         },
+      } as unknown as StreamingConnection;
+      const controller = new ConnectionController(
+         {} as unknown as EnvironmentStore,
+      );
+      sinon
+         .stub(
+            controller as unknown as {
+               getMalloyConnection: (...args: unknown[]) => Promise<Connection>;
+            },
+            "getMalloyConnection",
+         )
+         .resolves(fakeConnection as unknown as Connection);
+      return { controller, seenSql, seenOptions };
+   }
+
+   it("routes through runSQLStream and asks the driver for cap+1 rows", async () => {
+      process.env.PUBLISHER_MAX_QUERY_ROWS = "5";
+      const rows = [{ a: 1 }, { a: 2 }];
+      const { controller, seenSql, seenOptions } = buildStreamingController({
+         rows,
+      });
+
+      const result = await controller.getConnectionQueryData(
+         "env",
+         "conn",
+         "SELECT a FROM t",
+         "",
+      );
+
+      expect(seenSql.value).toBe("SELECT a FROM t");
+      expect(seenOptions.value?.rowLimit).toBe(6);
+      const parsed = JSON.parse(result.data ?? "") as { rows: QueryRecord[] };
+      expect(parsed.rows).toEqual(rows);
+   });
+
+   it("preserves a caller-supplied rowLimit when it is below the cap+1 ceiling", async () => {
+      process.env.PUBLISHER_MAX_QUERY_ROWS = "100";
+      const { controller, seenOptions } = buildStreamingController({
+         rows: [{ a: 1 }],
+      });
+
+      await controller.getConnectionQueryData(
+         "env",
+         "conn",
+         "SELECT a FROM t",
+         JSON.stringify({ rowLimit: 10 }),
+      );
+
+      expect(seenOptions.value?.rowLimit).toBe(10);
+   });
+
+   it("throws PayloadTooLargeError when the stream yields more than the row cap", async () => {
+      process.env.PUBLISHER_MAX_QUERY_ROWS = "2";
+      const rows = [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }];
+      const { controller } = buildStreamingController({
+         rows,
+         honorRowLimit: false,
+      });
+
+      await expect(
+         controller.getConnectionQueryData(
+            "env",
+            "conn",
+            "SELECT a FROM t",
+            "",
+         ),
+      ).rejects.toBeInstanceOf(PayloadTooLargeError);
+      await expect(
+         controller.getConnectionQueryData(
+            "env",
+            "conn",
+            "SELECT a FROM t",
+            "",
+         ),
+      ).rejects.toThrow("more than 2 rows");
+   });
+
+   it("throws PayloadTooLargeError when the stream exceeds the byte cap", async () => {
+      process.env.PUBLISHER_MAX_QUERY_ROWS = "1000";
+      process.env.PUBLISHER_MAX_RESPONSE_BYTES = "60";
+      const big = "x".repeat(40);
+      const rows = [{ s: big }, { s: big }, { s: big }];
+      const { controller } = buildStreamingController({
+         rows,
+         honorRowLimit: false,
+      });
+
+      await expect(
+         controller.getConnectionQueryData(
+            "env",
+            "conn",
+            "SELECT s FROM t",
+            "",
+         ),
+      ).rejects.toBeInstanceOf(PayloadTooLargeError);
+      await expect(
+         controller.getConnectionQueryData(
+            "env",
+            "conn",
+            "SELECT s FROM t",
+            "",
+         ),
+      ).rejects.toThrow("exceeded 60 bytes");
+   });
+
+   it("disables byte cap when PUBLISHER_MAX_RESPONSE_BYTES=0", async () => {
+      process.env.PUBLISHER_MAX_QUERY_ROWS = "1000";
+      process.env.PUBLISHER_MAX_RESPONSE_BYTES = "0";
+      const big = "x".repeat(10_000);
+      const rows: QueryRecord[] = Array.from({ length: 3 }, () => ({ s: big }));
+      const { controller } = buildStreamingController({
+         rows,
+         honorRowLimit: false,
+      });
+
+      const result = await controller.getConnectionQueryData(
+         "env",
+         "conn",
+         "SELECT s FROM t",
+         "",
+      );
+
+      const parsed = JSON.parse(result.data ?? "") as { rows: QueryRecord[] };
+      expect(parsed.rows.length).toBe(3);
+   });
+
+   it("omits rowLimit when PUBLISHER_MAX_QUERY_ROWS=0 and no caller limit is given", async () => {
+      process.env.PUBLISHER_MAX_QUERY_ROWS = "0";
+      const rows = [{ a: 1 }, { a: 2 }, { a: 3 }];
+      const { controller, seenOptions } = buildStreamingController({
+         rows,
+         honorRowLimit: false,
+      });
+
+      const result = await controller.getConnectionQueryData(
+         "env",
+         "conn",
+         "SELECT a FROM t",
+         "",
+      );
+
+      expect(seenOptions.value?.rowLimit).toBeUndefined();
+      const parsed = JSON.parse(result.data ?? "") as { rows: QueryRecord[] };
+      expect(parsed.rows.length).toBe(3);
+   });
+
+   it("replaces caller-supplied abortSignal with a real AbortSignal", async () => {
+      process.env.PUBLISHER_MAX_QUERY_ROWS = "10";
+      const { controller, seenOptions } = buildStreamingController({
+         rows: [{ a: 1 }],
+      });
+
+      await controller.getConnectionQueryData(
+         "env",
+         "conn",
+         "SELECT 1",
+         JSON.stringify({ abortSignal: {} }),
+      );
+
+      // The controller clears the caller-supplied abortSignal (which
+      // arrives over the wire as a JSON-shaped placeholder, not a
+      // real AbortSignal), and the streaming helper installs its own
+      // so it can abort the iterator on overflow.
+      const signal = seenOptions.value?.abortSignal;
+      expect(signal).toBeInstanceOf(AbortSignal);
+      expect(signal?.aborted).toBe(false);
    });
 });

--- a/packages/server/src/controller/connection.controller.ts
+++ b/packages/server/src/controller/connection.controller.ts
@@ -1,7 +1,7 @@
 import { Connection, RunSQLOptions, TableSourceDef } from "@malloydata/malloy";
 import { PersistSQLResults } from "@malloydata/malloy/connection";
 import { components } from "../api";
-import { getMaxQueryRows } from "../config";
+import { getMaxQueryRows, getMaxResponseBytes } from "../config";
 import {
    BadRequestError,
    ConnectionError,
@@ -17,6 +17,7 @@ import {
 } from "../service/db_utils";
 import type { Environment } from "../service/environment";
 import { EnvironmentStore } from "../service/environment_store";
+import { isStreamingConnection, streamSqlWithBudget } from "../stream_helpers";
 
 type ApiConnection = components["schemas"]["Connection"];
 type ApiConnectionStatus = components["schemas"]["ConnectionStatus"];
@@ -498,19 +499,50 @@ export class ConnectionController {
          runSQLOptions.abortSignal = undefined;
       }
 
-      // Bound the response by clamping rowLimit to (cap + 1). The +1 is a
-      // sentinel: a response of cap+1 rows means the original would have
-      // overflowed, and we fail the request with HTTP 413 rather than
-      // serializing it. A caller-supplied rowLimit lower than cap+1 is kept,
-      // so users can still ask for fewer rows; we only enforce the ceiling.
-      // Cap of 0 disables the bound. We trust the connector to honor
-      // RunSQLOptions.rowLimit; connectors that don't are upstream bugs.
+      // Bound the response with two layered caps:
+      //
+      //   - Row cap (PUBLISHER_MAX_QUERY_ROWS) — pushed to the driver as
+      //     RunSQLOptions.rowLimit = min(callerLimit, cap+1). The +1 is a
+      //     sentinel: a response of cap+1 rows means the original would have
+      //     overflowed, so we fail the request with HTTP 413 rather than
+      //     serializing it. A caller-supplied rowLimit lower than cap+1 is
+      //     kept; we only enforce the ceiling. Cap of 0 disables the bound.
+      //
+      //   - Byte cap (PUBLISHER_MAX_RESPONSE_BYTES) — the actual memory
+      //     bound, since a single 10 MB JSON column can blow past the
+      //     row cap's safe envelope. Only enforceable on streaming
+      //     connections; row-buffered `runSQL` has already done the
+      //     damage by the time we'd count bytes.
+      //
+      // We trust connectors to honor RunSQLOptions.rowLimit; connectors
+      // that don't are upstream bugs.
       const maxRows = getMaxQueryRows();
+      const maxBytes = getMaxResponseBytes();
       if (maxRows > 0) {
          runSQLOptions.rowLimit = Math.min(
             runSQLOptions.rowLimit ?? maxRows + 1,
             maxRows + 1,
          );
+      }
+
+      // Streaming-capable connections (Postgres, DuckDB, ...) go through
+      // streamSqlWithBudget so the byte cap can fire mid-stream. Other
+      // connections fall back to the buffered path; client-side byte
+      // counting there would be security theatre.
+      if (isStreamingConnection(malloyConnection)) {
+         let streamed;
+         try {
+            streamed = await streamSqlWithBudget(
+               malloyConnection,
+               sqlStatement,
+               runSQLOptions,
+               { maxRows, maxBytes },
+            );
+         } catch (error) {
+            if (error instanceof PayloadTooLargeError) throw error;
+            throw new ConnectionError((error as Error).message);
+         }
+         return { data: JSON.stringify(streamed) };
       }
 
       let result;

--- a/packages/server/src/service/model.spec.ts
+++ b/packages/server/src/service/model.spec.ts
@@ -1,9 +1,13 @@
-import { MalloyError, Runtime } from "@malloydata/malloy";
-import { describe, expect, it } from "bun:test";
+import { API, MalloyError, Runtime } from "@malloydata/malloy";
+import { afterEach, describe, expect, it } from "bun:test";
 import fs from "fs/promises";
 import sinon from "sinon";
 
-import { BadRequestError, ModelNotFoundError } from "../errors";
+import {
+   BadRequestError,
+   ModelNotFoundError,
+   PayloadTooLargeError,
+} from "../errors";
 import { Model, ModelType } from "./model";
 
 describe("service/model", () => {
@@ -286,6 +290,192 @@ describe("service/model", () => {
             });
 
             sinon.restore();
+         });
+
+         /**
+          * The row/byte caps live in `model_limits.ts` (unit-tested in
+          * `model_limits.spec.ts`); these tests just confirm the wiring —
+          * that `Model.getQueryResults` calls the helpers with the right
+          * values and that an overflow propagates as `PayloadTooLargeError`
+          * (HTTP 413), not the generic `BadRequestError` (HTTP 400).
+          */
+         describe("response caps", () => {
+            const originalRowsEnv = process.env.PUBLISHER_MAX_QUERY_ROWS;
+            const originalBytesEnv = process.env.PUBLISHER_MAX_RESPONSE_BYTES;
+            const originalDefaultEnv =
+               process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT;
+
+            afterEach(() => {
+               sinon.restore();
+               for (const [name, original] of [
+                  ["PUBLISHER_MAX_QUERY_ROWS", originalRowsEnv],
+                  ["PUBLISHER_MAX_RESPONSE_BYTES", originalBytesEnv],
+                  ["PUBLISHER_DEFAULT_QUERY_ROW_LIMIT", originalDefaultEnv],
+               ] as const) {
+                  if (original === undefined) {
+                     delete process.env[name];
+                  } else {
+                     process.env[name] = original;
+                  }
+               }
+            });
+
+            /**
+             * Build a Model whose `runnable.run` resolves to a fake Result
+             * with the given totalRows; stub `API.util.wrapResult` so we
+             * don't need to construct a real Malloy schema/queryResult.
+             */
+            function buildModelWithFakeRun(opts: {
+               userLimit?: number;
+               totalRows: number;
+               wrappedJson: object;
+            }): { model: Model; runStub: sinon.SinonStub } {
+               const preparedResultStub = sinon
+                  .stub()
+                  .resolves({ resultExplore: { limit: opts.userLimit ?? 0 } });
+               const fakeResult = {
+                  _queryResult: { data: { rawData: [] } },
+                  totalRows: opts.totalRows,
+                  data: { value: [] },
+                  connectionName: "fake",
+               };
+               const runStub = sinon.stub().resolves(fakeResult);
+               sinon
+                  .stub(API.util, "wrapResult")
+                  .returns(
+                     opts.wrappedJson as unknown as ReturnType<
+                        typeof API.util.wrapResult
+                     >,
+                  );
+               const modelMaterializer = {
+                  loadQuery: sinon.stub().returns({
+                     getPreparedResult: preparedResultStub,
+                     run: runStub,
+                  }),
+               };
+               const model = new Model(
+                  packageName,
+                  mockModelPath,
+                  {},
+                  "model",
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  modelMaterializer as any,
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  { contents: {}, exports: [], queryList: [] } as any,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+               );
+               return { model, runStub };
+            }
+
+            it("clamps user LIMIT to maxRows + 1 when the user requested more than the cap", async () => {
+               process.env.PUBLISHER_MAX_QUERY_ROWS = "100";
+               const { model, runStub } = buildModelWithFakeRun({
+                  userLimit: 1_000_000,
+                  totalRows: 10,
+                  wrappedJson: { rows: [] },
+               });
+
+               await model.getQueryResults(
+                  undefined,
+                  undefined,
+                  "run: orders -> summary",
+               );
+
+               expect(runStub.firstCall.args[0].rowLimit).toBe(101);
+            });
+
+            it("passes user LIMIT through when below maxRows", async () => {
+               process.env.PUBLISHER_MAX_QUERY_ROWS = "100";
+               const { model, runStub } = buildModelWithFakeRun({
+                  userLimit: 50,
+                  totalRows: 10,
+                  wrappedJson: { rows: [] },
+               });
+
+               await model.getQueryResults(
+                  undefined,
+                  undefined,
+                  "run: orders -> summary",
+               );
+
+               expect(runStub.firstCall.args[0].rowLimit).toBe(50);
+            });
+
+            it("falls back to PUBLISHER_DEFAULT_QUERY_ROW_LIMIT when the user query has no LIMIT", async () => {
+               process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT = "42";
+               delete process.env.PUBLISHER_MAX_QUERY_ROWS;
+               const { model, runStub } = buildModelWithFakeRun({
+                  userLimit: 0,
+                  totalRows: 10,
+                  wrappedJson: { rows: [] },
+               });
+
+               await model.getQueryResults(
+                  undefined,
+                  undefined,
+                  "run: orders -> summary",
+               );
+
+               expect(runStub.firstCall.args[0].rowLimit).toBe(42);
+            });
+
+            it("throws PayloadTooLargeError (not BadRequestError) when totalRows exceeds the cap", async () => {
+               process.env.PUBLISHER_MAX_QUERY_ROWS = "100";
+               const { model } = buildModelWithFakeRun({
+                  userLimit: 1000,
+                  totalRows: 101,
+                  wrappedJson: { rows: [] },
+               });
+
+               await expect(
+                  model.getQueryResults(
+                     undefined,
+                     undefined,
+                     "run: orders -> summary",
+                  ),
+               ).rejects.toBeInstanceOf(PayloadTooLargeError);
+            });
+
+            it("throws PayloadTooLargeError when the wrapped response exceeds the byte cap", async () => {
+               process.env.PUBLISHER_MAX_QUERY_ROWS = "1000";
+               process.env.PUBLISHER_MAX_RESPONSE_BYTES = "100";
+               const huge = "x".repeat(500);
+               const { model } = buildModelWithFakeRun({
+                  userLimit: 10,
+                  totalRows: 10,
+                  wrappedJson: { rows: [{ s: huge }] },
+               });
+
+               await expect(
+                  model.getQueryResults(
+                     undefined,
+                     undefined,
+                     "run: orders -> summary",
+                  ),
+               ).rejects.toBeInstanceOf(PayloadTooLargeError);
+            });
+
+            it("does not throw when both counts are within their caps", async () => {
+               process.env.PUBLISHER_MAX_QUERY_ROWS = "1000";
+               process.env.PUBLISHER_MAX_RESPONSE_BYTES = "10000";
+               const { model } = buildModelWithFakeRun({
+                  userLimit: 10,
+                  totalRows: 10,
+                  wrappedJson: { rows: [{ a: 1 }] },
+               });
+
+               await expect(
+                  model.getQueryResults(
+                     undefined,
+                     undefined,
+                     "run: orders -> summary",
+                  ),
+               ).resolves.toBeDefined();
+            });
          });
       });
 

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -35,15 +35,17 @@ import type {
    SerializedNotebookCell,
 } from "../package_load/protocol";
 import {
-   MODEL_FILE_SUFFIX,
-   NOTEBOOK_FILE_SUFFIX,
-   ROW_LIMIT,
-} from "../constants";
+   getDefaultQueryRowLimit,
+   getMaxQueryRows,
+   getMaxResponseBytes,
+} from "../config";
+import { MODEL_FILE_SUFFIX, NOTEBOOK_FILE_SUFFIX } from "../constants";
 import { HackyDataStylesAccumulator } from "../data_styles";
 import {
    BadRequestError,
    ModelCompilationError,
    ModelNotFoundError,
+   PayloadTooLargeError,
 } from "../errors";
 import { logger } from "../logger";
 import { BuildManifest } from "../storage/DatabaseInterface";
@@ -57,6 +59,10 @@ import {
    type FilterParams,
 } from "./filter";
 import { malloyGivenToApi, type MalloyGiven } from "./given";
+import {
+   assertWithinModelResponseLimits,
+   resolveModelQueryRowLimit,
+} from "./model_limits";
 
 type ApiCompiledModel = components["schemas"]["CompiledModel"];
 type ApiNotebookCell = components["schemas"]["NotebookCell"];
@@ -597,9 +603,12 @@ export class Model {
          throw new BadRequestError(`Invalid query: ${errorMessage}`);
       }
 
-      const rowLimit =
-         (await runnable.getPreparedResult({ givens })).resultExplore.limit ||
-         ROW_LIMIT;
+      const maxRows = getMaxQueryRows();
+      const maxBytes = getMaxResponseBytes();
+      const rowLimit = resolveModelQueryRowLimit(
+         (await runnable.getPreparedResult({ givens })).resultExplore.limit,
+         { defaultLimit: getDefaultQueryRowLimit(), maxRows },
+      );
       const endTime = performance.now();
       const executionTime = endTime - startTime;
 
@@ -638,6 +647,22 @@ export class Model {
          throw new BadRequestError(`Query execution failed: ${errorMessage}`);
       }
 
+      const wrappedResult = API.util.wrapResult(queryResults);
+      // Best-effort byte check: we've already buffered `queryResults` and
+      // built `wrappedResult` by the time we get here, so this surfaces
+      // oversize responses with a clean HTTP 413 instead of letting the
+      // controller transmit a half-megabyte payload — it is not OOM
+      // prevention. True prevention requires streaming `Result`
+      // construction, which is out of scope for this step. The row cap
+      // above is the primary OOM defense.
+      const serializedBytes =
+         maxBytes > 0
+            ? Buffer.byteLength(JSON.stringify(wrappedResult), "utf8")
+            : 0;
+      assertWithinModelResponseLimits(queryResults.totalRows, serializedBytes, {
+         maxRows,
+         maxBytes,
+      });
       this.queryExecutionHistogram.record(executionTime, {
          "malloy.model.path": this.modelPath,
          "malloy.model.query.name": queryName,
@@ -649,7 +674,7 @@ export class Model {
          "malloy.model.query.status": "success",
       });
       return {
-         result: API.util.wrapResult(queryResults),
+         result: wrappedResult,
          compactResult: queryResults.data.value,
          modelInfo: this.modelInfo,
          dataStyles: this.dataStyles,
@@ -792,9 +817,16 @@ export class Model {
                }
             }
 
-            const rowLimit =
+            const cellMaxRows = getMaxQueryRows();
+            const cellMaxBytes = getMaxResponseBytes();
+            const rowLimit = resolveModelQueryRowLimit(
                (await runnableToExecute.getPreparedResult({ givens }))
-                  .resultExplore.limit || ROW_LIMIT;
+                  .resultExplore.limit,
+               {
+                  defaultLimit: getDefaultQueryRowLimit(),
+                  maxRows: cellMaxRows,
+               },
+            );
             const result = await runnableToExecute.run({ rowLimit, givens });
             const query = (await runnableToExecute.getPreparedQuery())._query;
             queryName = (query as NamedQueryDef).as || query.name;
@@ -802,11 +834,29 @@ export class Model {
                result?._queryResult &&
                this.modelInfo &&
                JSON.stringify(API.util.wrapResult(result));
+            // Same caveat as `getQueryResults`: by the time we measure
+            // bytes the response has already been buffered and stringified,
+            // so this is loud-failure detection (clean 413 instead of
+            // partial transmission), not OOM prevention. The row cap above
+            // is the primary defense.
+            if (result?._queryResult && queryResult) {
+               assertWithinModelResponseLimits(
+                  result.totalRows,
+                  Buffer.byteLength(queryResult, "utf8"),
+                  { maxRows: cellMaxRows, maxBytes: cellMaxBytes },
+               );
+            }
          } catch (error) {
             if (error instanceof FilterValidationError) {
                throw new BadRequestError(error.message);
             }
             if (error instanceof MalloyError) {
+               throw error;
+            }
+            // Surface PayloadTooLargeError as-is so the error middleware
+            // maps it to HTTP 413; without this it would get swallowed
+            // into a generic 400 BadRequestError below.
+            if (error instanceof PayloadTooLargeError) {
                throw error;
             }
             const errorMessage =

--- a/packages/server/src/service/model_limits.spec.ts
+++ b/packages/server/src/service/model_limits.spec.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "bun:test";
+
+import { PayloadTooLargeError } from "../errors";
+import {
+   assertWithinModelResponseLimits,
+   resolveModelQueryRowLimit,
+} from "./model_limits";
+
+describe("resolveModelQueryRowLimit", () => {
+   it("uses the user's LIMIT when set and below the maxRows ceiling", () => {
+      expect(
+         resolveModelQueryRowLimit(500, {
+            defaultLimit: 1000,
+            maxRows: 100_000,
+         }),
+      ).toBe(500);
+   });
+
+   it("falls back to defaultLimit when the user's LIMIT is undefined", () => {
+      expect(
+         resolveModelQueryRowLimit(undefined, {
+            defaultLimit: 1000,
+            maxRows: 100_000,
+         }),
+      ).toBe(1000);
+   });
+
+   it("falls back to defaultLimit when the user's LIMIT is 0 (Malloy returns 0 for 'no limit')", () => {
+      // Malloy's PreparedResult returns 0 from `resultExplore.limit` when the
+      // query has no LIMIT clause; treat that as "no user limit".
+      expect(
+         resolveModelQueryRowLimit(0, {
+            defaultLimit: 1000,
+            maxRows: 100_000,
+         }),
+      ).toBe(1000);
+   });
+
+   it("clamps a too-high user LIMIT to the maxRows + 1 sentinel", () => {
+      expect(
+         resolveModelQueryRowLimit(1_000_000, {
+            defaultLimit: 1000,
+            maxRows: 100_000,
+         }),
+      ).toBe(100_001);
+   });
+
+   it("clamps a too-high defaultLimit to the maxRows + 1 sentinel", () => {
+      // Operator misconfigured DEFAULT > MAX; the hard cap still wins.
+      expect(
+         resolveModelQueryRowLimit(undefined, {
+            defaultLimit: 1_000_000,
+            maxRows: 50,
+         }),
+      ).toBe(51);
+   });
+
+   it("returns the requested limit unchanged when maxRows is 0 (cap disabled)", () => {
+      expect(
+         resolveModelQueryRowLimit(1_000_000, {
+            defaultLimit: 1000,
+            maxRows: 0,
+         }),
+      ).toBe(1_000_000);
+   });
+
+   it("returns the default unchanged when maxRows is 0 and no user limit", () => {
+      expect(
+         resolveModelQueryRowLimit(undefined, {
+            defaultLimit: 1000,
+            maxRows: 0,
+         }),
+      ).toBe(1000);
+   });
+
+   it("rejects negative user limits by treating them as 'no limit'", () => {
+      // Defensive — shouldn't happen in practice, but a -1 from a malformed
+      // PreparedResult shouldn't propagate as a negative rowLimit to the driver.
+      expect(
+         resolveModelQueryRowLimit(-1, {
+            defaultLimit: 1000,
+            maxRows: 100_000,
+         }),
+      ).toBe(1000);
+   });
+});
+
+describe("assertWithinModelResponseLimits", () => {
+   it("does not throw when both counts are below their caps", () => {
+      expect(() =>
+         assertWithinModelResponseLimits(500, 1_000, {
+            maxRows: 1000,
+            maxBytes: 10_000,
+         }),
+      ).not.toThrow();
+   });
+
+   it("does not throw when row count equals the cap exactly (sentinel hasn't fired)", () => {
+      expect(() =>
+         assertWithinModelResponseLimits(1000, 1_000, {
+            maxRows: 1000,
+            maxBytes: 10_000,
+         }),
+      ).not.toThrow();
+   });
+
+   it("throws PayloadTooLargeError with the row-cap message on row overflow", () => {
+      expect(() =>
+         assertWithinModelResponseLimits(1001, 1_000, {
+            maxRows: 1000,
+            maxBytes: 10_000,
+         }),
+      ).toThrow(PayloadTooLargeError);
+      expect(() =>
+         assertWithinModelResponseLimits(1001, 1_000, {
+            maxRows: 1000,
+            maxBytes: 10_000,
+         }),
+      ).toThrow("more than 1000 rows");
+   });
+
+   it("throws PayloadTooLargeError with the byte-cap message on byte overflow", () => {
+      expect(() =>
+         assertWithinModelResponseLimits(10, 50_000, {
+            maxRows: 1000,
+            maxBytes: 10_000,
+         }),
+      ).toThrow(PayloadTooLargeError);
+      expect(() =>
+         assertWithinModelResponseLimits(10, 50_000, {
+            maxRows: 1000,
+            maxBytes: 10_000,
+         }),
+      ).toThrow("exceeded 10000 bytes");
+   });
+
+   it("prefers the row-cap message when both caps would have fired (row check runs first)", () => {
+      expect(() =>
+         assertWithinModelResponseLimits(2000, 50_000, {
+            maxRows: 1000,
+            maxBytes: 10_000,
+         }),
+      ).toThrow("more than 1000 rows");
+   });
+
+   it("disables row cap when maxRows is 0", () => {
+      expect(() =>
+         assertWithinModelResponseLimits(1_000_000, 1_000, {
+            maxRows: 0,
+            maxBytes: 10_000,
+         }),
+      ).not.toThrow();
+   });
+
+   it("disables byte cap when maxBytes is 0", () => {
+      expect(() =>
+         assertWithinModelResponseLimits(10, 1_000_000_000, {
+            maxRows: 1000,
+            maxBytes: 0,
+         }),
+      ).not.toThrow();
+   });
+});

--- a/packages/server/src/service/model_limits.ts
+++ b/packages/server/src/service/model_limits.ts
@@ -1,0 +1,100 @@
+/**
+ * Memory guards for the Malloy model-query path (the `runnable.run`
+ * flow used by `getQueryResults` and notebook cell execution).
+ *
+ * Two layered defenses:
+ *
+ *   1. {@link resolveModelQueryRowLimit} — compute the effective
+ *      `rowLimit` to push down to `runnable.run`. The user's Malloy
+ *      `LIMIT` clause wins when present; otherwise the operator-
+ *      tunable default ({@link getDefaultQueryRowLimit}) fills in.
+ *      Either way the result is clamped to `maxRows + 1` so the
+ *      database itself stops producing rows when a user-supplied
+ *      `LIMIT 1_000_000` would otherwise blow up the process.
+ *
+ *   2. {@link assertWithinModelResponseLimits} — post-run overflow
+ *      detection. If the connector returned `maxRows + 1` rows
+ *      (the sentinel) or the JSON-serialized response exceeds the
+ *      byte cap, throw `PayloadTooLargeError` so the caller sees a
+ *      clean HTTP 413.
+ *
+ * Caveat on the byte cap: this path runs `runnable.run` (buffered),
+ * not `runStream`, so by the time we measure bytes the result has
+ * already been materialized in memory. The byte cap here is loud-
+ * failure detection — it surfaces oversize responses with a 413
+ * instead of letting the client receive a half-transmitted payload
+ * — not OOM prevention. True prevention requires streaming +
+ * `Result` reconstruction from `DataRecord`s, which is out of scope
+ * for this step (the model-query streaming path entangles with
+ * Malloy's `Result` schema metadata in non-trivial ways).
+ *
+ * Both helpers are pure so they can be unit-tested without spinning
+ * up a model runtime; the caller injects the env-derived limits.
+ */
+
+import { PayloadTooLargeError } from "../errors";
+
+export interface ResolveRowLimitConfig {
+   /**
+    * Result of {@link getDefaultQueryRowLimit}. Applied when the
+    * user's Malloy query doesn't carry a `LIMIT` clause.
+    */
+   defaultLimit: number;
+   /**
+    * Result of {@link getMaxQueryRows}. The effective row limit is
+    * clamped to `maxRows + 1` so a sentinel-count overflow check can
+    * distinguish "ran right up to the cap" from "would have
+    * overflowed". A value of `0` disables the cap.
+    */
+   maxRows: number;
+}
+
+/**
+ * Compute the `rowLimit` to pass to `runnable.run`. The +1 sentinel
+ * mirrors the Step 1 / Step 2 patterns on the connection-query path
+ * so behavior is uniform across all query surfaces.
+ */
+export function resolveModelQueryRowLimit(
+   userLimit: number | undefined,
+   { defaultLimit, maxRows }: ResolveRowLimitConfig,
+): number {
+   const requested = userLimit && userLimit > 0 ? userLimit : defaultLimit;
+   if (maxRows <= 0) return requested;
+   return Math.min(requested, maxRows + 1);
+}
+
+export interface ModelResponseLimitsConfig {
+   /** Result of {@link getMaxQueryRows}. `0` disables the row cap. */
+   maxRows: number;
+   /** Result of {@link getMaxResponseBytes}. `0` disables the byte cap. */
+   maxBytes: number;
+}
+
+/**
+ * Throw {@link PayloadTooLargeError} (HTTP 413) when a model-query
+ * response exceeds either configured cap. `rowCount` should be the
+ * raw row count Malloy actually fetched (typically
+ * `result._queryResult.data.rawData.length`); `serializedBytes`
+ * should be the byte length of the JSON-stringified response that
+ * would otherwise be returned to the client.
+ *
+ * Row check uses the `> maxRows` sentinel (not `>= maxRows`), since
+ * {@link resolveModelQueryRowLimit} asked the connector for
+ * `maxRows + 1` and we want to fail only when that sentinel fires.
+ */
+export function assertWithinModelResponseLimits(
+   rowCount: number,
+   serializedBytes: number,
+   { maxRows, maxBytes }: ModelResponseLimitsConfig,
+): void {
+   if (maxRows > 0 && rowCount > maxRows) {
+      throw new PayloadTooLargeError(
+         `Query returned more than ${maxRows} rows. Refine the query (add a LIMIT or more selective WHERE) or raise PUBLISHER_MAX_QUERY_ROWS.`,
+      );
+   }
+   if (maxBytes > 0 && serializedBytes > maxBytes) {
+      throw new PayloadTooLargeError(
+         `Query response exceeded ${maxBytes} bytes (was ${serializedBytes}). Project fewer columns, add a LIMIT, or raise PUBLISHER_MAX_RESPONSE_BYTES.`,
+      );
+   }
+}

--- a/packages/server/src/stream_helpers.spec.ts
+++ b/packages/server/src/stream_helpers.spec.ts
@@ -1,0 +1,249 @@
+import type {
+   QueryRecord,
+   RunSQLOptions,
+   StreamingConnection,
+} from "@malloydata/malloy";
+import { describe, expect, it } from "bun:test";
+
+import { PayloadTooLargeError } from "./errors";
+import { isStreamingConnection, streamSqlWithBudget } from "./stream_helpers";
+
+/**
+ * Build a fake StreamingConnection backed by a fixed row array. The
+ * fake records the abort signal so tests can confirm
+ * `streamSqlWithBudget` actually signaled the driver to stop —
+ * client-side counting alone is not enough; the whole point of the
+ * helper is to terminate fetching early.
+ */
+function fakeStreamingConnection(opts: {
+   rows: QueryRecord[];
+   /**
+    * When true (the default), the fake honors `RunSQLOptions.rowLimit`
+    * by slicing — same as real Postgres/DuckDB. Set false to drive
+    * the helper's own overflow detection (the (cap+1)-th row check).
+    */
+   honorRowLimit?: boolean;
+   /**
+    * Test hook: set to `true` when the fake observes `signal.aborted`
+    * flip via the listener it installed at the start of streaming.
+    */
+   abortObserved?: { value: boolean };
+   /**
+    * Test hook: captures the options the helper passed to
+    * `runSQLStream`, so tests can assert it preserved caller-supplied
+    * `rowLimit` (and the abortSignal it wired in).
+    */
+   capturedOptions?: { value: RunSQLOptions | undefined };
+}): StreamingConnection {
+   const { rows, honorRowLimit = true, abortObserved, capturedOptions } = opts;
+   return {
+      canStream(): true {
+         return true;
+      },
+      async *runSQLStream(
+         _sql: string,
+         options?: RunSQLOptions,
+      ): AsyncIterableIterator<QueryRecord> {
+         if (capturedOptions) capturedOptions.value = options;
+         if (abortObserved) {
+            options?.abortSignal?.addEventListener("abort", () => {
+               abortObserved.value = true;
+            });
+         }
+         const limit =
+            honorRowLimit && typeof options?.rowLimit === "number"
+               ? options.rowLimit
+               : rows.length;
+         for (let i = 0; i < Math.min(rows.length, limit); i += 1) {
+            yield rows[i];
+         }
+      },
+   } as unknown as StreamingConnection;
+}
+
+describe("isStreamingConnection", () => {
+   it("returns true for a connection whose canStream() returns true", () => {
+      const conn = fakeStreamingConnection({ rows: [] });
+      expect(isStreamingConnection(conn)).toBe(true);
+   });
+
+   it("returns false for a connection without canStream", () => {
+      expect(isStreamingConnection({} as never)).toBe(false);
+   });
+
+   it("returns false for a connection whose canStream() returns false", () => {
+      const conn = {
+         canStream() {
+            return false;
+         },
+      } as never;
+      expect(isStreamingConnection(conn)).toBe(false);
+   });
+});
+
+describe("streamSqlWithBudget", () => {
+   it("returns all rows when both budgets are comfortably above the stream", async () => {
+      const rows: QueryRecord[] = [{ a: 1 }, { a: 2 }, { a: 3 }];
+      const conn = fakeStreamingConnection({ rows });
+      const result = await streamSqlWithBudget(
+         conn,
+         "SELECT a FROM t",
+         { rowLimit: 10 },
+         { maxRows: 10, maxBytes: 1_000_000 },
+      );
+      expect(result.rows).toEqual(rows);
+      expect(result.totalRows).toBe(3);
+   });
+
+   it("forwards caller-supplied runSQLOptions (rowLimit) to the driver", async () => {
+      const captured = { value: undefined as RunSQLOptions | undefined };
+      const conn = fakeStreamingConnection({
+         rows: [{ a: 1 }, { a: 2 }],
+         capturedOptions: captured,
+      });
+      await streamSqlWithBudget(
+         conn,
+         "SELECT 1",
+         { rowLimit: 6 },
+         { maxRows: 5, maxBytes: 0 },
+      );
+      expect(captured.value?.rowLimit).toBe(6);
+      // abortSignal must be wired in so the helper can abort the
+      // iterator on overflow.
+      expect(captured.value?.abortSignal).toBeDefined();
+   });
+
+   it("overrides any caller-supplied abortSignal with its own", async () => {
+      const captured = { value: undefined as RunSQLOptions | undefined };
+      const callerAc = new AbortController();
+      const conn = fakeStreamingConnection({
+         rows: [{ a: 1 }],
+         capturedOptions: captured,
+      });
+      await streamSqlWithBudget(
+         conn,
+         "SELECT 1",
+         { rowLimit: 10, abortSignal: callerAc.signal },
+         { maxRows: 5, maxBytes: 0 },
+      );
+      // The signal the helper installed is its own (not the caller's),
+      // since aborting the caller's signal must not terminate the
+      // helper's iteration partway through.
+      expect(captured.value?.abortSignal).not.toBe(callerAc.signal);
+   });
+
+   it("throws PayloadTooLargeError and aborts the iterator on the (cap+1)-th row", async () => {
+      const rows: QueryRecord[] = [
+         { a: 1 },
+         { a: 2 },
+         { a: 3 },
+         { a: 4 },
+         { a: 5 },
+      ];
+      const abortObserved = { value: false };
+      const conn = fakeStreamingConnection({
+         rows,
+         abortObserved,
+         honorRowLimit: false,
+      });
+      await expect(
+         streamSqlWithBudget(
+            conn,
+            "SELECT a FROM t",
+            {},
+            { maxRows: 2, maxBytes: 1_000_000 },
+         ),
+      ).rejects.toBeInstanceOf(PayloadTooLargeError);
+      await expect(
+         streamSqlWithBudget(
+            conn,
+            "SELECT a FROM t",
+            {},
+            { maxRows: 2, maxBytes: 1_000_000 },
+         ),
+      ).rejects.toThrow("more than 2 rows");
+      // The helper must have fired the abort signal so a real driver
+      // (pg-query-stream / duckdb) would stop producing rows server-
+      // side, not just be discarded client-side.
+      expect(abortObserved.value).toBe(true);
+   });
+
+   it("throws PayloadTooLargeError when summed JSON byte size exceeds the cap", async () => {
+      const big = "x".repeat(40);
+      const rows: QueryRecord[] = [{ s: big }, { s: big }, { s: big }];
+      const abortObserved = { value: false };
+      const conn = fakeStreamingConnection({
+         rows,
+         abortObserved,
+         honorRowLimit: false,
+      });
+      await expect(
+         streamSqlWithBudget(
+            conn,
+            "SELECT s FROM t",
+            {},
+            { maxRows: 100, maxBytes: 60 },
+         ),
+      ).rejects.toThrow("exceeded 60 bytes");
+      expect(abortObserved.value).toBe(true);
+   });
+
+   it("returns all rows when the byte cap is disabled (maxBytes = 0)", async () => {
+      const big = "x".repeat(10_000);
+      const rows: QueryRecord[] = Array.from({ length: 3 }, () => ({ s: big }));
+      const conn = fakeStreamingConnection({ rows, honorRowLimit: false });
+      const result = await streamSqlWithBudget(
+         conn,
+         "SELECT s FROM t",
+         {},
+         { maxRows: 100, maxBytes: 0 },
+      );
+      expect(result.rows.length).toBe(3);
+   });
+
+   it("returns all rows when the row cap is disabled (maxRows = 0)", async () => {
+      const rows: QueryRecord[] = Array.from({ length: 50 }, (_, i) => ({
+         a: i,
+      }));
+      const conn = fakeStreamingConnection({ rows, honorRowLimit: false });
+      const result = await streamSqlWithBudget(
+         conn,
+         "SELECT a FROM t",
+         {},
+         { maxRows: 0, maxBytes: 1_000_000 },
+      );
+      expect(result.rows.length).toBe(50);
+   });
+
+   it("returns rows when count equals the cap exactly (not an overflow)", async () => {
+      const rows: QueryRecord[] = [{ a: 1 }, { a: 2 }, { a: 3 }];
+      const conn = fakeStreamingConnection({ rows, honorRowLimit: false });
+      const result = await streamSqlWithBudget(
+         conn,
+         "SELECT a FROM t",
+         {},
+         { maxRows: 3, maxBytes: 1_000_000 },
+      );
+      expect(result.rows.length).toBe(3);
+   });
+
+   it("re-throws non-overflow errors from the driver", async () => {
+      const conn = {
+         canStream(): true {
+            return true;
+         },
+         // eslint-disable-next-line require-yield
+         async *runSQLStream(): AsyncIterableIterator<QueryRecord> {
+            throw new Error("connection reset");
+         },
+      } as unknown as StreamingConnection;
+      await expect(
+         streamSqlWithBudget(
+            conn,
+            "SELECT 1",
+            {},
+            { maxRows: 10, maxBytes: 1_000 },
+         ),
+      ).rejects.toThrow("connection reset");
+   });
+});

--- a/packages/server/src/stream_helpers.ts
+++ b/packages/server/src/stream_helpers.ts
@@ -1,0 +1,134 @@
+/**
+ * Helpers for streaming the ad-hoc connection SQL endpoints
+ * (`/environments/.../connections/.../sqlQuery` and the deprecated
+ * `queryData` GET twin) so the publisher process never has to hold
+ * a whole result set in memory before returning it.
+ *
+ * The Step 1 row cap (`PUBLISHER_MAX_QUERY_ROWS`) is necessary but
+ * not sufficient: row count is a poor proxy for memory pressure
+ * because a single 10 MB JSON column blows past the 100k-row cap's
+ * safe envelope. The byte cap (`PUBLISHER_MAX_RESPONSE_BYTES`) is
+ * the actual memory bound, and bytes can only be enforced by
+ * iterating row-at-a-time on `runSQLStream` — `runSQL` returns a
+ * fully-buffered result, so by the time we'd count bytes the
+ * connector has already done the damage.
+ *
+ * On streaming-capable connections (Postgres, DuckDB, ...) the
+ * controller routes here. On other connections it stays on the
+ * Step 1 path; client-side byte counting after the fact would be
+ * security theatre.
+ */
+
+import type {
+   Connection,
+   MalloyQueryData,
+   QueryRecord,
+   RunSQLOptions,
+   StreamingConnection,
+} from "@malloydata/malloy";
+
+import { PayloadTooLargeError } from "./errors";
+
+/**
+ * Runtime check + type narrow for streaming-capable connections.
+ * `Connection.canStream` is declared as `this is StreamingConnection`
+ * by the Malloy SDK, so a positive result is enough to safely call
+ * `runSQLStream`.
+ */
+export function isStreamingConnection(
+   connection: Connection,
+): connection is StreamingConnection {
+   return (
+      typeof (connection as { canStream?: () => boolean }).canStream ===
+         "function" && (connection as StreamingConnection).canStream()
+   );
+}
+
+export interface StreamBudget {
+   /**
+    * Maximum number of rows to return. A value of `0` disables the
+    * row cap (the caller-supplied `rowLimit` in `runSQLOptions` may
+    * still bound the stream, but the helper will not raise on
+    * overflow).
+    */
+   maxRows: number;
+   /**
+    * Maximum aggregate JSON-serialized byte size of returned rows.
+    * `0` disables the byte cap. Measured as the sum of
+    * `Buffer.byteLength(JSON.stringify(row))` for each yielded row
+    * — the same bytes the eventual response will contain inside
+    * `result.rows`.
+    */
+   maxBytes: number;
+}
+
+/**
+ * Drain `runSQLStream` into a `MalloyQueryData`-shaped buffer,
+ * enforcing both a row cap and a byte cap. Aborts the underlying
+ * iterator via an internal `AbortController` the moment either cap
+ * is breached so the driver stops producing rows immediately
+ * (Postgres' `pg-query-stream` and DuckDB's streaming iterator both
+ * honor `abortSignal`).
+ *
+ * The row cap is detected by the `cap + 1` sentinel pattern: the
+ * controller has already clamped `runSQLOptions.rowLimit` to
+ * `min(callerLimit, cap + 1)`, so receiving `cap + 1` rows
+ * unambiguously means the request would have overflowed. This
+ * matches the non-streaming path's overflow detection so behavior
+ * is identical regardless of which connector served the request.
+ *
+ * On overflow the helper throws `PayloadTooLargeError` directly —
+ * the message includes the relevant env-var name so the operator
+ * sees a self-contained tuning hint without having to cross-
+ * reference the controller.
+ */
+export async function streamSqlWithBudget(
+   connection: StreamingConnection,
+   sql: string,
+   runSQLOptions: RunSQLOptions,
+   budget: StreamBudget,
+): Promise<MalloyQueryData> {
+   const { maxRows, maxBytes } = budget;
+   const ac = new AbortController();
+   const rows: QueryRecord[] = [];
+   let byteTotal = 0;
+   let overflowMessage: string | undefined;
+
+   try {
+      for await (const row of connection.runSQLStream(sql, {
+         ...runSQLOptions,
+         abortSignal: ac.signal,
+      })) {
+         rows.push(row);
+         if (maxBytes > 0) {
+            // Measure exactly what the eventual response body will
+            // contain for this row. O(rowSize) per row, duplicated
+            // against the final `JSON.stringify(result)` — the
+            // early-abort win on overflow dwarfs the bookkeeping
+            // cost in the bounded-success case.
+            byteTotal += Buffer.byteLength(JSON.stringify(row), "utf8");
+            if (byteTotal > maxBytes) {
+               overflowMessage = `Query response exceeded ${maxBytes} bytes (had at least ${byteTotal}). Refine the query (project fewer columns, add a LIMIT, or filter wide values) or raise PUBLISHER_MAX_RESPONSE_BYTES.`;
+               ac.abort();
+               break;
+            }
+         }
+         if (maxRows > 0 && rows.length > maxRows) {
+            overflowMessage = `Query returned more than ${maxRows} rows. Refine the query (add a LIMIT or more selective WHERE) or raise PUBLISHER_MAX_QUERY_ROWS.`;
+            ac.abort();
+            break;
+         }
+      }
+   } catch (err) {
+      // `pg-query-stream` surfaces `query.destroy()` (which our
+      // abort handler triggers) as a synthetic error in some
+      // versions. Swallow it iff we triggered the abort ourselves —
+      // otherwise it's a real connection error that the controller
+      // must see.
+      if (!overflowMessage) throw err;
+   }
+
+   if (overflowMessage) throw new PayloadTooLargeError(overflowMessage);
+
+   return { rows, totalRows: rows.length };
+}


### PR DESCRIPTION
## Summary

Combined PR for Step 2 + Step 3 of the OOM-mitigation plan. (PR #780 was accidentally merged into this branch instead of into `main`; this PR now carries both Step 2's streaming budget and Step 3's model-query caps, rebased cleanly onto current `main`.)

- **Step 2 — Ad-hoc SQL streaming with row + byte budget**: routes streaming-capable connections through `runSQLStream` so the byte cap (`PUBLISHER_MAX_RESPONSE_BYTES`, default 50 MB) can fire mid-stream and the driver can abort early. Non-streaming connections keep the buffered path.
- **Step 3 — Model-query row + byte caps**: applies the same row + byte caps to the Malloy model-query path (`Model.getQueryResults`), with a configurable default row limit.

## Motivation

Step 1's row cap (#778) is necessary but not sufficient. Row count is a poor proxy for memory pressure: a single 10 MB JSON column blows past the 100k-row cap's safe envelope. The byte cap is the actual memory bound — but bytes can only be enforced by iterating row-at-a-time on `runSQLStream`, because `runSQL` returns a fully-buffered result.

Step 3 closes the analogous gap on the Malloy model-query path: previously a model query could materialize unbounded result sets even if the same connection's ad-hoc SQL was now capped.

## Design

### Step 2: streaming ad-hoc SQL (`ConnectionController.getConnectionQueryData`)

Now branches on `isStreamingConnection`:

- **Streaming-capable connections (Postgres, DuckDB, ...)** route through a new `streamSqlWithBudget` helper that drains `runSQLStream` with both the row cap (same `cap + 1` sentinel pattern as the buffered path) and the byte cap. On overflow it fires an `AbortController` to stop the driver server-side and throws `PayloadTooLargeError` — HTTP 413.
- **Non-streaming connections** keep the existing buffered path. Client-side byte counting after `runSQL` would be security theatre — the connector has already buffered the whole result by the time we see it.

The helper deliberately:
- Replaces any caller-supplied `abortSignal` with its own so it can drive overflow termination.
- Preserves a caller-supplied `rowLimit` when it's below the `cap + 1` ceiling.
- Counts bytes as `Buffer.byteLength(JSON.stringify(row))` per yielded row, matching what the response body will contain inside `result.rows`.

### Step 3: model-query caps (`Model.getQueryResults`)

- New `assertWithinModelResponseLimits` helper in `model_limits.ts` applies both row and byte caps to the materialized Malloy result, throwing `PayloadTooLargeError` (HTTP 413) on overflow.
- The default row limit for model queries is now configurable via `PUBLISHER_MAX_MODEL_ROWS` (defaulting to the same cap as ad-hoc SQL) so operators can tune them independently if needed.
- Row check runs before byte check so the more selective \"refine your query\" error wins when both fire.

## Configuration

- `PUBLISHER_MAX_RESPONSE_BYTES` env var, defaults to **50 MB**. `0` opts out of the byte cap (row cap still applies).
- `PUBLISHER_MAX_MODEL_ROWS` env var, defaults to `PUBLISHER_MAX_QUERY_ROWS`.
- Loud-failure semantics match `PUBLISHER_MAX_QUERY_ROWS`: throws at startup on malformed input so a typo in a k8s manifest surfaces immediately.

## What's NOT in this PR

- No OpenAPI changes — `413 PayloadTooLarge` is already declared on these endpoints from Step 1.
- No changes to admission control, query timeouts, or per-pod concurrency — those land in the next PR (Steps 4–6).

## Test plan

- [x] Unit tests in `stream_helpers.spec.ts` cover both budgets, `cap + 1` sentinel detection, abort propagation to the driver, byte/row cap disable, exact-cap success, abortSignal replacement, and non-overflow error pass-through.
- [x] Streaming-branch tests in `connection.controller.spec.ts` cover verbatim SQL pass-through, caller-rowLimit preservation, row & byte 413s, both caps disabled, and abortSignal replacement.
- [x] `model_limits.spec.ts` covers row-only / byte-only / both / disable cases on the Malloy model-query path.
- [x] Env-var parser tests in `config.spec.ts` cover defaults, overrides, opt-out (`0`), and loud-failure on bad input.
- [x] All 140 tests across the five focused specs pass (config + stream_helpers + model_limits + model + connection.controller).
- [x] `bunx tsc --noEmit` clean.
- [x] `bunx eslint` clean.
- [x] Rebased onto current `main` (which contains #778); branch fast-forwards into `main`.

## Note on the rebase

PR #780 (the model-query cap work) was merged into this PR's branch instead of into `main`. I rebased this branch onto `main` to drop the now-duplicate Step 1 commits (already on main as #778) and preserve #780's content as the second commit here. No work is lost. #780 is effectively superseded by this PR.