### PR TITLE
test(cli): add integration tests for the materialization, manifest, model, notebook, and database commands

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,8 @@
     "lint": "bunx eslint ./src --fix",
     "format": "bunx prettier --write --parser typescript 'src/**/*.{ts,tsx}'",
     "typecheck": "bun run tsc --noEmit",
-    "test": "bun test"
+    "test": "bun test src/tests",
+    "test:integration": "bun test --timeout 200000 tests/integration --max-workers=1"
   },
   "dependencies": {
     "axios": "^1.7.7",

--- a/packages/cli/tests/harness/server.ts
+++ b/packages/cli/tests/harness/server.ts
@@ -1,0 +1,213 @@
+/// <reference types="bun-types" />
+
+import { spawn } from "child_process";
+import fs from "fs";
+import net from "net";
+import os from "os";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// packages/cli/tests/harness -> packages/server and packages/cli/src/index.ts
+const SERVER_DIR = path.resolve(__dirname, "../../../server");
+const CLI_ENTRY = path.resolve(__dirname, "../../src/index.ts");
+const PERSIST_FIXTURE = path.resolve(SERVER_DIR, "tests/fixtures/persist-test");
+
+export const TEST_ENV = "it-env";
+export const TEST_PKG = "persist-test";
+
+export interface TestServer {
+  baseUrl: string;
+  stop(): Promise<void>;
+}
+
+/** Allocate an OS-assigned free TCP port (avoids fixed-port collisions). */
+async function getFreePort(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const srv = net.createServer();
+    srv.on("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const found = typeof addr === "object" && addr ? addr.port : 0;
+      srv.close(() =>
+        found ? resolve(found) : reject(new Error("no free port")),
+      );
+    });
+  });
+}
+
+/**
+ * Boot a real Publisher server for CLI integration tests.
+ *
+ * The CLI package does not depend on the server package, so the server cannot
+ * be booted in-process (the way the server's own tests do). Instead we run it
+ * as a subprocess from source (`bun src/server.ts`, no `--watch` so there is
+ * no orphaned file watcher to clean up), on OS-assigned free ports, pointed at
+ * a temp SERVER_ROOT seeded with the committed `persist-test` fixture.
+ *
+ * If `CLI_TEST_SERVER_URL` is set, reuse that already-running server instead of
+ * spawning one (handy for CI). That server must be seeded with the
+ * `it-env`/`persist-test` fixture and have no pre-existing materializations,
+ * since the suite asserts on the empty initial state.
+ */
+export async function startTestServer(): Promise<TestServer> {
+  const externalUrl = process.env.CLI_TEST_SERVER_URL;
+  if (externalUrl) {
+    const baseUrl = externalUrl.replace(/\/$/, "");
+    await waitForPackage(baseUrl);
+    return { baseUrl, stop: async () => {} };
+  }
+
+  const serverRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cli-it-root-"));
+  fs.writeFileSync(
+    path.join(serverRoot, "publisher.config.json"),
+    JSON.stringify({
+      frozenConfig: false,
+      environments: [
+        {
+          name: TEST_ENV,
+          packages: [{ name: TEST_PKG, location: PERSIST_FIXTURE }],
+          connections: [],
+        },
+      ],
+    }),
+  );
+
+  const port = await getFreePort();
+  let mcpPort = await getFreePort();
+  while (mcpPort === port) {
+    mcpPort = await getFreePort();
+  }
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const proc = spawn("bun", ["src/server.ts"], {
+    cwd: SERVER_DIR,
+    env: {
+      ...process.env,
+      NODE_ENV: "development",
+      SERVER_ROOT: serverRoot,
+      PUBLISHER_HOST: "127.0.0.1",
+      PUBLISHER_PORT: String(port),
+      MCP_PORT: String(mcpPort),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  // Buffer server output so a startup failure can surface a useful tail.
+  let serverLog = "";
+  const capture = (d: Buffer) => {
+    serverLog = (serverLog + d.toString()).slice(-4000);
+  };
+  proc.stdout?.on("data", capture);
+  proc.stderr?.on("data", capture);
+
+  let exited = false;
+  proc.on("exit", () => {
+    exited = true;
+  });
+
+  try {
+    await waitForPackage(baseUrl, () => exited);
+  } catch (err) {
+    proc.kill("SIGKILL");
+    fs.rmSync(serverRoot, { recursive: true, force: true });
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(`${reason}\n--- server log tail ---\n${serverLog}`);
+  }
+
+  const stop = async (): Promise<void> => {
+    await new Promise<void>((resolve) => {
+      if (exited) {
+        resolve();
+        return;
+      }
+      // Backstop in case SIGTERM is ignored; cleared once the process exits.
+      const backstop = setTimeout(() => proc.kill("SIGKILL"), 5_000);
+      proc.on("exit", () => {
+        clearTimeout(backstop);
+        resolve();
+      });
+      proc.kill("SIGTERM");
+    });
+    fs.rmSync(serverRoot, { recursive: true, force: true });
+  };
+
+  return { baseUrl, stop };
+}
+
+/** Poll until the persist-test package is loaded and queryable. */
+async function waitForPackage(
+  baseUrl: string,
+  hasExited: () => boolean = () => false,
+): Promise<void> {
+  const url = `${baseUrl}/api/v0/environments/${TEST_ENV}/packages/${TEST_PKG}/models`;
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    if (hasExited()) {
+      throw new Error("Server process exited before becoming ready");
+    }
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        return;
+      }
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error("Server did not become ready within 120s");
+}
+
+export interface CliResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+  /** stdout + stderr, ANSI stripped, for substring assertions. */
+  output: string;
+}
+
+// ESC (0x1b) built via fromCharCode to avoid a control-char literal in source.
+const ANSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+
+/**
+ * Run the real CLI binary as a subprocess against `baseUrl`, capturing
+ * stdout/stderr and the exit code. This exercises the full path: argument
+ * parsing, command routing, the API client, HTTP, and the exit code.
+ */
+export async function runCli(
+  args: string[],
+  baseUrl: string,
+): Promise<CliResult> {
+  return new Promise<CliResult>((resolve, reject) => {
+    const proc = spawn("bun", [CLI_ENTRY, ...args], {
+      env: { ...process.env, NO_COLOR: "1", MALLOY_PUBLISHER_URL: baseUrl },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    proc.stdout?.on("data", (d) => {
+      stdout += d.toString();
+    });
+    proc.stderr?.on("data", (d) => {
+      stderr += d.toString();
+    });
+    proc.on("error", reject);
+    proc.on("close", (code) => {
+      const cleanOut = stdout.replace(ANSI, "");
+      const cleanErr = stderr.replace(ANSI, "");
+      resolve({
+        code: code ?? -1,
+        stdout: cleanOut,
+        stderr: cleanErr,
+        output: `${cleanOut}\n${cleanErr}`,
+      });
+    });
+  });
+}
+
+/** Extract a materialization id (epoch-ms + suffix) from CLI output. */
+export function extractMaterializationId(output: string): string | undefined {
+  const m = output.match(/[0-9]{13}-[a-z0-9]+/);
+  return m ? m[0] : undefined;
+}

--- a/packages/cli/tests/integration/cli.integration.test.ts
+++ b/packages/cli/tests/integration/cli.integration.test.ts
@@ -1,0 +1,171 @@
+/// <reference types="bun-types" />
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import {
+  type TestServer,
+  TEST_ENV,
+  TEST_PKG,
+  extractMaterializationId,
+  runCli,
+  startTestServer,
+} from "../harness/server";
+
+// Exercises the real malloy-pub binary against a real Publisher server (booted
+// by the harness against the committed persist-test fixture). Each test spawns
+// the CLI as a subprocess and asserts on its output and exit code, so the full
+// path is covered: argument parsing, command routing, the API client, HTTP,
+// and the process exit code.
+
+describe("CLI integration (real server)", () => {
+  let server: TestServer | null = null;
+  let baseUrl = "";
+  // Captured from the `materialize` step and reused by the get/stop/delete
+  // tests, so they don't depend on "first id in the list" or a clean server.
+  let createdId = "";
+  const SCOPE = ["--environment", TEST_ENV, "--package", TEST_PKG];
+
+  beforeAll(async () => {
+    server = await startTestServer();
+    baseUrl = server.baseUrl;
+  });
+
+  afterAll(async () => {
+    // If startup failed there is no server (and no URL) to clean up against.
+    if (!server) {
+      return;
+    }
+    // Best-effort: delete any materializations created during the run.
+    try {
+      const list = await runCli(["list", "materialization", ...SCOPE], baseUrl);
+      const ids = list.output.match(/[0-9]{13}-[a-z0-9]+/g) ?? [];
+      for (const id of ids) {
+        await runCli(["delete", "materialization", id, ...SCOPE], baseUrl);
+      }
+    } catch {
+      // ignore cleanup failures
+    }
+    await server.stop();
+    server = null;
+  });
+
+  // ── read-only resources ───────────────────────────────────────────
+
+  it("lists models", async () => {
+    const r = await runCli(["list", "model", ...SCOPE], baseUrl);
+    expect(r.code).toBe(0);
+    expect(r.output).toContain("persist_test.malloy");
+  });
+
+  it("gets a model by path", async () => {
+    const r = await runCli(
+      ["get", "model", "persist_test.malloy", ...SCOPE],
+      baseUrl,
+    );
+    expect(r.code).toBe(0);
+    expect(r.output).toContain("persist_test.malloy");
+  });
+
+  it("reports no notebooks for a package without any", async () => {
+    const r = await runCli(["list", "notebook", ...SCOPE], baseUrl);
+    expect(r.code).toBe(0);
+    expect(r.output).toContain("No notebooks");
+  });
+
+  it("lists databases", async () => {
+    const r = await runCli(["list", "database", ...SCOPE], baseUrl);
+    expect(r.code).toBe(0);
+    expect(r.output).toContain("orders.csv");
+  });
+
+  // ── input validation (fails before hitting the server) ────────────
+
+  it("rejects a non-numeric --limit", async () => {
+    const r = await runCli(
+      ["list", "materialization", ...SCOPE, "--limit", "abc"],
+      baseUrl,
+    );
+    expect(r.code).toBe(1);
+    expect(r.output).toContain("--limit must be a non-negative integer");
+  });
+
+  // ── materialization lifecycle ─────────────────────────────────────
+
+  it("reports no materializations initially", async () => {
+    const r = await runCli(["list", "materialization", ...SCOPE], baseUrl);
+    expect(r.code).toBe(0);
+    expect(r.output).toContain("No materializations");
+  });
+
+  it("materializes a package and waits for SUCCESS", async () => {
+    const r = await runCli(["materialize", ...SCOPE, "--wait"], baseUrl);
+    expect(r.code).toBe(0);
+    expect(r.output).toContain("SUCCESS");
+    // Capture the id this run produced so the later tests are state-agnostic.
+    const id = extractMaterializationId(r.output);
+    expect(id).toBeDefined();
+    createdId = id as string;
+  });
+
+  it("shows the produced table in the manifest", async () => {
+    const r = await runCli(["get", "manifest", ...SCOPE], baseUrl);
+    expect(r.code).toBe(0);
+    expect(r.output).toContain("order_summary");
+  });
+
+  it("reloads the manifest", async () => {
+    const r = await runCli(["reload-manifest", ...SCOPE], baseUrl);
+    expect(r.code).toBe(0);
+  });
+
+  it("lists the run and gets it by id", async () => {
+    const list = await runCli(["list", "materialization", ...SCOPE], baseUrl);
+    expect(list.code).toBe(0);
+    expect(list.output).toContain("SUCCESS");
+    expect(list.output).toContain(createdId);
+
+    const get = await runCli(
+      ["get", "materialization", createdId, ...SCOPE],
+      baseUrl,
+    );
+    expect(get.code).toBe(0);
+    expect(get.output).toContain(createdId);
+  });
+
+  it("refuses to stop a terminal materialization (exit 1)", async () => {
+    const r = await runCli(
+      ["stop-materialization", createdId, ...SCOPE],
+      baseUrl,
+    );
+    expect(r.code).toBe(1);
+    expect(r.output.toLowerCase()).toContain("cannot stop");
+  });
+
+  it("deletes the terminal materialization", async () => {
+    const del = await runCli(
+      ["delete", "materialization", createdId, ...SCOPE],
+      baseUrl,
+    );
+    expect(del.code).toBe(0);
+    expect(del.output).toContain("Deleted");
+  });
+
+  // ── exit-code contract on failure paths ───────────────────────────
+
+  it("exits non-zero when --wait times out", async () => {
+    const r = await runCli(
+      ["materialize", ...SCOPE, "--wait", "--timeout", "0"],
+      baseUrl,
+    );
+    expect(r.code).toBe(1);
+    expect(r.output).toContain("Timed out");
+  });
+
+  it("exits non-zero (404) for a non-existent materialization", async () => {
+    const r = await runCli(
+      ["get", "materialization", "does-not-exist", ...SCOPE],
+      baseUrl,
+    );
+    expect(r.code).toBe(1);
+    expect(r.output.toLowerCase()).toContain("not found");
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #809 (CLI parity) adding integration-test coverage for the new CLI commands. The existing CLI tests mock the API client; these run the real `malloy-pub` binary against a real Publisher server and assert on output and exit codes, so the full path is exercised: argument parsing, command routing, the API client, HTTP, and the process exit code.

## What it covers (14 tests)

- Read-only resources: `list`/`get` models, `list` notebooks (empty case), `list` databases.
- Build manifest: `get manifest`, `reload-manifest`.
- Materialization lifecycle: `materialize --wait` to SUCCESS, `list`, `get` by id, `stop-materialization` (refused on a terminal run, exit 1), `delete`.
- Exit-code contract on failures: `--wait` timeout, a 404, and `--limit` validation each exit non-zero.

## How it works

- `tests/harness/server.ts` boots a real server as a subprocess from source on OS-assigned free ports, pointed at a temp `SERVER_ROOT` seeded with the committed `persist-test` fixture, and polls until the package is queryable. (The CLI package has no dependency on the server package, so an in-process boot is not possible.)
- `runCli()` spawns the real CLI entry, captures stdout/stderr and the exit code (ANSI stripped). The lifecycle tests capture the materialization id from the `materialize` output and reuse it, so they do not depend on a clean server or on ordering by "first id in the list".
- Set `CLI_TEST_SERVER_URL` to run against an already-running server instead of spawning one.

## Running

```
cd packages/cli && bun run test:integration
```

The default `test` script stays unit-only (`bun test src/tests`), so it runs without a server.

## Note on CI

These integration tests are not wired into a CI job in this PR (the CLI test suite is not currently run in CI). They run on demand via `test:integration`, and the harness's `CLI_TEST_SERVER_URL` hook makes wiring them into an existing server-backed job straightforward as a follow-up.
