### PR TITLE
feat(server): instrument install pipeline + redact credentials from logs

### DIFF
--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -95,7 +95,9 @@ async function isDatabaseAttached(
          ? existingDatabases
          : existingDatabases.rows || [];
 
-      logger.debug(`Existing databases:`, rows);
+      logger.debug("connection.duckdb.databases.queried", {
+         count: rows.length,
+      });
 
       return rows.some((row: Record<string, unknown>) =>
          Object.values(row).some(
@@ -1132,7 +1134,9 @@ export async function createEnvironmentConnections(
 
    for (const connection of environmentConfig.apiConnections) {
       if (!connection.name) continue;
-      logger.info(`Adding connection ${connection.name}`, { connection });
+      logger.info(`Adding connection ${connection.name}`, {
+         type: connection.type,
+      });
       const malloyConnection =
          await environmentConfig.malloyConfig.connections.lookupConnection(
             connection.name,

--- a/packages/server/src/service/environment.ts
+++ b/packages/server/src/service/environment.ts
@@ -236,7 +236,10 @@ export class Environment {
       logger.info(
          `Loaded ${malloyConfig.apiConnections.length} connections for environment ${environmentName}`,
          {
-            apiConnections: malloyConfig.apiConnections,
+            connections: malloyConfig.apiConnections.map((c) => ({
+               name: c.name,
+               type: c.type,
+            })),
          },
       );
 
@@ -776,7 +779,6 @@ export class Environment {
          `Adding package ${packageName} to environment ${this.environmentName}`,
          {
             packagePath,
-            malloyConfig: this.malloyConfig.malloyConfig,
          },
       );
 
@@ -842,6 +844,12 @@ export class Environment {
       const stagingPath = this.allocateStagingPath(packageName);
       await fs.promises.mkdir(path.dirname(stagingPath), { recursive: true });
 
+      logger.debug("install.phase1.download.started", {
+         environmentName: this.environmentName,
+         packageName,
+         stagingPath,
+      });
+      const downloadStartedAt = performance.now();
       try {
          await downloader(stagingPath);
       } catch (err) {
@@ -850,8 +858,17 @@ export class Environment {
             .catch(() => {});
          throw err;
       }
+      logger.debug("install.phase1.download.completed", {
+         environmentName: this.environmentName,
+         packageName,
+         durationMs: performance.now() - downloadStartedAt,
+      });
 
       return this.withPackageLock(packageName, async () => {
+         logger.debug("install.phase2.swap.started", {
+            environmentName: this.environmentName,
+            packageName,
+         });
          const canonicalPath = safeJoinUnderRoot(
             this.environmentPath,
             packageName,
@@ -870,6 +887,11 @@ export class Environment {
                recursive: true,
             });
             await fs.promises.rename(canonicalPath, retiredPath);
+            logger.debug("install.phase2.retired_old", {
+               environmentName: this.environmentName,
+               packageName,
+               retiredPath,
+            });
          }
 
          let newPackage: Package;
@@ -883,6 +905,11 @@ export class Environment {
                canonicalPath,
                () => this.malloyConfig.malloyConfig,
             );
+            logger.debug("install.phase2.committed", {
+               environmentName: this.environmentName,
+               packageName,
+               canonicalPath,
+            });
          } catch (err) {
             // Rollback: clobber whatever (partial) content sits at canonical
             // — Package.create's own failure-cleanup may have already rm'd
@@ -894,9 +921,11 @@ export class Environment {
             await fs.promises
                .rm(canonicalPath, { recursive: true, force: true })
                .catch(() => {});
+            let restored = false;
             if (retiredPath) {
                try {
                   await fs.promises.rename(retiredPath, canonicalPath);
+                  restored = true;
                } catch (restoreErr) {
                   logger.error(
                      "Failed to restore retired package after install rollback",
@@ -912,6 +941,12 @@ export class Environment {
                .rm(stagingPath, { recursive: true, force: true })
                .catch(() => {});
             this.deletePackageStatus(packageName);
+            logger.debug("install.phase2.rollback", {
+               environmentName: this.environmentName,
+               packageName,
+               restored,
+               errorName: err instanceof Error ? err.name : "Unknown",
+            });
             throw err;
          }
 
@@ -927,6 +962,11 @@ export class Environment {
          if (retiredPath) {
             const pathToClean = retiredPath;
             setImmediate(() => {
+               logger.debug("install.phase3.retired_cleanup", {
+                  environmentName: this.environmentName,
+                  packageName,
+                  retiredPath: pathToClean,
+               });
                void fs.promises
                   .rm(pathToClean, { recursive: true, force: true })
                   .catch((err) => {

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -717,7 +717,6 @@ export class Model {
       const notebookCells: ApiNotebookCell[] = (
          this.runnableNotebookCells as RunnableNotebookCell[]
       ).map((cell) => {
-         logger.debug("cell.queryInfo", cell.queryInfo);
          return {
             type: cell.type,
             text: cell.text,
@@ -887,7 +886,6 @@ export class Model {
             } else {
                logger.error("Error message: ", errorMessage);
             }
-            logger.debug("Cell content: ", cellIndex, cell.type, cell.text);
             throw new BadRequestError(`Cell execution failed: ${errorMessage}`);
          }
       }


### PR DESCRIPTION
## Summary

- `installPackage` now emits `install.phase1.download.started/completed`,
  `install.phase2.swap.started/retired_old/committed/rollback`, and
  `install.phase3.retired_cleanup` at `logger.debug`.
- Three **INFO-level** log sites that were dumping full connection objects
  (Postgres password, BigQuery service account JSON, Snowflake private
  key, Databricks token, …) now log only `{name, type}` / `{type}`:
  `environment.ts:191`, `environment.ts:695`, `connection.ts:1131`.
- Three smaller debug-level leaks fixed: `SHOW DATABASES` row dump → count,
  `cell.queryInfo` and `cell.text` dumps removed.

## Why (debug events)

A failing install in staging today is opaque — you can see "package install
failed" but not whether the download, the atomic swap, the rollback, or the
retired-tree cleanup is where it broke. Phase-tagged events at `LOG_LEVEL=debug`
answer that in one log query.

## Test plan

- [x] typecheck, lint, 503/503 unit tests
- [x] Manual re-install emits the ordered phase sequence
- [x] No credential / row / given value / cell content in any event

Follow-up PR: worker pool, connection.attach, givens resolution, memory
admission events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)