### PR TITLE
refactor(server): extract shared source/query introspection helper

### DIFF
--- a/packages/server/src/package_load/package_load_worker.ts
+++ b/packages/server/src/package_load/package_load_worker.ts
@@ -55,16 +55,12 @@ import {
    type ModelDef,
    type ModelMaterializer,
    modelDefToModelInfo,
-   type NamedModelObject,
    type NamedQueryDef,
    type Query,
    Runtime,
    type SQLSourceDef,
    type SQLSourceRequest,
-   type StructDef,
    type TableSourceDef,
-   type TurtleDef,
-   isSourceDef,
 } from "@malloydata/malloy";
 import * as Malloy from "@malloydata/malloy-interfaces";
 import {
@@ -83,8 +79,12 @@ import {
    PACKAGE_MANIFEST_NAME,
 } from "../constants";
 import { HackyDataStylesAccumulator } from "../data_styles";
-import { annotationTexts, type AnnotationsDef } from "../service/annotations";
-import { parseFilters, type FilterDefinition } from "../service/filter";
+import { type AnnotationsDef } from "../service/annotations";
+import { type FilterDefinition } from "../service/filter";
+import {
+   extractQueriesFromModelDef,
+   extractSourcesFromModelDef,
+} from "../service/source_extraction";
 import {
    malloyGivenToApi,
    type MalloyGiven,
@@ -475,89 +475,20 @@ function appendLocalSourceInfos(
    }
 }
 
+// Source / query introspection is shared with the in-process path; see
+// service/source_extraction.ts. The worker has no logger, so a filter parse
+// failure is swallowed silently (no `onParseError` callback) — matching the
+// prior worker-local behavior.
 function extractSources(
    modelDef: ModelDef,
    givens: ApiGivenWire[] | undefined,
 ): { sources: ApiSourceWire[]; filterMap: Map<string, FilterDefinition[]> } {
-   const filterMap = new Map<string, FilterDefinition[]>();
-   const sources: ApiSourceWire[] = Object.values(modelDef.contents)
-      .filter((obj) => isSourceDef(obj))
-      .map((sourceObj) => {
-         const sourceName =
-            (sourceObj as StructDef).as || (sourceObj as StructDef).name;
-         const annotations = annotationTexts(
-            (sourceObj as StructDef).annotations,
-         );
-
-         const collected: string[][] = [];
-         let cur = (sourceObj as StructDef).annotations;
-         while (cur) {
-            if (cur.blockNotes) {
-               collected.push(cur.blockNotes.map((note) => note.text));
-            }
-            cur = cur.inherits;
-         }
-         const allAnnotations = collected.reverse().flat();
-         let filters: unknown[] | undefined;
-         if (allAnnotations.length > 0) {
-            try {
-               const parsed = parseFilters(allAnnotations);
-               if (parsed.length > 0) {
-                  filterMap.set(sourceName, parsed);
-                  const fields = (sourceObj as StructDef).fields;
-                  filters = parsed.map((f) => {
-                     const field = fields.find(
-                        (fd) => (fd.as || fd.name) === f.dimension,
-                     );
-                     return {
-                        name: f.name,
-                        dimension: f.dimension,
-                        type: f.type,
-                        implicit: f.implicit,
-                        required: f.required,
-                        dimensionType: field?.type as string | undefined,
-                     };
-                  });
-               }
-            } catch {
-               /* parse errors are warnings; matches in-process */
-            }
-         }
-
-         const views = (sourceObj as StructDef).fields
-            .filter((f) => f.type === "turtle")
-            .filter((turtle) =>
-               (turtle as TurtleDef).pipeline
-                  .map((stage) => stage.type)
-                  .every((type) => type === "reduce"),
-            )
-            .map((turtle) => ({
-               name: turtle.as || turtle.name,
-               annotations: annotationTexts(turtle.annotations),
-            }));
-
-         return {
-            name: sourceName,
-            annotations,
-            views,
-            filters,
-            givens,
-         } as ApiSourceWire;
-      });
-
-   return { sources, filterMap };
+   const { sources, filterMap } = extractSourcesFromModelDef(modelDef, givens);
+   return { sources: sources as unknown as ApiSourceWire[], filterMap };
 }
 
 function extractQueries(modelDef: ModelDef): ApiQueryWire[] {
-   const isNamedQuery = (obj: NamedModelObject): obj is NamedQueryDef =>
-      obj.type === "query";
-   return Object.values(modelDef.contents)
-      .filter(isNamedQuery)
-      .map((q) => ({
-         name: q.as || q.name,
-         sourceName: typeof q.structRef === "string" ? q.structRef : undefined,
-         annotations: annotationTexts(q.annotations),
-      }));
+   return extractQueriesFromModelDef(modelDef) as ApiQueryWire[];
 }
 
 function buildRuntimeForModel(

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -4,19 +4,15 @@ import {
    Connection,
    FixedConnectionMap,
    GivenValue,
-   isSourceDef,
    MalloyConfig,
    MalloyError,
    ModelDef,
    modelDefToModelInfo,
    ModelMaterializer,
-   NamedModelObject,
    NamedQueryDef,
    QueryData,
    QueryMaterializer,
    Runtime,
-   StructDef,
-   TurtleDef,
 } from "@malloydata/malloy";
 import * as Malloy from "@malloydata/malloy-interfaces";
 import {
@@ -50,16 +46,18 @@ import {
 import { logger } from "../logger";
 import { BuildManifest } from "../storage/DatabaseInterface";
 import { URL_READER } from "../utils";
-import { annotationTexts } from "./annotations";
 import {
    buildFilterClause,
    FilterValidationError,
    injectFilterRefinement,
-   parseFilters,
    type FilterDefinition,
    type FilterParams,
 } from "./filter";
 import { malloyGivenToApi, type MalloyGiven } from "./given";
+import {
+   extractQueriesFromModelDef,
+   extractSourcesFromModelDef,
+} from "./source_extraction";
 import {
    assertWithinModelResponseLimits,
    resolveModelQueryRowLimit,
@@ -69,9 +67,7 @@ type ApiCompiledModel = components["schemas"]["CompiledModel"];
 type ApiNotebookCell = components["schemas"]["NotebookCell"];
 type ApiRawNotebook = components["schemas"]["RawNotebook"];
 type ApiSource = components["schemas"]["Source"];
-type ApiFilter = components["schemas"]["Filter"];
 type ApiGiven = components["schemas"]["Given"];
-type ApiView = components["schemas"]["View"];
 type ApiQuery = components["schemas"]["Query"];
 export type ApiConnection = components["schemas"]["Connection"];
 export type SnowflakeConnection = components["schemas"]["SnowflakeConnection"];
@@ -963,20 +959,8 @@ export class Model {
    }
 
    private static getQueries(modelDef: ModelDef): ApiQuery[] {
-      const isNamedQuery = (
-         object: NamedModelObject,
-      ): object is NamedQueryDef => object.type === "query";
-      return Object.values(modelDef.contents)
-         .filter(isNamedQuery)
-         .map((queryObj: NamedQueryDef) => ({
-            name: queryObj.as || queryObj.name,
-            // What to do when the source is not a string?
-            sourceName:
-               typeof queryObj.structRef === "string"
-                  ? queryObj.structRef
-                  : undefined,
-            annotations: annotationTexts(queryObj.annotations),
-         }));
+      // Shared with the package-load worker — see service/source_extraction.ts.
+      return extractQueriesFromModelDef(modelDef) as ApiQuery[];
    }
 
    private static getSources(
@@ -986,97 +970,18 @@ export class Model {
       sources: ApiSource[];
       filterMap: Map<string, FilterDefinition[]>;
    } {
-      const filterMap = new Map<string, FilterDefinition[]>();
-
-      const sources = Object.values(modelDef.contents)
-         .filter((obj) => isSourceDef(obj))
-         .map((sourceObj) => {
-            const sourceName = sourceObj.as || sourceObj.name;
-            const annotations = annotationTexts(
-               (sourceObj as StructDef).annotations,
-            );
-
-            // Parse #(filter) from ALL annotations, traversing the inherits
-            // chain so that filters on a base source (e.g. `recalls`) are
-            // picked up by an extending source (`manufacturer_recalls is
-            // recalls extend {}`).  The Malloy compiler stores the base
-            // source's annotations in `annotations.inherits`.
-            //
-            // The chain goes child → parent, so we collect child-first.
-            // parseFilters uses "last wins" dedup, so we reverse to put
-            // parent annotations first and child annotations last (winning).
-            const collectedAnnotations: string[][] = [];
-            let curAnnotation = (sourceObj as StructDef).annotations;
-            while (curAnnotation) {
-               if (curAnnotation.blockNotes) {
-                  collectedAnnotations.push(
-                     curAnnotation.blockNotes.map((note) => note.text),
-                  );
-               }
-               curAnnotation = curAnnotation.inherits;
-            }
-            const allAnnotations = collectedAnnotations.reverse().flat();
-            let filters: ApiFilter[] | undefined;
-            if (allAnnotations.length > 0) {
-               try {
-                  const parsed = parseFilters(allAnnotations);
-                  if (parsed.length > 0) {
-                     filterMap.set(sourceName, parsed);
-                     const structFields = (sourceObj as StructDef).fields;
-                     filters = parsed.map((f) => {
-                        const field = structFields.find(
-                           (fd) => (fd.as || fd.name) === f.dimension,
-                        );
-                        return {
-                           name: f.name,
-                           dimension: f.dimension,
-                           type: f.type,
-                           implicit: f.implicit,
-                           required: f.required,
-                           dimensionType: field?.type as string | undefined,
-                        };
-                     });
-                  }
-               } catch (err) {
-                  logger.warn(
-                     `Failed to parse filter annotations on source "${sourceName}"`,
-                     { error: err },
-                  );
-               }
-            }
-
-            const views = (sourceObj as StructDef).fields
-               .filter((turtleObj) => turtleObj.type === "turtle")
-               .filter((turtleObj) =>
-                  // TODO(kjnesbit): Fix non-reduce views. Filter out
-                  // non-reduce views, i.e., indexes. Need to discuss with Will.
-                  (turtleObj as TurtleDef).pipeline
-                     .map((stage) => stage.type)
-                     .every((type) => type == "reduce"),
-               )
-               .map(
-                  (turtleObj) =>
-                     ({
-                        name: turtleObj.as || turtleObj.name,
-                        annotations: annotationTexts(turtleObj.annotations),
-                     }) as ApiView,
-               );
-
-            return {
-               name: sourceName,
-               annotations,
-               views,
-               filters,
-               // Malloy exposes givens at the model level, not per-source.
-               // First pass: surface the full model-level list on every source
-               // — matches how filter introspection already collapses
-               // inheritance into the per-source list. Refine to view-scoped
-               // filtering if a customer asks.
-               givens,
-            } as ApiSource;
-         });
-
-      return { sources, filterMap };
+      // Shared with the package-load worker — see service/source_extraction.ts.
+      // The service path logs filter parse failures; the worker stays silent.
+      const { sources, filterMap } = extractSourcesFromModelDef(
+         modelDef,
+         givens,
+         (sourceName, err) =>
+            logger.warn(
+               `Failed to parse filter annotations on source "${sourceName}"`,
+               { error: err },
+            ),
+      );
+      return { sources: sources as unknown as ApiSource[], filterMap };
    }
 
    static async getModelMaterializer(

--- a/packages/server/src/service/source_extraction.ts
+++ b/packages/server/src/service/source_extraction.ts
@@ -1,0 +1,162 @@
+/**
+ * Shared source / query introspection extracted from a compiled `ModelDef`.
+ *
+ * Both the in-process `Model.create` path (`service/model.ts`) and the
+ * package-load worker (`package_load/package_load_worker.ts`, which runs in a
+ * separate bundle and serializes the result over the worker protocol) need to
+ * walk a `ModelDef` and produce the same `sources` / `queries` shapes plus the
+ * `#(filter)` `filterMap`. These two call sites used to carry byte-for-byte
+ * copies of this logic; keeping them in lockstep by hand was a standing hazard
+ * (a change to one silently diverged from the other). This module is the single
+ * source of truth — the two callers differ only in how they type the result
+ * (generated API types vs. worker wire types — structurally identical, so each
+ * casts at its boundary) and in how they report a filter parse failure (the
+ * service logs a warning; the worker has no logger and stays silent), which is
+ * threaded through the optional `onParseError` callback.
+ */
+
+import {
+   isSourceDef,
+   ModelDef,
+   NamedModelObject,
+   NamedQueryDef,
+   StructDef,
+   TurtleDef,
+} from "@malloydata/malloy";
+import { annotationTexts } from "./annotations";
+import { parseFilters, type FilterDefinition } from "./filter";
+
+/** A `#(filter)` definition enriched with the dimension's Malloy type. */
+export interface ExtractedFilter {
+   name: string;
+   dimension: string;
+   type: string;
+   implicit: boolean;
+   required: boolean;
+   dimensionType: string | undefined;
+}
+
+export interface ExtractedView {
+   name: string;
+   annotations: string[] | undefined;
+}
+
+/**
+ * Structural source shape both callers cast to their own typed view
+ * (`ApiSource` in the service, `ApiSourceWire` in the worker). `givens` is
+ * attached verbatim from the caller-supplied list, so it stays `unknown` here.
+ */
+export interface ExtractedSource {
+   name: string;
+   annotations: string[] | undefined;
+   views: ExtractedView[];
+   filters: ExtractedFilter[] | undefined;
+   givens: unknown;
+}
+
+export interface ExtractedQuery {
+   name: string;
+   sourceName: string | undefined;
+   annotations: string[] | undefined;
+}
+
+/**
+ * Extract every source from a compiled model, parsing `#(filter)` annotations
+ * along the way.
+ *
+ * Filters are collected by walking the `annotations.inherits` chain so that
+ * filters declared on a base source flow to an extending source. The chain runs
+ * child → parent, so we collect child-first then reverse — `parseFilters` uses
+ * "last wins" dedup, which lets a child's `#(filter)` override the base's.
+ *
+ * `givens` is attached unchanged to every source (Malloy exposes givens at the
+ * model level, not per-source). `onParseError`, when supplied, is invoked with
+ * the source name and error if a source's filter annotations fail to parse;
+ * extraction continues regardless.
+ */
+export function extractSourcesFromModelDef(
+   modelDef: ModelDef,
+   givens: unknown,
+   onParseError?: (sourceName: string, err: unknown) => void,
+): { sources: ExtractedSource[]; filterMap: Map<string, FilterDefinition[]> } {
+   const filterMap = new Map<string, FilterDefinition[]>();
+
+   const sources: ExtractedSource[] = Object.values(modelDef.contents)
+      .filter((obj) => isSourceDef(obj))
+      .map((sourceObj) => {
+         const struct = sourceObj as StructDef;
+         const sourceName = struct.as || struct.name;
+         const annotations = annotationTexts(struct.annotations);
+
+         const collected: string[][] = [];
+         let cur = struct.annotations;
+         while (cur) {
+            if (cur.blockNotes) {
+               collected.push(cur.blockNotes.map((note) => note.text));
+            }
+            cur = cur.inherits;
+         }
+         const allAnnotations = collected.reverse().flat();
+
+         let filters: ExtractedFilter[] | undefined;
+         if (allAnnotations.length > 0) {
+            try {
+               const parsed = parseFilters(allAnnotations);
+               if (parsed.length > 0) {
+                  filterMap.set(sourceName, parsed);
+                  const fields = struct.fields;
+                  filters = parsed.map((f) => {
+                     const field = fields.find(
+                        (fd) => (fd.as || fd.name) === f.dimension,
+                     );
+                     return {
+                        name: f.name,
+                        dimension: f.dimension,
+                        type: f.type,
+                        implicit: f.implicit,
+                        required: f.required,
+                        dimensionType: field?.type as string | undefined,
+                     };
+                  });
+               }
+            } catch (err) {
+               onParseError?.(sourceName, err);
+            }
+         }
+
+         const views: ExtractedView[] = struct.fields
+            .filter((field) => field.type === "turtle")
+            .filter((turtle) =>
+               // Filter out non-reduce views (e.g. indexes).
+               (turtle as TurtleDef).pipeline
+                  .map((stage) => stage.type)
+                  .every((type) => type === "reduce"),
+            )
+            .map((turtle) => ({
+               name: turtle.as || turtle.name,
+               annotations: annotationTexts(turtle.annotations),
+            }));
+
+         return { name: sourceName, annotations, views, filters, givens };
+      });
+
+   return { sources, filterMap };
+}
+
+/** Extract every named query from a compiled model. */
+export function extractQueriesFromModelDef(
+   modelDef: ModelDef,
+): ExtractedQuery[] {
+   const isNamedQuery = (obj: NamedModelObject): obj is NamedQueryDef =>
+      obj.type === "query";
+   return Object.values(modelDef.contents)
+      .filter(isNamedQuery)
+      .map((queryObj) => ({
+         name: queryObj.as || queryObj.name,
+         sourceName:
+            typeof queryObj.structRef === "string"
+               ? queryObj.structRef
+               : undefined,
+         annotations: annotationTexts(queryObj.annotations),
+      }));
+}


### PR DESCRIPTION
**Part of a series** adding `#(authorize)` annotation support. This is the groundwork PR (0 of the stack); the ones that follow build on it:

0. **this PR** — extract shared source/query introspection
1. annotation parser + introspection (`#(authorize)` / `##(authorize)`)
2. compile-time validation
3. runtime gate (the actual access enforcement)
4. MCP + HTTP surface alignment
5. docs
6. end-to-end + example model

### What this one does
Pulls the duplicated "walk a `ModelDef` into sources/queries + the `#(filter)` map" logic out of both `service/model.ts` and the package-load worker into one shared `source_extraction.ts`. The two were drift-prone copies kept in sync by hand; now there's a single source of truth — so the authorize work in the next PRs lands in one place instead of two.

No behavior change. The two callers just differ in result typing (generated API types vs worker wire types) and in how they handle a filter parse error (service logs, worker stays silent), threaded through an optional callback.

### Tested
- `tsc --noEmit` + eslint clean
- 746 unit tests pass
- `filter_integration` (32 tests, includes the extend/inherits filter chains) pass
- MCP execute_query integration pass
- The one `concurrent_package` E2E failure is a pre-existing 200s timeout that reproduces identically on `main` — unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)