### PR TITLE
fix(app): keep sidebar toggle visible when collapsed

### DIFF
--- a/packages/app/src/components/layout/Sidebar/Sidebar.tsx
+++ b/packages/app/src/components/layout/Sidebar/Sidebar.tsx
@@ -101,10 +101,13 @@ function SidebarHeader({
    return (
       <Box
          sx={{
-            height: 56,
+            minHeight: 56,
             display: "flex",
+            flexDirection: isCollapsed ? "column" : "row",
             alignItems: "center",
             justifyContent: isCollapsed ? "center" : "space-between",
+            gap: isCollapsed ? 0.5 : 0,
+            py: isCollapsed ? 1 : 0,
             px: isCollapsed ? 0 : 2,
             flexShrink: 0,
          }}
@@ -141,15 +144,18 @@ function SidebarHeader({
                </Typography>
             )}
          </Box>
-         {!isCollapsed && (
+         <Tooltip
+            title={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+            placement="right"
+         >
             <IconButton
                size="small"
                onClick={onToggleCollapse}
-               aria-label="Collapse sidebar"
+               aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
             >
                <SidebarToggleIcon fontSize="small" />
             </IconButton>
-         )}
+         </Tooltip>
       </Box>
    );
 }


### PR DESCRIPTION
The toggle button was hidden when the sidebar was in its collapsed icon-rail state, leaving no UI to re-expand it (no keyboard shortcut, state not persisted). Always render the toggle button; in the collapsed state stack the logo and toggle vertically so the logo stays in the same column as the nav icons below. Add a Tooltip matching the other sidebar items and make aria-label state-aware.

Now
<img width="357" height="485" alt="Screenshot 2026-05-28 at 10 48 15 AM" src="https://github.com/user-attachments/assets/45b327a1-c936-4f6e-bc37-f35606bdacc9" />
