### PR TITLE
fix(server): wire path-safety helpers through service entry points

### DIFF
--- a/packages/server/src/controller/watch-mode.controller.ts
+++ b/packages/server/src/controller/watch-mode.controller.ts
@@ -1,8 +1,9 @@
 import chokidar, { FSWatcher } from "chokidar";
 import { RequestHandler } from "express";
-import path from "path";
 import { components } from "../api";
+import { internalErrorToHttpError } from "../errors";
 import { logger } from "../logger";
+import { assertSafePackageName, safeJoinUnderRoot } from "../path_safety";
 import { EnvironmentStore } from "../service/environment_store";
 
 type StartWatchReq = components["schemas"]["StartWatchRequest"];
@@ -32,6 +33,14 @@ export class WatchModeController {
       res,
    ) => {
       const watchName = req.body.environmentName ?? "";
+      try {
+         assertSafePackageName(watchName);
+      } catch (error) {
+         logger.error(error);
+         const { status } = internalErrorToHttpError(error as Error);
+         res.status(status).json({ error: (error as Error).message });
+         return;
+      }
       const environmentManifest =
          await EnvironmentStore.reloadEnvironmentManifest(
             this.environmentStore.serverRootPath,
@@ -53,7 +62,7 @@ export class WatchModeController {
          return;
       }
 
-      this.watchingPath = path.join(
+      this.watchingPath = safeJoinUnderRoot(
          this.environmentStore.serverRootPath,
          watchName,
       );

--- a/packages/server/src/path_safety.ts
+++ b/packages/server/src/path_safety.ts
@@ -44,7 +44,9 @@ const MAX_ENVIRONMENT_PATH_LEN = 4096;
  * production package name we've seen fits within it, and tightening
  * here costs nothing.
  */
-export function assertSafePackageName(packageName: unknown): void {
+export function assertSafePackageName(
+   packageName: unknown,
+): asserts packageName is string {
    if (typeof packageName !== "string" || !SAFE_NAME_RE.test(packageName)) {
       throw new BadRequestError(
          `Invalid package name: must be 1-255 characters of letters, digits, "-", "_", or "." and must not start with "."`,
@@ -58,7 +60,9 @@ export function assertSafePackageName(packageName: unknown): void {
  * live in subdirectories like `models/foo.malloy`); backslashes,
  * absolute paths, NUL bytes, and `..` / `.` segments are not.
  */
-export function assertSafeRelativeModelPath(modelPath: unknown): void {
+export function assertSafeRelativeModelPath(
+   modelPath: unknown,
+): asserts modelPath is string {
    if (
       typeof modelPath !== "string" ||
       modelPath.length === 0 ||
@@ -90,7 +94,9 @@ export function assertSafeRelativeModelPath(modelPath: unknown): void {
  * sanitizer-barrier pattern CodeQL's `js/path-injection` query
  * recognises.
  */
-export function assertSafeEnvironmentPath(environmentPath: unknown): void {
+export function assertSafeEnvironmentPath(
+   environmentPath: unknown,
+): asserts environmentPath is string {
    if (typeof environmentPath !== "string") {
       throw new BadRequestError(`Invalid environment path: must be a string`);
    }

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -22,10 +22,14 @@ import {
 import type { LookupConnection } from "@malloydata/malloy/connection";
 import { AxiosError } from "axios";
 import fs from "fs/promises";
-import path from "path";
 import { components } from "../api";
 import { logAxiosError, logger } from "../logger";
 import { redactPgSecrets } from "../pg_helpers";
+import {
+   assertSafeEnvironmentPath,
+   assertSafePackageName,
+   safeJoinUnderRoot,
+} from "../path_safety";
 import {
    assembleEnvironmentConnections,
    CoreConnectionEntry,
@@ -814,7 +818,9 @@ export async function deleteDuckLakeConnectionFile(
    connectionName: string,
    environmentPath: string,
 ): Promise<void> {
-   const ducklakePath = path.join(
+   assertSafePackageName(connectionName);
+   assertSafeEnvironmentPath(environmentPath);
+   const ducklakePath = safeJoinUnderRoot(
       environmentPath,
       `${connectionName}_ducklake.duckdb`,
    );

--- a/packages/server/src/service/environment.ts
+++ b/packages/server/src/service/environment.ts
@@ -176,6 +176,7 @@ export class Environment {
       environmentPath: string,
       connections: ApiConnection[],
    ): Promise<Environment> {
+      assertSafeEnvironmentPath(environmentPath);
       if (!(await fs.promises.stat(environmentPath))?.isDirectory()) {
          throw new EnvironmentNotFoundError(
             `Environment path ${environmentPath} not found`,
@@ -218,7 +219,7 @@ export class Environment {
       try {
          readme = (
             await fs.promises.readFile(
-               path.join(this.environmentPath, README_NAME),
+               safeJoinUnderRoot(this.environmentPath, README_NAME),
             )
          ).toString();
       } catch {

--- a/packages/server/src/service/environment_store.spec.ts
+++ b/packages/server/src/service/environment_store.spec.ts
@@ -5,6 +5,7 @@ import * as sinon from "sinon";
 import { components } from "../api";
 import { isPublisherConfigFrozen } from "../config";
 import { TEMP_DIR_PATH } from "../constants";
+import { BadRequestError } from "../errors";
 import { Environment } from "./environment";
 import { EnvironmentStore } from "./environment_store";
 
@@ -1017,6 +1018,108 @@ describe("Project Service Error Recovery", () => {
             expect(projectAgain.metadata.name).toBe(projectName);
          },
          { timeout: 30000 },
+      );
+   });
+});
+
+const TRAVERSAL_NAMES: ReadonlyArray<readonly [string, string]> = [
+   ["leading traversal", "../etc"],
+   ["embedded traversal", "foo/../../bar"],
+   ["slash in name", "foo/bar"],
+   ["backslash in name", "foo\\bar"],
+   ["leading dot", ".staging"],
+   ["bare dot-dot", ".."],
+   ["bare dot", "."],
+   ["empty", ""],
+   ["NUL byte", "foo\0bar"],
+   ["oversized", "a".repeat(256)],
+   ["absolute", "/etc/passwd"],
+] as const;
+
+describe("EnvironmentStore path-injection guards", () => {
+   let environmentStore: EnvironmentStore;
+
+   beforeEach(async () => {
+      if (existsSync(serverRootPath)) {
+         rmSync(serverRootPath, { recursive: true, force: true });
+      }
+      mkdirSync(serverRootPath);
+      mock(isPublisherConfigFrozen).mockReturnValue(false);
+      mock.module("../config", () => ({
+         isPublisherConfigFrozen: () => false,
+      }));
+      environmentStore = new EnvironmentStore(serverRootPath);
+      await environmentStore.finishedInitialization;
+   });
+
+   afterEach(() => {
+      if (existsSync(serverRootPath)) {
+         rmSync(serverRootPath, { recursive: true, force: true });
+      }
+      mkdirSync(serverRootPath);
+   });
+
+   describe("addEnvironment", () => {
+      it.each(TRAVERSAL_NAMES)(
+         "rejects %s as environment.name (%p)",
+         async (_label, name) => {
+            await expect(
+               environmentStore.addEnvironment({ name } as never, true),
+            ).rejects.toBeInstanceOf(BadRequestError);
+         },
+      );
+
+      it.each(TRAVERSAL_NAMES)(
+         "rejects %s as packages[].name (%p)",
+         async (_label, packageName) => {
+            await expect(
+               environmentStore.addEnvironment(
+                  {
+                     name: "ok-env",
+                     packages: [
+                        {
+                           name: packageName,
+                           location: "https://github.com/example/repo",
+                        },
+                     ],
+                  } as never,
+                  true,
+               ),
+            ).rejects.toBeInstanceOf(BadRequestError);
+         },
+      );
+   });
+
+   describe("updateEnvironment", () => {
+      it.each(TRAVERSAL_NAMES)(
+         "rejects %s as environment.name (%p)",
+         async (_label, name) => {
+            await expect(
+               environmentStore.updateEnvironment({ name } as never),
+            ).rejects.toBeInstanceOf(BadRequestError);
+         },
+      );
+   });
+
+   describe("deleteEnvironment", () => {
+      it.each(TRAVERSAL_NAMES)(
+         "rejects %s as environmentName (%p)",
+         async (_label, name) => {
+            await expect(
+               environmentStore.deleteEnvironment(name),
+            ).rejects.toBeInstanceOf(BadRequestError);
+         },
+      );
+   });
+
+   describe("getEnvironment", () => {
+      it.each(TRAVERSAL_NAMES)(
+         "rejects %s as environmentName (%p)",
+         async (_label, name) => {
+            await expect(
+               environmentStore.getEnvironment(name),
+            ).rejects.toBeInstanceOf(BadRequestError);
+         },
       );
    });
 });

--- a/packages/server/src/service/environment_store.ts
+++ b/packages/server/src/service/environment_store.ts
@@ -27,6 +27,11 @@ import {
 } from "../errors";
 import { getOperationalState, markNotReady, markReady } from "../health";
 import { formatDuration, logger } from "../logger";
+import {
+   assertSafeEnvironmentPath,
+   assertSafePackageName,
+   safeJoinUnderRoot,
+} from "../path_safety";
 import { Connection } from "../storage/DatabaseInterface";
 import { StorageConfig, StorageManager } from "../storage/StorageManager";
 import { Environment, PackageStatus } from "./environment";
@@ -756,6 +761,7 @@ export class EnvironmentStore {
       reload: boolean = false,
    ): Promise<Environment> {
       await this.finishedInitialization;
+      assertSafePackageName(environmentName);
 
       // Check if environment is already loaded first
       const environment = this.environments.get(environmentName);
@@ -816,9 +822,10 @@ export class EnvironmentStore {
       if (!skipInitialization && this.publisherConfigIsFrozen) {
          throw new FrozenConfigError();
       }
+      assertSafePackageName(environment.name);
       const environmentName = environment.name;
-      if (!environmentName) {
-         throw new Error("Environment name is required");
+      for (const _package of environment.packages || []) {
+         assertSafePackageName(_package.name);
       }
       // Check if environment already exists and update it instead of creating a new one
       const existingEnvironment = this.environments.get(environmentName);
@@ -884,6 +891,7 @@ export class EnvironmentStore {
    }
 
    public async unzipEnvironment(absoluteEnvironmentPath: string) {
+      assertSafeEnvironmentPath(absoluteEnvironmentPath);
       const startedAt = Date.now();
       logger.info(
          `Detected zip file at "${absoluteEnvironmentPath}". Unzipping...`,
@@ -930,9 +938,10 @@ export class EnvironmentStore {
          throw new FrozenConfigError();
       }
       validateEnvironmentAzureUrls(environment);
+      assertSafePackageName(environment.name);
       const environmentName = environment.name;
-      if (!environmentName) {
-         throw new Error("Environment name is required");
+      for (const _package of environment.packages || []) {
+         assertSafePackageName(_package.name);
       }
       const existingEnvironment = this.environments.get(environmentName);
       if (!existingEnvironment) {
@@ -953,6 +962,7 @@ export class EnvironmentStore {
       if (this.publisherConfigIsFrozen) {
          throw new FrozenConfigError();
       }
+      assertSafePackageName(environmentName);
       const environment = this.environments.get(environmentName);
       if (!environment) {
          return;
@@ -1027,15 +1037,17 @@ export class EnvironmentStore {
    }
 
    private async scaffoldEnvironment(environment: ApiEnvironment) {
+      assertSafePackageName(environment.name);
       const environmentName = environment.name;
-      if (!environmentName) {
-         throw new Error("Environment name is required");
-      }
-      const absoluteEnvironmentPath = `${this.serverRootPath}/${PUBLISHER_DATA_DIR}/${environmentName}`;
+      const absoluteEnvironmentPath = safeJoinUnderRoot(
+         this.serverRootPath,
+         PUBLISHER_DATA_DIR,
+         environmentName,
+      );
       await fs.promises.mkdir(absoluteEnvironmentPath, { recursive: true });
       if (environment.readme) {
          await fs.promises.writeFile(
-            path.join(absoluteEnvironmentPath, "README.md"),
+            safeJoinUnderRoot(absoluteEnvironmentPath, "README.md"),
             environment.readme,
          );
       }
@@ -1071,7 +1083,12 @@ export class EnvironmentStore {
       environmentName: string,
       packages: ApiEnvironment["packages"],
    ) {
-      const absoluteTargetPath = `${this.serverRootPath}/${PUBLISHER_DATA_DIR}/${environmentName}`;
+      assertSafePackageName(environmentName);
+      const absoluteTargetPath = safeJoinUnderRoot(
+         this.serverRootPath,
+         PUBLISHER_DATA_DIR,
+         environmentName,
+      );
 
       await fs.promises.mkdir(absoluteTargetPath, { recursive: true });
 
@@ -1126,7 +1143,10 @@ export class EnvironmentStore {
             .update(groupedLocation)
             .digest("hex")
             .substring(0, 16); // Use first 16 chars for shorter paths
-         const tempDownloadPath = `${absoluteTargetPath}/.temp_${locationHash}`;
+         const tempDownloadPath = safeJoinUnderRoot(
+            absoluteTargetPath,
+            `.temp_${locationHash}`,
+         );
          await fs.promises.mkdir(tempDownloadPath, { recursive: true });
          logger.info(`Created temporary directory: ${tempDownloadPath}`);
          try {
@@ -1140,7 +1160,11 @@ export class EnvironmentStore {
             // Extract each package from the downloaded content
             for (const _package of packagesForLocation) {
                const packageDir = _package.name;
-               const absolutePackagePath = `${absoluteTargetPath}/${packageDir}`;
+               assertSafePackageName(packageDir);
+               const absolutePackagePath = safeJoinUnderRoot(
+                  absoluteTargetPath,
+                  packageDir,
+               );
                // For GitHub URLs, extract the subdirectory path from the original location
                let sourcePath: string;
                if (this.isGitHubURL(_package.location)) {
@@ -1151,7 +1175,7 @@ export class EnvironmentStore {
                      const subPathMatch =
                         _package.location.match(/\/tree\/[^/]+\/(.+)$/);
                      if (subPathMatch) {
-                        sourcePath = path.join(
+                        sourcePath = safeJoinUnderRoot(
                            tempDownloadPath,
                            subPathMatch[1],
                         );
@@ -1168,7 +1192,10 @@ export class EnvironmentStore {
                   if (this.isLocalPath(_package.location)) {
                      sourcePath = _package.location;
                   } else {
-                     sourcePath = path.join(tempDownloadPath, groupedLocation);
+                     sourcePath = safeJoinUnderRoot(
+                        tempDownloadPath,
+                        groupedLocation,
+                     );
                   }
                }
 
@@ -1347,6 +1374,10 @@ export class EnvironmentStore {
       environmentName: string,
       packageName: string,
    ) {
+      // `environmentPath` is the operator-supplied mount source and may
+      // legitimately be a relative path that resolves outside the
+      // server root; only the target is asserted.
+      assertSafeEnvironmentPath(absoluteTargetPath);
       if (environmentPath.endsWith(".zip")) {
          environmentPath = await this.unzipEnvironment(environmentPath);
       }
@@ -1374,6 +1405,7 @@ export class EnvironmentStore {
       absoluteDirPath: string,
       isCompressedFile: boolean,
    ) {
+      assertSafeEnvironmentPath(absoluteDirPath);
       const trimmedPath = gcsPath.slice(5);
       const [bucketName, ...prefixParts] = trimmedPath.split("/");
       const prefix = prefixParts.join("/");
@@ -1396,10 +1428,15 @@ export class EnvironmentStore {
       }
       await Promise.all(
          files.map(async (file) => {
-            const relativeFilePath = file.name.replace(prefix, "");
+            // Strip leading `/` left over from prefix removal when the
+            // GCS prefix lacked a trailing slash — otherwise
+            // `safeJoinUnderRoot` treats it as absolute and rejects.
+            const relativeFilePath = file.name
+               .replace(prefix, "")
+               .replace(/^\/+/, "");
             const absoluteFilePath = isCompressedFile
                ? absoluteDirPath
-               : path.join(absoluteDirPath, relativeFilePath);
+               : safeJoinUnderRoot(absoluteDirPath, relativeFilePath);
             if (file.name.endsWith("/")) {
                return;
             }
@@ -1424,6 +1461,7 @@ export class EnvironmentStore {
       absoluteDirPath: string,
       isCompressedFile: boolean = false,
    ) {
+      assertSafeEnvironmentPath(absoluteDirPath);
       const trimmedPath = s3Path.slice(5);
       const [bucketName, ...prefixParts] = trimmedPath.split("/");
       const prefix = prefixParts.join("/");
@@ -1477,11 +1515,16 @@ export class EnvironmentStore {
             if (!key) {
                return;
             }
-            const relativeFilePath = key.replace(prefix, "");
+            // Strip leading `/` left over from prefix removal when the
+            // S3 prefix lacked a trailing slash — otherwise
+            // `safeJoinUnderRoot` treats it as absolute and rejects.
+            const relativeFilePath = key
+               .replace(prefix, "")
+               .replace(/^\/+/, "");
             if (!relativeFilePath || relativeFilePath.endsWith("/")) {
                return;
             }
-            const absoluteFilePath = path.join(
+            const absoluteFilePath = safeJoinUnderRoot(
                absoluteDirPath,
                relativeFilePath,
             );
@@ -1532,6 +1575,7 @@ export class EnvironmentStore {
    }
 
    async downloadGitHubDirectory(githubUrl: string, absoluteDirPath: string) {
+      assertSafeEnvironmentPath(absoluteDirPath);
       // First we'll clone the repo without the additional path
       // E.g. we're removing `/tree/main/imdb` from https://github.com/credibledata/malloy-samples/tree/main/imdb
       const githubInfo = this.parseGitHubUrl(githubUrl);
@@ -1539,7 +1583,11 @@ export class EnvironmentStore {
          throw new Error(`Invalid GitHub URL: ${githubUrl}`);
       }
       const { owner, repoName, packagePath } = githubInfo;
-      const cleanPackagePath = packagePath?.replace("/tree/main", "") || "";
+      // `packagePath` is captured with a leading `/`; strip it so the
+      // value is a relative segment usable with `safeJoinUnderRoot`.
+      const cleanPackagePath = (
+         packagePath?.replace("/tree/main", "") || ""
+      ).replace(/^\/+/, "");
 
       // We'll make sure whatever was in absoluteDirPath is removed,
       // so we have a nice a clean directory where we can clone the repo
@@ -1579,7 +1627,10 @@ export class EnvironmentStore {
 
       // Remove all contents of absoluteDirPath (/var/publisher/asd123)
       // except for the cleanPackagePath directory (/var/publisher/asd123/imdb)
-      const packageFullPath = path.join(absoluteDirPath, cleanPackagePath);
+      const packageFullPath = safeJoinUnderRoot(
+         absoluteDirPath,
+         cleanPackagePath,
+      );
 
       // Check if the cleanPackagePath (/var/publisher/asd123/imdb) exists
       const packageExists = await fs.promises
@@ -1598,7 +1649,7 @@ export class EnvironmentStore {
       for (const entry of dirContents) {
          // Don't remove the cleanPackagePath directory itself (/var/publisher/asd123/imdb)
          if (entry !== cleanPackagePath.replace(/^\/+/, "").split("/")[0]) {
-            await fs.promises.rm(path.join(absoluteDirPath, entry), {
+            await fs.promises.rm(safeJoinUnderRoot(absoluteDirPath, entry), {
                recursive: true,
                force: true,
             });
@@ -1609,8 +1660,8 @@ export class EnvironmentStore {
       const packageContents = await fs.promises.readdir(packageFullPath);
       for (const entry of packageContents) {
          await fs.promises.rename(
-            path.join(packageFullPath, entry),
-            path.join(absoluteDirPath, entry),
+            safeJoinUnderRoot(packageFullPath, entry),
+            safeJoinUnderRoot(absoluteDirPath, entry),
          );
       }
 

--- a/packages/server/src/service/package.spec.ts
+++ b/packages/server/src/service/package.spec.ts
@@ -13,7 +13,7 @@ import { Package } from "./package";
 type PartialModel = Pick<Model, "getPath">;
 
 describe("service/package", () => {
-   const testPackageDirectory = "testPackage";
+   const testPackageDirectory = resolve("testPackage");
 
    beforeEach(async () => {
       await fs.mkdir(testPackageDirectory, { recursive: true });
@@ -100,11 +100,7 @@ describe("service/package", () => {
                   testPackageDirectory,
                   new Map(),
                ),
-            ).rejects.toThrowError(
-               new PackageNotFoundError(
-                  "Package manifest for testPackage does not exist.",
-               ),
-            );
+            ).rejects.toBeInstanceOf(PackageNotFoundError);
          });
          it(
             "should return a Package object if the package exists",

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -28,6 +28,7 @@ import {
    ServiceUnavailableError,
 } from "../errors";
 import { formatDuration, logger } from "../logger";
+import { assertSafeEnvironmentPath, safeJoinUnderRoot } from "../path_safety";
 import { BuildManifest } from "../storage/DatabaseInterface";
 import { ignoreDotfiles } from "../utils";
 import { Model } from "./model";
@@ -90,6 +91,7 @@ export class Package {
       packagePath: string,
       environmentMalloyConfig: PackageConnectionInput,
    ): Promise<Package> {
+      assertSafeEnvironmentPath(packagePath);
       const startTime = performance.now();
       await Package.validatePackageManifestExistsOrThrowError(packagePath);
       const manifestValidationTime = performance.now();
@@ -515,7 +517,10 @@ export class Package {
    private static async validatePackageManifestExistsOrThrowError(
       packagePath: string,
    ) {
-      const packageConfigPath = path.join(packagePath, PACKAGE_MANIFEST_NAME);
+      const packageConfigPath = safeJoinUnderRoot(
+         packagePath,
+         PACKAGE_MANIFEST_NAME,
+      );
       try {
          await fs.stat(packageConfigPath);
       } catch {

--- a/packages/server/src/service/path_injection.spec.ts
+++ b/packages/server/src/service/path_injection.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { BadRequestError } from "../errors";
+import { deleteDuckLakeConnectionFile } from "./connection";
+
+const TRAVERSAL_NAMES: ReadonlyArray<readonly [string, string]> = [
+   ["leading traversal", "../etc"],
+   ["embedded traversal", "foo/../../bar"],
+   ["slash in name", "foo/bar"],
+   ["backslash in name", "foo\\bar"],
+   ["leading dot", ".staging"],
+   ["bare dot-dot", ".."],
+   ["bare dot", "."],
+   ["empty", ""],
+   ["NUL byte", "foo\0bar"],
+   ["oversized", "a".repeat(256)],
+   ["absolute", "/etc/passwd"],
+] as const;
+
+describe("deleteDuckLakeConnectionFile path-injection guards", () => {
+   it.each(TRAVERSAL_NAMES)(
+      "rejects %s as connectionName (%p)",
+      async (_label, connectionName) => {
+         await expect(
+            deleteDuckLakeConnectionFile(connectionName, "/tmp/env"),
+         ).rejects.toBeInstanceOf(BadRequestError);
+      },
+   );
+
+   it.each([
+      ["relative", "relative/path"],
+      ["traversal", "/var/lib/../../etc"],
+      ["NUL byte", "/var/lib/env\0"],
+      ["bare dot-dot", ".."],
+   ])("rejects %s as environmentPath (%p)", async (_label, environmentPath) => {
+      await expect(
+         deleteDuckLakeConnectionFile("conn", environmentPath),
+      ).rejects.toBeInstanceOf(BadRequestError);
+   });
+});


### PR DESCRIPTION
## Summary

CodeQL flags 45 reachable `js/path-injection` sinks (38 in `environment_store.ts`, plus `environment.ts`, `package.ts`, `connection.ts`, `watch-mode.controller.ts`). `path_safety.ts` already exports the sanitisers and CodeQL recognises them, but only `environment.ts` was wired up.

`POST /api/v0/environments` is unauthenticated by default and concatenated `environment.name` / `packages[].name` into paths used by `fs.mkdir` / `fs.cp` / `fs.rm` with `{recursive: true}`. A `name` like `"../../etc/foo"` escaped `publisher_data/` and the server `cp`'d attacker-controlled GitHub content into it.

This PR routes the existing helpers through every flagged sink:

- `assertSafePackageName` at every public service entry point that takes a name (`addEnvironment`, `updateEnvironment`, `deleteEnvironment`, `getEnvironment`, `deleteDuckLakeConnectionFile`, `startWatching`). Invalid payloads → `BadRequestError` (HTTP 400) before any I/O.
- `safeJoinUnderRoot` replaces template-string / bare `path.join` at every flagged sink; `assertSafeEnvironmentPath` at the inner async methods so the sanitiser is on the dominator path of each fs sink.
- `assertSafe*` now declare `asserts x is string`, dropping the redundant truthy guards.
- Strip leading `/+` from GCS / S3 / GitHub-subdir paths before joining — `path.join` absorbed them, the new `path.resolve`-based join would reject them as absolute.

PR #775 does not introduce these — they pre-exist on `main`. The "noise to dismiss" framing there was incorrect.

## Out of scope

Adding auth to the publisher server. Other open CodeQL alert classes (`missing-workflow-permissions`, `incomplete-sanitization`, `double-escaping`, `missing-rate-limiting`, `polynomial-redos`, `py/clear-text-logging`).

## Test plan

- [x] `bun run lint`, `bun run tsc --noEmit`, `bunx prettier --check` — clean
- [x] `bun test src/path_safety.spec.ts src/service/path_injection.spec.ts src/service/environment_store.spec.ts src/service/package.spec.ts src/service/filter_integration.spec.ts src/service/model.spec.ts` — 196/0
- [x] New traversal-attempt coverage on every entry point (`..`, slash, backslash, leading-dot, dot-dot, dot, empty, NUL, oversized, absolute)
- [x] Live smoke against a running publisher: 7 traversal payloads (POST `/environments` name + `packages[].name`, POST `/watch-mode/start`, GET `/environments/<traversal>`) all → 400 with `Invalid package name`; `publisher_data/` empty after attempts (no disk escape). Happy paths: scaffold-with-readme, GitHub-subdir (`/tree/main/faa`), GitHub repo-root, list/get/delete — all 200 with expected files on disk.
- [ ] GCS / S3 sources — not tested locally (need cloud creds). The leading-`/` normalisation path is identical to GitHub's which was live-verified.