### PR TITLE
feat(server): cap row + byte size on the model-query path

### DIFF
--- a/packages/server/src/config.spec.ts
+++ b/packages/server/src/config.spec.ts
@@ -1266,3 +1266,55 @@ describe("getMaxResponseBytes", () => {
       expect(() => getMaxResponseBytes()).toThrow();
    });
 });
+
+describe("getDefaultQueryRowLimit", () => {
+   beforeEach(() => {
+      delete process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT;
+   });
+   afterEach(() => {
+      delete process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT;
+   });
+
+   it("returns DEFAULT_QUERY_ROW_LIMIT when the env var is unset", async () => {
+      const { getDefaultQueryRowLimit } = await import("./config");
+      const { DEFAULT_QUERY_ROW_LIMIT } = await import("./constants");
+      expect(getDefaultQueryRowLimit()).toBe(DEFAULT_QUERY_ROW_LIMIT);
+   });
+
+   it("returns DEFAULT_QUERY_ROW_LIMIT when the env var is empty", async () => {
+      process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT = "";
+      const { getDefaultQueryRowLimit } = await import("./config");
+      const { DEFAULT_QUERY_ROW_LIMIT } = await import("./constants");
+      expect(getDefaultQueryRowLimit()).toBe(DEFAULT_QUERY_ROW_LIMIT);
+   });
+
+   it("returns the override when the env var is set", async () => {
+      process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT = "250";
+      const { getDefaultQueryRowLimit } = await import("./config");
+      expect(getDefaultQueryRowLimit()).toBe(250);
+   });
+
+   it("rejects 0 (a default of 'zero rows' is always a misconfiguration)", async () => {
+      process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT = "0";
+      const { getDefaultQueryRowLimit } = await import("./config");
+      expect(() => getDefaultQueryRowLimit()).toThrow();
+   });
+
+   it("rejects a negative override", async () => {
+      process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT = "-1";
+      const { getDefaultQueryRowLimit } = await import("./config");
+      expect(() => getDefaultQueryRowLimit()).toThrow();
+   });
+
+   it("rejects a non-integer override", async () => {
+      process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT = "1.5";
+      const { getDefaultQueryRowLimit } = await import("./config");
+      expect(() => getDefaultQueryRowLimit()).toThrow();
+   });
+
+   it("rejects a non-numeric override", async () => {
+      process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT = "lots";
+      const { getDefaultQueryRowLimit } = await import("./config");
+      expect(() => getDefaultQueryRowLimit()).toThrow();
+   });
+});

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -6,6 +6,7 @@ import {
    API_PREFIX,
    DEFAULT_MAX_QUERY_ROWS,
    DEFAULT_MAX_RESPONSE_BYTES,
+   DEFAULT_QUERY_ROW_LIMIT,
    PUBLISHER_CONFIG_NAME,
 } from "./constants";
 import { logger } from "./logger";
@@ -272,6 +273,30 @@ export const getMaxResponseBytes = (): number => {
    if (raw < 0) {
       throw new Error(
          `PUBLISHER_MAX_RESPONSE_BYTES must be a non-negative integer (got ${raw})`,
+      );
+   }
+   return raw;
+};
+
+/**
+ * Resolve the default row limit applied to Malloy model queries
+ * (the `runnable.run` path used by `getQueryResults` and notebook
+ * cell execution) when the user's query doesn't carry its own
+ * `LIMIT`. Reads `PUBLISHER_DEFAULT_QUERY_ROW_LIMIT`; falls back to
+ * {@link DEFAULT_QUERY_ROW_LIMIT} when unset or empty.
+ *
+ * Unlike {@link getMaxQueryRows}, `0` is rejected — a default of
+ * "return zero rows" is almost certainly a misconfiguration (it
+ * would silently break every notebook), and the operator probably
+ * wanted `PUBLISHER_MAX_QUERY_ROWS=0` to opt out of the *hard cap*
+ * instead. Loud failure surfaces the typo at startup.
+ */
+export const getDefaultQueryRowLimit = (): number => {
+   const raw = parseIntEnv("PUBLISHER_DEFAULT_QUERY_ROW_LIMIT");
+   if (raw === undefined) return DEFAULT_QUERY_ROW_LIMIT;
+   if (raw <= 0) {
+      throw new Error(
+         `PUBLISHER_DEFAULT_QUERY_ROW_LIMIT must be a positive integer (got ${raw})`,
       );
    }
    return raw;

--- a/packages/server/src/constants.ts
+++ b/packages/server/src/constants.ts
@@ -5,7 +5,24 @@ export const PUBLISHER_CONFIG_NAME = "publisher.config.json";
 export const PACKAGE_MANIFEST_NAME = "publisher.json";
 export const MODEL_FILE_SUFFIX = ".malloy";
 export const NOTEBOOK_FILE_SUFFIX = ".malloynb";
-export const ROW_LIMIT = 1000;
+/**
+ * Default row cap applied to Malloy model queries (the `runnable.run`
+ * path used by `getQueryResults` and notebook cell execution) when
+ * the user's query doesn't carry its own `LIMIT`. Override at startup
+ * via `PUBLISHER_DEFAULT_QUERY_ROW_LIMIT`.
+ *
+ * This is *the default*, not a hard ceiling. A Malloy query that
+ * carries `LIMIT 50000` overrides this. The hard ceiling is
+ * {@link DEFAULT_MAX_QUERY_ROWS} (env-tuned via
+ * `PUBLISHER_MAX_QUERY_ROWS`), which the model-query path now also
+ * enforces — preventing a user `LIMIT 10000000` from blowing up the
+ * process.
+ *
+ * Tuned conservatively (1000) because notebook UIs typically render
+ * tabular previews; operators who need larger ad-hoc exports can
+ * raise it.
+ */
+export const DEFAULT_QUERY_ROW_LIMIT = 1000;
 /**
  * Maximum number of rows the ad-hoc connection SQL endpoints
  * (`/environments/.../connections/.../sqlQuery` and the deprecated

--- a/packages/server/src/service/model.spec.ts
+++ b/packages/server/src/service/model.spec.ts
@@ -1,9 +1,13 @@
-import { MalloyError, Runtime } from "@malloydata/malloy";
-import { describe, expect, it } from "bun:test";
+import { API, MalloyError, Runtime } from "@malloydata/malloy";
+import { afterEach, describe, expect, it } from "bun:test";
 import fs from "fs/promises";
 import sinon from "sinon";
 
-import { BadRequestError, ModelNotFoundError } from "../errors";
+import {
+   BadRequestError,
+   ModelNotFoundError,
+   PayloadTooLargeError,
+} from "../errors";
 import { Model, ModelType } from "./model";
 
 describe("service/model", () => {
@@ -286,6 +290,192 @@ describe("service/model", () => {
             });
 
             sinon.restore();
+         });
+
+         /**
+          * The row/byte caps live in `model_limits.ts` (unit-tested in
+          * `model_limits.spec.ts`); these tests just confirm the wiring —
+          * that `Model.getQueryResults` calls the helpers with the right
+          * values and that an overflow propagates as `PayloadTooLargeError`
+          * (HTTP 413), not the generic `BadRequestError` (HTTP 400).
+          */
+         describe("response caps", () => {
+            const originalRowsEnv = process.env.PUBLISHER_MAX_QUERY_ROWS;
+            const originalBytesEnv = process.env.PUBLISHER_MAX_RESPONSE_BYTES;
+            const originalDefaultEnv =
+               process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT;
+
+            afterEach(() => {
+               sinon.restore();
+               for (const [name, original] of [
+                  ["PUBLISHER_MAX_QUERY_ROWS", originalRowsEnv],
+                  ["PUBLISHER_MAX_RESPONSE_BYTES", originalBytesEnv],
+                  ["PUBLISHER_DEFAULT_QUERY_ROW_LIMIT", originalDefaultEnv],
+               ] as const) {
+                  if (original === undefined) {
+                     delete process.env[name];
+                  } else {
+                     process.env[name] = original;
+                  }
+               }
+            });
+
+            /**
+             * Build a Model whose `runnable.run` resolves to a fake Result
+             * with the given totalRows; stub `API.util.wrapResult` so we
+             * don't need to construct a real Malloy schema/queryResult.
+             */
+            function buildModelWithFakeRun(opts: {
+               userLimit?: number;
+               totalRows: number;
+               wrappedJson: object;
+            }): { model: Model; runStub: sinon.SinonStub } {
+               const preparedResultStub = sinon
+                  .stub()
+                  .resolves({ resultExplore: { limit: opts.userLimit ?? 0 } });
+               const fakeResult = {
+                  _queryResult: { data: { rawData: [] } },
+                  totalRows: opts.totalRows,
+                  data: { value: [] },
+                  connectionName: "fake",
+               };
+               const runStub = sinon.stub().resolves(fakeResult);
+               sinon
+                  .stub(API.util, "wrapResult")
+                  .returns(
+                     opts.wrappedJson as unknown as ReturnType<
+                        typeof API.util.wrapResult
+                     >,
+                  );
+               const modelMaterializer = {
+                  loadQuery: sinon.stub().returns({
+                     getPreparedResult: preparedResultStub,
+                     run: runStub,
+                  }),
+               };
+               const model = new Model(
+                  packageName,
+                  mockModelPath,
+                  {},
+                  "model",
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  modelMaterializer as any,
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  { contents: {}, exports: [], queryList: [] } as any,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+               );
+               return { model, runStub };
+            }
+
+            it("clamps user LIMIT to maxRows + 1 when the user requested more than the cap", async () => {
+               process.env.PUBLISHER_MAX_QUERY_ROWS = "100";
+               const { model, runStub } = buildModelWithFakeRun({
+                  userLimit: 1_000_000,
+                  totalRows: 10,
+                  wrappedJson: { rows: [] },
+               });
+
+               await model.getQueryResults(
+                  undefined,
+                  undefined,
+                  "run: orders -> summary",
+               );
+
+               expect(runStub.firstCall.args[0].rowLimit).toBe(101);
+            });
+
+            it("passes user LIMIT through when below maxRows", async () => {
+               process.env.PUBLISHER_MAX_QUERY_ROWS = "100";
+               const { model, runStub } = buildModelWithFakeRun({
+                  userLimit: 50,
+                  totalRows: 10,
+                  wrappedJson: { rows: [] },
+               });
+
+               await model.getQueryResults(
+                  undefined,
+                  undefined,
+                  "run: orders -> summary",
+               );
+
+               expect(runStub.firstCall.args[0].rowLimit).toBe(50);
+            });
+
+            it("falls back to PUBLISHER_DEFAULT_QUERY_ROW_LIMIT when the user query has no LIMIT", async () => {
+               process.env.PUBLISHER_DEFAULT_QUERY_ROW_LIMIT = "42";
+               delete process.env.PUBLISHER_MAX_QUERY_ROWS;
+               const { model, runStub } = buildModelWithFakeRun({
+                  userLimit: 0,
+                  totalRows: 10,
+                  wrappedJson: { rows: [] },
+               });
+
+               await model.getQueryResults(
+                  undefined,
+                  undefined,
+                  "run: orders -> summary",
+               );
+
+               expect(runStub.firstCall.args[0].rowLimit).toBe(42);
+            });
+
+            it("throws PayloadTooLargeError (not BadRequestError) when totalRows exceeds the cap", async () => {
+               process.env.PUBLISHER_MAX_QUERY_ROWS = "100";
+               const { model } = buildModelWithFakeRun({
+                  userLimit: 1000,
+                  totalRows: 101,
+                  wrappedJson: { rows: [] },
+               });
+
+               await expect(
+                  model.getQueryResults(
+                     undefined,
+                     undefined,
+                     "run: orders -> summary",
+                  ),
+               ).rejects.toBeInstanceOf(PayloadTooLargeError);
+            });
+
+            it("throws PayloadTooLargeError when the wrapped response exceeds the byte cap", async () => {
+               process.env.PUBLISHER_MAX_QUERY_ROWS = "1000";
+               process.env.PUBLISHER_MAX_RESPONSE_BYTES = "100";
+               const huge = "x".repeat(500);
+               const { model } = buildModelWithFakeRun({
+                  userLimit: 10,
+                  totalRows: 10,
+                  wrappedJson: { rows: [{ s: huge }] },
+               });
+
+               await expect(
+                  model.getQueryResults(
+                     undefined,
+                     undefined,
+                     "run: orders -> summary",
+                  ),
+               ).rejects.toBeInstanceOf(PayloadTooLargeError);
+            });
+
+            it("does not throw when both counts are within their caps", async () => {
+               process.env.PUBLISHER_MAX_QUERY_ROWS = "1000";
+               process.env.PUBLISHER_MAX_RESPONSE_BYTES = "10000";
+               const { model } = buildModelWithFakeRun({
+                  userLimit: 10,
+                  totalRows: 10,
+                  wrappedJson: { rows: [{ a: 1 }] },
+               });
+
+               await expect(
+                  model.getQueryResults(
+                     undefined,
+                     undefined,
+                     "run: orders -> summary",
+                  ),
+               ).resolves.toBeDefined();
+            });
          });
       });
 

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -35,15 +35,17 @@ import type {
    SerializedNotebookCell,
 } from "../package_load/protocol";
 import {
-   MODEL_FILE_SUFFIX,
-   NOTEBOOK_FILE_SUFFIX,
-   ROW_LIMIT,
-} from "../constants";
+   getDefaultQueryRowLimit,
+   getMaxQueryRows,
+   getMaxResponseBytes,
+} from "../config";
+import { MODEL_FILE_SUFFIX, NOTEBOOK_FILE_SUFFIX } from "../constants";
 import { HackyDataStylesAccumulator } from "../data_styles";
 import {
    BadRequestError,
    ModelCompilationError,
    ModelNotFoundError,
+   PayloadTooLargeError,
 } from "../errors";
 import { logger } from "../logger";
 import { BuildManifest } from "../storage/DatabaseInterface";
@@ -57,6 +59,10 @@ import {
    type FilterParams,
 } from "./filter";
 import { malloyGivenToApi, type MalloyGiven } from "./given";
+import {
+   assertWithinModelResponseLimits,
+   resolveModelQueryRowLimit,
+} from "./model_limits";
 
 type ApiCompiledModel = components["schemas"]["CompiledModel"];
 type ApiNotebookCell = components["schemas"]["NotebookCell"];
@@ -597,9 +603,12 @@ export class Model {
          throw new BadRequestError(`Invalid query: ${errorMessage}`);
       }
 
-      const rowLimit =
-         (await runnable.getPreparedResult({ givens })).resultExplore.limit ||
-         ROW_LIMIT;
+      const maxRows = getMaxQueryRows();
+      const maxBytes = getMaxResponseBytes();
+      const rowLimit = resolveModelQueryRowLimit(
+         (await runnable.getPreparedResult({ givens })).resultExplore.limit,
+         { defaultLimit: getDefaultQueryRowLimit(), maxRows },
+      );
       const endTime = performance.now();
       const executionTime = endTime - startTime;
 
@@ -638,6 +647,22 @@ export class Model {
          throw new BadRequestError(`Query execution failed: ${errorMessage}`);
       }
 
+      const wrappedResult = API.util.wrapResult(queryResults);
+      // Best-effort byte check: we've already buffered `queryResults` and
+      // built `wrappedResult` by the time we get here, so this surfaces
+      // oversize responses with a clean HTTP 413 instead of letting the
+      // controller transmit a half-megabyte payload — it is not OOM
+      // prevention. True prevention requires streaming `Result`
+      // construction, which is out of scope for this step. The row cap
+      // above is the primary OOM defense.
+      const serializedBytes =
+         maxBytes > 0
+            ? Buffer.byteLength(JSON.stringify(wrappedResult), "utf8")
+            : 0;
+      assertWithinModelResponseLimits(queryResults.totalRows, serializedBytes, {
+         maxRows,
+         maxBytes,
+      });
       this.queryExecutionHistogram.record(executionTime, {
          "malloy.model.path": this.modelPath,
          "malloy.model.query.name": queryName,
@@ -649,7 +674,7 @@ export class Model {
          "malloy.model.query.status": "success",
       });
       return {
-         result: API.util.wrapResult(queryResults),
+         result: wrappedResult,
          compactResult: queryResults.data.value,
          modelInfo: this.modelInfo,
          dataStyles: this.dataStyles,
@@ -792,9 +817,16 @@ export class Model {
                }
             }
 
-            const rowLimit =
+            const cellMaxRows = getMaxQueryRows();
+            const cellMaxBytes = getMaxResponseBytes();
+            const rowLimit = resolveModelQueryRowLimit(
                (await runnableToExecute.getPreparedResult({ givens }))
-                  .resultExplore.limit || ROW_LIMIT;
+                  .resultExplore.limit,
+               {
+                  defaultLimit: getDefaultQueryRowLimit(),
+                  maxRows: cellMaxRows,
+               },
+            );
             const result = await runnableToExecute.run({ rowLimit, givens });
             const query = (await runnableToExecute.getPreparedQuery())._query;
             queryName = (query as NamedQueryDef).as || query.name;
@@ -802,11 +834,29 @@ export class Model {
                result?._queryResult &&
                this.modelInfo &&
                JSON.stringify(API.util.wrapResult(result));
+            // Same caveat as `getQueryResults`: by the time we measure
+            // bytes the response has already been buffered and stringified,
+            // so this is loud-failure detection (clean 413 instead of
+            // partial transmission), not OOM prevention. The row cap above
+            // is the primary defense.
+            if (result?._queryResult && queryResult) {
+               assertWithinModelResponseLimits(
+                  result.totalRows,
+                  Buffer.byteLength(queryResult, "utf8"),
+                  { maxRows: cellMaxRows, maxBytes: cellMaxBytes },
+               );
+            }
          } catch (error) {
             if (error instanceof FilterValidationError) {
                throw new BadRequestError(error.message);
             }
             if (error instanceof MalloyError) {
+               throw error;
+            }
+            // Surface PayloadTooLargeError as-is so the error middleware
+            // maps it to HTTP 413; without this it would get swallowed
+            // into a generic 400 BadRequestError below.
+            if (error instanceof PayloadTooLargeError) {
                throw error;
             }
             const errorMessage =

--- a/packages/server/src/service/model_limits.spec.ts
+++ b/packages/server/src/service/model_limits.spec.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "bun:test";
+
+import { PayloadTooLargeError } from "../errors";
+import {
+   assertWithinModelResponseLimits,
+   resolveModelQueryRowLimit,
+} from "./model_limits";
+
+describe("resolveModelQueryRowLimit", () => {
+   it("uses the user's LIMIT when set and below the maxRows ceiling", () => {
+      expect(
+         resolveModelQueryRowLimit(500, {
+            defaultLimit: 1000,
+            maxRows: 100_000,
+         }),
+      ).toBe(500);
+   });
+
+   it("falls back to defaultLimit when the user's LIMIT is undefined", () => {
+      expect(
+         resolveModelQueryRowLimit(undefined, {
+            defaultLimit: 1000,
+            maxRows: 100_000,
+         }),
+      ).toBe(1000);
+   });
+
+   it("falls back to defaultLimit when the user's LIMIT is 0 (Malloy returns 0 for 'no limit')", () => {
+      // Malloy's PreparedResult returns 0 from `resultExplore.limit` when the
+      // query has no LIMIT clause; treat that as "no user limit".
+      expect(
+         resolveModelQueryRowLimit(0, {
+            defaultLimit: 1000,
+            maxRows: 100_000,
+         }),
+      ).toBe(1000);
+   });
+
+   it("clamps a too-high user LIMIT to the maxRows + 1 sentinel", () => {
+      expect(
+         resolveModelQueryRowLimit(1_000_000, {
+            defaultLimit: 1000,
+            maxRows: 100_000,
+         }),
+      ).toBe(100_001);
+   });
+
+   it("clamps a too-high defaultLimit to the maxRows + 1 sentinel", () => {
+      // Operator misconfigured DEFAULT > MAX; the hard cap still wins.
+      expect(
+         resolveModelQueryRowLimit(undefined, {
+            defaultLimit: 1_000_000,
+            maxRows: 50,
+         }),
+      ).toBe(51);
+   });
+
+   it("returns the requested limit unchanged when maxRows is 0 (cap disabled)", () => {
+      expect(
+         resolveModelQueryRowLimit(1_000_000, {
+            defaultLimit: 1000,
+            maxRows: 0,
+         }),
+      ).toBe(1_000_000);
+   });
+
+   it("returns the default unchanged when maxRows is 0 and no user limit", () => {
+      expect(
+         resolveModelQueryRowLimit(undefined, {
+            defaultLimit: 1000,
+            maxRows: 0,
+         }),
+      ).toBe(1000);
+   });
+
+   it("rejects negative user limits by treating them as 'no limit'", () => {
+      // Defensive — shouldn't happen in practice, but a -1 from a malformed
+      // PreparedResult shouldn't propagate as a negative rowLimit to the driver.
+      expect(
+         resolveModelQueryRowLimit(-1, {
+            defaultLimit: 1000,
+            maxRows: 100_000,
+         }),
+      ).toBe(1000);
+   });
+});
+
+describe("assertWithinModelResponseLimits", () => {
+   it("does not throw when both counts are below their caps", () => {
+      expect(() =>
+         assertWithinModelResponseLimits(500, 1_000, {
+            maxRows: 1000,
+            maxBytes: 10_000,
+         }),
+      ).not.toThrow();
+   });
+
+   it("does not throw when row count equals the cap exactly (sentinel hasn't fired)", () => {
+      expect(() =>
+         assertWithinModelResponseLimits(1000, 1_000, {
+            maxRows: 1000,
+            maxBytes: 10_000,
+         }),
+      ).not.toThrow();
+   });
+
+   it("throws PayloadTooLargeError with the row-cap message on row overflow", () => {
+      expect(() =>
+         assertWithinModelResponseLimits(1001, 1_000, {
+            maxRows: 1000,
+            maxBytes: 10_000,
+         }),
+      ).toThrow(PayloadTooLargeError);
+      expect(() =>
+         assertWithinModelResponseLimits(1001, 1_000, {
+            maxRows: 1000,
+            maxBytes: 10_000,
+         }),
+      ).toThrow("more than 1000 rows");
+   });
+
+   it("throws PayloadTooLargeError with the byte-cap message on byte overflow", () => {
+      expect(() =>
+         assertWithinModelResponseLimits(10, 50_000, {
+            maxRows: 1000,
+            maxBytes: 10_000,
+         }),
+      ).toThrow(PayloadTooLargeError);
+      expect(() =>
+         assertWithinModelResponseLimits(10, 50_000, {
+            maxRows: 1000,
+            maxBytes: 10_000,
+         }),
+      ).toThrow("exceeded 10000 bytes");
+   });
+
+   it("prefers the row-cap message when both caps would have fired (row check runs first)", () => {
+      expect(() =>
+         assertWithinModelResponseLimits(2000, 50_000, {
+            maxRows: 1000,
+            maxBytes: 10_000,
+         }),
+      ).toThrow("more than 1000 rows");
+   });
+
+   it("disables row cap when maxRows is 0", () => {
+      expect(() =>
+         assertWithinModelResponseLimits(1_000_000, 1_000, {
+            maxRows: 0,
+            maxBytes: 10_000,
+         }),
+      ).not.toThrow();
+   });
+
+   it("disables byte cap when maxBytes is 0", () => {
+      expect(() =>
+         assertWithinModelResponseLimits(10, 1_000_000_000, {
+            maxRows: 1000,
+            maxBytes: 0,
+         }),
+      ).not.toThrow();
+   });
+});

--- a/packages/server/src/service/model_limits.ts
+++ b/packages/server/src/service/model_limits.ts
@@ -1,0 +1,100 @@
+/**
+ * Memory guards for the Malloy model-query path (the `runnable.run`
+ * flow used by `getQueryResults` and notebook cell execution).
+ *
+ * Two layered defenses:
+ *
+ *   1. {@link resolveModelQueryRowLimit} — compute the effective
+ *      `rowLimit` to push down to `runnable.run`. The user's Malloy
+ *      `LIMIT` clause wins when present; otherwise the operator-
+ *      tunable default ({@link getDefaultQueryRowLimit}) fills in.
+ *      Either way the result is clamped to `maxRows + 1` so the
+ *      database itself stops producing rows when a user-supplied
+ *      `LIMIT 1_000_000` would otherwise blow up the process.
+ *
+ *   2. {@link assertWithinModelResponseLimits} — post-run overflow
+ *      detection. If the connector returned `maxRows + 1` rows
+ *      (the sentinel) or the JSON-serialized response exceeds the
+ *      byte cap, throw `PayloadTooLargeError` so the caller sees a
+ *      clean HTTP 413.
+ *
+ * Caveat on the byte cap: this path runs `runnable.run` (buffered),
+ * not `runStream`, so by the time we measure bytes the result has
+ * already been materialized in memory. The byte cap here is loud-
+ * failure detection — it surfaces oversize responses with a 413
+ * instead of letting the client receive a half-transmitted payload
+ * — not OOM prevention. True prevention requires streaming +
+ * `Result` reconstruction from `DataRecord`s, which is out of scope
+ * for this step (the model-query streaming path entangles with
+ * Malloy's `Result` schema metadata in non-trivial ways).
+ *
+ * Both helpers are pure so they can be unit-tested without spinning
+ * up a model runtime; the caller injects the env-derived limits.
+ */
+
+import { PayloadTooLargeError } from "../errors";
+
+export interface ResolveRowLimitConfig {
+   /**
+    * Result of {@link getDefaultQueryRowLimit}. Applied when the
+    * user's Malloy query doesn't carry a `LIMIT` clause.
+    */
+   defaultLimit: number;
+   /**
+    * Result of {@link getMaxQueryRows}. The effective row limit is
+    * clamped to `maxRows + 1` so a sentinel-count overflow check can
+    * distinguish "ran right up to the cap" from "would have
+    * overflowed". A value of `0` disables the cap.
+    */
+   maxRows: number;
+}
+
+/**
+ * Compute the `rowLimit` to pass to `runnable.run`. The +1 sentinel
+ * mirrors the Step 1 / Step 2 patterns on the connection-query path
+ * so behavior is uniform across all query surfaces.
+ */
+export function resolveModelQueryRowLimit(
+   userLimit: number | undefined,
+   { defaultLimit, maxRows }: ResolveRowLimitConfig,
+): number {
+   const requested = userLimit && userLimit > 0 ? userLimit : defaultLimit;
+   if (maxRows <= 0) return requested;
+   return Math.min(requested, maxRows + 1);
+}
+
+export interface ModelResponseLimitsConfig {
+   /** Result of {@link getMaxQueryRows}. `0` disables the row cap. */
+   maxRows: number;
+   /** Result of {@link getMaxResponseBytes}. `0` disables the byte cap. */
+   maxBytes: number;
+}
+
+/**
+ * Throw {@link PayloadTooLargeError} (HTTP 413) when a model-query
+ * response exceeds either configured cap. `rowCount` should be the
+ * raw row count Malloy actually fetched (typically
+ * `result._queryResult.data.rawData.length`); `serializedBytes`
+ * should be the byte length of the JSON-stringified response that
+ * would otherwise be returned to the client.
+ *
+ * Row check uses the `> maxRows` sentinel (not `>= maxRows`), since
+ * {@link resolveModelQueryRowLimit} asked the connector for
+ * `maxRows + 1` and we want to fail only when that sentinel fires.
+ */
+export function assertWithinModelResponseLimits(
+   rowCount: number,
+   serializedBytes: number,
+   { maxRows, maxBytes }: ModelResponseLimitsConfig,
+): void {
+   if (maxRows > 0 && rowCount > maxRows) {
+      throw new PayloadTooLargeError(
+         `Query returned more than ${maxRows} rows. Refine the query (add a LIMIT or more selective WHERE) or raise PUBLISHER_MAX_QUERY_ROWS.`,
+      );
+   }
+   if (maxBytes > 0 && serializedBytes > maxBytes) {
+      throw new PayloadTooLargeError(
+         `Query response exceeded ${maxBytes} bytes (was ${serializedBytes}). Project fewer columns, add a LIMIT, or raise PUBLISHER_MAX_RESPONSE_BYTES.`,
+      );
+   }
+}


### PR DESCRIPTION
## Summary

Step 3 of the OOM-mitigation plan, stacked on top of #779 (and transitively #778). Extends the row + byte caps from the ad-hoc connection SQL path onto the Malloy model-query path (`runnable.run` in `getQueryResults` and notebook cell execution).

## Motivation

Until now the model-query path trusted whatever \`LIMIT\` the user's Malloy query carried, falling back to a hardcoded \`ROW_LIMIT = 1000\`. A user who wrote \`LIMIT 1_000_000\` got 1M rows; a wide-row query that slipped through the row count still OOMed the worker.

## Design

Three layered guards, mirroring Steps 1 + 2's semantics:

- **\`PUBLISHER_DEFAULT_QUERY_ROW_LIMIT\`** (default 1000) replaces the hardcoded \`ROW_LIMIT\` constant. Operator-tunable default when the user's Malloy query has no \`LIMIT\`. Loud-failure on bad input; \`0\` is rejected since a default of \"zero rows\" is always a misconfiguration.

- **\`PUBLISHER_MAX_QUERY_ROWS\`** (the env var Step 1 introduced) now also applies as a hard ceiling on model queries. Effective \`rowLimit = min(userOrDefault, max + 1)\`, using the same \`cap + 1\` sentinel pattern as the connection path. If the connector returns \`max + 1\` rows we throw \`PayloadTooLargeError\` (HTTP 413).

- **\`PUBLISHER_MAX_RESPONSE_BYTES\`** (the env var Step 2 introduced) also fires a 413 if the JSON-serialized response would exceed the cap.

## What this PR does *not* do

The byte cap is loud-failure **detection**, not OOM **prevention** — by the time we measure, \`runnable.run\` has already buffered the result. True prevention requires streaming \`Result\` reconstruction from \`DataRecord\`s, which entangles with Malloy's schema metadata in non-trivial ways and is appropriately deferred (Steps 4+). The row cap above is the primary OOM defense on this path.

## Implementation

- New \`service/model_limits.ts\` with two pure helpers — \`resolveModelQueryRowLimit\` and \`assertWithinModelResponseLimits\` — so the bounds-check logic is unit-testable without spinning up a Malloy runtime.
- Both \`runnable.run\` callsites (\`getQueryResults\` line ~600 and the notebook cell loop ~800) call the helpers with env-derived limits.
- Notebook cell catch block now re-throws \`PayloadTooLargeError\` explicitly so it isn't swallowed as a 400 \`BadRequestError\`.

## Test plan

- [x] 15 unit tests in \`model_limits.spec.ts\` cover user-LIMIT preservation, default fallback, clamping to \`cap + 1\`, both caps disabled (\`0\`), row-cap-first message preference, and exact-cap success.
- [x] 7 new env-var parser tests in \`config.spec.ts\` cover defaults, overrides, opt-out, and loud-failure on bad input.
- [x] 6 new integration tests in \`model.spec.ts\` cover clamping, user-LIMIT preservation, default fallback, row overflow → 413, byte overflow → 413, and success within both caps.
- [x] All 103 tests in the four focused suites pass (config + model_limits + model + errors).
- [x] \`bunx tsc --noEmit\` clean.
- [x] \`bunx eslint\` clean on all touched files.
- [x] Full \`bun test\` regression-checked: 665 pass / 50 fail with my changes vs. 49 fail on Step 2 baseline. The +1 is normal E2E variance — all failures are pre-existing \`TypeError: fetch() URL is invalid\` setup issues in \`legacy_routes\` integration tests, none of which touch the model-query path.

## Stacked on

#779 (Step 2) → #778 (Step 1). Review the stack from the bottom up; this PR's base is \`stream-connection-query-with-budget\`.

Made with [Cursor](https://cursor.com)