### PR TITLE
feat(server): report memory back-pressure as operationalState "throttled"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ curl -s http://localhost:4000/api/v0/environments | jq '.[].name'    # → list 
 - **`serving`** — ready to handle requests.
 - **`initializing`** — loading packages and connections from `publisher.config.json`. Normal on boot, and especially noticeable on the first run when sample packages need to be cloned from GitHub. Wait for `serving`.
 - **`draining`** — graceful shutdown in progress: the server is waiting for in-flight requests to finish before closing. Controlled by `SHUTDOWN_DRAIN_DURATION_SECONDS` and `SHUTDOWN_GRACEFUL_CLOSE_TIMEOUT_SECONDS` (see [Configuration](#configuration)).
+- **`throttled`** — the memory governor has hit its back-pressure limit and is rejecting new package loads and queries to stay under `PUBLISHER_MAX_MEMORY_BYTES`. Already-loaded packages remain serviceable; the control plane should treat the worker as unhealthy for new load until memory drops. Only reported when the memory governor is enabled.
 
 ---
 

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -2480,11 +2480,16 @@ components:
           description: Whether the server is fully initialized and ready to serve requests
         operationalState:
           type: string
-          enum: [ "initializing", "serving", "draining" ]
+          enum: [ "initializing", "serving", "draining", "throttled" ]
           description: Status of the server; initializing when the server is loading
             environments, packages and connections, serving when the server is
-            initialized and ready to serve requests, and draining when the
-            server is going to shut down
+            initialized and ready to serve requests, draining when the
+            server is going to shut down, and throttled when the server has hit
+            its memory back-pressure limit and is rejecting new package loads and
+            queries to stay under PUBLISHER_MAX_MEMORY_BYTES (see the memory
+            governor). Already-loaded packages remain serviceable while throttled;
+            the control plane treats a throttled worker as unhealthy for new load.
+            Only reported when the memory governor is enabled.
         frozenConfig:
           type: boolean
           description: Whether the server configuration is frozen (read-only mode). When

--- a/packages/server/src/service/environment_store.ts
+++ b/packages/server/src/service/environment_store.ts
@@ -708,13 +708,25 @@ export class EnvironmentStore {
    }
 
    public async getStatus() {
+      // Surface the memory governor's back-pressure as a "throttled"
+      // operational state so the control plane can stop routing new package
+      // loads/queries to a throttled worker. Draining takes precedence: a
+      // shutting-down server should keep reporting "draining". When the
+      // governor is disabled (no PUBLISHER_MAX_MEMORY_BYTES) this never fires.
+      const baseState = getOperationalState();
+      const operationalState = (
+         baseState !== "draining" &&
+         (this.memoryGovernor?.isBackpressured() ?? false)
+            ? "throttled"
+            : baseState
+      ) as components["schemas"]["ServerStatus"]["operationalState"];
+
       const status = {
          timestamp: Date.now(),
          environments: [] as Array<components["schemas"]["Environment"]>,
          initialized: this.isInitialized,
          frozenConfig: isPublisherConfigFrozen(this.serverRootPath),
-         operationalState:
-            getOperationalState() as components["schemas"]["ServerStatus"]["operationalState"],
+         operationalState,
       };
 
       const environments = await this.listEnvironments(true);


### PR DESCRIPTION
## Summary

- Replaces the standalone `memoryThrottled: boolean` field on `ServerStatus` with a new `throttled` value on the `operationalState` enum.
- `EnvironmentStore.getStatus()` now composes the lifecycle state (from `health.ts`) with the memory governor's back-pressure flag at read time. `draining` takes precedence, so a shutting-down server keeps reporting `draining` even under memory pressure.
- `throttled` is only ever reported when the memory governor is enabled (`PUBLISHER_MAX_MEMORY_BYTES` set); the governor stays a self-contained boolean source and never writes lifecycle state directly.
- Regenerated API types (server `api.ts`, SDK/CLI clients) and documented the new state in `README.md`.

### Why derive rather than have the governor set state directly

Lifecycle (`initializing`/`serving`/`draining`) and memory pressure are orthogonal facts with different owners and update cadences (pressure flaps on a hysteresis band). Composing them at read time avoids a dual-writer state machine that would clobber `draining`/`initializing` and require "restore to what?" bookkeeping when pressure clears.

## Test plan

- [ ] `curl /api/v0/status | jq .operationalState` returns `serving` normally, `throttled` when the governor is back-pressured, and `draining` during shutdown (draining wins over throttled).
- [ ] With the memory governor disabled (no `PUBLISHER_MAX_MEMORY_BYTES`), `operationalState` never reports `throttled`.
- [ ] CI / Playwright / docker health checks still gate on `serving` and pass.

Signed-off-by: Kyle Nesbit <kjnesbit@ms2.co>

Made with [Cursor](https://cursor.com)