### PR TITLE
feat(server): validate #(authorize) expressions at model-load (compile-only)

### DIFF
--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -98,7 +98,10 @@ export class ConnectionAuthError extends Error {
 }
 
 export class ModelCompilationError extends Error {
-   constructor(error: MalloyError) {
+   // Accepts a MalloyError or any message-bearing object, so callers that add
+   // context around a compile failure (e.g. naming the source whose authorize
+   // annotation failed) can reuse this 424 mapping without a separate class.
+   constructor(error: { message: string }) {
       super(error.message);
    }
 }

--- a/packages/server/src/package_load/package_load_worker.ts
+++ b/packages/server/src/package_load/package_load_worker.ts
@@ -79,6 +79,7 @@ import {
    PACKAGE_MANIFEST_NAME,
 } from "../constants";
 import { HackyDataStylesAccumulator } from "../data_styles";
+import { ModelCompilationError } from "../errors";
 import { type AnnotationsDef } from "../service/annotations";
 import { validateAuthorizeProbes } from "../service/authorize";
 import { type FilterDefinition } from "../service/filter";
@@ -831,6 +832,18 @@ function serializeError(error: unknown): SerializedError {
          message: error.message,
          stack: error.stack,
          malloyProblems: error.problems as unknown[],
+         isCompilationError: true,
+      };
+   }
+   // ModelCompilationError (e.g. an invalid #(authorize) annotation caught by
+   // validateAuthorizeProbes) carries no Malloy `problems`, but it must keep its
+   // compilation-error classification across the worker boundary so the main
+   // thread re-wraps it as a 424, not a generic 500.
+   if (error instanceof ModelCompilationError) {
+      return {
+         name: error.name,
+         message: error.message,
+         stack: error.stack,
          isCompilationError: true,
       };
    }

--- a/packages/server/src/package_load/package_load_worker.ts
+++ b/packages/server/src/package_load/package_load_worker.ts
@@ -80,6 +80,7 @@ import {
 } from "../constants";
 import { HackyDataStylesAccumulator } from "../data_styles";
 import { type AnnotationsDef } from "../service/annotations";
+import { validateAuthorizeProbes } from "../service/authorize";
 import { type FilterDefinition } from "../service/filter";
 import {
    extractQueriesFromModelDef,
@@ -551,6 +552,10 @@ async function compileMalloyModel(
 
    const { sources, filterMap } = extractSources(modelDef, givens);
    const queries = extractQueries(modelDef);
+   // Validate #(authorize) at compile time (shared with Model.create). Throws
+   // on an unknown given / source-field reference; compileOneModel's catch
+   // turns it into this model's compilationError.
+   await validateAuthorizeProbes(mm, sources);
 
    return {
       modelPath,
@@ -730,6 +735,8 @@ async function compileNotebookModel(
       finalSources = extracted.sources;
       finalFilterMap = extracted.filterMap;
       finalQueries = extractQueries(finalModelDef);
+      // Validate #(authorize) at compile time (shared with Model.create).
+      await validateAuthorizeProbes(mm, finalSources);
    }
 
    return {

--- a/packages/server/src/service/authorize.ts
+++ b/packages/server/src/service/authorize.ts
@@ -11,17 +11,84 @@
  * so we cannot reuse filter.ts's whitespace tokenizer — we unwrap exactly one
  * layer of double quotes and hand the inner expression back untouched.
  *
- * This module only parses and collects. Evaluating the expression (the actual
- * access gate) and validating it at compile time land in later PRs; both reuse
- * the maps built here. Kept dependency-free so it bundles cleanly into the
- * package-load worker.
+ * This module parses, collects, and (at compile time) validates authorize
+ * annotations. Evaluating the expression — the actual access gate — lands in a
+ * later PR and reuses `buildAuthorizeProbe`. Kept light so it bundles cleanly
+ * into the package-load worker (the only non-type import is the shared
+ * `ModelCompilationError`).
  */
+
+import { ModelCompilationError } from "../errors";
 
 const SOURCE_PREFIX = "#(authorize)";
 const FILE_PREFIX = "##(authorize)";
 
 /** source name → effective authorize expressions (file-level then source-level). */
 export type AuthorizeMap = Map<string, string[]>;
+
+/**
+ * Build the synthetic probe query that evaluates a source's authorize
+ * expressions. Each expression becomes a boolean `select` column over a
+ * one-row, warehouse-independent DuckDB source (the `"duckdb"` sandbox is
+ * registered for every package, so this never touches the model's real
+ * warehouse). Compiling this probe validates the expressions against the
+ * model's `given:` block (unknown givens and source-field references surface as
+ * compile errors); running it evaluates the gate. The reserved dummy column
+ * name is deliberately obscure so a real authorize expression is unlikely to
+ * collide with it — a bare field reference in an expression is meant to fail.
+ */
+export function buildAuthorizeProbe(exprs: string[]): string {
+   const selects = exprs
+      .map((expr, i) => `__auth_${i} is (${expr})`)
+      .join("\n      ");
+   return `run: duckdb.sql("SELECT 1 AS __authorize_probe_row") -> {
+    select:
+      ${selects}
+    limit: 1
+  }`;
+}
+
+/** Minimal materializer surface needed to compile (not run) the probe. */
+interface AuthorizeProbeCompiler {
+   loadQuery(query: string): { getPreparedQuery(): Promise<unknown> };
+}
+
+/** A source plus its effective authorize expressions. */
+interface SourceWithAuthorize {
+   name?: string;
+   authorize?: string[];
+}
+
+/**
+ * Translation-time validation. For each source carrying authorize expressions,
+ * compile the probe (no givens, no DB execution) so unknown givens and
+ * source-field references surface as compile errors at model load instead of
+ * first request. Type mismatches such as `$ROLE = 5` are NOT Malloy compile
+ * errors, so they are not caught here — they fail closed at the runtime gate.
+ *
+ * Throws `ModelCompilationError` naming the source on the first invalid
+ * annotation. Shared by `Model.create` and the package-load worker so both
+ * compile paths validate identically.
+ */
+export async function validateAuthorizeProbes(
+   compiler: AuthorizeProbeCompiler,
+   sources: readonly SourceWithAuthorize[],
+): Promise<void> {
+   for (const source of sources) {
+      const exprs = source.authorize;
+      if (!exprs || exprs.length === 0) continue;
+      try {
+         await compiler
+            .loadQuery(buildAuthorizeProbe(exprs))
+            .getPreparedQuery();
+      } catch (err) {
+         const detail = err instanceof Error ? err.message : String(err);
+         throw new ModelCompilationError({
+            message: `Invalid #(authorize) annotation on source "${source.name ?? "(unnamed)"}" [${exprs.join(" | ")}]: ${detail}`,
+         });
+      }
+   }
+}
 
 /**
  * Parse a single annotation string into its authorize expression.

--- a/packages/server/src/service/authorize_integration.spec.ts
+++ b/packages/server/src/service/authorize_integration.spec.ts
@@ -286,4 +286,59 @@ source: gated is duckdb.table('customers')
 
       expect(model.getNotebookError()).toBeUndefined();
    });
+
+   it("fails model load when a file-level ##(authorize) references an unknown given", async () => {
+      await writeModel(
+         "file_unknown_given.malloy",
+         `##! experimental.givens
+
+given:
+  ROLE :: string
+
+##(authorize) "$NOPE = 'x'"
+
+source: gated is duckdb.table('customers')
+`,
+      );
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "file_unknown_given.malloy",
+         getConnections(),
+      );
+
+      const err = model.getNotebookError();
+      expect(err).toBeDefined();
+      expect(err?.message).toContain("gated");
+      expect(err?.message).toMatch(/NOPE|not declared/i);
+   });
+
+   it("validates expressions over number and list givens, not just strings", async () => {
+      await writeModel(
+         "given_types.malloy",
+         `##! experimental.givens
+
+given:
+  AGE :: number
+  TENANT :: string
+  ALLOWED :: string[]
+
+#(authorize) "$AGE > 18"
+#(authorize) "$TENANT in $ALLOWED"
+source: gated is duckdb.table('customers')
+`,
+      );
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "given_types.malloy",
+         getConnections(),
+      );
+
+      expect(model.getNotebookError()).toBeUndefined();
+      expect(model.getAuthorize("gated")).toEqual([
+         "$AGE > 18",
+         "$TENANT in $ALLOWED",
+      ]);
+   });
 });

--- a/packages/server/src/service/authorize_integration.spec.ts
+++ b/packages/server/src/service/authorize_integration.spec.ts
@@ -191,3 +191,99 @@ source: broken is duckdb.table('customers')
       expect(sourceNamed(model, "open_source")?.authorize).toBeUndefined();
    });
 });
+
+describe("authorize annotation compile-time validation", () => {
+   it("loads a valid expression that references a value-less given", async () => {
+      // The probe is compiled, not run, so a given with no default/value does
+      // NOT cause a false failure (the original getSQL approach would have).
+      await writeModel(
+         "valid_valueless.malloy",
+         `##! experimental.givens
+
+given:
+  ROLE :: string
+
+#(authorize) "$ROLE = 'analyst'"
+source: gated is duckdb.table('customers')
+`,
+      );
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "valid_valueless.malloy",
+         getConnections(),
+      );
+
+      expect(model.getNotebookError()).toBeUndefined();
+      expect(model.getAuthorize("gated")).toEqual(["$ROLE = 'analyst'"]);
+   });
+
+   it("fails model load when an expression references an unknown given", async () => {
+      await writeModel(
+         "unknown_given.malloy",
+         `##! experimental.givens
+
+given:
+  ROLE :: string
+
+#(authorize) "$NOPE = 'x'"
+source: gated is duckdb.table('customers')
+`,
+      );
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "unknown_given.malloy",
+         getConnections(),
+      );
+
+      const err = model.getNotebookError();
+      expect(err).toBeDefined();
+      // Names the source and surfaces the underlying Malloy reason.
+      expect(err?.message).toContain("gated");
+      expect(err?.message).toMatch(/NOPE|not declared/i);
+   });
+
+   it("fails model load when an expression references a source field", async () => {
+      await writeModel(
+         "field_ref.malloy",
+         `#(authorize) "some_field = 1"
+source: gated is duckdb.table('customers')
+`,
+      );
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "field_ref.malloy",
+         getConnections(),
+      );
+
+      const err = model.getNotebookError();
+      expect(err).toBeDefined();
+      expect(err?.message).toContain("gated");
+   });
+
+   it("does not reject a type-mismatched comparison (not a Malloy compile error)", async () => {
+      // Documents the boundary: `$ROLE = 5` is not a compile error; such a gate
+      // simply evaluates per the warehouse at the runtime gate.
+      await writeModel(
+         "type_mismatch.malloy",
+         `##! experimental.givens
+
+given:
+  ROLE :: string
+
+#(authorize) "$ROLE = 5"
+source: gated is duckdb.table('customers')
+`,
+      );
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "type_mismatch.malloy",
+         getConnections(),
+      );
+
+      expect(model.getNotebookError()).toBeUndefined();
+   });
+});

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -53,6 +53,7 @@ import {
    type FilterDefinition,
    type FilterParams,
 } from "./filter";
+import { validateAuthorizeProbes } from "./authorize";
 import { malloyGivenToApi, type MalloyGiven } from "./given";
 import {
    extractQueriesFromModelDef,
@@ -271,6 +272,12 @@ export class Model {
             sources = sourceResult.sources;
             filterMap = sourceResult.filterMap;
             queries = Model.getQueries(modelDef);
+
+            // Translation-time validation of #(authorize) annotations (shared
+            // with the package-load worker so both compile paths validate
+            // identically). Compiling the probe surfaces unknown givens and
+            // source-field references at model-load instead of first request.
+            await validateAuthorizeProbes(modelMaterializer, sources ?? []);
 
             // Collect sourceInfos from imported models first
             // This follows the same pattern as notebook imports handling

--- a/packages/server/src/service/package_worker_path.spec.ts
+++ b/packages/server/src/service/package_worker_path.spec.ts
@@ -211,11 +211,15 @@ given:
 source: gated is duckdb.sql("select 1 as id")`,
       );
 
+      const { ModelCompilationError } = await import("../errors");
       const { malloyConfig, duckdb } = await makeMalloyConfig();
       try {
+         // Must surface as a 424 ModelCompilationError across the worker
+         // boundary, not a generic 500 — the worker serializes it with
+         // isCompilationError so the main thread re-wraps it.
          await expect(
             Package.create("env", "pkg", tempDir, malloyConfig),
-         ).rejects.toBeInstanceOf(Error);
+         ).rejects.toBeInstanceOf(ModelCompilationError);
       } finally {
          await duckdb.close();
       }

--- a/packages/server/src/service/package_worker_path.spec.ts
+++ b/packages/server/src/service/package_worker_path.spec.ts
@@ -225,6 +225,61 @@ source: gated is duckdb.sql("select 1 as id")`,
       }
    });
 
+   it("validates a valid #(authorize) source in a .malloynb notebook through the worker", async () => {
+      writeManifest();
+      fs.writeFileSync(
+         path.join(tempDir, "gated.malloynb"),
+         `>>>markdown
+# Gated notebook
+
+>>>malloy
+##! experimental.givens
+
+given:
+  ROLE :: string
+
+#(authorize) "$ROLE = 'analyst'"
+source: gated is duckdb.sql("select 1 as id")`,
+      );
+
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const model = pkg.getModel("gated.malloynb");
+         // compileNotebookModel ran authorize validation (no throw) and
+         // surfaced the gate — the notebook compile path was previously
+         // unexercised by tests.
+         expect(model!.getAuthorize("gated")).toEqual(["$ROLE = 'analyst'"]);
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("rejects a .malloynb notebook whose #(authorize) references an unknown given", async () => {
+      writeManifest();
+      fs.writeFileSync(
+         path.join(tempDir, "badgate.malloynb"),
+         `>>>malloy
+##! experimental.givens
+
+given:
+  ROLE :: string
+
+#(authorize) "$NOPE = 'x'"
+source: gated is duckdb.sql("select 1 as id")`,
+      );
+
+      const { ModelCompilationError } = await import("../errors");
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         await expect(
+            Package.create("env", "pkg", tempDir, malloyConfig),
+         ).rejects.toBeInstanceOf(ModelCompilationError);
+      } finally {
+         await duckdb.close();
+      }
+   });
+
    // NB: kept last in this describe — swapping the singleton for a
    // pre-shutdown pool also tears down the shared `pool` (the swap
    // implementation shuts down the outgoing singleton). Subsequent

--- a/packages/server/src/service/package_worker_path.spec.ts
+++ b/packages/server/src/service/package_worker_path.spec.ts
@@ -167,6 +167,60 @@ describe("Package.create via worker pool", () => {
       }
    });
 
+   it("validates and surfaces a valid #(authorize) model through the worker", async () => {
+      writeManifest();
+      fs.writeFileSync(
+         path.join(tempDir, "gated.malloy"),
+         `##! experimental.givens
+
+given:
+  ROLE :: string
+
+#(authorize) "$ROLE = 'analyst'"
+source: gated is duckdb.sql("select 1 as id")`,
+      );
+
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const model = pkg.getModel("gated.malloy");
+         const apiModel = (await model!.getModel()) as {
+            sources?: { name?: string; authorize?: string[] }[];
+         };
+         // The worker compiled the authorize probe (no throw) and surfaced the
+         // effective expression list — proves worker-path validation runs.
+         expect(apiModel.sources?.[0]?.authorize).toEqual([
+            "$ROLE = 'analyst'",
+         ]);
+         expect(model!.getAuthorize("gated")).toEqual(["$ROLE = 'analyst'"]);
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("rejects a package whose #(authorize) references an unknown given (worker validation)", async () => {
+      writeManifest();
+      fs.writeFileSync(
+         path.join(tempDir, "badgate.malloy"),
+         `##! experimental.givens
+
+given:
+  ROLE :: string
+
+#(authorize) "$NOPE = 'x'"
+source: gated is duckdb.sql("select 1 as id")`,
+      );
+
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         await expect(
+            Package.create("env", "pkg", tempDir, malloyConfig),
+         ).rejects.toBeInstanceOf(Error);
+      } finally {
+         await duckdb.close();
+      }
+   });
+
    // NB: kept last in this describe — swapping the singleton for a
    // pre-shutdown pool also tears down the shared `pool` (the swap
    // implementation shuts down the outgoing singleton). Subsequent


### PR DESCRIPTION
**PR 2 of the `#(authorize)` series.** PR 0 (#802) and PR 1 (#804) are merged; this targets `main`.

3. runtime gate (the actual access enforcement) — next
4. MCP + HTTP surface alignment
5. docs
6. end-to-end + example model

### What this one does
Catches a bad authorize expression at model load instead of first query. Compiles a synthetic probe (`run: duckdb.sql("SELECT 1") -> { select: __auth_i is (expr) }`) with `getPreparedQuery` — no givens, no DB execution. Unknown givens and source-field references surface as compile errors, wrapped in `ModelCompilationError` (424) naming the source. The per-package `duckdb` sandbox is always registered, so the probe never touches the real warehouse.

Wired into **both** compile paths — `Model.create` and the package-load worker (the primary path) — via one shared `validateAuthorizeProbes`, and the worker preserves the `ModelCompilationError` classification across its serialization boundary.

**Scope note:** a type-mismatched comparison like `$ROLE = 5` is *not* a Malloy compile error, so it isn't caught here — it fails closed at the runtime gate in PR 3. Syntactic malformed annotations already fail loud in PR 1.

### Tested
- `tsc` + eslint clean; 780 unit tests pass
- Compile-time validation (`Model.create`): valid value-less given loads (probe is compiled, not run), unknown-given (source-level AND file-level `##(authorize)`) and source-field-ref fail with the source named, type-mismatch loads, and number/list givens validate (not string-only)
- Worker path via `Package.create` — both `.malloy` and `.malloynb`: valid surfaces; unknown-given rejects as a **424 ModelCompilationError** (asserts the classification survives the worker boundary)
- `filter_integration` (32) green
- Independent multi-agent code review (bugs / git-history / comment-convention lenses): no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)