### PR TITLE
feat(server): enforce #(authorize) at query time (runtime gate)

### DIFF
--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -6,6 +6,8 @@ export function internalErrorToHttpError(error: Error) {
       return httpError(400, error.message);
    } else if (error instanceof FrozenConfigError) {
       return httpError(403, error.message);
+   } else if (error instanceof AccessDeniedError) {
+      return httpError(403, error.message);
    } else if (error instanceof EnvironmentNotFoundError) {
       return httpError(404, error.message);
    } else if (error instanceof PackageNotFoundError) {
@@ -111,6 +113,18 @@ export class FrozenConfigError extends Error {
       message = `Publisher config can't be updated when ${PUBLISHER_CONFIG_NAME} has { "frozenConfig": true }`,
    ) {
       super(message);
+   }
+}
+
+/**
+ * A request was denied by a source's `#(authorize)` gate (HTTP 403). Thrown by
+ * the runtime authorize check when no in-scope expression evaluates true for
+ * the supplied givens (including when a referenced given has no value).
+ */
+export class AccessDeniedError extends Error {
+   constructor(message: string) {
+      super(message);
+      this.name = "AccessDeniedError";
    }
 }
 

--- a/packages/server/src/service/authorize.spec.ts
+++ b/packages/server/src/service/authorize.spec.ts
@@ -1,5 +1,23 @@
 import { describe, expect, it } from "bun:test";
-import { collectAuthorizeExprs, parseAuthorizeAnnotation } from "./authorize";
+import {
+   collectAuthorizeExprs,
+   isProbeTrue,
+   parseAuthorizeAnnotation,
+} from "./authorize";
+
+describe("isProbeTrue", () => {
+   it("grants only on a genuine true / 1 / 'true'", () => {
+      expect(isProbeTrue(true)).toBe(true);
+      expect(isProbeTrue(1)).toBe(true);
+      expect(isProbeTrue("true")).toBe(true);
+   });
+
+   it("denies on anything else (fail closed)", () => {
+      for (const v of [false, 0, "false", "", null, undefined, {}, "TRUE", 2]) {
+         expect(isProbeTrue(v)).toBe(false);
+      }
+   });
+});
 
 describe("parseAuthorizeAnnotation", () => {
    it("parses a source-level #(authorize) expression", () => {

--- a/packages/server/src/service/authorize.ts
+++ b/packages/server/src/service/authorize.ts
@@ -75,24 +75,42 @@ interface AuthorizeProbeExecutor {
 }
 
 /**
- * Evaluate a source's authorize disjunction against the supplied givens by
- * running the probe. Returns true if ANY expression evaluates true (OR
- * semantics). A missing row counts as false. Throws if the probe itself fails
- * (e.g. a referenced given has no supplied value and no default) — the caller
- * treats any throw as denial (fail closed), which is how "missing given value"
- * becomes a 403 rather than a server error.
+ * Evaluate a source's authorize disjunction against the supplied givens.
+ * Returns true if ANY expression evaluates true (OR semantics).
+ *
+ * Each expression is probed INDEPENDENTLY rather than batched into one query.
+ * That is what preserves OR semantics: an expression that can't be evaluated —
+ * e.g. it references a given the request didn't supply, so Malloy throws "no
+ * value" — counts as "does not grant" (false), and the next disjunct is still
+ * tried. Batching them would let a missing given in one unused branch throw and
+ * sink the whole request (denying an admin who matched a different branch).
+ *
+ * Per-branch failures are swallowed to false (fail closed at the branch level);
+ * access is granted only if some branch genuinely returns true. Short-circuits
+ * on the first true. Returns false (→ caller denies) if none grant.
  */
 export async function evaluateAuthorize(
    executor: AuthorizeProbeExecutor,
    exprs: string[],
    givens: Record<string, GivenValue>,
 ): Promise<boolean> {
-   const result = await executor
-      .loadQuery(buildAuthorizeProbe(exprs))
-      .run({ rowLimit: 1, givens });
-   const row = result?.data?.value?.[0];
-   if (!row) return false;
-   return exprs.some((_, i) => isProbeTrue(row[`__auth_${i}`]));
+   for (const expr of exprs) {
+      try {
+         const result = await executor
+            .loadQuery(buildAuthorizeProbe([expr]))
+            .run({ rowLimit: 1, givens });
+         const row = result?.data?.value?.[0];
+         if (row && isProbeTrue(row.__auth_0)) {
+            return true;
+         }
+      } catch {
+         // This disjunct can't be evaluated (e.g. a referenced given has no
+         // value) — treat as not-granting and try the next. It does not fail
+         // the whole request, which is what keeps OR semantics intact.
+         continue;
+      }
+   }
+   return false;
 }
 
 /** A source plus its effective authorize expressions. */

--- a/packages/server/src/service/authorize.ts
+++ b/packages/server/src/service/authorize.ts
@@ -18,6 +18,7 @@
  * `ModelCompilationError`).
  */
 
+import { type GivenValue } from "@malloydata/malloy";
 import { ModelCompilationError } from "../errors";
 
 const SOURCE_PREFIX = "#(authorize)";
@@ -48,9 +49,50 @@ export function buildAuthorizeProbe(exprs: string[]): string {
   }`;
 }
 
+/**
+ * Strict, fail-closed truthiness for a probe result cell. DuckDB (the probe's
+ * connection) returns a native boolean, but normalize defensively: only a real
+ * `true` / SQL `1` / `"true"` grants access. null, undefined, `0`, `false`, a
+ * missing cell — anything else — denies.
+ */
+export function isProbeTrue(cell: unknown): boolean {
+   return cell === true || cell === 1 || cell === "true";
+}
+
 /** Minimal materializer surface needed to compile (not run) the probe. */
 interface AuthorizeProbeCompiler {
    loadQuery(query: string): { getPreparedQuery(): Promise<unknown> };
+}
+
+/** Minimal materializer surface needed to run the probe (the runtime gate). */
+interface AuthorizeProbeExecutor {
+   loadQuery(query: string): {
+      run(opts: {
+         rowLimit?: number;
+         givens?: Record<string, GivenValue>;
+      }): Promise<{ data: { value: ReadonlyArray<Record<string, unknown>> } }>;
+   };
+}
+
+/**
+ * Evaluate a source's authorize disjunction against the supplied givens by
+ * running the probe. Returns true if ANY expression evaluates true (OR
+ * semantics). A missing row counts as false. Throws if the probe itself fails
+ * (e.g. a referenced given has no supplied value and no default) — the caller
+ * treats any throw as denial (fail closed), which is how "missing given value"
+ * becomes a 403 rather than a server error.
+ */
+export async function evaluateAuthorize(
+   executor: AuthorizeProbeExecutor,
+   exprs: string[],
+   givens: Record<string, GivenValue>,
+): Promise<boolean> {
+   const result = await executor
+      .loadQuery(buildAuthorizeProbe(exprs))
+      .run({ rowLimit: 1, givens });
+   const row = result?.data?.value?.[0];
+   if (!row) return false;
+   return exprs.some((_, i) => isProbeTrue(row[`__auth_${i}`]));
 }
 
 /** A source plus its effective authorize expressions. */

--- a/packages/server/src/service/authorize_integration.spec.ts
+++ b/packages/server/src/service/authorize_integration.spec.ts
@@ -539,6 +539,42 @@ query: secret is gated -> { aggregate: c }
       expect(result.data).toBeDefined();
    });
 
+   it("gates a notebook cell that runs a NAMED QUERY targeting a gated source", async () => {
+      // `run: secret` has no `->`, so source resolution must come from the
+      // compiled query, not a text regex — otherwise the gate is bypassed.
+      await writeModel(
+         "rt_nb.malloynb",
+         `>>>malloy
+##! experimental.givens
+
+given:
+  ROLE :: string
+
+#(authorize) "$ROLE = 'analyst'"
+source: gated is duckdb.table('customers') extend { measure: c is count() }
+query: secret is gated -> { aggregate: c }
+
+>>>malloy
+run: secret
+`,
+      );
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "rt_nb.malloynb",
+         getConnections(),
+      );
+      // Cell 1 is `run: secret` — must be denied without the gate-passing given.
+      await expect(
+         model.executeNotebookCell(1, undefined, false, { ROLE: "intern" }),
+      ).rejects.toBeInstanceOf(AccessDeniedError);
+      // ...and allowed when the gate passes.
+      const ok = await model.executeNotebookCell(1, undefined, false, {
+         ROLE: "analyst",
+      });
+      expect(ok.result).toBeDefined();
+   });
+
    const LOCKED_BASE = `##! experimental.givens
 
 given:

--- a/packages/server/src/service/authorize_integration.spec.ts
+++ b/packages/server/src/service/authorize_integration.spec.ts
@@ -632,6 +632,35 @@ source: open_src is duckdb.table('customers') extend { measure: c is count() }
       expect(result.data).toBeDefined();
    });
 
+   it("gates a quoted-identifier source BEFORE compilation (no schema oracle)", async () => {
+      // A gated source whose Malloy name must be quoted (here, a hyphen) must be
+      // recognized by the early gate too. Otherwise a denied caller could probe
+      // a non-existent field and learn the schema from a pre-compilation Malloy
+      // field error instead of a clean 403.
+      await writeModel(
+         "rt_quoted.malloy",
+         `##! experimental.givens
+
+given:
+  ROLE :: string
+
+#(authorize) "$ROLE = 'analyst'"
+source: \`gated-source\` is duckdb.table('customers') extend {
+  measure: c is count()
+}
+`,
+      );
+      // Probing a field that doesn't exist must deny (403) before compilation,
+      // not surface a Malloy "field not found" error.
+      await expect(
+         runGated(
+            "rt_quoted.malloy",
+            "run: `gated-source` -> { group_by: no_such_field }",
+            { ROLE: "viewer" },
+         ),
+      ).rejects.toBeInstanceOf(AccessDeniedError);
+   });
+
    it("gates a notebook cell that runs a NAMED QUERY targeting a gated source", async () => {
       // `run: secret` has no `->`, so source resolution must come from the
       // compiled query, not a text regex — otherwise the gate is bypassed.

--- a/packages/server/src/service/authorize_integration.spec.ts
+++ b/packages/server/src/service/authorize_integration.spec.ts
@@ -575,33 +575,59 @@ given:
 source: declared is duckdb.table('customers') extend { measure: c is count() }
 `;
 
-   it("applies a file-level gate to an ad-hoc inline duckdb.sql query (no raw-SQL bypass)", async () => {
+   it("applies a file-level gate to an ad-hoc query (no gate bypass)", async () => {
       await writeModel("rt_filelevel.malloy", FILE_LEVEL);
-      // Inline SQL source is not a declared model source; the model-wide
-      // file-level gate must still apply, or it's a raw-warehouse bypass.
+      // The model-wide file-level gate must apply to any ad-hoc query against
+      // the model, denying a non-admin with a 403.
       await expect(
-         runGated(
-            "rt_filelevel.malloy",
-            `run: duckdb.sql("SELECT 1 AS id") -> { aggregate: c is count() }`,
-            { ROLE: "user" },
-         ),
+         runGated("rt_filelevel.malloy", "run: declared -> { aggregate: c }", {
+            ROLE: "user",
+         }),
       ).rejects.toBeInstanceOf(AccessDeniedError);
       // An admin (file-level gate satisfied) can run it.
       const { result } = await runGated(
          "rt_filelevel.malloy",
-         `run: duckdb.sql("SELECT 1 AS id") -> { aggregate: c is count() }`,
+         "run: declared -> { aggregate: c }",
          { ROLE: "admin" },
       );
       expect(result.data).toBeDefined();
    });
 
-   it("does not over-gate ad-hoc inline SQL when the model has no file-level gate", async () => {
-      // Control: a per-source gate is NOT model-wide, so an inline ad-hoc query
-      // in a model whose only gate is source-level stays unrestricted.
-      await writeModel("rt_single.malloy", SINGLE_GATE);
+   it("rejects an ad-hoc inline-SQL query (restricted mode closes the raw-warehouse path)", async () => {
+      // Pre-#807 the file-level #(authorize) gate was the only thing between a
+      // caller and raw `duckdb.sql(...)`. #807's restricted mode now rejects
+      // inline raw SQL outright while resolving the compiled source — before the
+      // gate is reached — so the raw-warehouse path is closed at the compile
+      // layer regardless of givens (even for an admin who satisfies the gate).
+      await writeModel("rt_filelevel.malloy", FILE_LEVEL);
+      await expect(
+         runGated(
+            "rt_filelevel.malloy",
+            `run: duckdb.sql("SELECT 1 AS id") -> { aggregate: c is count() }`,
+            { ROLE: "admin" },
+         ),
+      ).rejects.toThrow(/raw SQL is not permitted/);
+   });
+
+   const MIXED_SOURCE_GATE = `##! experimental.givens
+
+given:
+  ROLE :: string
+
+#(authorize) "$ROLE = 'analyst'"
+source: gated is duckdb.table('customers') extend { measure: c is count() }
+
+source: open_src is duckdb.table('customers') extend { measure: c is count() }
+`;
+
+   it("does not over-gate: a source-level gate is not model-wide", async () => {
+      // Control: a per-source gate applies only to that source, not the whole
+      // model. An ad-hoc query against an ungated declared source in the same
+      // model runs without any given.
+      await writeModel("rt_mixed.malloy", MIXED_SOURCE_GATE);
       const { result } = await runGated(
-         "rt_single.malloy",
-         `run: duckdb.sql("SELECT 1 AS id") -> { aggregate: c is count() }`,
+         "rt_mixed.malloy",
+         "run: open_src -> { aggregate: c }",
       );
       expect(result.data).toBeDefined();
    });

--- a/packages/server/src/service/authorize_integration.spec.ts
+++ b/packages/server/src/service/authorize_integration.spec.ts
@@ -1,15 +1,14 @@
 import { DuckDBConnection } from "@malloydata/db-duckdb";
-import { Connection } from "@malloydata/malloy";
+import { Connection, GivenValue } from "@malloydata/malloy";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
+import { AccessDeniedError } from "../errors";
 import { Model } from "./model";
 
-// Introspection-level tests for #(authorize) / ##(authorize) collection (PR1).
-// Runtime enforcement is added in a later PR; here we only assert that the
-// effective expression lists are collected correctly and surfaced via
-// getAuthorize() / Source.authorize.
+// Introspection (PR1), compile-time validation (PR2), and the runtime gate
+// (PR3) for #(authorize) / ##(authorize).
 
 const TEST_DIR = path.join(os.tmpdir(), "authorize-integration-tests");
 const TEST_DB_DIR = path.join(TEST_DIR, "db");
@@ -340,5 +339,194 @@ source: gated is duckdb.table('customers')
          "$AGE > 18",
          "$TENANT in $ALLOWED",
       ]);
+   });
+});
+
+describe("authorize runtime gate", () => {
+   // Helper: run an ad-hoc query through the full getQueryResults path (which
+   // is where the gate fires). Returns the result or throws AccessDeniedError.
+   async function runGated(
+      modelFile: string,
+      query: string,
+      givens?: Record<string, GivenValue>,
+      bypassFilters?: boolean,
+   ) {
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         modelFile,
+         getConnections(),
+      );
+      return model.getQueryResults(
+         undefined,
+         undefined,
+         query,
+         undefined,
+         bypassFilters,
+         givens,
+      );
+   }
+
+   const SINGLE_GATE = `##! experimental.givens
+
+given:
+  ROLE :: string
+
+#(authorize) "$ROLE = 'analyst'"
+source: gated is duckdb.table('customers') extend { measure: c is count() }
+`;
+
+   it("allows the query when a given satisfies the gate", async () => {
+      await writeModel("rt_single.malloy", SINGLE_GATE);
+      const { result } = await runGated(
+         "rt_single.malloy",
+         "run: gated -> { aggregate: c }",
+         { ROLE: "analyst" },
+      );
+      expect(result.data).toBeDefined();
+   });
+
+   it("denies (403) when no given satisfies the gate", async () => {
+      await writeModel("rt_single.malloy", SINGLE_GATE);
+      await expect(
+         runGated("rt_single.malloy", "run: gated -> { aggregate: c }", {
+            ROLE: "intern",
+         }),
+      ).rejects.toBeInstanceOf(AccessDeniedError);
+   });
+
+   it("denies when the referenced given has no value (fail closed)", async () => {
+      await writeModel("rt_single.malloy", SINGLE_GATE);
+      await expect(
+         runGated("rt_single.malloy", "run: gated -> { aggregate: c }", {}),
+      ).rejects.toBeInstanceOf(AccessDeniedError);
+   });
+
+   it("still enforces the gate when bypassFilters is true (authorize is not a filter)", async () => {
+      await writeModel("rt_single.malloy", SINGLE_GATE);
+      await expect(
+         runGated(
+            "rt_single.malloy",
+            "run: gated -> { aggregate: c }",
+            { ROLE: "intern" },
+            true,
+         ),
+      ).rejects.toBeInstanceOf(AccessDeniedError);
+   });
+
+   const DISJUNCTION = `##! experimental.givens
+
+given:
+  ROLE :: string
+  REGION :: string
+
+##(authorize) "$ROLE = 'admin'"
+
+#(authorize) "$REGION = 'us-west'"
+source: regional is duckdb.table('customers') extend { measure: c is count() }
+`;
+
+   it("grants when the file-level gate alone is satisfied (disjunction)", async () => {
+      await writeModel("rt_disj.malloy", DISJUNCTION);
+      const { result } = await runGated(
+         "rt_disj.malloy",
+         "run: regional -> { aggregate: c }",
+         { ROLE: "admin", REGION: "nowhere" },
+      );
+      expect(result.data).toBeDefined();
+   });
+
+   it("grants when the source-level gate alone is satisfied (disjunction)", async () => {
+      await writeModel("rt_disj.malloy", DISJUNCTION);
+      const { result } = await runGated(
+         "rt_disj.malloy",
+         "run: regional -> { aggregate: c }",
+         { ROLE: "nobody", REGION: "us-west" },
+      );
+      expect(result.data).toBeDefined();
+   });
+
+   it("denies when neither disjunct is satisfied", async () => {
+      await writeModel("rt_disj.malloy", DISJUNCTION);
+      await expect(
+         runGated("rt_disj.malloy", "run: regional -> { aggregate: c }", {
+            ROLE: "nobody",
+            REGION: "nowhere",
+         }),
+      ).rejects.toBeInstanceOf(AccessDeniedError);
+   });
+
+   it("leaves a source with no authorize annotations unrestricted", async () => {
+      await writeModel(
+         "rt_open.malloy",
+         `source: open_src is duckdb.table('customers') extend { measure: c is count() }
+`,
+      );
+      const { result } = await runGated(
+         "rt_open.malloy",
+         "run: open_src -> { aggregate: c }",
+      );
+      expect(result.data).toBeDefined();
+   });
+
+   const LOCKED_BASE = `##! experimental.givens
+
+given:
+  ROLE :: string
+
+#(authorize) "false"
+source: base_locked is duckdb.table('customers') extend { measure: c is count() }
+
+#(authorize) "$ROLE = 'analyst'"
+source: ext_gated is base_locked extend {}
+
+source: ext_nogate is base_locked extend {}
+
+source: joiner is duckdb.table('customers') extend {
+  join_one: base_locked on id = base_locked.id
+  measure: c is count()
+}
+`;
+
+   it('denies a direct query against a base locked with #(authorize) "false"', async () => {
+      await writeModel("rt_locked.malloy", LOCKED_BASE);
+      await expect(
+         runGated("rt_locked.malloy", "run: base_locked -> { aggregate: c }", {
+            ROLE: "analyst",
+         }),
+      ).rejects.toBeInstanceOf(AccessDeniedError);
+   });
+
+   it("allows an extension of a locked base when the extension's own gate passes", async () => {
+      await writeModel("rt_locked.malloy", LOCKED_BASE);
+      const { result } = await runGated(
+         "rt_locked.malloy",
+         "run: ext_gated -> { aggregate: c }",
+         { ROLE: "analyst" },
+      );
+      expect(result.data).toBeDefined();
+   });
+
+   it("denies an extension that declares no own gate — it inherits the base lock (safe default)", async () => {
+      // Malloy carries the base's #(authorize) onto an extension UNLESS the
+      // extension declares its own. So a bare `is base_locked extend {}` with
+      // no own gate stays locked by the base's "false". An extension escapes
+      // the base gate only by declaring its own #(authorize) (see ext_gated).
+      await writeModel("rt_locked.malloy", LOCKED_BASE);
+      await expect(
+         runGated("rt_locked.malloy", "run: ext_nogate -> { aggregate: c }", {
+            ROLE: "analyst",
+         }),
+      ).rejects.toBeInstanceOf(AccessDeniedError);
+   });
+
+   it("[documented limitation] a query joining a locked base via an ungated source is allowed (top-level-source only)", async () => {
+      await writeModel("rt_locked.malloy", LOCKED_BASE);
+      const { result } = await runGated(
+         "rt_locked.malloy",
+         "run: joiner -> { aggregate: c }",
+         {},
+      );
+      expect(result.data).toBeDefined();
    });
 });

--- a/packages/server/src/service/authorize_integration.spec.ts
+++ b/packages/server/src/service/authorize_integration.spec.ts
@@ -526,6 +526,32 @@ query: secret is gated -> { aggregate: c }
       ).rejects.toBeInstanceOf(AccessDeniedError);
    });
 
+   it("gates the source the query actually RUNS, not a decoy leading statement", async () => {
+      // Malloy runs the LAST `run:`. A multi-statement ad-hoc query that names
+      // an ungated source first and the gated source last must be gated on the
+      // gated source (the one that executes), not fooled by the leading one.
+      await writeModel(
+         "rt_multi.malloy",
+         `##! experimental.givens
+
+given:
+  ROLE :: string
+
+source: ungated is duckdb.table('customers') extend { measure: c is count() }
+
+#(authorize) "$ROLE = 'analyst'"
+source: gated is duckdb.table('customers') extend { measure: c is count() }
+`,
+      );
+      await expect(
+         runGated(
+            "rt_multi.malloy",
+            "run: ungated -> { aggregate: c }\nrun: gated -> { aggregate: c }",
+            { ROLE: "intern" },
+         ),
+      ).rejects.toBeInstanceOf(AccessDeniedError);
+   });
+
    it("leaves a source with no authorize annotations unrestricted", async () => {
       await writeModel(
          "rt_open.malloy",

--- a/packages/server/src/service/authorize_integration.spec.ts
+++ b/packages/server/src/service/authorize_integration.spec.ts
@@ -426,22 +426,25 @@ given:
 source: regional is duckdb.table('customers') extend { measure: c is count() }
 `;
 
-   it("grants when the file-level gate alone is satisfied (disjunction)", async () => {
+   it("grants on the file-level gate even when the OTHER disjunct's given is missing", async () => {
+      // The key OR-semantics case: admin supplies only ROLE; REGION is absent.
+      // A disjunct that can't evaluate (missing given) must not sink the whole
+      // request — the satisfied $ROLE='admin' branch still grants.
       await writeModel("rt_disj.malloy", DISJUNCTION);
       const { result } = await runGated(
          "rt_disj.malloy",
          "run: regional -> { aggregate: c }",
-         { ROLE: "admin", REGION: "nowhere" },
+         { ROLE: "admin" },
       );
       expect(result.data).toBeDefined();
    });
 
-   it("grants when the source-level gate alone is satisfied (disjunction)", async () => {
+   it("grants on the source-level gate even when the file-level disjunct's given is missing", async () => {
       await writeModel("rt_disj.malloy", DISJUNCTION);
       const { result } = await runGated(
          "rt_disj.malloy",
          "run: regional -> { aggregate: c }",
-         { ROLE: "nobody", REGION: "us-west" },
+         { REGION: "us-west" },
       );
       expect(result.data).toBeDefined();
    });
@@ -453,6 +456,73 @@ source: regional is duckdb.table('customers') extend { measure: c is count() }
             ROLE: "nobody",
             REGION: "nowhere",
          }),
+      ).rejects.toBeInstanceOf(AccessDeniedError);
+   });
+
+   it("gates a named query that targets a gated source (no sourceName supplied)", async () => {
+      await writeModel(
+         "rt_namedq.malloy",
+         `##! experimental.givens
+
+given:
+  ROLE :: string
+
+#(authorize) "$ROLE = 'analyst'"
+source: gated is duckdb.table('customers') extend { measure: c is count() }
+
+query: secret is gated -> { aggregate: c }
+`,
+      );
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "rt_namedq.malloy",
+         getConnections(),
+      );
+      // Named query, no sourceName — must still resolve to `gated` and gate it.
+      await expect(
+         model.getQueryResults(
+            undefined,
+            "secret",
+            undefined,
+            undefined,
+            false,
+            {
+               ROLE: "intern",
+            },
+         ),
+      ).rejects.toBeInstanceOf(AccessDeniedError);
+      // And it runs when the gate passes.
+      const { result } = await model.getQueryResults(
+         undefined,
+         "secret",
+         undefined,
+         undefined,
+         false,
+         { ROLE: "analyst" },
+      );
+      expect(result.data).toBeDefined();
+   });
+
+   it("gates an ad-hoc query even when a blank sourceName is supplied", async () => {
+      await writeModel("rt_single.malloy", SINGLE_GATE);
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "rt_single.malloy",
+         getConnections(),
+      );
+      // Blank sourceName must not skip the gate while the query-builder treats
+      // it as absent and runs the ad-hoc query.
+      await expect(
+         model.getQueryResults(
+            "",
+            undefined,
+            "run: gated -> { aggregate: c }",
+            undefined,
+            false,
+            { ROLE: "intern" },
+         ),
       ).rejects.toBeInstanceOf(AccessDeniedError);
    });
 

--- a/packages/server/src/service/authorize_integration.spec.ts
+++ b/packages/server/src/service/authorize_integration.spec.ts
@@ -565,6 +565,47 @@ source: gated is duckdb.table('customers') extend { measure: c is count() }
       expect(result.data).toBeDefined();
    });
 
+   const FILE_LEVEL = `##! experimental.givens
+
+given:
+  ROLE :: string
+
+##(authorize) "$ROLE = 'admin'"
+
+source: declared is duckdb.table('customers') extend { measure: c is count() }
+`;
+
+   it("applies a file-level gate to an ad-hoc inline duckdb.sql query (no raw-SQL bypass)", async () => {
+      await writeModel("rt_filelevel.malloy", FILE_LEVEL);
+      // Inline SQL source is not a declared model source; the model-wide
+      // file-level gate must still apply, or it's a raw-warehouse bypass.
+      await expect(
+         runGated(
+            "rt_filelevel.malloy",
+            `run: duckdb.sql("SELECT 1 AS id") -> { aggregate: c is count() }`,
+            { ROLE: "user" },
+         ),
+      ).rejects.toBeInstanceOf(AccessDeniedError);
+      // An admin (file-level gate satisfied) can run it.
+      const { result } = await runGated(
+         "rt_filelevel.malloy",
+         `run: duckdb.sql("SELECT 1 AS id") -> { aggregate: c is count() }`,
+         { ROLE: "admin" },
+      );
+      expect(result.data).toBeDefined();
+   });
+
+   it("does not over-gate ad-hoc inline SQL when the model has no file-level gate", async () => {
+      // Control: a per-source gate is NOT model-wide, so an inline ad-hoc query
+      // in a model whose only gate is source-level stays unrestricted.
+      await writeModel("rt_single.malloy", SINGLE_GATE);
+      const { result } = await runGated(
+         "rt_single.malloy",
+         `run: duckdb.sql("SELECT 1 AS id") -> { aggregate: c is count() }`,
+      );
+      expect(result.data).toBeDefined();
+   });
+
    it("gates a notebook cell that runs a NAMED QUERY targeting a gated source", async () => {
       // `run: secret` has no `->`, so source resolution must come from the
       // compiled query, not a text regex — otherwise the gate is bypassed.

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -319,9 +319,17 @@ export class Model {
     */
    private extractSourceName(query?: string): string | undefined {
       if (!query) return undefined;
-      const runMatch = query.match(/run\s*:\s*(\w+)\s*->/);
-      const arrowMatch = query.match(/^\s*(\w+)\s*->/m);
-      return runMatch?.[1] ?? arrowMatch?.[1];
+      // Match a bare `\w+` identifier or a backtick-quoted Malloy identifier
+      // (e.g. `gated-source`, which needs quoting for the hyphen). Quoted names
+      // must be recognized here too, or the early schema-oracle gate would miss
+      // a gated source with a quoted name and let a denied caller probe its
+      // columns via a pre-compilation field error. The quoted capture returns
+      // the inner name (no backticks), matching how sources are keyed.
+      const runMatch = query.match(/run\s*:\s*(?:`([^`]+)`|(\w+))\s*->/);
+      const arrowMatch = query.match(/^\s*(?:`([^`]+)`|(\w+))\s*->/m);
+      return (
+         runMatch?.[1] ?? runMatch?.[2] ?? arrowMatch?.[1] ?? arrowMatch?.[2]
+      );
    }
 
    /**

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -660,7 +660,22 @@ export class Model {
       // compilation, and regardless of bypassFilters (authorize is an access
       // gate, not a filter). Kept outside the loadQuery try below so an
       // AccessDeniedError propagates as a 403 instead of being rewrapped 400.
-      const authorizeSource = sourceName ?? this.extractSourceName(query);
+      //
+      // Resolve the gated source the same three ways a request can name one:
+      //  - explicit sourceName (normalize "" → undefined; the query-builder
+      //    treats blank as absent, so a blank here must not skip the gate);
+      //  - a named query (run: <queryName>), whose source we look up so a
+      //    `query: secret is gated -> ...` request can't dodge the gate;
+      //  - an ad-hoc query string.
+      let authorizeSource = sourceName || undefined;
+      if (!authorizeSource && queryName) {
+         authorizeSource = this.queries?.find(
+            (q) => q.name === queryName,
+         )?.sourceName;
+      }
+      if (!authorizeSource) {
+         authorizeSource = this.extractSourceName(query);
+      }
       if (authorizeSource) {
          await this.assertAuthorized(authorizeSource, givens ?? {});
       }

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -54,7 +54,11 @@ import {
    type FilterDefinition,
    type FilterParams,
 } from "./filter";
-import { evaluateAuthorize, validateAuthorizeProbes } from "./authorize";
+import {
+   collectAuthorizeExprs,
+   evaluateAuthorize,
+   validateAuthorizeProbes,
+} from "./authorize";
 import { malloyGivenToApi, type MalloyGiven } from "./given";
 import {
    extractQueriesFromModelDef,
@@ -115,6 +119,9 @@ export class Model {
     *  `Model.givens` already collapses inheritance; we just stash the list
     *  for surfacing on the compiled-model response. */
    private givens: ApiGiven[] | undefined;
+   /** Model-wide `##(authorize)` expressions; apply to every query in the
+    *  model, including ad-hoc inline sources not declared in the model. */
+   private fileLevelAuthorize: string[] = [];
    private meter = metrics.getMeter("publisher");
    private queryExecutionHistogram = this.meter.createHistogram(
       "malloy_model_query_duration",
@@ -162,6 +169,24 @@ export class Model {
       this.compilationError = compilationError;
       this.filterMap = filterMap ?? new Map();
       this.givens = givens;
+      // Model-wide ##(authorize) gates, derived from the file-level annotations
+      // on the modelDef (which survives the worker boundary). These apply to
+      // any query in the model, including ad-hoc inline `duckdb.sql(...)`
+      // sources that aren't declared model sources — so a file-level gate
+      // can't be bypassed by querying the warehouse through raw SQL. A
+      // successfully-loaded model has already had these validated; guard the
+      // parse defensively so the constructor never throws.
+      try {
+         this.fileLevelAuthorize = this.modelDef
+            ? collectAuthorizeExprs(
+                 (this.modelDef.annotations?.notes ?? []).map(
+                    (note) => note.text,
+                 ),
+              )
+            : [];
+      } catch {
+         this.fileLevelAuthorize = [];
+      }
       this.modelInfo =
          modelInfo ??
          (this.modelDef ? modelDefToModelInfo(this.modelDef) : undefined);
@@ -206,9 +231,24 @@ export class Model {
    }
 
    /**
+    * Effective authorize expressions for whatever a query runs against:
+    *  - a declared model source → its own list (file-level ++ source-level);
+    *  - anything else (an ad-hoc inline `duckdb.sql(...)` source, or a source
+    *    we couldn't name) → the model-wide file-level `##(authorize)` gates.
+    * The second case is what stops a file-level gate from being bypassed by
+    * querying the warehouse through raw inline SQL.
+    */
+   private effectiveAuthorizeFor(sourceName: string | undefined): string[] {
+      if (sourceName && this.sources?.some((s) => s.name === sourceName)) {
+         return this.getAuthorize(sourceName);
+      }
+      return this.fileLevelAuthorize;
+   }
+
+   /**
     * Runtime authorize gate. Throws `AccessDeniedError` (403) unless at least
-    * one of the source's in-scope authorize expressions evaluates true for the
-    * supplied givens. A source with no authorize annotations is unrestricted.
+    * one in-scope authorize expression evaluates true for the supplied givens.
+    * No in-scope expressions = unrestricted.
     *
     * Fail closed: any failure to evaluate the probe — a missing given value, a
     * transient probe error, a missing/non-true result — denies. (Expression
@@ -217,39 +257,33 @@ export class Model {
     * is not leaked to the caller.
     */
    public async assertAuthorized(
-      sourceName: string,
+      sourceName: string | undefined,
       givens: Record<string, GivenValue>,
    ): Promise<void> {
-      const exprs = this.getAuthorize(sourceName);
+      const exprs = this.effectiveAuthorizeFor(sourceName);
       if (exprs.length === 0) return; // unrestricted
-      if (!this.modelMaterializer) {
-         throw new AccessDeniedError(
-            `Access denied for source "${sourceName}".`,
-         );
-      }
+      const label = sourceName ?? "(query)";
+      const deny = () => {
+         throw new AccessDeniedError(`Access denied for source "${label}".`);
+      };
+      if (!this.modelMaterializer) deny();
       let passed = false;
       try {
          passed = await evaluateAuthorize(
-            this.modelMaterializer,
+            this.modelMaterializer!,
             exprs,
             givens,
          );
       } catch (err) {
          // Fail closed — e.g. a referenced given had no supplied value.
          logger.debug("Authorize probe failed; denying", {
-            sourceName,
+            sourceName: label,
             modelPath: this.modelPath,
             error: err instanceof Error ? err.message : String(err),
          });
-         throw new AccessDeniedError(
-            `Access denied for source "${sourceName}".`,
-         );
+         deny();
       }
-      if (!passed) {
-         throw new AccessDeniedError(
-            `Access denied for source "${sourceName}".`,
-         );
-      }
+      if (!passed) deny();
    }
 
    /**
@@ -682,6 +716,24 @@ export class Model {
       if (!this.modelMaterializer || !this.modelDef || !this.modelInfo)
          throw new BadRequestError("Model has no queryable entities.");
 
+      // Early fast-path authorize gate (before loadQuery). Resolve the source
+      // from surface syntax; gate if it names one. This runs BEFORE compilation
+      // so the gate can't be used as a schema oracle — without it, a denied
+      // caller probing `run: gated -> { group_by: maybe_field }` would get a
+      // Malloy "field not found" vs a 403 and learn the gated source's columns.
+      // It does NOT replace the authoritative compiled-source gate below (which
+      // always runs and catches named-query / multi-statement forms surface
+      // syntax can't resolve); it only fails fast for the common case.
+      const earlySource =
+         sourceName ||
+         (queryName
+            ? this.queries?.find((q) => q.name === queryName)?.sourceName
+            : undefined) ||
+         this.extractSourceName(query);
+      if (earlySource) {
+         await this.assertAuthorized(earlySource, givens ?? {});
+      }
+
       // Wrap loadQuery calls in try-catch to handle query parsing errors
       try {
          let queryString: string;
@@ -768,20 +820,25 @@ export class Model {
          throw new BadRequestError(`Invalid query: ${errorMessage}`);
       }
 
-      // Authorize gate. Resolve the gated source from the COMPILED query —
-      // the source Malloy actually runs (the LAST `run:` statement) — not from
-      // surface syntax. Surface-syntax resolution is both bypassable (a
-      // first-statement regex vs. last-statement execution: `run: ungated\nrun:
-      // gated` would gate `ungated` while running `gated`) and over-restrictive
-      // (it would gate a non-running leading statement). Gating the compiled
-      // structRef is authoritative and handles named-query / blank-source /
-      // multi-statement forms uniformly. Runs after loadQuery (so we have the
-      // compiled query) but OUTSIDE its try, so AccessDeniedError stays a 403;
-      // it is independent of bypassFilters (authorize is not a filter).
-      const authorizeSource =
+      // Authoritative authorize gate: resolve the gated source from the
+      // COMPILED query — the source Malloy actually runs (the LAST `run:`
+      // statement) — not from surface syntax. Surface-syntax resolution alone
+      // is both bypassable (first-statement regex vs. last-statement execution:
+      // `run: ungated\nrun: gated` would gate `ungated` while running `gated`)
+      // and over-restrictive, so this compiled check always runs and is the
+      // source of truth; it handles named-query / blank-source / multi-statement
+      // forms uniformly. Skip only the redundant re-probe when it's the same
+      // source the early gate already cleared. Outside the loadQuery try so
+      // AccessDeniedError stays a 403; independent of bypassFilters.
+      const compiledSource =
          await this.resolveAuthorizeSourceFromRunnable(runnable);
-      if (authorizeSource) {
-         await this.assertAuthorized(authorizeSource, givens ?? {});
+      // Run unless it's the redundant re-probe of the exact named source the
+      // early gate already cleared. When compiledSource is unknown/unresolved
+      // (e.g. an ad-hoc inline `duckdb.sql(...)` source), this still runs and
+      // assertAuthorized applies the model-wide file-level gate via
+      // effectiveAuthorizeFor — closing the inline-SQL bypass of `##(authorize)`.
+      if (!(compiledSource && compiledSource === earlySource)) {
+         await this.assertAuthorized(compiledSource, givens ?? {});
       }
 
       const maxRows = getMaxQueryRows();
@@ -981,15 +1038,17 @@ export class Model {
          };
       }
 
-      // Authorize gate — before filter injection / execution, regardless of
-      // bypassFilters. Resolve the gated source from the COMPILED cell query
+      // Authorize gate — only cells that actually run a query touch data, so
+      // gate exactly those (a source-def / import cell has no runnable and
+      // accesses nothing). Resolve the source from the COMPILED cell query
       // (authoritative — survives `run: <named query>` cells the text regex
-      // misses); fall back to text extraction when there's no runnable. Sits
-      // before the execution try below so AccessDeniedError stays a 403.
-      const authorizeSource = cell.runnable
-         ? await this.resolveAuthorizeSourceFromRunnable(cell.runnable)
-         : this.extractSourceName(cell.text);
-      if (authorizeSource) {
+      // misses); assertAuthorized applies the source's gate, or the model-wide
+      // file-level gate for an unknown/inline source. Before the execution try
+      // below so AccessDeniedError stays a 403; independent of bypassFilters.
+      if (cell.runnable) {
+         const authorizeSource = await this.resolveAuthorizeSourceFromRunnable(
+            cell.runnable,
+         );
          await this.assertAuthorized(authorizeSource, givens ?? {});
       }
 

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -38,6 +38,7 @@ import {
 import { MODEL_FILE_SUFFIX, NOTEBOOK_FILE_SUFFIX } from "../constants";
 import { HackyDataStylesAccumulator } from "../data_styles";
 import {
+   AccessDeniedError,
    BadRequestError,
    ModelCompilationError,
    ModelNotFoundError,
@@ -53,7 +54,7 @@ import {
    type FilterDefinition,
    type FilterParams,
 } from "./filter";
-import { validateAuthorizeProbes } from "./authorize";
+import { evaluateAuthorize, validateAuthorizeProbes } from "./authorize";
 import { malloyGivenToApi, type MalloyGiven } from "./given";
 import {
    extractQueriesFromModelDef,
@@ -195,13 +196,60 @@ export class Model {
     * one OR disjunction at request time. Empty array means unrestricted. Reads
     * the per-source list surfaced on `sources` (which rides the worker
     * serialization boundary), so it works for both freshly-created and
-    * deserialized models. Enforcement wiring lands in a later PR.
+    * deserialized models.
     */
    public getAuthorize(sourceName: string): string[] {
       return (
          this.sources?.find((source) => source.name === sourceName)
             ?.authorize ?? []
       );
+   }
+
+   /**
+    * Runtime authorize gate. Throws `AccessDeniedError` (403) unless at least
+    * one of the source's in-scope authorize expressions evaluates true for the
+    * supplied givens. A source with no authorize annotations is unrestricted.
+    *
+    * Fail closed: any failure to evaluate the probe — a missing given value, a
+    * transient probe error, a missing/non-true result — denies. (Expression
+    * well-formedness was already validated at model load; see authorize.ts.)
+    * The 403 message names only the source, never the expression, so gate logic
+    * is not leaked to the caller.
+    */
+   public async assertAuthorized(
+      sourceName: string,
+      givens: Record<string, GivenValue>,
+   ): Promise<void> {
+      const exprs = this.getAuthorize(sourceName);
+      if (exprs.length === 0) return; // unrestricted
+      if (!this.modelMaterializer) {
+         throw new AccessDeniedError(
+            `Access denied for source "${sourceName}".`,
+         );
+      }
+      let passed = false;
+      try {
+         passed = await evaluateAuthorize(
+            this.modelMaterializer,
+            exprs,
+            givens,
+         );
+      } catch (err) {
+         // Fail closed — e.g. a referenced given had no supplied value.
+         logger.debug("Authorize probe failed; denying", {
+            sourceName,
+            modelPath: this.modelPath,
+            error: err instanceof Error ? err.message : String(err),
+         });
+         throw new AccessDeniedError(
+            `Access denied for source "${sourceName}".`,
+         );
+      }
+      if (!passed) {
+         throw new AccessDeniedError(
+            `Access denied for source "${sourceName}".`,
+         );
+      }
    }
 
    /**
@@ -608,6 +656,15 @@ export class Model {
       if (!this.modelMaterializer || !this.modelDef || !this.modelInfo)
          throw new BadRequestError("Model has no queryable entities.");
 
+      // Authorize gate — runs first, before filter injection or query
+      // compilation, and regardless of bypassFilters (authorize is an access
+      // gate, not a filter). Kept outside the loadQuery try below so an
+      // AccessDeniedError propagates as a 403 instead of being rewrapped 400.
+      const authorizeSource = sourceName ?? this.extractSourceName(query);
+      if (authorizeSource) {
+         await this.assertAuthorized(authorizeSource, givens ?? {});
+      }
+
       // Wrap loadQuery calls in try-catch to handle query parsing errors
       try {
          let queryString: string;
@@ -889,6 +946,14 @@ export class Model {
             type: cell.type,
             text: cell.text,
          };
+      }
+
+      // Authorize gate — before filter injection / execution, regardless of
+      // bypassFilters. Outside the execution try below so AccessDeniedError
+      // propagates as a 403.
+      const authorizeSource = this.extractSourceName(cell.text);
+      if (authorizeSource) {
+         await this.assertAuthorized(authorizeSource, givens ?? {});
       }
 
       // For code cells, execute the runnable if available

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -253,6 +253,32 @@ export class Model {
    }
 
    /**
+    * Resolve the source a compiled query reads, from its prepared query's
+    * `structRef`. This is authoritative — it survives named-query indirection
+    * and bare `run: <query>` forms that surface-syntax extraction misses — so
+    * the authorize gate can't be dodged by how a request names the query.
+    * Returns undefined if the source can't be determined.
+    */
+   private async resolveAuthorizeSourceFromRunnable(runnable: {
+      getPreparedQuery(): Promise<unknown>;
+   }): Promise<string | undefined> {
+      try {
+         const prepared = (await runnable.getPreparedQuery()) as {
+            _query?: { structRef?: unknown };
+         };
+         const structRef = prepared._query?.structRef;
+         if (typeof structRef === "string") return structRef;
+         if (structRef && typeof structRef === "object") {
+            const s = structRef as { as?: string; name?: string };
+            return s.as || s.name;
+         }
+      } catch {
+         // Can't resolve — caller simply has no name to gate on here.
+      }
+      return undefined;
+   }
+
+   /**
     * Best-effort extraction of a source name from an ad-hoc Malloy query string.
     * Matches patterns like `run: source_name -> ...` or `source_name -> ...`.
     */
@@ -766,6 +792,20 @@ export class Model {
          throw new BadRequestError(`Invalid query: ${errorMessage}`);
       }
 
+      // Backstop: if surface syntax couldn't name a source above (e.g. a named
+      // query whose source isn't a plain string ref), resolve the gated source
+      // from the COMPILED query — the authoritative source it actually reads —
+      // and gate on that. Only runs when the early gate found nothing, so the
+      // common path keeps its single probe and gate-before-filter ordering.
+      // Outside the loadQuery try so AccessDeniedError stays a 403.
+      if (!authorizeSource) {
+         const compiledSource =
+            await this.resolveAuthorizeSourceFromRunnable(runnable);
+         if (compiledSource) {
+            await this.assertAuthorized(compiledSource, givens ?? {});
+         }
+      }
+
       const maxRows = getMaxQueryRows();
       const maxBytes = getMaxResponseBytes();
       const rowLimit = resolveModelQueryRowLimit(
@@ -964,9 +1004,13 @@ export class Model {
       }
 
       // Authorize gate — before filter injection / execution, regardless of
-      // bypassFilters. Outside the execution try below so AccessDeniedError
-      // propagates as a 403.
-      const authorizeSource = this.extractSourceName(cell.text);
+      // bypassFilters. Resolve the gated source from the COMPILED cell query
+      // (authoritative — survives `run: <named query>` cells the text regex
+      // misses); fall back to text extraction when there's no runnable. Sits
+      // before the execution try below so AccessDeniedError stays a 403.
+      const authorizeSource = cell.runnable
+         ? await this.resolveAuthorizeSourceFromRunnable(cell.runnable)
+         : this.extractSourceName(cell.text);
       if (authorizeSource) {
          await this.assertAuthorized(authorizeSource, givens ?? {});
       }

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -682,30 +682,6 @@ export class Model {
       if (!this.modelMaterializer || !this.modelDef || !this.modelInfo)
          throw new BadRequestError("Model has no queryable entities.");
 
-      // Authorize gate — runs first, before filter injection or query
-      // compilation, and regardless of bypassFilters (authorize is an access
-      // gate, not a filter). Kept outside the loadQuery try below so an
-      // AccessDeniedError propagates as a 403 instead of being rewrapped 400.
-      //
-      // Resolve the gated source the same three ways a request can name one:
-      //  - explicit sourceName (normalize "" → undefined; the query-builder
-      //    treats blank as absent, so a blank here must not skip the gate);
-      //  - a named query (run: <queryName>), whose source we look up so a
-      //    `query: secret is gated -> ...` request can't dodge the gate;
-      //  - an ad-hoc query string.
-      let authorizeSource = sourceName || undefined;
-      if (!authorizeSource && queryName) {
-         authorizeSource = this.queries?.find(
-            (q) => q.name === queryName,
-         )?.sourceName;
-      }
-      if (!authorizeSource) {
-         authorizeSource = this.extractSourceName(query);
-      }
-      if (authorizeSource) {
-         await this.assertAuthorized(authorizeSource, givens ?? {});
-      }
-
       // Wrap loadQuery calls in try-catch to handle query parsing errors
       try {
          let queryString: string;
@@ -792,18 +768,20 @@ export class Model {
          throw new BadRequestError(`Invalid query: ${errorMessage}`);
       }
 
-      // Backstop: if surface syntax couldn't name a source above (e.g. a named
-      // query whose source isn't a plain string ref), resolve the gated source
-      // from the COMPILED query — the authoritative source it actually reads —
-      // and gate on that. Only runs when the early gate found nothing, so the
-      // common path keeps its single probe and gate-before-filter ordering.
-      // Outside the loadQuery try so AccessDeniedError stays a 403.
-      if (!authorizeSource) {
-         const compiledSource =
-            await this.resolveAuthorizeSourceFromRunnable(runnable);
-         if (compiledSource) {
-            await this.assertAuthorized(compiledSource, givens ?? {});
-         }
+      // Authorize gate. Resolve the gated source from the COMPILED query —
+      // the source Malloy actually runs (the LAST `run:` statement) — not from
+      // surface syntax. Surface-syntax resolution is both bypassable (a
+      // first-statement regex vs. last-statement execution: `run: ungated\nrun:
+      // gated` would gate `ungated` while running `gated`) and over-restrictive
+      // (it would gate a non-running leading statement). Gating the compiled
+      // structRef is authoritative and handles named-query / blank-source /
+      // multi-statement forms uniformly. Runs after loadQuery (so we have the
+      // compiled query) but OUTSIDE its try, so AccessDeniedError stays a 403;
+      // it is independent of bypassFilters (authorize is not a filter).
+      const authorizeSource =
+         await this.resolveAuthorizeSourceFromRunnable(runnable);
+      if (authorizeSource) {
+         await this.assertAuthorized(authorizeSource, givens ?? {});
       }
 
       const maxRows = getMaxQueryRows();

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -171,9 +171,10 @@ export class Model {
       this.givens = givens;
       // Model-wide ##(authorize) gates, derived from the file-level annotations
       // on the modelDef (which survives the worker boundary). These apply to
-      // any query in the model, including ad-hoc inline `duckdb.sql(...)`
-      // sources that aren't declared model sources — so a file-level gate
-      // can't be bypassed by querying the warehouse through raw SQL. A
+      // any query that resolves to a model source (or to no nameable source),
+      // model-wide. (Raw-SQL access to the warehouse is closed separately by
+      // restricted mode, which rejects inline `duckdb.sql(...)` on the caller
+      // query path before any gate runs — see getQueryResults.) A
       // successfully-loaded model has already had these validated; guard the
       // parse defensively so the constructor never throws.
       try {
@@ -833,10 +834,14 @@ export class Model {
       const compiledSource =
          await this.resolveAuthorizeSourceFromRunnable(runnable);
       // Run unless it's the redundant re-probe of the exact named source the
-      // early gate already cleared. When compiledSource is unknown/unresolved
-      // (e.g. an ad-hoc inline `duckdb.sql(...)` source), this still runs and
-      // assertAuthorized applies the model-wide file-level gate via
-      // effectiveAuthorizeFor — closing the inline-SQL bypass of `##(authorize)`.
+      // early gate already cleared. When compiledSource is unknown/unresolved,
+      // this still runs and assertAuthorized applies the model-wide file-level
+      // gate via effectiveAuthorizeFor. Note: on this path an ad-hoc inline
+      // `duckdb.sql(...)` query is rejected by restricted mode (the raw-SQL
+      // ban from loadRestrictedQuery above) before it can run, so the
+      // raw-warehouse bypass is closed by restricted mode — not by this gate.
+      // This fallback's job is to apply the file-level gate to permitted ad-hoc
+      // forms (declared-source references) whose source can't be named.
       if (!(compiledSource && compiledSource === earlySource)) {
          await this.assertAuthorized(compiledSource, givens ?? {});
       }

--- a/packages/server/src/service/source_extraction.ts
+++ b/packages/server/src/service/source_extraction.ts
@@ -84,13 +84,18 @@ export interface ExtractedQuery {
  * they propagate (a malformed gate fails model load) so a security gate is never
  * silently dropped.
  *
- * Authorize (`#(authorize)` / `##(authorize)`) is collected differently from
- * filters: it does NOT walk the `inherits` chain (a base source's gate is not
- * inherited by an extension — that is intentional, enforcement is top-level
- * only). The effective list per source is the file-level `##(authorize)`
- * expressions (from `modelDef.annotations.notes`) followed by the source's own
- * `#(authorize)` expressions (from its own `blockNotes`), evaluated as one OR
- * disjunction at request time.
+ * Authorize (`#(authorize)` / `##(authorize)`) is collected from the source's
+ * own `blockNotes` only — we do NOT walk the `inherits` chain. Note Malloy's
+ * behavior for `X is Y extend {...}`: if X declares its own `#(authorize)`,
+ * X.blockNotes holds only X's gates (Y's are dropped — the intended "curated
+ * re-exposure"); if X declares none, Malloy surfaces Y's blockNotes on X, so
+ * the base gate carries to the un-annotated extension (a safe default — a
+ * locked base stays locked unless an extension explicitly re-exposes itself).
+ * This carry happens through `blockNotes`, not the `inherits` chain, so reading
+ * own-blockNotes is sufficient. Joins are a separate concern and are not gated.
+ * The effective list per source is the file-level `##(authorize)` expressions
+ * (from `modelDef.annotations.notes`) followed by the source's own
+ * `#(authorize)` expressions, evaluated as one OR disjunction at request time.
  */
 export function extractSourcesFromModelDef(
    modelDef: ModelDef,


### PR DESCRIPTION
**PR 3 of the `#(authorize)` series** — the runtime gate, i.e. the actual access enforcement. Builds on #805; base it on #805.

Remaining after this: PR 4 (MCP + HTTP `/compile` surface), PR 5 (docs), PR 6 (e2e + example).

### What this one does
Before a query touches an authorize-annotated source, evaluate the gate; deny with **403** unless at least one in-scope expression is true for the supplied givens.

- `Model.assertAuthorized(source, givens)` — empty annotations = unrestricted; otherwise runs `buildAuthorizeProbe` via `.run({ givens })` and grants on **any** true expression (OR semantics).
- **Fail closed:** any probe error (notably a referenced given with no supplied value), a missing row, or a non-true result → `AccessDeniedError`. This is how "missing given → deny" falls out for free. The 403 names only the source, never the expression.
- `isProbeTrue` is strict (`true`/`1`/`"true"` grant; null/missing/anything-else deny).
- Gate runs **first** in `getQueryResults` and `executeNotebookCell` — before filter injection / `loadQuery`, **regardless of `bypassFilters`** (authorize is an access gate, not a filter), and outside the loadQuery try so the 403 isn't rewrapped as a 400. Covers **POST /query**, the **notebook-cell GET**, and the **MCP `executeQuery`** tool (routes through `getQueryResults`). The **`/compile`** path is carried into PR 4 with the rest of the HTTP/MCP surface.

### Behavioral correction (found while testing)
The plan assumed authorize is *not* inherited through `extend` (a documented "footgun"). Reality is **safer**: Malloy carries a base's `#(authorize)` onto an extension **unless the extension declares its own**. So a base locked with `#(authorize) "false"` also locks every extension that doesn't re-expose itself with its own gate. Joins stay ungated (top-level source only). Comments corrected; both behaviors are pinned by tests.

### Tested
- `tsc` + eslint clean; 794 unit tests pass
- Runtime gate: allow when satisfied; deny when not; **deny on missing given value (fail closed)**; gate still enforced under `bypassFilters`; file-level vs source-level disjunction (each alone grants; neither denies); unrestricted source passes
- Locked-base pattern: direct query on `#(authorize) "false"` base denied; gated extension allowed; **ungated extension denied (inherits the base lock)**; join-to-locked-base allowed (documented top-level-only limitation)
- `isProbeTrue` unit matrix
- worker-path + `filter_integration` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)