### PR TITLE
Harden execute_query: restricted mode + filter enforcement across source derivations

### DIFF
--- a/packages/server/src/service/filter.spec.ts
+++ b/packages/server/src/service/filter.spec.ts
@@ -423,7 +423,7 @@ describe("service/filter", () => {
          const query = "run: orders -> summary";
          const clause = "`status` = 'active'";
          expect(injectFilterRefinement(query, clause)).toBe(
-            "run: orders -> summary + {where: `status` = 'active'}",
+            "run: orders -> summary\n+ {where: `status` = 'active'}",
          );
       });
 
@@ -432,7 +432,7 @@ describe("service/filter", () => {
             "run: orders -> { group_by: status; aggregate: order_count }";
          const clause = "`region` = 'US'";
          expect(injectFilterRefinement(query, clause)).toBe(
-            "run: orders -> { group_by: status; aggregate: order_count } + {where: `region` = 'US'}",
+            "run: orders -> { group_by: status; aggregate: order_count }\n+ {where: `region` = 'US'}",
          );
       });
 
@@ -440,8 +440,19 @@ describe("service/filter", () => {
          const query = "run: orders -> summary   \n  ";
          const clause = "`status` = 'active'";
          expect(injectFilterRefinement(query, clause)).toBe(
-            "run: orders -> summary + {where: `status` = 'active'}",
+            "run: orders -> summary\n+ {where: `status` = 'active'}",
          );
+      });
+
+      it("places refinement on its own line so a trailing comment cannot swallow it", () => {
+         const clause = "`org_id` = 'acme'";
+         // A trailing line comment must not extend over the injected filter.
+         for (const comment of ["//", "-- sneaky"]) {
+            const query = `run: orders -> { group_by: status } ${comment}`;
+            const refined = injectFilterRefinement(query, clause);
+            const lastLine = refined.split("\n").pop() ?? "";
+            expect(lastLine).toBe(`+ {where: ${clause}}`);
+         }
       });
    });
 });

--- a/packages/server/src/service/filter.ts
+++ b/packages/server/src/service/filter.ts
@@ -272,6 +272,10 @@ export function buildFilterClause(
  * Append a filter refinement to a Malloy query string.
  * Uses Malloy's `+ {where: ...}` refinement syntax.
  *
+ * The refinement is placed on its own line so that a trailing line comment
+ * (`//` or `--`) on the caller's query cannot extend over it and neutralize
+ * the filter.
+ *
  * If `filterClause` is empty, returns the original query unchanged.
  */
 export function injectFilterRefinement(
@@ -281,7 +285,7 @@ export function injectFilterRefinement(
    if (!filterClause) {
       return query;
    }
-   return `${query.trimEnd()} + {where: ${filterClause}}`;
+   return `${query.trimEnd()}\n+ {where: ${filterClause}}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/service/filter_bypass.spec.ts
+++ b/packages/server/src/service/filter_bypass.spec.ts
@@ -1,0 +1,418 @@
+/**
+ * Filter-param (`#(filter)`) enforcement across source-derivation paths.
+ *
+ * A `#(filter)` annotation marks a source as protected: a required filter (e.g.
+ * the implicit multi-tenant `org_id` boundary) must be supplied before the
+ * source can be read. The aim is to enforce that without narrowing the query
+ * shapes `execute_query` accepts.
+ *
+ * Cases guarded here:
+ *   - Direct read of a protected source: rejected (400) naming the missing
+ *     required filter; scoped to the supplied values once provided.
+ *   - Reaching a protected source under an ad-hoc name (alias / extend / chain):
+ *     enforced identically — the query still runs, scoped — rather than being
+ *     refused for its shape.
+ *   - Unprotected sources are unaffected; `bypassFilters` skips enforcement.
+ *
+ * Language-level escapes (import, raw tables, raw SQL) are out of scope here and
+ * covered in `restricted_mode.spec.ts`.
+ */
+
+import { DuckDBConnection } from "@malloydata/db-duckdb";
+import { Connection } from "@malloydata/malloy";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { BadRequestError } from "../errors";
+import { Model } from "./model";
+import type { FilterParams } from "./filter";
+
+const TEST_DIR = path.join(os.tmpdir(), "filter-bypass-tests");
+const TEST_DB_DIR = path.join(TEST_DIR, "db");
+const TEST_DB_PATH = path.join(TEST_DB_DIR, "test.duckdb");
+const TEST_PKG_DIR = path.join(TEST_DIR, "pkg");
+
+let duckdbConnection: DuckDBConnection;
+
+// Three tenants. org_id is the partition key, so any cross-org leak shows up
+// directly as extra rows when we `group_by: org_id` (acme has 2 products).
+const SEED_SQL = `
+CREATE TABLE IF NOT EXISTS products (
+   org_id VARCHAR,
+   product_name VARCHAR
+);
+INSERT INTO products VALUES
+   ('acme', 'AcmeAnvil'),
+   ('acme', 'AcmeRocket'),
+   ('globex', 'GlobexPhone'),
+   ('initech', 'InitechStapler');
+
+CREATE TABLE IF NOT EXISTS orders (
+   org_id VARCHAR,
+   category VARCHAR,
+   region VARCHAR
+);
+INSERT INTO orders VALUES
+   ('acme', 'widgets', 'US'),
+   ('acme', 'gadgets', 'EU'),
+   ('globex', 'widgets', 'US'),
+   ('initech', 'gadgets', 'APAC');
+
+CREATE TABLE IF NOT EXISTS events (
+   org_id VARCHAR,
+   kind VARCHAR
+);
+INSERT INTO events VALUES
+   ('acme', 'click'),
+   ('globex', 'view'),
+   ('initech', 'scroll');
+`;
+
+// products: implicit Organization filter only (the multi-tenant boundary).
+const PRODUCTS_MODEL = `
+#(filter) name=Organization dimension=org_id type=equal implicit required
+source: products is duckdb.table('products') extend {
+   measure: n is count()
+   view: by_org is {
+      group_by: org_id, product_name
+      aggregate: n
+   }
+}
+`;
+
+// orders: implicit Organization + required-explicit Category + optional Region.
+const ORDERS_MODEL = `
+#(filter) name=Organization dimension=org_id type=equal implicit required
+#(filter) name=Category dimension=category type=equal required
+#(filter) name=Region dimension=region type=in
+source: orders is duckdb.table('orders') extend {
+   measure: n is count()
+}
+`;
+
+// A model that neither defines nor imports any protected source. Used as the
+// target for the unprotected-source regression.
+const ANALYTICS_MODEL = `
+source: metrics is duckdb.table('events') extend {
+   measure: c is count()
+}
+`;
+
+beforeAll(async () => {
+   await fs.mkdir(TEST_DB_DIR, { recursive: true });
+   await fs.mkdir(TEST_PKG_DIR, { recursive: true });
+   duckdbConnection = new DuckDBConnection("duckdb", TEST_DB_PATH, TEST_DB_DIR);
+   for (const stmt of SEED_SQL.trim().split(";").filter(Boolean)) {
+      await duckdbConnection.runSQL(stmt.trim() + ";");
+   }
+   await fs.writeFile(
+      path.join(TEST_PKG_DIR, "products.malloy"),
+      PRODUCTS_MODEL,
+      "utf-8",
+   );
+   await fs.writeFile(
+      path.join(TEST_PKG_DIR, "orders.malloy"),
+      ORDERS_MODEL,
+      "utf-8",
+   );
+   await fs.writeFile(
+      path.join(TEST_PKG_DIR, "analytics.malloy"),
+      ANALYTICS_MODEL,
+      "utf-8",
+   );
+});
+
+afterAll(async () => {
+   try {
+      await duckdbConnection.close();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await fs.rm(TEST_DIR, { recursive: true, force: true });
+   } catch {
+      // Ignore cleanup errors
+   }
+});
+
+function getConnections(): Map<string, Connection> {
+   const map = new Map<string, Connection>();
+   map.set("duckdb", duckdbConnection);
+   return map;
+}
+
+type Row = Record<string, unknown>;
+
+function asRows(compactResult: unknown): Row[] {
+   return compactResult as Row[];
+}
+
+async function makeModel(modelPath: string): Promise<Model> {
+   return Model.create("test-pkg", TEST_PKG_DIR, modelPath, getConnections());
+}
+
+/** Run an ad-hoc query string and return the result rows. */
+async function runAdHoc(
+   model: Model,
+   query: string,
+   filterParams?: FilterParams,
+): Promise<Row[]> {
+   const { compactResult } = await model.getQueryResults(
+      undefined,
+      undefined,
+      query,
+      filterParams,
+   );
+   return asRows(compactResult);
+}
+
+/**
+ * Assert an ad-hoc query is rejected with a 400 whose message names a missing
+ * required filter (`expectedSubstring`, e.g. "Organization"). If the query
+ * instead succeeds, the assertion fails reporting the row count — a filter
+ * bypass / data leak slipped through.
+ */
+async function expectFilterRejected(
+   model: Model,
+   query: string,
+   filterParams: FilterParams | undefined,
+   expectedSubstring: string,
+): Promise<void> {
+   let leakedRows: number | undefined;
+   try {
+      const { compactResult } = await model.getQueryResults(
+         undefined,
+         undefined,
+         query,
+         filterParams,
+      );
+      leakedRows = asRows(compactResult).length;
+   } catch (error) {
+      expect(error).toBeInstanceOf(BadRequestError);
+      expect((error as Error).message).toContain(expectedSubstring);
+      return;
+   }
+   throw new Error(
+      `Expected a 400 naming "${expectedSubstring}", but the query succeeded ` +
+         `and returned ${leakedRows} rows (FILTER BYPASS / LEAK).`,
+   );
+}
+
+/** Assert every returned row is scoped to acme and the count matches. */
+function expectAcmeScoped(rows: Row[], expectedRows: number): void {
+   expect(rows.length).toBe(expectedRows);
+   for (const row of rows) expect(row.org_id).toBe("acme");
+}
+
+// ===========================================================================
+// Enforced: direct reads of a protected source.
+// ===========================================================================
+
+describe("direct read of a protected source is enforced", () => {
+   it("rejects a direct query with no filter params", async () => {
+      const model = await makeModel("products.malloy");
+      await expectFilterRejected(
+         model,
+         "run: products -> { group_by: org_id, product_name; aggregate: n is count() }",
+         undefined,
+         "Organization",
+      );
+   });
+
+   it("scopes a direct query when Organization is supplied", async () => {
+      const model = await makeModel("products.malloy");
+      const rows = await runAdHoc(
+         model,
+         "run: products -> { group_by: org_id, product_name; aggregate: n is count() }",
+         { Organization: "acme" },
+      );
+      expectAcmeScoped(rows, 2); // acme has exactly 2 products
+   });
+
+   // A predefined view on the trusted source is still the direct path.
+   it("enforces filters on a direct named-view read", async () => {
+      const model = await makeModel("products.malloy");
+      await expectFilterRejected(
+         model,
+         "run: products -> by_org",
+         undefined,
+         "Organization",
+      );
+      const rows = await runAdHoc(model, "run: products -> by_org", {
+         Organization: "acme",
+      });
+      expect(rows.length).toBe(2);
+   });
+
+   // orders — implicit Organization + required-explicit Category. Both required
+   // filters are enforced; the error names whichever is still missing.
+   it("rejects orders with no filter params (names Organization)", async () => {
+      const model = await makeModel("orders.malloy");
+      await expectFilterRejected(
+         model,
+         "run: orders -> { group_by: org_id, category; aggregate: n is count() }",
+         undefined,
+         "Organization",
+      );
+   });
+
+   it("rejects orders with only Category supplied (still missing Organization)", async () => {
+      const model = await makeModel("orders.malloy");
+      await expectFilterRejected(
+         model,
+         "run: orders -> { group_by: org_id, category; aggregate: n is count() }",
+         { Category: "widgets" },
+         "Organization",
+      );
+   });
+
+   it("rejects orders with only Organization supplied (still missing Category)", async () => {
+      const model = await makeModel("orders.malloy");
+      await expectFilterRejected(
+         model,
+         "run: orders -> { group_by: org_id, category; aggregate: n is count() }",
+         { Organization: "acme" },
+         "Category",
+      );
+   });
+
+   it("scopes orders when both Organization and Category are supplied", async () => {
+      const model = await makeModel("orders.malloy");
+      const rows = await runAdHoc(
+         model,
+         "run: orders -> { group_by: org_id, category; aggregate: n is count() }",
+         { Organization: "acme", Category: "widgets" },
+      );
+      expect(rows.length).toBe(1); // acme + widgets → one group
+      expect(rows[0].org_id).toBe("acme");
+      expect(rows[0].category).toBe("widgets");
+   });
+});
+
+// ===========================================================================
+// Enforced: alias / extend / chain of a protected source.
+//
+// Reaching a protected source under an ad-hoc name carries the SAME filter
+// requirement. The query is not rejected for its shape — it runs, scoped — so
+// the `execute_query` surface stays intact.
+// ===========================================================================
+
+interface EnforcedVector {
+   label: string;
+   modelPath: string;
+   query: string;
+   /** Required filter named in the missing-param rejection. */
+   missing: string;
+   /** Params satisfying every required filter on the protected source. */
+   validParams: FilterParams;
+   /** Rows expected once scoped to acme. */
+   expectedRows: number;
+}
+
+const enforcedVectors: EnforcedVector[] = [
+   {
+      // Plain alias — a pure rename of the protected source.
+      label: "alias (source a is products)",
+      modelPath: "products.malloy",
+      query: "source: a is products\nrun: a -> { group_by: org_id, product_name; aggregate: n is count() }",
+      missing: "Organization",
+      validParams: { Organization: "acme" },
+      expectedRows: 2,
+   },
+   {
+      // Extend with an extra measure. The body adds to the curated surface but
+      // does not touch the filter dimension, so enforcement is unaffected.
+      label: "extend (source e is products extend { … })",
+      modelPath: "products.malloy",
+      query: "source: e is products extend { measure: rc is count() }\nrun: e -> { group_by: org_id, product_name; aggregate: rc }",
+      missing: "Organization",
+      validParams: { Organization: "acme" },
+      expectedRows: 2,
+   },
+   {
+      // Chained derivation — protection is inherited link by link and resolved
+      // back to products.
+      label: "chained (a is products; b is a)",
+      modelPath: "products.malloy",
+      query: "source: a is products\nsource: b is a\nrun: b -> { group_by: org_id, product_name; aggregate: n is count() }",
+      missing: "Organization",
+      validParams: { Organization: "acme" },
+      expectedRows: 2,
+   },
+   {
+      // Ad-hoc `#(filter)` annotation in the query text declaring a NON-required
+      // Organization filter on the alias, attempting to drop the requirement.
+      // Annotations written in the query are not honored — only the protected
+      // source's own annotation counts — so the requirement still stands.
+      label: "ad-hoc #(filter) annotation override is ignored",
+      modelPath: "products.malloy",
+      query:
+         "#(filter) name=Organization dimension=org_id type=equal\n" +
+         "source: a is products extend {}\n" +
+         "run: a -> { group_by: org_id, product_name; aggregate: n is count() }",
+      missing: "Organization",
+      validParams: { Organization: "acme" },
+      expectedRows: 2,
+   },
+   {
+      // orders alias — confirms enforcement on a multi-required-filter source.
+      label: "orders alias (source a is orders)",
+      modelPath: "orders.malloy",
+      query: "source: a is orders\nrun: a -> { group_by: org_id, category; aggregate: n is count() }",
+      missing: "Organization",
+      validParams: { Organization: "acme", Category: "widgets" },
+      expectedRows: 1,
+   },
+   {
+      // orders extend.
+      label: "orders extend",
+      modelPath: "orders.malloy",
+      query: "source: e is orders extend { measure: rc is count() }\nrun: e -> { group_by: org_id, category; aggregate: rc }",
+      missing: "Organization",
+      validParams: { Organization: "acme", Category: "widgets" },
+      expectedRows: 1,
+   },
+];
+
+describe("alias/extend/chain of a protected source is enforced (not restricted)", () => {
+   for (const v of enforcedVectors) {
+      describe(v.label, () => {
+         it("rejects when the required filter is missing", async () => {
+            const model = await makeModel(v.modelPath);
+            await expectFilterRejected(model, v.query, undefined, v.missing);
+         });
+
+         it("runs scoped when valid filter params are supplied", async () => {
+            const model = await makeModel(v.modelPath);
+            const rows = await runAdHoc(model, v.query, v.validParams);
+            expectAcmeScoped(rows, v.expectedRows);
+         });
+      });
+   }
+});
+
+// ===========================================================================
+// Regression: unprotected sources stay open; bypassFilters short-circuits
+// filter enforcement.
+// ===========================================================================
+
+describe("regressions", () => {
+   it("runs an unprotected source with no filter params (no spurious demand)", async () => {
+      const model = await makeModel("analytics.malloy");
+      const rows = await runAdHoc(
+         model,
+         "run: metrics -> { group_by: org_id; aggregate: c is count() }",
+      );
+      expect(rows.length).toBe(3); // all three orgs, unfiltered
+   });
+
+   it("bypassFilters short-circuits filter enforcement on a derivation", async () => {
+      const model = await makeModel("products.malloy");
+      const { compactResult } = await model.getQueryResults(
+         undefined,
+         undefined,
+         "source: a is products\nrun: a -> { group_by: org_id; aggregate: n is count() }",
+         {},
+         true,
+      );
+      expect(asRows(compactResult).length).toBe(3);
+   });
+});

--- a/packages/server/src/service/model.spec.ts
+++ b/packages/server/src/service/model.spec.ts
@@ -317,6 +317,78 @@ describe("service/model", () => {
             sinon.restore();
          });
 
+         // Both caller-driven compile paths — the free-form `query` text and the
+         // `run: source->view` string built from `sourceName`/`queryName` — must
+         // go through restricted mode. The trusted `loadQuery` is reserved for
+         // author-curated content (notebook cells) and must never be reached from
+         // `getQueryResults`. These tests pin the dispatch so a regression that
+         // re-routes either path back to `loadQuery` is caught.
+         describe("compile dispatch", () => {
+            function buildDispatchModel(): {
+               model: Model;
+               loadQuery: sinon.SinonStub;
+               loadRestrictedQuery: sinon.SinonStub;
+            } {
+               // getPreparedResult rejects so execution stops right after the
+               // loader call; we only assert which loader was invoked.
+               const runnableStub = {
+                  getPreparedResult: sinon
+                     .stub()
+                     .rejects(new MalloyError("stub-stop", [])),
+                  run: sinon.stub().rejects(new MalloyError("stub-stop", [])),
+               };
+               const loadQuery = sinon.stub().returns(runnableStub);
+               const loadRestrictedQuery = sinon.stub().returns(runnableStub);
+               const modelMaterializer = { loadQuery, loadRestrictedQuery };
+               const model = new Model(
+                  packageName,
+                  mockModelPath,
+                  {},
+                  "model",
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  modelMaterializer as any,
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  { contents: {}, exports: [], queryList: [] } as any,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+               );
+               return { model, loadQuery, loadRestrictedQuery };
+            }
+
+            afterEach(() => sinon.restore());
+
+            it("compiles ad-hoc query text in restricted mode, never trusted loadQuery", async () => {
+               const { model, loadQuery, loadRestrictedQuery } =
+                  buildDispatchModel();
+
+               await expect(
+                  model.getQueryResults(
+                     undefined,
+                     undefined,
+                     "run: orders -> { aggregate: c is count() }",
+                  ),
+               ).rejects.toThrow(MalloyError);
+
+               expect(loadRestrictedQuery.calledOnce).toBe(true);
+               expect(loadQuery.called).toBe(false);
+            });
+
+            it("compiles the named source/view path in restricted mode, never trusted loadQuery", async () => {
+               const { model, loadQuery, loadRestrictedQuery } =
+                  buildDispatchModel();
+
+               await expect(
+                  model.getQueryResults("orders", "summary"),
+               ).rejects.toThrow(MalloyError);
+
+               expect(loadRestrictedQuery.calledOnce).toBe(true);
+               expect(loadQuery.called).toBe(false);
+            });
+         });
+
          it("forwards givens to runnable.getPreparedResult and .run", async () => {
             const givensArg = { region: "EU" };
             const preparedResultStub = sinon

--- a/packages/server/src/service/model.spec.ts
+++ b/packages/server/src/service/model.spec.ts
@@ -325,11 +325,13 @@ describe("service/model", () => {
             const runStub = sinon
                .stub()
                .rejects(new MalloyError("stub-stop", []));
+            const runnableStub = {
+               getPreparedResult: preparedResultStub,
+               run: runStub,
+            };
             const modelMaterializer = {
-               loadQuery: sinon.stub().returns({
-                  getPreparedResult: preparedResultStub,
-                  run: runStub,
-               }),
+               loadQuery: sinon.stub().returns(runnableStub),
+               loadRestrictedQuery: sinon.stub().returns(runnableStub),
             };
 
             const model = new Model(
@@ -425,11 +427,13 @@ describe("service/model", () => {
                         typeof API.util.wrapResult
                      >,
                   );
+               const runnableStub = {
+                  getPreparedResult: preparedResultStub,
+                  run: runStub,
+               };
                const modelMaterializer = {
-                  loadQuery: sinon.stub().returns({
-                     getPreparedResult: preparedResultStub,
-                     run: runStub,
-                  }),
+                  loadQuery: sinon.stub().returns(runnableStub),
+                  loadRestrictedQuery: sinon.stub().returns(runnableStub),
                };
                const model = new Model(
                   packageName,

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -216,6 +216,38 @@ export class Model {
    }
 
    /**
+    * Resolve the run target of an ad-hoc query to the model-defined source
+    * whose filters apply, following source-derivation declarations so that a
+    * filter-protected source carries its filter requirements when read under a
+    * derived name. The declared filter belongs to the source, not to the name
+    * it is read under. Returns undefined when the run target does not derive
+    * from a protected source.
+    */
+   private resolveFilterSource(query?: string): string | undefined {
+      const target = this.extractSourceName(query);
+      if (!target || !query) return undefined;
+
+      // Map each ad-hoc source name to the base it derives from
+      // (`source: NAME is BASE ...` → NAME → BASE).
+      const aliasOf = new Map<string, string>();
+      const declRe = /source\s*:\s*(\w+)\s+is\s+(\w+)/g;
+      let match: RegExpExecArray | null;
+      while ((match = declRe.exec(query)) !== null) {
+         aliasOf.set(match[1], match[2]);
+      }
+
+      // Walk the derivation chain until we hit a protected source or run out.
+      let current: string | undefined = target;
+      const seen = new Set<string>();
+      while (current && !seen.has(current)) {
+         if (this.filterMap.has(current)) return current;
+         seen.add(current);
+         current = aliasOf.get(current);
+      }
+      return undefined;
+   }
+
+   /**
     * Compile a single model in-process. Kept as a library entry point
     * for test fixtures and any future caller that needs an ad-hoc
     * `Model` from a `.malloy` / `.malloynb` file. Production package
@@ -598,9 +630,18 @@ export class Model {
             );
          }
 
-         // Inject source filter predicates unless bypassed
+         // Untrusted ad-hoc query text (no sourceName/queryName) is compiled in
+         // restricted mode below; publisher-constructed `run: source->view`
+         // strings are trusted.
+         const isAdHocQuery = !sourceName && !queryName && !!query;
+
+         // Inject source filter predicates unless bypassed. For ad-hoc queries
+         // resolve the run target through any alias/extend/chain so a protected
+         // source can't be read unfiltered under a different name.
          if (!bypassFilters) {
-            const effectiveSource = sourceName ?? this.extractSourceName(query);
+            const effectiveSource = isAdHocQuery
+               ? this.resolveFilterSource(query)
+               : sourceName;
             if (effectiveSource) {
                const filters = this.getFilters(effectiveSource);
                if (filters.length > 0) {
@@ -616,7 +657,13 @@ export class Model {
             }
          }
 
-         runnable = this.modelMaterializer.loadQuery(queryString);
+         // Restricted mode keeps untrusted query text inside the model's curated
+         // surface — it rejects `import`, raw `connection.table(...)` /
+         // `connection.sql(...)`, raw-SQL functions, and `##!` flags. The
+         // model's own definitions are unaffected.
+         runnable = isAdHocQuery
+            ? this.modelMaterializer.loadRestrictedQuery(queryString)
+            : this.modelMaterializer.loadQuery(queryString);
       } catch (error) {
          // Re-throw BadRequestError as-is
          if (error instanceof BadRequestError) {

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -630,9 +630,10 @@ export class Model {
             );
          }
 
-         // Untrusted ad-hoc query text (no sourceName/queryName) is compiled in
-         // restricted mode below; publisher-constructed `run: source->view`
-         // strings are trusted.
+         // Distinguishes free-form query text from the named `source->view`
+         // form. Both are driven by untrusted caller input and compiled in
+         // restricted mode below; this flag only controls how the protected
+         // source is resolved for filter injection.
          const isAdHocQuery = !sourceName && !queryName && !!query;
 
          // Inject source filter predicates unless bypassed. For ad-hoc queries
@@ -660,10 +661,11 @@ export class Model {
          // Restricted mode keeps untrusted query text inside the model's curated
          // surface — it rejects `import`, raw `connection.table(...)` /
          // `connection.sql(...)`, raw-SQL functions, and `##!` flags. The
-         // model's own definitions are unaffected.
-         runnable = isAdHocQuery
-            ? this.modelMaterializer.loadRestrictedQuery(queryString)
-            : this.modelMaterializer.loadQuery(queryString);
+         // model's own definitions are unaffected. Both the ad-hoc `query` text
+         // and the `run: source->view` string built from the caller-supplied
+         // `sourceName`/`queryName` pair are untrusted, so both compile here;
+         // only author-curated notebook cells use the unrestricted `loadQuery`.
+         runnable = this.modelMaterializer.loadRestrictedQuery(queryString);
       } catch (error) {
          // Re-throw BadRequestError as-is
          if (error instanceof BadRequestError) {

--- a/packages/server/src/service/restricted_mode.spec.ts
+++ b/packages/server/src/service/restricted_mode.spec.ts
@@ -1,0 +1,244 @@
+/**
+ * Restricted-mode containment for untrusted ad-hoc query text.
+ *
+ * The `query` text that reaches `execute_query` is authored by an untrusted
+ * caller (an MCP/LLM client, a UI field, an HTTP body), but it runs against a
+ * warehouse connection that can see far more than any one model curates.
+ * Compiling that text with `loadRestrictedQuery` keeps the caller inside the
+ * model's published surface — its sources, views, dimensions and measures —
+ * and stops it from using Malloy as a general-purpose handle to the underlying
+ * database or filesystem.
+ *
+ * These tests are written from the publisher's threat model: each is a way an
+ * untrusted query could try to reach data or compute the model never exposed,
+ * paired with the assertion that restricted mode blocks it. They are not a
+ * re-test of Malloy's per-construct rejection logic — the point is the misuse
+ * scenario, not the grammar.
+ *
+ * The setup: the connection holds a `secrets` table that the `catalog` model
+ * never references. The model only exposes `widgets`. Any query that manages to
+ * return a row of `secrets` has escaped the curated surface.
+ */
+
+import { DuckDBConnection } from "@malloydata/db-duckdb";
+import { Connection } from "@malloydata/malloy";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { Model } from "./model";
+
+const TEST_DIR = path.join(os.tmpdir(), "restricted-mode-tests");
+const TEST_DB_DIR = path.join(TEST_DIR, "db");
+const TEST_DB_PATH = path.join(TEST_DB_DIR, "test.duckdb");
+const TEST_PKG_DIR = path.join(TEST_DIR, "pkg");
+
+let duckdbConnection: DuckDBConnection;
+
+// `widgets` is the curated, model-exposed table. `secrets` lives in the same
+// connection but is never referenced by the model the caller queries — it
+// stands in for any table the deployment did not mean to publish.
+const SEED_SQL = `
+CREATE TABLE IF NOT EXISTS widgets (
+   region VARCHAR,
+   name VARCHAR
+);
+INSERT INTO widgets VALUES
+   ('US', 'Alpha'),
+   ('EU', 'Beta'),
+   ('APAC', 'Gamma');
+
+CREATE TABLE IF NOT EXISTS secrets (
+   id VARCHAR,
+   ssn VARCHAR
+);
+INSERT INTO secrets VALUES
+   ('1', '111-11-1111'),
+   ('2', '222-22-2222');
+`;
+
+// The model the ad-hoc queries are issued against. It publishes `widgets` and
+// nothing else — `secrets` is deliberately absent.
+const CATALOG_MODEL = `
+source: widgets is duckdb.table('widgets') extend {
+   measure: n is count()
+   view: by_region is {
+      group_by: region
+      aggregate: n
+   }
+}
+`;
+
+// A second model that DOES expose secrets. It is never loaded by the caller;
+// it exists only as the target of an `import` escalation attempt.
+const VAULT_MODEL = `
+source: vault is duckdb.table('secrets') extend {
+   measure: n is count()
+}
+`;
+
+beforeAll(async () => {
+   await fs.mkdir(TEST_DB_DIR, { recursive: true });
+   await fs.mkdir(TEST_PKG_DIR, { recursive: true });
+   duckdbConnection = new DuckDBConnection("duckdb", TEST_DB_PATH, TEST_DB_DIR);
+   for (const stmt of SEED_SQL.trim().split(";").filter(Boolean)) {
+      await duckdbConnection.runSQL(stmt.trim() + ";");
+   }
+   await fs.writeFile(
+      path.join(TEST_PKG_DIR, "catalog.malloy"),
+      CATALOG_MODEL,
+      "utf-8",
+   );
+   await fs.writeFile(
+      path.join(TEST_PKG_DIR, "vault.malloy"),
+      VAULT_MODEL,
+      "utf-8",
+   );
+});
+
+afterAll(async () => {
+   try {
+      await duckdbConnection.close();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await fs.rm(TEST_DIR, { recursive: true, force: true });
+   } catch {
+      // Ignore cleanup errors
+   }
+});
+
+function getConnections(): Map<string, Connection> {
+   const map = new Map<string, Connection>();
+   map.set("duckdb", duckdbConnection);
+   return map;
+}
+
+type Row = Record<string, unknown>;
+
+function asRows(compactResult: unknown): Row[] {
+   return compactResult as Row[];
+}
+
+async function makeModel(modelPath: string): Promise<Model> {
+   return Model.create("test-pkg", TEST_PKG_DIR, modelPath, getConnections());
+}
+
+/** Run an ad-hoc query string and return the result rows. */
+async function runAdHoc(model: Model, query: string): Promise<Row[]> {
+   const { compactResult } = await model.getQueryResults(
+      undefined,
+      undefined,
+      query,
+   );
+   return asRows(compactResult);
+}
+
+/**
+ * Restricted-mode rejections surface as a Malloy compile error: the message
+ * quotes the offending source text and states the rule, and the underlying
+ * `problems` carry `code: 'restricted-construct-forbidden'`. We accept either
+ * signal so the assertion is robust to how `model.ts` re-wraps the error.
+ */
+function looksRestricted(error: unknown): boolean {
+   const message = ((error as Error)?.message ?? String(error)).toLowerCase();
+   if (message.includes("restricted")) return true;
+   const problems = (error as { problems?: Array<{ code?: string }> })
+      ?.problems;
+   return (
+      Array.isArray(problems) &&
+      problems.some((p) => (p.code ?? "").includes("restricted"))
+   );
+}
+
+/**
+ * Assert an untrusted ad-hoc query is blocked before it can reach unpublished
+ * data. If it instead succeeds, report the row count — the caller escaped the
+ * curated surface and that is the leak we are guarding against.
+ */
+async function expectBlocked(model: Model, query: string): Promise<void> {
+   let leakedRows: number | undefined;
+   try {
+      const rows = await runAdHoc(model, query);
+      leakedRows = rows.length;
+   } catch (error) {
+      expect(looksRestricted(error)).toBe(true);
+      return;
+   }
+   throw new Error(
+      `Expected the query to be blocked by restricted mode, but it succeeded ` +
+         `and returned ${leakedRows} rows (escaped the curated surface).`,
+   );
+}
+
+// ===========================================================================
+// The published surface stays fully usable — restriction must not break the
+// legitimate path it is wrapped around.
+// ===========================================================================
+
+describe("the curated model surface stays usable under restriction", () => {
+   it("runs an ad-hoc query over a published source", async () => {
+      const model = await makeModel("catalog.malloy");
+      const rows = await runAdHoc(
+         model,
+         "run: widgets -> { group_by: region; aggregate: n is count() }",
+      );
+      expect(rows.length).toBe(3); // US, EU, APAC
+   });
+
+   it("runs a published named view", async () => {
+      const model = await makeModel("catalog.malloy");
+      const rows = await runAdHoc(model, "run: widgets -> by_region");
+      expect(rows.length).toBe(3);
+   });
+});
+
+// ===========================================================================
+// Misuse vectors: an untrusted query trying to read `secrets`, which the
+// catalog model never published. Each must be blocked.
+// ===========================================================================
+
+describe("an untrusted query cannot reach data the model never published", () => {
+   // The connection can see every table; the model curated only `widgets`.
+   // Naming another table directly would turn the model into a handle on the
+   // whole warehouse.
+   it("cannot point a source at an arbitrary warehouse table", async () => {
+      const model = await makeModel("catalog.malloy");
+      await expectBlocked(
+         model,
+         "run: duckdb.table('secrets') -> { aggregate: c is count() }",
+      );
+   });
+
+   // Raw SQL would let the caller run anything the connection's credentials
+   // allow — arbitrary reads, cross-table joins, even writes on a writable role.
+   it("cannot execute arbitrary SQL against the connection", async () => {
+      const model = await makeModel("catalog.malloy");
+      await expectBlocked(
+         model,
+         'run: duckdb.sql("SELECT id, ssn FROM secrets") -> { group_by: ssn }',
+      );
+   });
+
+   // Importing another model would pull in surfaces the queried model chose not
+   // to expose (and the file path is caller-controlled).
+   it("cannot import another model to borrow its surface", async () => {
+      const model = await makeModel("catalog.malloy");
+      await expectBlocked(
+         model,
+         'import "vault.malloy"\n' +
+            "run: vault -> { aggregate: c is count() }",
+      );
+   });
+
+   // Combining the curated surface with a raw table — joining `secrets` onto the
+   // published `widgets` — must not slip a raw table past the restriction.
+   it("cannot smuggle a raw table in through a join on a published source", async () => {
+      const model = await makeModel("catalog.malloy");
+      await expectBlocked(
+         model,
+         "source: x is widgets extend {\n" +
+            "   join_cross: s is duckdb.table('secrets')\n" +
+            "}\n" +
+            "run: x -> { group_by: s.ssn }",
+      );
+   });
+});

--- a/packages/server/src/service/restricted_mode.spec.ts
+++ b/packages/server/src/service/restricted_mode.spec.ts
@@ -169,6 +169,34 @@ async function expectBlocked(model: Model, query: string): Promise<void> {
    );
 }
 
+/**
+ * Same assertion as `expectBlocked`, but exercised through the named
+ * `sourceName`/`queryName` request shape rather than the free-form `query`
+ * field — those identifiers are concatenated into a `run: …` string and so are
+ * just as caller-controlled.
+ */
+async function expectNamedBlocked(
+   model: Model,
+   sourceName: string | undefined,
+   queryName: string,
+): Promise<void> {
+   let leakedRows: number | undefined;
+   try {
+      const { compactResult } = await model.getQueryResults(
+         sourceName,
+         queryName,
+      );
+      leakedRows = asRows(compactResult).length;
+   } catch (error) {
+      expect(looksRestricted(error)).toBe(true);
+      return;
+   }
+   throw new Error(
+      `Expected the named-path request to be blocked by restricted mode, but ` +
+         `it succeeded and returned ${leakedRows} rows (escaped the curated surface).`,
+   );
+}
+
 // ===========================================================================
 // The published surface stays fully usable — restriction must not break the
 // legitimate path it is wrapped around.
@@ -240,5 +268,32 @@ describe("an untrusted query cannot reach data the model never published", () =>
             "}\n" +
             "run: x -> { group_by: s.ssn }",
       );
+   });
+});
+
+// ===========================================================================
+// The named `sourceName`/`queryName` request shape reaches the same compiler
+// path as ad-hoc text, so it must inherit the same restriction. A real name is
+// a bare identifier; anything that smuggles in a disallowed construct must be
+// blocked, while legitimate published names keep working.
+// ===========================================================================
+
+describe("the named source/view path is restricted too", () => {
+   it("blocks a disallowed construct supplied through the sourceName/queryName fields", async () => {
+      const model = await makeModel("catalog.malloy");
+      await expectNamedBlocked(
+         model,
+         "duckdb.table('secrets')",
+         "{ group_by: ssn }",
+      );
+   });
+
+   it("still runs a legitimate published source and view by name", async () => {
+      const model = await makeModel("catalog.malloy");
+      const { compactResult } = await model.getQueryResults(
+         "widgets",
+         "by_region",
+      );
+      expect(asRows(compactResult).length).toBe(3);
    });
 });


### PR DESCRIPTION
## Summary

Hardens `execute_query` against untrusted ad-hoc Malloy by adding cooperating protections:

1. **Restricted-mode compilation for all caller-driven query text.** Both the ad-hoc `query` string and the `run: source->view` string built from the caller-supplied `sourceName`/`queryName` pair are now compiled with Malloy's `loadRestrictedQuery`. This keeps a caller inside the model's published surface (its sources, views, dimensions, measures) and prevents using Malloy as a general-purpose handle to the underlying database or filesystem. The unrestricted compile path is now reserved for author-curated content (notebook cells), which is trusted.

2. **Filter enforcement across source derivations.** A `#(filter)`-protected source now carries its filter requirements even when it's read under a derived name (alias / extend / chain), instead of only when referenced directly. The required filter is validated and the query is scoped — the query still runs, so the accepted query surface is unchanged.

3. **Comment-safe filter injection.** The injected `+ {where: …}` refinement is now placed on its own line so a trailing line comment (`//` or `--`) on the caller's query can't extend over it and neutralize the filter.

## What changed

- `service/model.ts`
  - Added `resolveFilterSource`, which resolves an ad-hoc query's run target back to the model-defined source whose filters apply.
  - `getQueryResults` now compiles every caller-driven query — both ad-hoc text and the named `source->view` path — via `loadRestrictedQuery`; the unrestricted `loadQuery` is reserved for notebook cells.
- `service/filter.ts` — `injectFilterRefinement` places the refinement on its own line so a trailing comment can't swallow it.
- `service/filter_bypass.spec.ts` (new) — `#(filter)` enforcement across direct reads and alias/extend/chain derivations, plus regressions for unprotected sources and `bypassFilters`.
- `service/restricted_mode.spec.ts` (new) — restricted-mode containment written from the publisher's threat model: confirms the curated surface stays usable (via both ad-hoc and named requests) and that untrusted queries can't reach an unpublished table via raw table access, raw SQL, `import`, a smuggled raw-table join, or a construct injected through the `sourceName`/`queryName` fields.
- `service/filter.spec.ts` — updated `injectFilterRefinement` expectations for the own-line form, plus a regression that a trailing comment can't swallow the filter.
- `service/model.spec.ts` — distinct `loadQuery` / `loadRestrictedQuery` mocks, asserting both the ad-hoc and named paths dispatch to restricted mode and never reach the trusted `loadQuery`.

## Notes

- `#(filter)` is a temporary mechanism on its way to being replaced by Malloy `given:`; the enforcement here is intentionally scoped to that interim need and does not change the set of query shapes `execute_query` accepts. A handful of known `#(filter)` limitations are intentionally left for the `given:` migration rather than absorbing larger structural changes here.
- Restricted mode is independent of `#(filter)` and is the durable layer; its tests are kept in a separate file so they survive `#(filter)` removal.

## Test plan

- [ ] `bun test src/service/filter_bypass.spec.ts src/service/restricted_mode.spec.ts`
- [ ] `bun test src/service/filter.spec.ts src/service/model.spec.ts src/service/filter_integration.spec.ts src/service/givens_integration.spec.ts`
- [ ] Confirm legitimate ad-hoc queries and named queries/views against published sources still run; confirm raw table / raw SQL / `import` in either ad-hoc text or the `sourceName`/`queryName` fields is rejected.