### PR TITLE
feat(cli): add materialization, manifest, model, notebook, and database commands

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -12,17 +12,29 @@ npm install -g @malloydata/publisher-cli
 # Set the Publisher server URL (optional, defaults to http://localhost:4000)
 export MALLOY_PUBLISHER_URL=http://localhost:4000
 
-# List projects
-malloy-pub list project
+# Environments, packages, connections
+malloy-pub list environment
+malloy-pub create environment my-environment
+malloy-pub update environment my-environment --readme "Updated readme"
+malloy-pub list package --environment my-environment
+malloy-pub create connection --environment my-environment --file connections.json
 
-# Create a project
-malloy-pub create project my-project
+# Materializations (build a package's persisted sources)
+malloy-pub list materialization --environment my-environment --package my-package
+malloy-pub materialize --environment my-environment --package my-package --wait
+malloy-pub get materialization <id> --environment my-environment --package my-package
+malloy-pub stop-materialization <id> --environment my-environment --package my-package
+malloy-pub delete materialization <id> --environment my-environment --package my-package
 
-# Update a project
-malloy-pub update project my-project --readme "Updated readme"
+# Build manifest (the tables a materialization produced)
+malloy-pub get manifest --environment my-environment --package my-package
+malloy-pub reload-manifest --environment my-environment --package my-package
 
-# Create connections from file
-malloy-pub create connection --project my-project --file connections.json
+# Read-only package contents
+malloy-pub list model --environment my-environment --package my-package
+malloy-pub get model flights.malloy --environment my-environment --package my-package
+malloy-pub list notebook --environment my-environment --package my-package
+malloy-pub list database --environment my-environment --package my-package
 ```
 
 ## Development
@@ -40,13 +52,29 @@ npm run build
 npm link
 
 # Test
-malloy-pub list project --url http://localhost:4000
+malloy-pub list environment --url http://localhost:4000
 ```
 
 ## Commands
 
-- `malloy-pub list <resource>` - List resources (project, package, connection)
-- `malloy-pub get <resource> <name>` - Get resource details
-- `malloy-pub create <resource> <name>` - Create a resource
-- `malloy-pub update <resource> <name>` - Update a resource
-- `malloy-pub delete <resource> <name>` - Delete a resource
+Resource (CRUD) verbs:
+
+- `malloy-pub list <resource>` - List resources (environment, package, connection, materialization, model, notebook, database). `list materialization` also accepts `--limit <n>` and `--offset <n>` for pagination.
+- `malloy-pub get <resource> [name]` - Get resource details (environment, package, connection, materialization, model, notebook, manifest)
+- `malloy-pub create <resource> [name]` - Create a resource (environment, package, connection)
+- `malloy-pub update <resource> [name]` - Update a resource (environment, package, connection)
+- `malloy-pub delete <resource> [name]` - Delete a resource (environment, package, connection, materialization)
+
+Action commands:
+
+- `malloy-pub materialize --environment <env> --package <pkg> [--force-refresh] [--auto-load-manifest] [--wait] [--timeout <seconds>] [--poll-interval <seconds>]` - Create and start a materialization build. With `--wait`, poll until it reaches a terminal state and exit non-zero if it fails, is cancelled, or times out; otherwise it returns the id so you can check status with `get materialization`. `--wait` defaults to a 120-second timeout and a 2-second poll interval; raise `--timeout` for long builds.
+- `malloy-pub stop-materialization <id> --environment <env> --package <pkg>` - Stop a pending or running materialization.
+- `malloy-pub reload-manifest --environment <env> --package <pkg>` - Reload the build manifest and recompile the package's models.
+
+Models, notebooks, and databases are deployed package artifacts and are read-only. Models and notebooks support `list` and `get`; databases support `list` only (the API exposes no get-by-id for databases).
+
+Common options:
+
+- `--url <server>` - Publisher server URL (overrides `MALLOY_PUBLISHER_URL`)
+- `--environment <name>` - Environment name (required for every resource except `environment` itself)
+- `--package <name>` - Package name (required for materialization, model, notebook, database, and manifest)

--- a/packages/cli/src/api/client.ts
+++ b/packages/cli/src/api/client.ts
@@ -3,7 +3,15 @@ import { logAxiosError } from "../utils/logger.js";
 import {
   Configuration,
   ConnectionsApi,
+  CreateMaterializationRequest,
+  DatabasesApi,
   EnvironmentsApi,
+  ManifestActionActionEnum,
+  ManifestsApi,
+  MaterializationActionActionEnum,
+  MaterializationsApi,
+  ModelsApi,
+  NotebooksApi,
   PackagesApi,
 } from "./generated";
 
@@ -11,6 +19,11 @@ export class PublisherClient {
   private environmentsApi: EnvironmentsApi;
   private packagesApi: PackagesApi;
   private connectionsApi: ConnectionsApi;
+  private materializationsApi: MaterializationsApi;
+  private manifestsApi: ManifestsApi;
+  private modelsApi: ModelsApi;
+  private notebooksApi: NotebooksApi;
+  private databasesApi: DatabasesApi;
   private baseURL: string;
 
   constructor(urlOverride?: string) {
@@ -23,6 +36,11 @@ export class PublisherClient {
     this.environmentsApi = new EnvironmentsApi(config);
     this.packagesApi = new PackagesApi(config);
     this.connectionsApi = new ConnectionsApi(config);
+    this.materializationsApi = new MaterializationsApi(config);
+    this.manifestsApi = new ManifestsApi(config);
+    this.modelsApi = new ModelsApi(config);
+    this.notebooksApi = new NotebooksApi(config);
+    this.databasesApi = new DatabasesApi(config);
   }
 
   private resolveServerURL(urlOverride?: string): string {
@@ -228,6 +246,209 @@ export class PublisherClient {
         environmentName,
         connectionName,
       );
+    } catch (error) {
+      throw this.handleError(error as AxiosError);
+    }
+  }
+
+  // Materializations
+  async listMaterializations(
+    environmentName: string,
+    packageName: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<any[]> {
+    try {
+      const response = await this.materializationsApi.listMaterializations(
+        environmentName,
+        packageName,
+        limit,
+        offset,
+      );
+      return response.data;
+    } catch (error) {
+      throw this.handleError(error as AxiosError);
+    }
+  }
+
+  async getMaterialization(
+    environmentName: string,
+    packageName: string,
+    materializationId: string,
+  ): Promise<any> {
+    try {
+      const response = await this.materializationsApi.getMaterialization(
+        environmentName,
+        packageName,
+        materializationId,
+      );
+      return response.data;
+    } catch (error) {
+      throw this.handleError(error as AxiosError);
+    }
+  }
+
+  async createMaterialization(
+    environmentName: string,
+    packageName: string,
+    request: CreateMaterializationRequest,
+  ): Promise<any> {
+    try {
+      const response = await this.materializationsApi.createMaterialization(
+        environmentName,
+        packageName,
+        request,
+      );
+      return response.data;
+    } catch (error) {
+      throw this.handleError(error as AxiosError);
+    }
+  }
+
+  async materializationAction(
+    environmentName: string,
+    packageName: string,
+    materializationId: string,
+    action: "start" | "stop",
+  ): Promise<any> {
+    try {
+      const response = await this.materializationsApi.materializationAction(
+        environmentName,
+        packageName,
+        materializationId,
+        action as MaterializationActionActionEnum,
+      );
+      return response.data;
+    } catch (error) {
+      throw this.handleError(error as AxiosError);
+    }
+  }
+
+  async deleteMaterialization(
+    environmentName: string,
+    packageName: string,
+    materializationId: string,
+  ): Promise<void> {
+    try {
+      await this.materializationsApi.deleteMaterialization(
+        environmentName,
+        packageName,
+        materializationId,
+      );
+    } catch (error) {
+      throw this.handleError(error as AxiosError);
+    }
+  }
+
+  // Build manifest
+  async getManifest(
+    environmentName: string,
+    packageName: string,
+  ): Promise<any> {
+    try {
+      const response = await this.manifestsApi.getManifest(
+        environmentName,
+        packageName,
+      );
+      return response.data;
+    } catch (error) {
+      throw this.handleError(error as AxiosError);
+    }
+  }
+
+  async reloadManifest(
+    environmentName: string,
+    packageName: string,
+  ): Promise<any> {
+    try {
+      const response = await this.manifestsApi.manifestAction(
+        environmentName,
+        packageName,
+        ManifestActionActionEnum.Reload,
+      );
+      return response.data;
+    } catch (error) {
+      throw this.handleError(error as AxiosError);
+    }
+  }
+
+  // Models (read-only)
+  async listModels(
+    environmentName: string,
+    packageName: string,
+  ): Promise<any[]> {
+    try {
+      const response = await this.modelsApi.listModels(
+        environmentName,
+        packageName,
+      );
+      return response.data;
+    } catch (error) {
+      throw this.handleError(error as AxiosError);
+    }
+  }
+
+  async getModel(
+    environmentName: string,
+    packageName: string,
+    path: string,
+  ): Promise<any> {
+    try {
+      const response = await this.modelsApi.getModel(
+        environmentName,
+        packageName,
+        path,
+      );
+      return response.data;
+    } catch (error) {
+      throw this.handleError(error as AxiosError);
+    }
+  }
+
+  // Notebooks (read-only)
+  async listNotebooks(
+    environmentName: string,
+    packageName: string,
+  ): Promise<any[]> {
+    try {
+      const response = await this.notebooksApi.listNotebooks(
+        environmentName,
+        packageName,
+      );
+      return response.data;
+    } catch (error) {
+      throw this.handleError(error as AxiosError);
+    }
+  }
+
+  async getNotebook(
+    environmentName: string,
+    packageName: string,
+    path: string,
+  ): Promise<any> {
+    try {
+      const response = await this.notebooksApi.getNotebook(
+        environmentName,
+        packageName,
+        path,
+      );
+      return response.data;
+    } catch (error) {
+      throw this.handleError(error as AxiosError);
+    }
+  }
+
+  // Databases (read-only)
+  async listDatabases(
+    environmentName: string,
+    packageName: string,
+  ): Promise<any[]> {
+    try {
+      const response = await this.databasesApi.listDatabases(
+        environmentName,
+        packageName,
+      );
+      return response.data;
     } catch (error) {
       throw this.handleError(error as AxiosError);
     }

--- a/packages/cli/src/commands/databases.ts
+++ b/packages/cli/src/commands/databases.ts
@@ -1,0 +1,26 @@
+import { PublisherClient } from "../api/client.js";
+import Table from "cli-table3";
+import { logInfo, logOutput } from "../utils/logger.js";
+
+export async function listDatabases(
+  client: PublisherClient,
+  environmentName: string,
+  packageName: string,
+): Promise<void> {
+  const databases = await client.listDatabases(environmentName, packageName);
+
+  if (databases.length === 0) {
+    logInfo(`No databases in package: ${packageName}`);
+    return;
+  }
+
+  const table = new Table({
+    head: ["Path", "Type"],
+  });
+
+  databases.forEach((d: any) => {
+    table.push([d.path ?? "", d.type ?? ""]);
+  });
+
+  logOutput(table.toString());
+}

--- a/packages/cli/src/commands/manifests.ts
+++ b/packages/cli/src/commands/manifests.ts
@@ -1,0 +1,37 @@
+import { PublisherClient } from "../api/client.js";
+import Table from "cli-table3";
+import { logSuccess, logInfo, logOutput } from "../utils/logger.js";
+
+export async function getManifest(
+  client: PublisherClient,
+  environmentName: string,
+  packageName: string,
+): Promise<void> {
+  const manifest = await client.getManifest(environmentName, packageName);
+  const entries = (manifest && manifest.entries) || {};
+  const buildIds = Object.keys(entries);
+
+  if (buildIds.length === 0) {
+    logInfo(`No materialized tables in manifest for package: ${packageName}`);
+    return;
+  }
+
+  const table = new Table({
+    head: ["Build ID", "Table"],
+  });
+
+  buildIds.forEach((buildId) => {
+    table.push([buildId, entries[buildId]?.tableName ?? ""]);
+  });
+
+  logOutput(table.toString());
+}
+
+export async function reloadManifest(
+  client: PublisherClient,
+  environmentName: string,
+  packageName: string,
+): Promise<void> {
+  await client.reloadManifest(environmentName, packageName);
+  logSuccess(`Reloaded manifest for package: ${packageName}`);
+}

--- a/packages/cli/src/commands/materializations.ts
+++ b/packages/cli/src/commands/materializations.ts
@@ -1,0 +1,166 @@
+import { PublisherClient } from "../api/client.js";
+import Table from "cli-table3";
+import { logSuccess, logInfo, logOutput, truncate } from "../utils/logger.js";
+
+const TERMINAL_STATUSES = ["SUCCESS", "FAILED", "CANCELLED"];
+
+export async function listMaterializations(
+  client: PublisherClient,
+  environmentName: string,
+  packageName: string,
+  options: { limit?: number; offset?: number } = {},
+): Promise<void> {
+  const materializations = await client.listMaterializations(
+    environmentName,
+    packageName,
+    options.limit,
+    options.offset,
+  );
+
+  if (materializations.length === 0) {
+    logInfo(`No materializations in package: ${packageName}`);
+    return;
+  }
+
+  const table = new Table({
+    head: ["ID", "Status", "Started", "Completed", "Error"],
+  });
+
+  materializations.forEach((m: any) => {
+    table.push([
+      m.id ?? "",
+      m.status ?? "",
+      m.startedAt ?? "",
+      m.completedAt ?? "",
+      m.error ? truncate(m.error) : "",
+    ]);
+  });
+
+  logOutput(table.toString());
+}
+
+export async function getMaterialization(
+  client: PublisherClient,
+  environmentName: string,
+  packageName: string,
+  materializationId: string,
+): Promise<void> {
+  const materialization = await client.getMaterialization(
+    environmentName,
+    packageName,
+    materializationId,
+  );
+  logOutput(JSON.stringify(materialization, null, 2));
+}
+
+/**
+ * Create a materialization and start it. With `wait`, poll until the build
+ * reaches a terminal state (mirrors the UI's create-then-start flow). Without
+ * `wait`, return immediately with a hint for checking status, since live
+ * polling is awkward in a non-interactive CLI.
+ */
+export async function materialize(
+  client: PublisherClient,
+  environmentName: string,
+  packageName: string,
+  options: {
+    forceRefresh?: boolean;
+    autoLoadManifest?: boolean;
+    wait?: boolean;
+    pollIntervalMs?: number;
+    timeoutMs?: number;
+  } = {},
+): Promise<void> {
+  const created = await client.createMaterialization(
+    environmentName,
+    packageName,
+    {
+      forceRefresh: options.forceRefresh,
+      autoLoadManifest: options.autoLoadManifest,
+    },
+  );
+  const id = created.id as string | undefined;
+  if (!id) {
+    throw new Error("Publisher returned a materialization with no id");
+  }
+  logSuccess(`Created materialization: ${id}`);
+
+  let current = await client.materializationAction(
+    environmentName,
+    packageName,
+    id,
+    "start",
+  );
+  logInfo(`Started materialization: ${id} (status: ${current.status})`);
+
+  if (!options.wait) {
+    logInfo(
+      `Run "malloy-pub get materialization ${id} --environment ${environmentName} --package ${packageName}" to check status.`,
+    );
+    return;
+  }
+
+  const pollIntervalMs = options.pollIntervalMs ?? 2000;
+  const timeoutMs = options.timeoutMs ?? 120000;
+  const deadline = Date.now() + timeoutMs;
+
+  while (!TERMINAL_STATUSES.includes(current.status) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    current = await client.getMaterialization(environmentName, packageName, id);
+  }
+
+  // Always print the final record for visibility.
+  logOutput(JSON.stringify(current, null, 2));
+
+  if (current.status === "SUCCESS") {
+    logSuccess(`Materialization ${id} completed: SUCCESS`);
+    return;
+  }
+
+  // Non-success: throw so the CLI exits non-zero. The index.ts action's catch
+  // turns a thrown error into logError + process.exit(1), which is what a
+  // CI/automation caller relying on --wait's exit code needs.
+  if (!TERMINAL_STATUSES.includes(current.status)) {
+    throw new Error(
+      `Timed out waiting for materialization ${id} after ${Math.round(
+        timeoutMs / 1000,
+      )}s (last status: ${current.status}). It may still be running.`,
+    );
+  }
+  throw new Error(
+    `Materialization ${id} finished: ${current.status}${
+      current.error ? ` - ${current.error}` : ""
+    }`,
+  );
+}
+
+export async function stopMaterialization(
+  client: PublisherClient,
+  environmentName: string,
+  packageName: string,
+  materializationId: string,
+): Promise<void> {
+  const result = await client.materializationAction(
+    environmentName,
+    packageName,
+    materializationId,
+    "stop",
+  );
+  logSuccess(
+    `Stopped materialization: ${materializationId} (status: ${result.status})`,
+  );
+}
+
+export async function deleteMaterialization(
+  client: PublisherClient,
+  environmentName: string,
+  packageName: string,
+  materializationId: string,
+): Promise<void> {
+  await client.deleteMaterialization(
+    environmentName,
+    packageName,
+    materializationId,
+  );
+  logSuccess(`Deleted materialization: ${materializationId}`);
+}

--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -1,0 +1,36 @@
+import { PublisherClient } from "../api/client.js";
+import Table from "cli-table3";
+import { logInfo, logOutput, truncate } from "../utils/logger.js";
+
+export async function listModels(
+  client: PublisherClient,
+  environmentName: string,
+  packageName: string,
+): Promise<void> {
+  const models = await client.listModels(environmentName, packageName);
+
+  if (models.length === 0) {
+    logInfo(`No models in package: ${packageName}`);
+    return;
+  }
+
+  const table = new Table({
+    head: ["Path", "Error"],
+  });
+
+  models.forEach((m: any) => {
+    table.push([m.path ?? "", m.error ? truncate(m.error) : ""]);
+  });
+
+  logOutput(table.toString());
+}
+
+export async function getModel(
+  client: PublisherClient,
+  environmentName: string,
+  packageName: string,
+  path: string,
+): Promise<void> {
+  const model = await client.getModel(environmentName, packageName, path);
+  logOutput(JSON.stringify(model, null, 2));
+}

--- a/packages/cli/src/commands/notebooks.ts
+++ b/packages/cli/src/commands/notebooks.ts
@@ -1,0 +1,36 @@
+import { PublisherClient } from "../api/client.js";
+import Table from "cli-table3";
+import { logInfo, logOutput, truncate } from "../utils/logger.js";
+
+export async function listNotebooks(
+  client: PublisherClient,
+  environmentName: string,
+  packageName: string,
+): Promise<void> {
+  const notebooks = await client.listNotebooks(environmentName, packageName);
+
+  if (notebooks.length === 0) {
+    logInfo(`No notebooks in package: ${packageName}`);
+    return;
+  }
+
+  const table = new Table({
+    head: ["Path", "Error"],
+  });
+
+  notebooks.forEach((n: any) => {
+    table.push([n.path ?? "", n.error ? truncate(n.error) : ""]);
+  });
+
+  logOutput(table.toString());
+}
+
+export async function getNotebook(
+  client: PublisherClient,
+  environmentName: string,
+  packageName: string,
+  path: string,
+): Promise<void> {
+  const notebook = await client.getNotebook(environmentName, packageName, path);
+  logOutput(JSON.stringify(notebook, null, 2));
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,11 @@ import { logError, logOutput, logWarning } from "./utils/logger.js";
 import * as environmentCommands from "./commands/environments.js";
 import * as packageCommands from "./commands/packages.js";
 import * as connectionCommands from "./commands/connections.js";
+import * as materializationCommands from "./commands/materializations.js";
+import * as manifestCommands from "./commands/manifests.js";
+import * as modelCommands from "./commands/models.js";
+import * as notebookCommands from "./commands/notebooks.js";
+import * as databaseCommands from "./commands/databases.js";
 
 const program = new Command();
 
@@ -41,14 +46,39 @@ function getClient(): PublisherClient {
   return new PublisherClient(globalUrl);
 }
 
+// Parse an optional non-negative integer flag (e.g. --limit / --offset),
+// erroring clearly instead of forwarding NaN to the server.
+function parseOptionalCount(
+  value: string | undefined,
+  flag: string,
+): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    logError(`${flag} must be a non-negative integer`);
+    process.exit(1);
+  }
+  return parsed;
+}
+
 // LIST COMMAND
 program
   .command("list <resource>")
-  .description("List resources (environment, package, connection)")
+  .description(
+    "List resources (environment, package, connection, materialization, model, notebook, database)",
+  )
   .option(
     "--environment <n>",
-    "Environment name (required for package/connection)",
+    "Environment name (required for all but environment)",
   )
+  .option(
+    "--package <n>",
+    "Package name (required for materialization/model/notebook/database)",
+  )
+  .option("--limit <n>", "Max materializations to return")
+  .option("--offset <n>", "Materializations to skip")
   .action(async (resource, options) => {
     try {
       const client = getClient();
@@ -71,9 +101,59 @@ program
           }
           await connectionCommands.listConnections(client, options.environment);
           break;
+        case "materialization":
+          if (!options.environment || !options.package) {
+            logError("--environment and --package are required");
+            process.exit(1);
+          }
+          await materializationCommands.listMaterializations(
+            client,
+            options.environment,
+            options.package,
+            {
+              limit: parseOptionalCount(options.limit, "--limit"),
+              offset: parseOptionalCount(options.offset, "--offset"),
+            },
+          );
+          break;
+        case "model":
+          if (!options.environment || !options.package) {
+            logError("--environment and --package are required");
+            process.exit(1);
+          }
+          await modelCommands.listModels(
+            client,
+            options.environment,
+            options.package,
+          );
+          break;
+        case "notebook":
+          if (!options.environment || !options.package) {
+            logError("--environment and --package are required");
+            process.exit(1);
+          }
+          await notebookCommands.listNotebooks(
+            client,
+            options.environment,
+            options.package,
+          );
+          break;
+        case "database":
+          if (!options.environment || !options.package) {
+            logError("--environment and --package are required");
+            process.exit(1);
+          }
+          await databaseCommands.listDatabases(
+            client,
+            options.environment,
+            options.package,
+          );
+          break;
         default:
           logError(`Unknown resource: ${resource}`);
-          logOutput("Valid types: environment, package, connection");
+          logOutput(
+            "Valid types: environment, package, connection, materialization, model, notebook, database",
+          );
           process.exit(1);
       }
     } catch (error: any) {
@@ -121,8 +201,58 @@ program
             name,
           );
           break;
+        case "materialization":
+          if (!options.environment || !options.package) {
+            logError("--environment and --package are required");
+            process.exit(1);
+          }
+          await materializationCommands.getMaterialization(
+            client,
+            options.environment,
+            options.package,
+            name,
+          );
+          break;
+        case "model":
+          if (!options.environment || !options.package) {
+            logError("--environment and --package are required");
+            process.exit(1);
+          }
+          await modelCommands.getModel(
+            client,
+            options.environment,
+            options.package,
+            name,
+          );
+          break;
+        case "notebook":
+          if (!options.environment || !options.package) {
+            logError("--environment and --package are required");
+            process.exit(1);
+          }
+          await notebookCommands.getNotebook(
+            client,
+            options.environment,
+            options.package,
+            name,
+          );
+          break;
+        case "manifest":
+          if (!options.environment || !options.package) {
+            logError("--environment and --package are required");
+            process.exit(1);
+          }
+          await manifestCommands.getManifest(
+            client,
+            options.environment,
+            options.package,
+          );
+          break;
         default:
           logError(`Unknown resource: ${resource}`);
+          logOutput(
+            "Valid types: environment, package, connection, materialization, model, notebook, manifest",
+          );
           process.exit(1);
       }
     } catch (error: any) {
@@ -280,10 +410,115 @@ program
             name,
           );
           break;
+        case "materialization":
+          if (!options.environment || !options.package) {
+            logError("--environment and --package are required");
+            process.exit(1);
+          }
+          await materializationCommands.deleteMaterialization(
+            client,
+            options.environment,
+            options.package,
+            name,
+          );
+          break;
         default:
           logError(`Unknown resource: ${resource}`);
           process.exit(1);
       }
+    } catch (error: any) {
+      logError("Command failed", error);
+      process.exit(1);
+    }
+  });
+
+// The standalone action verbs below (materialize / stop-materialization /
+// reload-manifest) always require --environment and --package, so they use
+// Commander's requiredOption(). The verb-first switch commands above multiplex
+// resources with differing requirements (e.g. `list environment` needs no
+// --package), so they validate manually inside each case instead.
+
+// MATERIALIZE COMMAND (create + start a materialization build)
+program
+  .command("materialize")
+  .description("Create and start a materialization build for a package")
+  .requiredOption("--environment <n>", "Environment name")
+  .requiredOption("--package <n>", "Package name")
+  .option("--force-refresh", "Rebuild all sources, ignoring existing build IDs")
+  .option(
+    "--auto-load-manifest",
+    "Reload the manifest after a successful build",
+  )
+  .option("--wait", "Poll until the build reaches a terminal state")
+  .option(
+    "--timeout <seconds>",
+    "With --wait, seconds to wait before giving up (default 120)",
+  )
+  .option(
+    "--poll-interval <seconds>",
+    "With --wait, seconds between status checks (default 2)",
+  )
+  .action(async (options) => {
+    try {
+      const client = getClient();
+      const timeoutSec = parseOptionalCount(options.timeout, "--timeout");
+      const pollSec = parseOptionalCount(
+        options.pollInterval,
+        "--poll-interval",
+      );
+      await materializationCommands.materialize(
+        client,
+        options.environment,
+        options.package,
+        {
+          forceRefresh: options.forceRefresh,
+          autoLoadManifest: options.autoLoadManifest,
+          wait: options.wait,
+          timeoutMs: timeoutSec !== undefined ? timeoutSec * 1000 : undefined,
+          pollIntervalMs: pollSec !== undefined ? pollSec * 1000 : undefined,
+        },
+      );
+    } catch (error: any) {
+      logError("Command failed", error);
+      process.exit(1);
+    }
+  });
+
+// STOP-MATERIALIZATION COMMAND
+program
+  .command("stop-materialization <id>")
+  .description("Stop a pending or running materialization")
+  .requiredOption("--environment <n>", "Environment name")
+  .requiredOption("--package <n>", "Package name")
+  .action(async (id, options) => {
+    try {
+      const client = getClient();
+      await materializationCommands.stopMaterialization(
+        client,
+        options.environment,
+        options.package,
+        id,
+      );
+    } catch (error: any) {
+      logError("Command failed", error);
+      process.exit(1);
+    }
+  });
+
+// RELOAD-MANIFEST COMMAND
+program
+  .command("reload-manifest")
+  .description("Reload the build manifest and recompile a package's models")
+  .requiredOption("--environment <n>", "Environment name")
+  .requiredOption("--package <n>", "Package name")
+  .action(async (options) => {
+    try {
+      const client = getClient();
+      await manifestCommands.reloadManifest(
+        client,
+        options.environment,
+        options.package,
+      );
     } catch (error: any) {
       logError("Command failed", error);
       process.exit(1);

--- a/packages/cli/src/tests/databases.test.ts
+++ b/packages/cli/src/tests/databases.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { PublisherClient } from "../api/client";
+import * as databaseCommands from "../commands/databases";
+
+describe("Database Commands", () => {
+  beforeEach(() => {
+    console.log = mock(() => {}) as any;
+  });
+
+  test("listDatabases calls the API", async () => {
+    const mockClient = {
+      listDatabases: mock(() =>
+        Promise.resolve([{ path: "data.parquet", type: "embedded" }]),
+      ),
+    } as unknown as PublisherClient;
+
+    await databaseCommands.listDatabases(mockClient, "env", "pkg");
+
+    expect(mockClient.listDatabases).toHaveBeenCalledWith("env", "pkg");
+  });
+
+  test("listDatabases handles empty list", async () => {
+    const mockClient = {
+      listDatabases: mock(() => Promise.resolve([])),
+    } as unknown as PublisherClient;
+
+    await databaseCommands.listDatabases(mockClient, "env", "pkg");
+
+    expect(mockClient.listDatabases).toHaveBeenCalledWith("env", "pkg");
+  });
+});

--- a/packages/cli/src/tests/logger.test.ts
+++ b/packages/cli/src/tests/logger.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "bun:test";
+import { truncate } from "../utils/logger";
+
+describe("truncate", () => {
+  test("returns short strings unchanged", () => {
+    expect(truncate("ok")).toBe("ok");
+  });
+
+  test("collapses newlines and whitespace runs to single spaces", () => {
+    expect(truncate("line one\n   line two\t\tline three")).toBe(
+      "line one line two line three",
+    );
+  });
+
+  test("caps length with an ellipsis", () => {
+    const long = "x".repeat(100);
+    const out = truncate(long, 10);
+    expect(out.length).toBe(10);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  test("collapses a long multi-line error and truncates it", () => {
+    const err = "Compile error:\n  unexpected token\n  at line 5\n".repeat(5);
+    const out = truncate(err);
+    expect(out.includes("\n")).toBe(false);
+    expect(out.length).toBeLessThanOrEqual(60);
+  });
+});

--- a/packages/cli/src/tests/manifests.test.ts
+++ b/packages/cli/src/tests/manifests.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { PublisherClient } from "../api/client";
+import * as manifestCommands from "../commands/manifests";
+
+describe("Manifest Commands", () => {
+  beforeEach(() => {
+    console.log = mock(() => {}) as any;
+  });
+
+  test("getManifest renders entries", async () => {
+    const mockClient = {
+      getManifest: mock(() =>
+        Promise.resolve({ entries: { build1: { tableName: "orders" } } }),
+      ),
+    } as unknown as PublisherClient;
+
+    await manifestCommands.getManifest(mockClient, "env", "pkg");
+
+    expect(mockClient.getManifest).toHaveBeenCalledWith("env", "pkg");
+  });
+
+  test("getManifest handles empty manifest", async () => {
+    const mockClient = {
+      getManifest: mock(() => Promise.resolve({ entries: {} })),
+    } as unknown as PublisherClient;
+
+    await manifestCommands.getManifest(mockClient, "env", "pkg");
+
+    expect(mockClient.getManifest).toHaveBeenCalledWith("env", "pkg");
+  });
+
+  test("reloadManifest calls reload API", async () => {
+    const mockClient = {
+      reloadManifest: mock(() => Promise.resolve({ entries: {} })),
+    } as unknown as PublisherClient;
+
+    await manifestCommands.reloadManifest(mockClient, "env", "pkg");
+
+    expect(mockClient.reloadManifest).toHaveBeenCalledWith("env", "pkg");
+  });
+});

--- a/packages/cli/src/tests/materializations.test.ts
+++ b/packages/cli/src/tests/materializations.test.ts
@@ -1,0 +1,187 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { PublisherClient } from "../api/client";
+import * as materializationCommands from "../commands/materializations";
+
+describe("Materialization Commands", () => {
+  beforeEach(() => {
+    console.log = mock(() => {}) as any;
+  });
+
+  test("listMaterializations passes pagination through", async () => {
+    const mockClient = {
+      listMaterializations: mock(() =>
+        Promise.resolve([{ id: "m1", status: "SUCCESS" }]),
+      ),
+    } as unknown as PublisherClient;
+
+    await materializationCommands.listMaterializations(
+      mockClient,
+      "env",
+      "pkg",
+      { limit: 10, offset: 5 },
+    );
+
+    expect(mockClient.listMaterializations).toHaveBeenCalledWith(
+      "env",
+      "pkg",
+      10,
+      5,
+    );
+  });
+
+  test("listMaterializations handles empty list", async () => {
+    const mockClient = {
+      listMaterializations: mock(() => Promise.resolve([])),
+    } as unknown as PublisherClient;
+
+    await materializationCommands.listMaterializations(
+      mockClient,
+      "env",
+      "pkg",
+    );
+
+    expect(mockClient.listMaterializations).toHaveBeenCalledWith(
+      "env",
+      "pkg",
+      undefined,
+      undefined,
+    );
+  });
+
+  test("getMaterialization fetches and prints JSON", async () => {
+    const mat = { id: "m1", status: "RUNNING" };
+    const mockClient = {
+      getMaterialization: mock(() => Promise.resolve(mat)),
+    } as unknown as PublisherClient;
+
+    await materializationCommands.getMaterialization(
+      mockClient,
+      "env",
+      "pkg",
+      "m1",
+    );
+
+    expect(mockClient.getMaterialization).toHaveBeenCalledWith(
+      "env",
+      "pkg",
+      "m1",
+    );
+  });
+
+  test("materialize creates then starts, no poll without wait", async () => {
+    const mockClient = {
+      createMaterialization: mock(() => Promise.resolve({ id: "m1" })),
+      materializationAction: mock(() =>
+        Promise.resolve({ id: "m1", status: "RUNNING" }),
+      ),
+      getMaterialization: mock(() => Promise.resolve({ status: "SUCCESS" })),
+    } as unknown as PublisherClient;
+
+    await materializationCommands.materialize(mockClient, "env", "pkg", {
+      forceRefresh: true,
+      autoLoadManifest: true,
+    });
+
+    expect(mockClient.createMaterialization).toHaveBeenCalledWith(
+      "env",
+      "pkg",
+      {
+        forceRefresh: true,
+        autoLoadManifest: true,
+      },
+    );
+    expect(mockClient.materializationAction).toHaveBeenCalledWith(
+      "env",
+      "pkg",
+      "m1",
+      "start",
+    );
+    expect(mockClient.getMaterialization).not.toHaveBeenCalled();
+  });
+
+  test("materialize with wait polls until terminal", async () => {
+    let calls = 0;
+    const mockClient = {
+      createMaterialization: mock(() => Promise.resolve({ id: "m1" })),
+      materializationAction: mock(() =>
+        Promise.resolve({ id: "m1", status: "RUNNING" }),
+      ),
+      getMaterialization: mock(() => {
+        calls += 1;
+        return Promise.resolve({
+          id: "m1",
+          status: calls >= 2 ? "SUCCESS" : "RUNNING",
+        });
+      }),
+    } as unknown as PublisherClient;
+
+    await materializationCommands.materialize(mockClient, "env", "pkg", {
+      wait: true,
+      pollIntervalMs: 1,
+      timeoutMs: 1000,
+    });
+
+    expect(calls).toBeGreaterThanOrEqual(2);
+  });
+
+  test("materialize with wait throws on a FAILED build (non-zero exit)", async () => {
+    const mockClient = {
+      createMaterialization: mock(() => Promise.resolve({ id: "m1" })),
+      materializationAction: mock(() =>
+        Promise.resolve({ id: "m1", status: "RUNNING" }),
+      ),
+      getMaterialization: mock(() =>
+        Promise.resolve({ id: "m1", status: "FAILED", error: "boom" }),
+      ),
+    } as unknown as PublisherClient;
+
+    await expect(
+      materializationCommands.materialize(mockClient, "env", "pkg", {
+        wait: true,
+        pollIntervalMs: 1,
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow(/FAILED/);
+  });
+
+  test("stopMaterialization calls action stop", async () => {
+    const mockClient = {
+      materializationAction: mock(() =>
+        Promise.resolve({ id: "m1", status: "CANCELLED" }),
+      ),
+    } as unknown as PublisherClient;
+
+    await materializationCommands.stopMaterialization(
+      mockClient,
+      "env",
+      "pkg",
+      "m1",
+    );
+
+    expect(mockClient.materializationAction).toHaveBeenCalledWith(
+      "env",
+      "pkg",
+      "m1",
+      "stop",
+    );
+  });
+
+  test("deleteMaterialization calls delete API", async () => {
+    const mockClient = {
+      deleteMaterialization: mock(() => Promise.resolve()),
+    } as unknown as PublisherClient;
+
+    await materializationCommands.deleteMaterialization(
+      mockClient,
+      "env",
+      "pkg",
+      "m1",
+    );
+
+    expect(mockClient.deleteMaterialization).toHaveBeenCalledWith(
+      "env",
+      "pkg",
+      "m1",
+    );
+  });
+});

--- a/packages/cli/src/tests/models.test.ts
+++ b/packages/cli/src/tests/models.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { PublisherClient } from "../api/client";
+import * as modelCommands from "../commands/models";
+
+describe("Model Commands", () => {
+  beforeEach(() => {
+    console.log = mock(() => {}) as any;
+  });
+
+  test("listModels calls the API", async () => {
+    const mockClient = {
+      listModels: mock(() =>
+        Promise.resolve([{ path: "flights.malloy", error: "" }]),
+      ),
+    } as unknown as PublisherClient;
+
+    await modelCommands.listModels(mockClient, "env", "pkg");
+
+    expect(mockClient.listModels).toHaveBeenCalledWith("env", "pkg");
+  });
+
+  test("listModels handles empty list", async () => {
+    const mockClient = {
+      listModels: mock(() => Promise.resolve([])),
+    } as unknown as PublisherClient;
+
+    await modelCommands.listModels(mockClient, "env", "pkg");
+
+    expect(mockClient.listModels).toHaveBeenCalledWith("env", "pkg");
+  });
+
+  test("getModel fetches and prints JSON", async () => {
+    const model = { path: "flights.malloy", queries: [] };
+    const mockClient = {
+      getModel: mock(() => Promise.resolve(model)),
+    } as unknown as PublisherClient;
+
+    await modelCommands.getModel(mockClient, "env", "pkg", "flights.malloy");
+
+    expect(mockClient.getModel).toHaveBeenCalledWith(
+      "env",
+      "pkg",
+      "flights.malloy",
+    );
+  });
+});

--- a/packages/cli/src/tests/notebooks.test.ts
+++ b/packages/cli/src/tests/notebooks.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { PublisherClient } from "../api/client";
+import * as notebookCommands from "../commands/notebooks";
+
+describe("Notebook Commands", () => {
+  beforeEach(() => {
+    console.log = mock(() => {}) as any;
+  });
+
+  test("listNotebooks calls the API", async () => {
+    const mockClient = {
+      listNotebooks: mock(() =>
+        Promise.resolve([{ path: "analysis.malloynb", error: "" }]),
+      ),
+    } as unknown as PublisherClient;
+
+    await notebookCommands.listNotebooks(mockClient, "env", "pkg");
+
+    expect(mockClient.listNotebooks).toHaveBeenCalledWith("env", "pkg");
+  });
+
+  test("listNotebooks handles empty list", async () => {
+    const mockClient = {
+      listNotebooks: mock(() => Promise.resolve([])),
+    } as unknown as PublisherClient;
+
+    await notebookCommands.listNotebooks(mockClient, "env", "pkg");
+
+    expect(mockClient.listNotebooks).toHaveBeenCalledWith("env", "pkg");
+  });
+
+  test("getNotebook fetches and prints JSON", async () => {
+    const notebook = { path: "analysis.malloynb", notebookCells: [] };
+    const mockClient = {
+      getNotebook: mock(() => Promise.resolve(notebook)),
+    } as unknown as PublisherClient;
+
+    await notebookCommands.getNotebook(
+      mockClient,
+      "env",
+      "pkg",
+      "analysis.malloynb",
+    );
+
+    expect(mockClient.getNotebook).toHaveBeenCalledWith(
+      "env",
+      "pkg",
+      "analysis.malloynb",
+    );
+  });
+});

--- a/packages/cli/src/utils/logger.ts
+++ b/packages/cli/src/utils/logger.ts
@@ -62,6 +62,20 @@ export function formatDuration(durationMs: number): string {
 }
 
 /**
+ * Truncate a string for table display: collapse newlines/whitespace runs to a
+ * single space and cap the length with an ellipsis. Used for error columns,
+ * which can hold long, multi-line compile/build errors that would otherwise
+ * wreck a cli-table3 layout.
+ */
+export function truncate(text: string, max = 60): string {
+  const collapsed = text.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= max) {
+    return collapsed;
+  }
+  return `${collapsed.slice(0, max - 1)}…`;
+}
+
+/**
  * Log axios errors with detailed information
  */
 export const logAxiosError = (error: AxiosError) => {


### PR DESCRIPTION
## Summary

Brings the `malloy-pub` CLI up to parity with the REST API and web UI for the resources the server already exposes: materializations, the build manifest, and read-only models, notebooks, and databases. Until now the CLI only covered environments, packages, and connections. The generated API clients for these resources already shipped in the CLI but were never wrapped in `PublisherClient` or wired into the command surface; this PR connects them, so no OpenAPI or codegen change is required.

## What's added

Materializations:
- `list materialization` (with `--limit` / `--offset` pagination), `get materialization <id>`
- `materialize` (create + start in one step; `--force-refresh`, `--auto-load-manifest`, `--wait`, `--timeout <seconds>`, `--poll-interval <seconds>`)
- `stop-materialization <id>`, `delete materialization <id>`

Build manifest:
- `get manifest`, `reload-manifest`

Read-only package contents:
- `list model` / `get model <path>`, `list notebook` / `get notebook <path>`, `list database`

## Command structure

The existing verb-first commands (`list` / `get` / `delete <resource>`) are extended with the new resources. Operations that don't fit CRUD are added as standalone action verbs (`materialize`, `stop-materialization`, `reload-manifest`).

`materialize` mirrors the UI's create-then-start flow. With `--wait` it polls until the build reaches a terminal state and exits non-zero if it fails, is cancelled, or times out, so it is usable from CI; without `--wait` it prints the id and a hint for checking status. The poll timeout defaults to 120 seconds and is overridable with `--timeout`.

## Design notes

Models, notebooks, and databases remain read-only (no create / update / delete), matching their deployed-artifact model. Databases are `list`-only because the API exposes no get-by-id for them. Error responses from the server (for example the one-active-materialization 409, terminal-only delete, and not-found) surface through the existing error handler with a non-zero exit code.

## Testing

Automated: 23 unit tests across the new command modules plus the shared `truncate` helper. They mock the client and assert each command calls the right wrapper with the right arguments, including `materialize`'s create-then-start sequence, `--wait` polling to a terminal state, and the throw-on-failure path.

Manual (live CLI against a running server with a persist-source package and the ecommerce sample): exercised `list` / `get` across all new resources, `materialize --wait` to SUCCESS (verifying `--force-refresh` / `--auto-load-manifest` are honored), `get manifest` / `reload-manifest`, and `stop` / `delete`. Verified exit codes (SUCCESS exits 0; failed, timed-out, 409, and 404 cases exit non-zero) and flag validation (`--limit`, `--timeout`).

## Docs

Updates `packages/cli/README.md` with the new commands, flags, and common options.
