### PR TITLE
fix(duckdb): bake all extensions offline (CA certs + verification), drop external ADBC driver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,6 +270,47 @@ jobs:
               || { echo "✗ Missing/empty OCI label: org.opencontainers.image.$key"; exit 1; }
           done
           echo "✓ All five OCI image labels present"
+      - name: Verify baked DuckDB extensions
+        run: |
+          # The image bakes the DuckDB extensions the server loads at runtime
+          # (packages/server build runs bake-duckdb-extensions; the builder's
+          # ~/.duckdb/extensions is copied into the final image). This asserts
+          # they are actually present and LOAD *offline* -- with the network cut
+          # off, so a load can only succeed from the baked on-disk cache, never a
+          # fallback download. Catches a broken bake, a version mismatch between
+          # the baked dir and the CLI, or the snowflake bundled-driver regression
+          # (we removed the external ADBC driver install).
+          set -e
+          version="${{ steps.duckdb.outputs.version }}"
+
+          # 1. The CLI version must match the version we baked against, or the
+          #    baked v<version>/ dir is invisible to it.
+          cli_version=$(docker run --rm --entrypoint duckdb \
+            malloy-publisher:smoke-test -noheader -list -c "SELECT version();")
+          echo "CLI version: $cli_version (expected v$version)"
+          echo "$cli_version" | grep -q "v$version" \
+            || { echo "✗ DuckDB CLI version != baked version"; exit 1; }
+
+          # 2. Each core extension must LOAD with no network (--network none).
+          #    INSTALL is a no-op when already baked; LOAD proves it's usable.
+          for ext in httpfs aws azure postgres ducklake; do
+            docker run --rm --network none --entrypoint duckdb \
+              malloy-publisher:smoke-test -c "INSTALL $ext; LOAD $ext;" \
+              || { echo "✗ core extension '$ext' failed to load offline"; exit 1; }
+            echo "✓ $ext loads offline"
+          done
+
+          # 3. The community extensions (bigquery, snowflake) must load offline
+          #    too. snowflake in particular loads via its BUNDLED ADBC driver --
+          #    we removed the external ADBC driver install, so a failure here
+          #    means the extension no longer self-provides the driver.
+          for ext in bigquery snowflake; do
+            docker run --rm --network none --entrypoint duckdb \
+              malloy-publisher:smoke-test -c "LOAD $ext;" \
+              || { echo "✗ community extension '$ext' failed to load offline (bundled driver missing?)"; exit 1; }
+            echo "✓ $ext loads offline"
+          done
+          echo "✓ All baked DuckDB extensions load offline"
       - name: Start container
         run: |
           docker run -d --name malloy-publisher-smoke \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ARG DUCKDB_VERSION=1.5.3
 RUN DUCKDB_VERSION=${DUCKDB_VERSION} bash -c "curl -L https://install.duckdb.org | bash" && \
     ln -s /root/.duckdb/cli/${DUCKDB_VERSION}/duckdb /usr/local/bin/duckdb && \
-    curl -sSL https://raw.githubusercontent.com/iqea-ai/duckdb-snowflake/main/scripts/install-adbc-driver.sh | bash && \
-    ldconfig && \
     duckdb -c "INSTALL snowflake FROM community; LOAD snowflake; SELECT snowflake_version();" || \
     echo "Snowflake verification skipped (offline build)" && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,14 @@ ENV PATH=$JAVA_HOME/bin:$PATH
 ENV NODE_ENV=production
 WORKDIR /publisher
 
+# CA certificates are required for the DuckDB extension bake (run by
+# packages/server's build): without them @duckdb/node-api can't verify TLS to
+# extensions.duckdb.org and every download fails with an SSL CA cert error.
+# The bun:slim base ships without them.
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && \
+    update-ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 # Copy package files first for better layer caching
 COPY package.json bun.lock api-doc.yaml ./
 COPY packages/server/package.json ./packages/server/package.json

--- a/packages/server/scripts/bake-duckdb-extensions.js
+++ b/packages/server/scripts/bake-duckdb-extensions.js
@@ -29,11 +29,13 @@ import { DuckDBInstance } from "@duckdb/node-api";
 //
 // `community: true` mirrors the runtime's `FORCE INSTALL '<name>' FROM community`
 // (bigquery, snowflake); the rest are core extensions installed by name.
+// `registered` is the name the extension reports in duckdb_extensions() when it
+// differs from the INSTALL name (only postgres -> postgres_scanner).
 const EXTENSIONS = [
    { name: "httpfs", community: false }, // cloud storage (gcs/s3/azure) + per-package sandbox
    { name: "aws", community: false }, // s3 credential chain
    { name: "azure", community: false }, // azure blob storage
-   { name: "postgres", community: false }, // postgres attach + ducklake postgres catalog
+   { name: "postgres", community: false, registered: "postgres_scanner" }, // postgres attach + ducklake postgres catalog
    { name: "ducklake", community: false }, // materialization catalog
    { name: "bigquery", community: true },
    { name: "snowflake", community: true },
@@ -43,18 +45,50 @@ async function main() {
    const instance = await DuckDBInstance.create(":memory:");
    const connection = await instance.connect();
 
-   for (const { name, community } of EXTENSIONS) {
+   const results = [];
+   for (const { name, community, registered } of EXTENSIONS) {
       try {
          const install = community
             ? `FORCE INSTALL '${name}' FROM community;`
             : `INSTALL ${name};`;
          await connection.run(`${install} LOAD ${name};`);
-         console.log(`baked DuckDB extension: ${name}`);
+
+         // Verify the extension actually reports as loaded, rather than trusting
+         // that INSTALL/LOAD returned without error.
+         const reader = await connection.runAndReadAll(
+            `SELECT loaded, installed FROM duckdb_extensions() WHERE extension_name = '${registered ?? name}';`,
+         );
+         const row = reader.getRowObjectsJS()[0];
+         const loaded = row?.loaded === true;
+         const installed = row?.installed === true;
+
+         results.push({ name, installed, loaded });
+         if (loaded) {
+            console.log(`baked DuckDB extension: ${name} (loaded)`);
+         } else {
+            console.warn(
+               `DuckDB extension "${name}" installed=${installed} but not loaded`,
+            );
+         }
       } catch (err) {
          const message = err instanceof Error ? err.message : String(err);
+         results.push({
+            name,
+            installed: false,
+            loaded: false,
+            error: message,
+         });
          console.warn(`skipped DuckDB extension "${name}": ${message}`);
       }
    }
+
+   const ok = results.filter((r) => r.loaded).map((r) => r.name);
+   const missing = results.filter((r) => !r.loaded).map((r) => r.name);
+   console.log(
+      `DuckDB extensions baked: ${ok.length}/${results.length} loaded` +
+         (ok.length ? ` [${ok.join(", ")}]` : "") +
+         (missing.length ? `; not loaded [${missing.join(", ")}]` : ""),
+   );
 
    connection.closeSync();
    instance.closeSync();


### PR DESCRIPTION
## Summary

Removes the external ADBC Snowflake driver install from the image, fixes the CA-cert gap that broke the extension bake, and adds offline verification of the baked extensions. Stacked on #819.

## Changes

- **Remove the external ADBC driver install** (`install-adbc-driver.sh` + `ldconfig`) from the Dockerfile. The Snowflake community extension on 1.5.x bundles its own driver (verified offline in built `linux/amd64` and `linux/arm64` images: with no external driver present, `snowflake_query` loads and reaches credential validation). This also drops a network dependency from the build.
- **Install `ca-certificates` in the builder stage.** The `bun:slim` base ships without them, so the extension bake (run by `packages/server`'s build in the builder) failed every download with an SSL CA-cert error and baked only 1 of 7 extensions. base-deps already had the certs; the builder did not.
- **Verify baked extensions in the bake script.** After `INSTALL`/`LOAD`, query `duckdb_extensions()` to confirm each reports `loaded`, and print an `N/7 loaded` summary (non-fatal -- the bake is an optimization, not a build gate).
- **Verify baked extensions in the Docker smoke test.** With the network cut off (`--network none`), assert the CLI version matches the baked version and that every extension (httpfs, aws, azure, postgres, ducklake, bigquery, snowflake) loads from the on-disk cache. This catches a broken bake, a version/dir mismatch, or a Snowflake bundled-driver regression at build time rather than at a user's first attach.

## Verification

- Built `base-deps` on `linux/amd64` and `linux/arm64`; Snowflake loads offline via the bundled driver with no external `.so` present.
- The smoke-test offline check correctly fails when an extension is not baked (proven against a stage that omits it).
