### PR TITLE
fix: remove modelPath filter from query annotations

### DIFF
--- a/packages/server/src/package_load/package_load_worker.ts
+++ b/packages/server/src/package_load/package_load_worker.ts
@@ -46,26 +46,26 @@
  */
 import {
    contextOverlay,
+   isSourceDef,
+   MalloyConfig,
+   MalloyError,
+   modelDefToModelInfo,
+   Runtime,
    type Annotation,
    type BuildManifestEntry,
    type Connection,
    type FetchSchemaOptions,
    type LookupConnection,
-   MalloyConfig,
-   MalloyError,
    type ModelDef,
    type ModelMaterializer,
-   modelDefToModelInfo,
    type NamedModelObject,
    type NamedQueryDef,
    type Query,
-   Runtime,
    type SQLSourceDef,
    type SQLSourceRequest,
    type StructDef,
    type TableSourceDef,
    type TurtleDef,
-   isSourceDef,
 } from "@malloydata/malloy";
 import * as Malloy from "@malloydata/malloy-interfaces";
 import {
@@ -73,8 +73,8 @@ import {
    MalloySQLStatementType,
 } from "@malloydata/malloy-sql";
 import * as fs from "fs";
-import * as path from "path";
 import { parentPort, threadId } from "node:worker_threads";
+import * as path from "path";
 import recursive from "recursive-readdir";
 import { fileURLToPath, pathToFileURL } from "url";
 

--- a/packages/server/src/package_load/package_load_worker.ts
+++ b/packages/server/src/package_load/package_load_worker.ts
@@ -556,11 +556,10 @@ function extractQueries(modelPath: string, modelDef: ModelDef): ApiQueryWire[] {
       .map((q) => ({
          name: q.as || q.name,
          sourceName: typeof q.structRef === "string" ? q.structRef : undefined,
-         annotations: q?.annotation?.blockNotes
-            ?.filter((note: { at: { url: string } }) =>
-               note.at.url.includes(modelPath),
-            )
-            .map((note: { text: string }) => note.text),
+         annotations:
+            q?.annotation?.blockNotes?.map(
+               (note: { text: string }) => note.text,
+            ) ?? [],
       }));
 }
 

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -29,11 +29,6 @@ import * as fs from "fs/promises";
 import { createRequire } from "module";
 import * as path from "path";
 import { components } from "../api";
-import { deserializeError } from "../package_load/package_load_pool";
-import type {
-   SerializedModel,
-   SerializedNotebookCell,
-} from "../package_load/protocol";
 import {
    getDefaultQueryRowLimit,
    getMaxQueryRows,
@@ -48,6 +43,11 @@ import {
    PayloadTooLargeError,
 } from "../errors";
 import { logger } from "../logger";
+import { deserializeError } from "../package_load/package_load_pool";
+import type {
+   SerializedModel,
+   SerializedNotebookCell,
+} from "../package_load/protocol";
 import { BuildManifest } from "../storage/DatabaseInterface";
 import { URL_READER } from "../utils";
 import {

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -977,11 +977,10 @@ export class Model {
                typeof queryObj.structRef === "string"
                   ? queryObj.structRef
                   : undefined,
-            annotations: queryObj?.annotation?.blockNotes
-               ?.filter((note: { at: { url: string } }) =>
-                  note.at.url.includes(modelPath),
-               )
-               .map((note: { text: string }) => note.text),
+            annotations:
+               queryObj?.annotation?.blockNotes?.map(
+                  (note: { text: string }) => note.text,
+               ) ?? [],
          }));
    }
 


### PR DESCRIPTION
## Summary

Query annotations were being incorrectly filtered by `modelPath`, causing annotations on imported queries to be stripped from API responses.

When `main.malloy` imports `project.malloy`, queries defined in `project.malloy` have their `note.at.url` pointing to `project.malloy`. The `note.at.url.includes(modelPath)` filter rejects them because `modelPath` is `main.malloy`.

## Changes

Removed the `.filter((note) => note.at.url.includes(modelPath))` from the annotations mapping in:
- `Model.getQueries()` in `packages/server/src/service/model.ts`
- `extractQueries()` in `packages/server/src/package_load/package_load_worker.ts`

Annotations are now mapped directly from `blockNotes` without path filtering, falling back to `[]` when none exist.

## Why this is safe

- **Queries don't have annotation inheritance** (no `annotation.inherits` chain) like sources do
- **A query's `blockNotes` contains only the annotations directly applied to that query definition**
- **The `modelPath` filter was serving no useful purpose for queries** — it only caused annotations from imported queries to be lost

## Testing

### Before

Annotations from .malloy model directly

```
GET /api/v0/environments/{orgId}/packages/operational-metrics/models/project.malloy

  index_project_taxonomy: ["#(doc) Taxonomy index for projects. `unique_projects` is the count of..."]
  index_project_fields: ["#(doc) Taxonomy index for projects. \n"]
```

Annotations from queries imported into .malloy model:

```
GET /api/v0/environments/{orgId}/packages/operational-metrics/models/main.malloy

Queries:
  index_project_taxonomy: annotations: []
  index_project_fields: annotations: []
  ...
```

### After

```
GET /api/v0/environments/{orgId}/packages/operational-metrics/models/main.malloy

  ✅ index_project_taxonomy: #(doc) Taxonomy index for projects...
  ✅ index_project_fields: #(doc) Taxonomy index for projects.

```

## Note on sources

The same `modelPath` filter pattern exists in `getSources()` for both source annotations and view annotations. The `sources[]` array in the API response likely has the same issue, but client code reads source annotations from `sourceInfos` instead, which correctly preserves them via the Malloy `modelDefToModelInfo()` path. This PR scopes the fix to queries only.