### PR TITLE
feat(server): surface each given's default as a source literal

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -2746,6 +2746,13 @@ components:
           description: Annotations attached to the given declaration
           items:
             type: string
+        default:
+          type: string
+          description: The given's default value as a Malloy source literal
+            (e.g. `'WN'`, `2003`, `@2024-01-01`, `f'WN'`), exactly as written in
+            the model. Omitted when the given declares no default. Consumers
+            render or prefill it per the given's `type` (e.g. unquote a string
+            literal for a text input).
 
     Givens:
       type: object

--- a/packages/app/tests/playwright/notebook-givens.spec.ts
+++ b/packages/app/tests/playwright/notebook-givens.spec.ts
@@ -113,8 +113,23 @@ test.describe("notebook-givens", () => {
    test("description annotation surfaces as helper text", async ({ page }) => {
       await openGivensNotebook(page);
 
+      // Not exact: the helper line now also carries the `Default: …` caption.
       await expect(
-         page.getByText("Two-letter IATA carrier code", { exact: true }),
+         page.getByText("Two-letter IATA carrier code", { exact: false }),
+      ).toBeVisible();
+   });
+
+   test("model default surfaces as a helper line", async ({ page }) => {
+      await openGivensNotebook(page);
+
+      // target_code defaults to 'WN' (string literal unquoted) and cutoff to
+      // @2024-01-01 (date, @ stripped). Both shown as a Default caption while
+      // the inputs stay empty — the value still comes from the model default.
+      await expect(
+         page.getByText("Default: WN", { exact: false }),
+      ).toBeVisible();
+      await expect(
+         page.getByText("Default: 2024-01-01", { exact: false }),
       ).toBeVisible();
    });
 

--- a/packages/sdk/src/components/given/GivenInput.tsx
+++ b/packages/sdk/src/components/given/GivenInput.tsx
@@ -63,17 +63,25 @@ function annotationHelperText(given: Given): string | undefined {
  * adornment appears when the field has a value. DatePicker, Checkbox, and
  * multi-Autocomplete have their own native clear affordances.
  *
- * A given's model default (if any) is surfaced as a ghost placeholder on the
- * text-based widgets and as a `Default: …` helper line on the date picker
- * (which has no usable placeholder). The value itself stays empty, so leaving
- * the field blank still means "use the model default". Boolean givens render
- * as a checkbox with no helper slot, so their default isn't surfaced.
+ * A given's model default (if any) is surfaced as an always-visible
+ * `Default: …` helper line (plus a ghost placeholder on the text widgets — a
+ * bonus that MUI only reveals once the field is focused, since the floating
+ * label sits in the placeholder's spot at rest). The value itself stays empty,
+ * so leaving the field blank still means "use the model default". Boolean
+ * givens render as a checkbox with no helper slot, so their default isn't
+ * surfaced.
  */
 export function GivenInput({ given, value, onChange }: GivenInputProps) {
    const label = given.name ?? "";
    const type = given.type ?? "string";
    const helperText = annotationHelperText(given);
    const defaultDisplay = renderGivenDefault(type, given.default);
+   // Append the default as an always-visible helper line. The ghost placeholder
+   // on text inputs is hidden behind MUI's floating label until focus, so this
+   // caption is what communicates the default at rest.
+   const helperWithDefault = defaultDisplay
+      ? [helperText, `Default: ${defaultDisplay}`].filter(Boolean).join("\n")
+      : helperText;
 
    if (type === "boolean") {
       const checked = value === true;
@@ -103,7 +111,7 @@ export function GivenInput({ given, value, onChange }: GivenInputProps) {
                onChange(v === "" ? null : Number(v));
             }}
             placeholder={defaultDisplay}
-            helperText={helperText}
+            helperText={helperWithDefault}
             slotProps={{
                input: {
                   endAdornment: num !== "" && (
@@ -119,11 +127,8 @@ export function GivenInput({ given, value, onChange }: GivenInputProps) {
 
    if (type === "date" || type === "timestamp" || type === "timestamptz") {
       const dateValue = value instanceof Date ? dayjs.utc(value) : null;
-      // The date picker has no usable placeholder (it shows a format mask), so
-      // surface the default as a helper line instead of a ghost value.
-      const dateHelper = defaultDisplay
-         ? [helperText, `Default: ${defaultDisplay}`].filter(Boolean).join("\n")
-         : helperText;
+      // The date picker shows a format mask, not a placeholder, so the default
+      // rides on the shared helper line.
       return (
          <LocalizationProvider dateAdapter={AdapterDayjs}>
             <DatePicker
@@ -134,7 +139,7 @@ export function GivenInput({ given, value, onChange }: GivenInputProps) {
                   textField: {
                      fullWidth: true,
                      size: "small",
-                     helperText: dateHelper,
+                     helperText: helperWithDefault,
                   },
                   field: { clearable: true, onClear: () => onChange(null) },
                }}
@@ -160,7 +165,7 @@ export function GivenInput({ given, value, onChange }: GivenInputProps) {
                   label={label}
                   size="small"
                   placeholder={list.length === 0 ? defaultDisplay : undefined}
-                  helperText={helperText}
+                  helperText={helperWithDefault}
                />
             )}
             fullWidth
@@ -181,7 +186,7 @@ export function GivenInput({ given, value, onChange }: GivenInputProps) {
          placeholder={
             defaultDisplay ?? (type.startsWith("filter<") ? type : undefined)
          }
-         helperText={helperText}
+         helperText={helperWithDefault}
          slotProps={{
             input: {
                endAdornment: str !== "" && (

--- a/packages/sdk/src/components/given/GivenInput.tsx
+++ b/packages/sdk/src/components/given/GivenInput.tsx
@@ -2,7 +2,9 @@ import ClearIcon from "@mui/icons-material/Clear";
 import {
    Autocomplete,
    Checkbox,
+   FormControl,
    FormControlLabel,
+   FormHelperText,
    IconButton,
    InputAdornment,
    TextField,
@@ -64,12 +66,11 @@ function annotationHelperText(given: Given): string | undefined {
  * multi-Autocomplete have their own native clear affordances.
  *
  * A given's model default (if any) is surfaced as an always-visible
- * `Default: …` helper line (plus a ghost placeholder on the text widgets — a
- * bonus that MUI only reveals once the field is focused, since the floating
- * label sits in the placeholder's spot at rest). The value itself stays empty,
- * so leaving the field blank still means "use the model default". Boolean
- * givens render as a checkbox with no helper slot, so their default isn't
- * surfaced.
+ * `Default: …` helper line on every widget — including the boolean checkbox,
+ * which gets a wrapping FormControl for the slot — plus a ghost placeholder on
+ * the text widgets (a bonus MUI only reveals on focus, since the floating label
+ * sits in the placeholder's spot at rest). The value itself stays empty, so
+ * leaving the field blank still means "use the model default".
  */
 export function GivenInput({ given, value, onChange }: GivenInputProps) {
    const label = given.name ?? "";
@@ -78,24 +79,44 @@ export function GivenInput({ given, value, onChange }: GivenInputProps) {
    const defaultDisplay = renderGivenDefault(type, given.default);
    // Append the default as an always-visible helper line. The ghost placeholder
    // on text inputs is hidden behind MUI's floating label until focus, so this
-   // caption is what communicates the default at rest.
-   const helperWithDefault = defaultDisplay
-      ? [helperText, `Default: ${defaultDisplay}`].filter(Boolean).join("\n")
-      : helperText;
+   // caption is what communicates the default at rest. Test `=== undefined`,
+   // not truthiness: an explicit empty-string default (`is ''`) renders as ""
+   // and must still show (as `(empty)`), not be mistaken for "no default".
+   const helperWithDefault =
+      defaultDisplay !== undefined
+         ? [
+              helperText,
+              `Default: ${defaultDisplay === "" ? "(empty)" : defaultDisplay}`,
+           ]
+              .filter(Boolean)
+              .join("\n")
+         : helperText;
 
    if (type === "boolean") {
       const checked = value === true;
-      // Checkbox wrapped in FormControlLabel — no helperText slot available.
+      // A checkbox has no helperText slot of its own and no "unset" visual, so
+      // wrap it in a FormControl to carry the annotation + `Default: …` line.
+      // This matters most for a `boolean is true` given: the box reads unchecked
+      // when untouched, but the query runs with the default, so the caption is
+      // what tells the user that. (The deeper "no unset state" checkbox quirk is
+      // a pre-existing givens limitation, not specific to defaults.)
       return (
-         <FormControlLabel
-            control={
-               <Checkbox
-                  checked={checked}
-                  onChange={(e) => onChange(e.target.checked)}
-               />
-            }
-            label={label}
-         />
+         <FormControl>
+            <FormControlLabel
+               control={
+                  <Checkbox
+                     checked={checked}
+                     onChange={(e) => onChange(e.target.checked)}
+                  />
+               }
+               label={label}
+            />
+            {helperWithDefault && (
+               <FormHelperText sx={{ whiteSpace: "pre-line" }}>
+                  {helperWithDefault}
+               </FormHelperText>
+            )}
+         </FormControl>
       );
    }
 

--- a/packages/sdk/src/components/given/GivenInput.tsx
+++ b/packages/sdk/src/components/given/GivenInput.tsx
@@ -77,20 +77,25 @@ export function GivenInput({ given, value, onChange }: GivenInputProps) {
    const type = given.type ?? "string";
    const helperText = annotationHelperText(given);
    const defaultDisplay = renderGivenDefault(type, given.default);
-   // Append the default as an always-visible helper line. The ghost placeholder
-   // on text inputs is hidden behind MUI's floating label until focus, so this
-   // caption is what communicates the default at rest. Test `=== undefined`,
-   // not truthiness: an explicit empty-string default (`is ''`) renders as ""
-   // and must still show (as `(empty)`), not be mistaken for "no default".
-   const helperWithDefault =
+   // Always-visible default caption. Test `=== undefined`, not truthiness: an
+   // explicit empty-string default (`is ''`) renders as "" and must still show
+   // (as `(empty)`), not be mistaken for "no default".
+   const defaultLine =
       defaultDisplay !== undefined
-         ? [
-              helperText,
-              `Default: ${defaultDisplay === "" ? "(empty)" : defaultDisplay}`,
-           ]
-              .filter(Boolean)
-              .join("\n")
-         : helperText;
+         ? `Default: ${defaultDisplay === "" ? "(empty)" : defaultDisplay}`
+         : undefined;
+   // Render annotation and default on separate lines via an explicit <br/>
+   // rather than a \n + `white-space: pre-line`: the latter doesn't reach the
+   // TextField nested inside MUI's DatePicker, so the date helper ran together.
+   // A ReactNode helperText works uniformly across every widget.
+   const helperNode =
+      helperText || defaultLine ? (
+         <>
+            {helperText}
+            {helperText && defaultLine ? <br /> : null}
+            {defaultLine}
+         </>
+      ) : undefined;
 
    if (type === "boolean") {
       const checked = value === true;
@@ -111,11 +116,7 @@ export function GivenInput({ given, value, onChange }: GivenInputProps) {
                }
                label={label}
             />
-            {helperWithDefault && (
-               <FormHelperText sx={{ whiteSpace: "pre-line" }}>
-                  {helperWithDefault}
-               </FormHelperText>
-            )}
+            {helperNode && <FormHelperText>{helperNode}</FormHelperText>}
          </FormControl>
       );
    }
@@ -132,7 +133,7 @@ export function GivenInput({ given, value, onChange }: GivenInputProps) {
                onChange(v === "" ? null : Number(v));
             }}
             placeholder={defaultDisplay}
-            helperText={helperWithDefault}
+            helperText={helperNode}
             slotProps={{
                input: {
                   endAdornment: num !== "" && (
@@ -160,7 +161,7 @@ export function GivenInput({ given, value, onChange }: GivenInputProps) {
                   textField: {
                      fullWidth: true,
                      size: "small",
-                     helperText: helperWithDefault,
+                     helperText: helperNode,
                   },
                   field: { clearable: true, onClear: () => onChange(null) },
                }}
@@ -186,7 +187,7 @@ export function GivenInput({ given, value, onChange }: GivenInputProps) {
                   label={label}
                   size="small"
                   placeholder={list.length === 0 ? defaultDisplay : undefined}
-                  helperText={helperWithDefault}
+                  helperText={helperNode}
                />
             )}
             fullWidth
@@ -207,7 +208,7 @@ export function GivenInput({ given, value, onChange }: GivenInputProps) {
          placeholder={
             defaultDisplay ?? (type.startsWith("filter<") ? type : undefined)
          }
-         helperText={helperWithDefault}
+         helperText={helperNode}
          slotProps={{
             input: {
                endAdornment: str !== "" && (

--- a/packages/sdk/src/components/given/GivenInput.tsx
+++ b/packages/sdk/src/components/given/GivenInput.tsx
@@ -14,6 +14,7 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { Given } from "../../client";
 import { GivenValue } from "../../hooks/useGivensForm";
+import { renderGivenDefault } from "./utils";
 
 dayjs.extend(utc);
 
@@ -61,11 +62,18 @@ function annotationHelperText(given: Given): string | undefined {
  * For text-based inputs (string, number, filter, default), a clear (×)
  * adornment appears when the field has a value. DatePicker, Checkbox, and
  * multi-Autocomplete have their own native clear affordances.
+ *
+ * A given's model default (if any) is surfaced as a ghost placeholder on the
+ * text-based widgets and as a `Default: …` helper line on the date picker
+ * (which has no usable placeholder). The value itself stays empty, so leaving
+ * the field blank still means "use the model default". Boolean givens render
+ * as a checkbox with no helper slot, so their default isn't surfaced.
  */
 export function GivenInput({ given, value, onChange }: GivenInputProps) {
    const label = given.name ?? "";
    const type = given.type ?? "string";
    const helperText = annotationHelperText(given);
+   const defaultDisplay = renderGivenDefault(type, given.default);
 
    if (type === "boolean") {
       const checked = value === true;
@@ -94,6 +102,7 @@ export function GivenInput({ given, value, onChange }: GivenInputProps) {
                const v = e.target.value;
                onChange(v === "" ? null : Number(v));
             }}
+            placeholder={defaultDisplay}
             helperText={helperText}
             slotProps={{
                input: {
@@ -110,6 +119,11 @@ export function GivenInput({ given, value, onChange }: GivenInputProps) {
 
    if (type === "date" || type === "timestamp" || type === "timestamptz") {
       const dateValue = value instanceof Date ? dayjs.utc(value) : null;
+      // The date picker has no usable placeholder (it shows a format mask), so
+      // surface the default as a helper line instead of a ghost value.
+      const dateHelper = defaultDisplay
+         ? [helperText, `Default: ${defaultDisplay}`].filter(Boolean).join("\n")
+         : helperText;
       return (
          <LocalizationProvider dateAdapter={AdapterDayjs}>
             <DatePicker
@@ -117,7 +131,11 @@ export function GivenInput({ given, value, onChange }: GivenInputProps) {
                value={dateValue}
                onChange={(next) => onChange(next ? next.toDate() : null)}
                slotProps={{
-                  textField: { fullWidth: true, size: "small", helperText },
+                  textField: {
+                     fullWidth: true,
+                     size: "small",
+                     helperText: dateHelper,
+                  },
                   field: { clearable: true, onClear: () => onChange(null) },
                }}
             />
@@ -141,6 +159,7 @@ export function GivenInput({ given, value, onChange }: GivenInputProps) {
                   {...params}
                   label={label}
                   size="small"
+                  placeholder={list.length === 0 ? defaultDisplay : undefined}
                   helperText={helperText}
                />
             )}
@@ -159,7 +178,9 @@ export function GivenInput({ given, value, onChange }: GivenInputProps) {
             const v = e.target.value;
             onChange(v === "" ? null : v);
          }}
-         placeholder={type.startsWith("filter<") ? type : undefined}
+         placeholder={
+            defaultDisplay ?? (type.startsWith("filter<") ? type : undefined)
+         }
          helperText={helperText}
          slotProps={{
             input: {

--- a/packages/sdk/src/components/given/utils.spec.ts
+++ b/packages/sdk/src/components/given/utils.spec.ts
@@ -2,12 +2,19 @@ import { describe, expect, it } from "bun:test";
 import { renderGivenDefault } from "./utils";
 
 describe("renderGivenDefault", () => {
-   it("unquotes a string literal", () => {
+   it("unquotes a single-quoted string literal", () => {
       expect(renderGivenDefault("string", "'WN'")).toBe("WN");
    });
 
-   it("undoubles escaped quotes in a string literal", () => {
-      expect(renderGivenDefault("string", "'O''Hare'")).toBe("O'Hare");
+   it("unquotes a double-quoted string literal", () => {
+      // Double-quoted strings are valid Malloy (DQ_STRING); the server forwards
+      // the raw source literal, so the UI must strip either quote form.
+      expect(renderGivenDefault("string", '"WN"')).toBe("WN");
+   });
+
+   it("decodes JSON-style backslash escapes (Malloy's form, not doubled quotes)", () => {
+      expect(renderGivenDefault("string", "'O\\'Hare'")).toBe("O'Hare");
+      expect(renderGivenDefault("string", '"say \\"hi\\""')).toBe('say "hi"');
    });
 
    it("drops the @ sigil from a date literal", () => {

--- a/packages/sdk/src/components/given/utils.spec.ts
+++ b/packages/sdk/src/components/given/utils.spec.ts
@@ -32,6 +32,12 @@ describe("renderGivenDefault", () => {
       expect(renderGivenDefault("string", "   ")).toBeUndefined();
    });
 
+   it("distinguishes an explicit empty-string default from no default", () => {
+      // `given: x :: string is ''` -> literal "''" -> "" (present, not undefined),
+      // so the caller can show it as "(empty)" rather than suppress it.
+      expect(renderGivenDefault("string", "''")).toBe("");
+   });
+
    it("leaves a non-quoted value untouched", () => {
       // Defensive: a malformed/already-rendered default isn't mangled.
       expect(renderGivenDefault("string", "WN")).toBe("WN");

--- a/packages/sdk/src/components/given/utils.spec.ts
+++ b/packages/sdk/src/components/given/utils.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { renderGivenDefault } from "./utils";
+
+describe("renderGivenDefault", () => {
+   it("unquotes a string literal", () => {
+      expect(renderGivenDefault("string", "'WN'")).toBe("WN");
+   });
+
+   it("undoubles escaped quotes in a string literal", () => {
+      expect(renderGivenDefault("string", "'O''Hare'")).toBe("O'Hare");
+   });
+
+   it("drops the @ sigil from a date literal", () => {
+      expect(renderGivenDefault("date", "@2024-01-01")).toBe("2024-01-01");
+      expect(renderGivenDefault("timestamp", "@2024-01-01 12:00:00")).toBe(
+         "2024-01-01 12:00:00",
+      );
+   });
+
+   it("unwraps a filter literal", () => {
+      expect(renderGivenDefault("filter<string>", "f'WN'")).toBe("WN");
+   });
+
+   it("shows numbers and booleans verbatim", () => {
+      expect(renderGivenDefault("number", "2003")).toBe("2003");
+      expect(renderGivenDefault("boolean", "true")).toBe("true");
+   });
+
+   it("returns undefined when there is no default", () => {
+      expect(renderGivenDefault("string", undefined)).toBeUndefined();
+      expect(renderGivenDefault("string", "")).toBeUndefined();
+      expect(renderGivenDefault("string", "   ")).toBeUndefined();
+   });
+
+   it("leaves a non-quoted value untouched", () => {
+      // Defensive: a malformed/already-rendered default isn't mangled.
+      expect(renderGivenDefault("string", "WN")).toBe("WN");
+   });
+});

--- a/packages/sdk/src/components/given/utils.spec.ts
+++ b/packages/sdk/src/components/given/utils.spec.ts
@@ -24,8 +24,13 @@ describe("renderGivenDefault", () => {
       );
    });
 
-   it("unwraps a filter literal", () => {
+   it("unwraps a single-value filter literal but leaves a compound one verbatim", () => {
       expect(renderGivenDefault("filter<string>", "f'WN'")).toBe("WN");
+      // A compound filter expression is not a plain string — keep it intact
+      // instead of mangling the outer quotes.
+      expect(renderGivenDefault("filter<string>", "f'WN','AA'")).toBe(
+         "'WN','AA'",
+      );
    });
 
    it("shows numbers and booleans verbatim", () => {

--- a/packages/sdk/src/components/given/utils.ts
+++ b/packages/sdk/src/components/given/utils.ts
@@ -1,0 +1,60 @@
+/**
+ * Render a given's `default` (a raw Malloy source literal) for display in the
+ * input as placeholder / helper text. Returns undefined when there is no
+ * default to show.
+ *
+ * The server surfaces `Given.default` exactly as written in the model
+ * (`'WN'`, `2003`, `@2024-01-01`, `f'WN'`). For display we unquote string
+ * literals, drop the date `@` sigil, and unwrap filter literals so the user
+ * sees `WN` / `2024-01-01` rather than the raw source form. Non-string scalars
+ * (number, boolean) and anything we don't special-case are shown verbatim.
+ *
+ * This only affects what the user *sees* — the value stays empty, so leaving
+ * the field blank still means "use the model default" (the server fills it in).
+ */
+export function renderGivenDefault(
+   type: string | undefined,
+   rawDefault: string | undefined,
+): string | undefined {
+   if (!rawDefault) return undefined;
+   const literal = rawDefault.trim();
+   if (!literal) return undefined;
+
+   const givenType = type ?? "string";
+
+   if (
+      givenType === "date" ||
+      givenType === "timestamp" ||
+      givenType === "timestamptz"
+   ) {
+      // `@2024-01-01` -> `2024-01-01`
+      return literal.replace(/^@/, "");
+   }
+
+   if (givenType.startsWith("filter<")) {
+      // `f'WN'` -> `WN`: drop the filter-literal `f` prefix, then unquote.
+      return unquoteStringLiteral(literal.replace(/^f/, ""));
+   }
+
+   if (givenType === "string") {
+      return unquoteStringLiteral(literal);
+   }
+
+   // number, boolean, array, or unknown: show the literal as authored.
+   return literal;
+}
+
+/**
+ * Strip the surrounding single quotes from a Malloy string literal and undouble
+ * any escaped quotes (`''` -> `'`). Leaves a non-quoted input untouched.
+ */
+function unquoteStringLiteral(literal: string): string {
+   if (
+      literal.length >= 2 &&
+      literal.startsWith("'") &&
+      literal.endsWith("'")
+   ) {
+      return literal.slice(1, -1).replace(/''/g, "'");
+   }
+   return literal;
+}

--- a/packages/sdk/src/components/given/utils.ts
+++ b/packages/sdk/src/components/given/utils.ts
@@ -3,11 +3,13 @@
  * input as placeholder / helper text. Returns undefined when there is no
  * default to show.
  *
- * The server surfaces `Given.default` exactly as written in the model
- * (`'WN'`, `2003`, `@2024-01-01`, `f'WN'`). For display we unquote string
- * literals, drop the date `@` sigil, and unwrap filter literals so the user
- * sees `WN` / `2024-01-01` rather than the raw source form. Non-string scalars
- * (number, boolean) and anything we don't special-case are shown verbatim.
+ * The server surfaces `Given.default` exactly as written in the model — one
+ * literal per type, e.g. `'WN'` / `"WN"` (string), `2003` (number), `true`
+ * (boolean), `@2024-01-01` (date), `f'WN'` (filter). For display we unquote
+ * string literals, drop the date `@` sigil, and unwrap single-value filter
+ * literals so the user sees `WN` / `2024-01-01` rather than the raw source form.
+ * Non-string scalars (number, boolean) and anything we don't special-case are
+ * shown verbatim.
  *
  * This only affects what the user *sees* — the value stays empty, so leaving
  * the field blank still means "use the model default" (the server fills it in).

--- a/packages/sdk/src/components/given/utils.ts
+++ b/packages/sdk/src/components/given/utils.ts
@@ -45,16 +45,25 @@ export function renderGivenDefault(
 }
 
 /**
- * Strip the surrounding single quotes from a Malloy string literal and undouble
- * any escaped quotes (`''` -> `'`). Leaves a non-quoted input untouched.
+ * Strip the surrounding quotes from a Malloy string literal — single (`'WN'`)
+ * or double (`"WN"`), both valid Malloy string forms — and decode its escapes.
+ * Malloy strings use JSON-style backslash escapes (`\'`, `\"`, `\\`, `\n`),
+ * not SQL-style doubled quotes (see ParseUtil.parseString in @malloydata).
+ * Leaves a non-quoted input untouched.
  */
 function unquoteStringLiteral(literal: string): string {
+   const quote = literal[0];
    if (
       literal.length >= 2 &&
-      literal.startsWith("'") &&
-      literal.endsWith("'")
+      (quote === "'" || quote === '"') &&
+      literal[literal.length - 1] === quote
    ) {
-      return literal.slice(1, -1).replace(/''/g, "'");
+      return literal.slice(1, -1).replace(/\\(["'\\ntr])/g, (_match, c) => {
+         if (c === "n") return "\n";
+         if (c === "t") return "\t";
+         if (c === "r") return "\r";
+         return c; // \" \' \\ -> the bare character
+      });
    }
    return literal;
 }

--- a/packages/sdk/src/components/given/utils.ts
+++ b/packages/sdk/src/components/given/utils.ts
@@ -32,8 +32,13 @@ export function renderGivenDefault(
    }
 
    if (givenType.startsWith("filter<")) {
-      // `f'WN'` -> `WN`: drop the filter-literal `f` prefix, then unquote.
-      return unquoteStringLiteral(literal.replace(/^f/, ""));
+      // Drop the filter-literal `f` prefix. A filter value is an expression, not
+      // a plain string, so only unquote when it's a single simple quoted literal
+      // (`f'WN'` -> `WN`); leave a compound expression (`f'WN','AA'`) verbatim
+      // rather than mangling it by stripping the outermost quotes.
+      const expr = literal.replace(/^f/, "");
+      const single = expr.match(/^'([^'\\]*)'$/) ?? expr.match(/^"([^"\\]*)"$/);
+      return single ? single[1] : expr;
    }
 
    if (givenType === "string") {

--- a/packages/server/src/service/given.ts
+++ b/packages/server/src/service/given.ts
@@ -37,9 +37,11 @@ export interface MalloyGivenApi {
    type: string;
    annotations?: string[];
    /**
-    * The given's default as a Malloy source literal (`'WN'`, `2003`,
-    * `@2024-01-01`, `f'WN'`), or omitted when the given has no default.
-    * Consumers render/prefill it per `type` (e.g. unquote a string).
+    * The given's default as a Malloy source literal — one literal per declared
+    * `type`. Examples across the type range: `'WN'` or `"WN"` (string), `2003`
+    * (number), `true` (boolean), `@2024-01-01` (date), `f'WN'` (filter). Omitted
+    * when the given has no default. Consumers render/prefill it per `type` (e.g.
+    * unquote a string).
     */
    default?: string;
 }
@@ -57,11 +59,12 @@ export interface MalloyGivenApi {
  *   sanitised package-relative path if a client needs it.
  *
  * - `default` is surfaced as the rendered source literal
- *   (`given._internal.defaultText` — e.g. `'WN'`, `2003`,
- *   `@2024-01-01`). Malloy's public surface still exposes only the
- *   parsed `.default` AST; `_internal.defaultText` is the
- *   already-rendered string, so we forward it verbatim rather than
- *   re-implement the printer. Omitted when the given has no default.
+ *   (`given._internal.defaultText` — e.g. a string `'WN'`, number
+ *   `2003`, boolean `true`, date `@2024-01-01`, or filter `f'WN'`).
+ *   Malloy's public surface still exposes only the parsed `.default`
+ *   AST; `_internal.defaultText` is the already-rendered string, so we
+ *   forward it verbatim rather than re-implement the printer. Omitted
+ *   when the given has no default.
  *
  * `annotations` is restricted to app-route annotations (bracketed,
  * caller-facing, e.g. `#(doc)`), excluding Malloy's reserved routes

--- a/packages/server/src/service/given.ts
+++ b/packages/server/src/service/given.ts
@@ -36,6 +36,12 @@ export interface MalloyGivenApi {
    name: string;
    type: string;
    annotations?: string[];
+   /**
+    * The given's default as a Malloy source literal (`'WN'`, `2003`,
+    * `@2024-01-01`, `f'WN'`), or omitted when the given has no default.
+    * Consumers render/prefill it per `type` (e.g. unquote a string).
+    */
+   default?: string;
 }
 
 /**
@@ -50,10 +56,12 @@ export interface MalloyGivenApi {
  *   location either; matching that floor. A future PR can add a
  *   sanitised package-relative path if a client needs it.
  *
- * - `default` / `defaultText` — Malloy's API only exposes the
- *   parsed `ConstantExpr` AST, not a rendered source string.
- *   Rendering it here would duplicate the Malloy printer. Add
- *   when Malloy surfaces a stringified accessor.
+ * - `default` is surfaced as the rendered source literal
+ *   (`given._internal.defaultText` — e.g. `'WN'`, `2003`,
+ *   `@2024-01-01`). Malloy's public surface still exposes only the
+ *   parsed `.default` AST; `_internal.defaultText` is the
+ *   already-rendered string, so we forward it verbatim rather than
+ *   re-implement the printer. Omitted when the given has no default.
  *
  * `annotations` is restricted to app-route annotations (bracketed,
  * caller-facing, e.g. `#(doc)`), excluding Malloy's reserved routes
@@ -82,5 +90,13 @@ export function malloyGivenToApi(given: MalloyGiven): MalloyGivenApi {
          .forRoute(undefined)
          .filter((note) => !isReservedRoute(note.route))
          .map((note) => note.text),
+      // `_internal.defaultText` is the already-rendered source literal of the
+      // given's default. It lives on Malloy's private `_internal` (the public
+      // surface exposes only the parsed `.default` AST node, not a stringified
+      // form), so we reach it through a localized cast rather than widening the
+      // duck-typed `MalloyGiven` — which would collide with the SDK `Given`'s
+      // own private `_internal` at every `as MalloyGiven` cast site.
+      default: (given as { _internal?: { defaultText?: string } })._internal
+         ?.defaultText,
    };
 }

--- a/packages/server/src/service/givens_integration.spec.ts
+++ b/packages/server/src/service/givens_integration.spec.ts
@@ -123,8 +123,36 @@ describe("givens introspection", () => {
 
       expect(region).toBeDefined();
       expect(region?.type).toBe("string");
+      expect(region?.default).toBe("'US'");
       expect(cutoff).toBeDefined();
       expect(cutoff?.type).toBe("date");
+      expect(cutoff?.default).toBe("@2024-02-01");
+   });
+
+   it("omits default for a given declared without one", async () => {
+      await fs.writeFile(
+         path.join(TEST_PKG_DIR, "mixed_defaults.malloy"),
+         `##! experimental.givens
+
+given: with_default :: string is 'WN'
+given: no_default :: string
+
+source: orders is duckdb.table('orders') extend {
+   primary_key: order_id
+}
+`,
+      );
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "mixed_defaults.malloy",
+         getConnections(),
+      );
+      const byName = new Map(
+         ((await model.getModel()).givens ?? []).map((g) => [g.name, g]),
+      );
+      expect(byName.get("with_default")?.default).toBe("'WN'");
+      expect(byName.get("no_default")?.default).toBeUndefined();
    });
 
    it("attaches the model-level givens list to every source", async () => {


### PR DESCRIPTION
Surfaces each given's declared default and shows it in the givens UI, so the input communicates the default instead of looking blank.

**API** (`server`): givens introspection now carries `Given.default` — Malloy's already-rendered source literal (`'WN'`, `2003`, `@2024-01-01`, `f'WN'`), omitted when there's no default.

**UI** (`sdk` GivensPanel): the default shows as a *hint*, not a prefill — the input stays empty so leaving it blank still means "use the model default" (the server fills it in); the user just now sees what it is. An always-visible `Default: …` helper line on every widget (string, number, date, filter, array, boolean), plus a ghost placeholder on the text inputs (a bonus MUI reveals on focus). The raw literal is rendered per type by `renderGivenDefault` (`'WN'`→`WN`, `@2024-01-01`→`2024-01-01`, `f'WN'`→`WN`, `\'`→`(empty)`).

Also unblocks the ms2data/service report-givens panel (the original #4966 review item), which consumes the same `Given.default`.

### Tested
- `server`: `givens_integration` — a defaulted given surfaces its literal (`region_filter → 'US'`, `cutoff_date → @2024-02-01`), a no-default given omits it.
- `sdk`: `renderGivenDefault` unit tests (string / escaped-quote / date / filter / number / empty-string / no-default); full sdk suite 25/25.
- `app` Playwright (`notebook-givens`): updated the description-helper assertion (the line now also carries the default) and added **"model default surfaces as a helper line"** asserting `target_code → Default: WN` (string) and `cutoff → Default: 2024-01-01` (date). 7/7 pass locally.
- **End-to-end through the live UI** against `faa-givens-demo`: `carrier` (string) shows `Default: WN`, `after` (timestamp) shows `Default: 2003-01-01 00:00:00`, inputs empty, queries still running on the model defaults (Southwest / 46,489 flights).
- `tsc` + `eslint` clean in both packages.

Coverage gap: the boolean-default caption is tsc/eslint-verified but not exercised by a browser test (no boolean given in the fixtures).

### Review
- Design decision (placeholder-hint vs prefill) recorded in a [PR comment](https://github.com/malloydata/publisher/pull/811#issuecomment-4617221414).
- `/codex review` (gate PASS) caught two display-logic edge cases — boolean defaults (a `boolean is true` given showed an unchecked box while running `true`) and explicit empty-string defaults being suppressed. Both fixed: the checkbox now carries the same `Default: …` caption, and the helper line tests `!== undefined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)