### PR TITLE
feat(server): emit Source.givens in notebook newSources

### DIFF
--- a/packages/server/src/service/model.spec.ts
+++ b/packages/server/src/service/model.spec.ts
@@ -191,6 +191,84 @@ describe("service/model", () => {
 
             sinon.restore();
          });
+
+         it("embeds model-level givens in each newSources SourceInfo", async () => {
+            const sourceInfo = {
+               name: "carriers",
+               schema: { fields: [] },
+            };
+            const givens = [
+               {
+                  name: "region",
+                  type: "string",
+                  annotations: ["#(doc) Region"],
+               },
+            ];
+            const model = new Model(
+               packageName,
+               "test.malloynb",
+               {},
+               "notebook",
+               undefined, // modelMaterializer
+               undefined, // modelDef
+               undefined, // sources
+               undefined, // queries
+               undefined, // sourceInfos
+               [
+                  {
+                     type: "code",
+                     text: "import 'carriers.malloy'",
+                     newSources: [sourceInfo],
+                  },
+               ], // runnableNotebookCells
+               undefined, // compilationError
+               undefined, // filterMap
+               givens, // givens
+            );
+
+            const notebook = await model.getNotebook();
+            expect(notebook.notebookCells).toHaveLength(1);
+            const parsed = JSON.parse(
+               notebook.notebookCells![0].newSources![0],
+            );
+            expect(parsed.name).toBe("carriers");
+            // SourceInfo fields are preserved untouched.
+            expect(parsed.schema).toEqual({ fields: [] });
+            // Givens ride along verbatim — no second getModel round-trip needed.
+            expect(parsed.givens).toEqual(givens);
+         });
+
+         it("omits givens from newSources when the model declares none", async () => {
+            const sourceInfo = { name: "carriers", schema: { fields: [] } };
+            const model = new Model(
+               packageName,
+               "test.malloynb",
+               {},
+               "notebook",
+               undefined,
+               undefined,
+               undefined,
+               undefined,
+               undefined,
+               [
+                  {
+                     type: "code",
+                     text: "import 'carriers.malloy'",
+                     newSources: [sourceInfo],
+                  },
+               ],
+               undefined,
+               undefined,
+               undefined, // no givens
+            );
+
+            const notebook = await model.getNotebook();
+            const parsed = JSON.parse(
+               notebook.notebookCells![0].newSources![0],
+            );
+            expect(parsed.name).toBe("carriers");
+            expect(parsed).not.toHaveProperty("givens");
+         });
       });
 
       describe("getQueryResults", () => {
@@ -528,6 +606,47 @@ describe("service/model", () => {
             });
 
             sinon.restore();
+         });
+
+         it("embeds model-level givens in executed cell newSources", async () => {
+            const sourceInfo = { name: "carriers", schema: { fields: [] } };
+            const givens = [
+               {
+                  name: "region",
+                  type: "string",
+                  annotations: ["#(doc) Region"],
+               },
+            ];
+            // A source-only code cell (no runnable) still emits newSources.
+            const runnableCells = [
+               {
+                  type: "code" as const,
+                  text: "import 'carriers.malloy'",
+                  newSources: [sourceInfo],
+               },
+            ];
+
+            const model = new Model(
+               packageName,
+               "test.malloynb",
+               {},
+               "notebook",
+               undefined, // modelMaterializer
+               undefined, // modelDef
+               undefined, // sources
+               undefined, // queries
+               undefined, // sourceInfos
+               // eslint-disable-next-line @typescript-eslint/no-explicit-any
+               runnableCells as any, // runnableNotebookCells
+               undefined, // compilationError
+               undefined, // filterMap
+               givens, // givens
+            );
+
+            const result = await model.executeNotebookCell(0);
+            const parsed = JSON.parse(result.newSources![0]);
+            expect(parsed.name).toBe("carriers");
+            expect(parsed.givens).toEqual(givens);
          });
       });
    });

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -724,6 +724,32 @@ export class Model {
       } as ApiCompiledModel;
    }
 
+   /**
+    * Serialize a notebook cell's `newSources` to the wire shape (an array
+    * of JSON strings), embedding the model-level `givens` on every
+    * SourceInfo so consumers iterating `newSources` can render `given:`
+    * inputs without a second getModel round-trip. Matches `Source.givens`
+    * in the API spec ("Identical to CompiledModel.givens") and how
+    * `getSources` already copies the full list onto each CompiledModel
+    * source. When the model declares no givens, the SourceInfo is emitted
+    * untouched (no empty `givens` key).
+    *
+    * Shared by `getNotebookModel` (the notebook GET endpoint) and
+    * `executeNotebookCell` (the cell-run endpoint) so both surface givens
+    * identically.
+    */
+   private serializeNewSources(
+      newSources: Malloy.SourceInfo[] | undefined,
+   ): string[] | undefined {
+      return newSources?.map((source) =>
+         JSON.stringify(
+            this.givens && this.givens.length > 0
+               ? { ...source, givens: this.givens }
+               : source,
+         ),
+      );
+   }
+
    private async getNotebookModel(): Promise<ApiRawNotebook> {
       // Return raw cell contents without executing them
       const notebookCells: ApiNotebookCell[] = (
@@ -732,9 +758,7 @@ export class Model {
          return {
             type: cell.type,
             text: cell.text,
-            newSources: cell.newSources?.map((source) =>
-               JSON.stringify(source),
-            ),
+            newSources: this.serializeNewSources(cell.newSources),
             queryInfo: cell.queryInfo
                ? JSON.stringify(cell.queryInfo)
                : undefined,
@@ -892,7 +916,7 @@ export class Model {
          text: cell.text,
          queryName: queryName,
          result: queryResult,
-         newSources: cell.newSources?.map((source) => JSON.stringify(source)),
+         newSources: this.serializeNewSources(cell.newSources),
       };
    }
 


### PR DESCRIPTION
## What

Notebook responses now carry `givens` on every `SourceInfo` in `newSources`.
Both the notebook GET and the cell-run endpoint share a `serializeNewSources`
helper, so they surface givens identically. Models that declare no givens emit
unchanged SourceInfo (no empty key).

## Why

The spec already documents `Source.givens` as "Identical to
`CompiledModel.givens` ... so consumers iterating sources can render inputs
without a second lookup" — but the runtime never populated it on the notebook
path. Consumers rendering `given:` UI were doing an extra `getModel` round-trip
per import to recover it. This closes that loop: the Givens panel renders off
the existing notebook response, zero extra HTTP calls.

### Tested
- New unit tests on both endpoints (givens present + absent cases)
- Full server service suite: 440 pass, 0 fail; `tsc` + ESLint clean

No SDK or API-spec changes — the spec already documents the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)