### PR TITLE
docs: document #(authorize) source access gates

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,12 @@ For releases that warrant narrative — redesigns, breaking changes, migration s
 
 ---
 
+## [Unreleased] — Source access gates (`#(authorize)`)
+
+**Sources can now gate query access on givens.** A `#(authorize) "<bool expr>"` annotation (source-level) or `##(authorize)` (file-level) is evaluated against the request's [givens](docs/givens.md) before any query that reads the source runs; access is denied with **HTTP 403** unless at least one in-scope expression is `true` (OR semantics). Enforced on `POST /…/query`, the notebook-cell `GET`, `POST /…/compile`, and the MCP `malloy_executeQuery` tool. Malformed or invalid annotations fail model load with **424**.
+
+**Important — this is a trusted-tier boundary, not end-user authn.** Givens are caller-asserted, so `#(authorize)` enforces policy only when Publisher sits behind a trusted tier that sets givens from verified context and the query API is network-isolated from untrusted callers. See [docs/authorize.md](docs/authorize.md) (Security model) for the deployment contract, the locked-base + curated-extension pattern, and known limitations.
+
 ## [Unreleased] — planned (post-givens-migration)
 
 **Givens are now the recommended way to supply runtime parameters.** Models declare `given:` blocks (per [Malloy's experimental givens feature](https://docs.malloydata.dev/documentation/experiments/givens)); callers send values via the new `givens` body field on `POST /…/query` and `POST /…/compile`, the `givens` query parameter on the notebook-cell GET, or the `givens` argument on the MCP `malloy_executeQuery` tool. The notebook UI automatically renders a Parameters panel for any model that declares givens.

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -2920,13 +2920,14 @@ components:
             $ref: "#/components/schemas/Given"
         authorize:
           type: array
-          description: Effective authorize expressions declared on this source via
+          description: >-
+            Effective authorize expressions declared on this source via
             `#(authorize)` / `##(authorize)` annotations — file-level expressions
             first, then the source's own. Each is a Malloy boolean expression over
-            declared givens, evaluated as a disjunction (OR). Enforced at query
-            time: a request that reads this source is denied with HTTP 403 unless
+            declared givens, evaluated as a disjunction (OR) and enforced at query
+            time. A request that reads this source is denied with HTTP 403 unless
             at least one expression evaluates true for the supplied givens; an
-            empty/absent list means unrestricted. Givens are caller-asserted, so
+            empty or absent list means unrestricted. Givens are caller-asserted, so
             this is a boundary only behind a trusted tier — see docs/authorize.md.
           items:
             type: string

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -2923,9 +2923,11 @@ components:
           description: Effective authorize expressions declared on this source via
             `#(authorize)` / `##(authorize)` annotations — file-level expressions
             first, then the source's own. Each is a Malloy boolean expression over
-            declared givens. Surfaced for introspection only; these expressions
-            are NOT yet enforced by the query path (enforcement lands in a later
-            release), so their presence does not currently restrict access.
+            declared givens, evaluated as a disjunction (OR). Enforced at query
+            time: a request that reads this source is denied with HTTP 403 unless
+            at least one expression evaluates true for the supplied givens; an
+            empty/absent list means unrestricted. Givens are caller-asserted, so
+            this is a boundary only behind a trusted tier — see docs/authorize.md.
           items:
             type: string
 

--- a/docs/authorize.md
+++ b/docs/authorize.md
@@ -1,0 +1,188 @@
+# Authorize (Source Access Gates)
+
+`#(authorize)` annotations gate query access to a Malloy source based on the request's [givens](givens.md). Before Publisher runs any query that reads a gated source, it evaluates the source's in-scope authorize expressions against the supplied givens; if **at least one** returns `true` the request proceeds, otherwise it is rejected with **HTTP 403**. A source with no in-scope annotations is unrestricted.
+
+Authorize is evaluated by Publisher (not core Malloy) using a synthetic 0-row probe query, so the expression language is Malloy's, but the gate runs entirely over `given:` values — it never touches your warehouse data.
+
+> ⚠️ **Read [Security model](#security-model) before deploying this as an access control.** Givens are **caller-asserted**: anyone who can reach the query API can claim a favorable given. `#(authorize)` is only a real boundary when the API sits behind a trusted tier that sets givens from its own verified context. It is not, on its own, end-user authentication.
+
+For the Malloy expression reference, see [Malloy: Expressions](https://docs.malloydata.dev/documentation/language/expressions). For givens, see [givens.md](givens.md).
+
+## Declaring Gates
+
+Authorize annotations attach to a source (`#(authorize)`) or to the whole file (`##(authorize)`). The body is a quoted Malloy boolean expression over declared givens (`$NAME`):
+
+```malloy
+##! experimental.givens
+
+given:
+  ROLE :: string
+
+#(authorize) "$ROLE = 'analyst'"
+source: orders is duckdb.table('orders.parquet') extend {
+  measure: order_count is count()
+}
+```
+
+- **Source-level** `#(authorize) "<expr>"` — gates that one source. Stack multiple on a source; see [OR semantics](#or-semantics).
+- **File-level** `##(authorize) "<expr>"` — applies to every query in the file; folded into the same disjunction as each source's own gates. A permissive file-level gate is a **model-wide override** (see [file-level override](#file-level-is-a-model-wide-override)).
+- A source with no in-scope annotations is **unrestricted**.
+
+### Expression Language
+
+The expression is any Malloy boolean expression over `$given` references and literals: `=`, `!=`, `<`, `>`, `<=`, `>=`, `and`, `or`, `not`, `in [...]`, etc. Examples:
+
+```malloy
+#(authorize) "$ROLE = 'analyst'"
+#(authorize) "$ROLE in ['analyst', 'admin']"
+#(authorize) "$REGION = 'us-west' and $ROLE != 'guest'"
+#(authorize) "$TENANT = 'acme'"
+```
+
+**No source-field references.** The gate is a 0-row probe — it has no row context, so an expression may reference only givens and literals, never a column of the gated source. A field reference fails at model load (see [Validation](#validation)).
+
+Embedded quotes follow Malloy string rules: write inner string literals with single quotes inside the double-quoted annotation, e.g. `#(authorize) "$ROLE = 'analyst'"`.
+
+## Semantics
+
+### OR semantics
+
+Multiple in-scope expressions (source-level + file-level) are evaluated as a single **disjunction** — access is granted if **any one** returns `true`.
+
+```malloy
+given:
+  ROLE :: string
+  TENANT :: string
+
+#(authorize) "$ROLE = 'admin'"
+#(authorize) "$TENANT = 'acme'"
+source: orders is duckdb.table('orders.parquet')
+```
+
+`orders` is queryable by an admin **or** by an acme-tenant caller. Stacking gates **widens** access — if you expect AND, this will surprise you. Express conjunction within a single expression instead: `#(authorize) "$ROLE = 'admin' and $TENANT = 'acme'"`.
+
+### File-level is a model-wide override
+
+A `##(authorize)` expression is in scope for **every** source in the file and joins the disjunction for each. Because the disjunction grants on any `true`, a permissive file-level gate **unlocks every source in the file**, regardless of stricter source-level gates:
+
+```malloy
+##(authorize) "$ROLE = 'admin'"      // admins can query ANY source in this file
+
+#(authorize) "$ROLE = 'analyst'"     // analysts can ALSO query `orders`
+source: orders is duckdb.table('orders.parquet')
+```
+
+This is the intended admin-override idiom — use it deliberately.
+
+### Top-level source only (not inherited, not joined)
+
+Authorize is checked **only on the source the query directly runs against**. It is **not** inherited through `extend` and **not** walked through joins:
+
+- **Extend footgun:** a source that extends a locked base is governed *solely by its own* annotations. `source: b is a extend { … }` does **not** inherit `a`'s gate — if `b` declares none, `b` is unrestricted even if `a` is `#(authorize) "false"`.
+- **Joins:** a gate on a source reached only via `join_*` does not fire; the gate applies to the run target, not its joins.
+
+To keep a locked base's data from leaking through an extension or join, pair the gate with Malloy [access modifiers](https://docs.malloydata.dev/documentation/experiments/include) (`include { public: …, private: * }`) so the extension re-exposes only a curated column surface. See the [recommended pattern](#recommended-pattern-locked-base--curated-extensions).
+
+## Recommended pattern: locked base + curated extensions
+
+Lock sensitive base sources with `#(authorize) "false"` and re-expose curated subsets through extension sources, each with its own gate and access modifiers:
+
+```malloy
+##! experimental.givens
+##! experimental.access_modifiers
+
+given:
+  REGION :: string
+  ROLE :: string
+
+// Base source: locked. Direct queries are denied — the only in-scope
+// authorize expression is the constant `false`.
+#(authorize) "false"
+source: customers_raw is duckdb.table('customers.parquet')
+
+// Extension: re-exposes a curated subset and adds an analyst-role gate.
+// `private: *` hides every other column on the base.
+#(authorize) "$ROLE = 'analyst'"
+source: customers_marketing is customers_raw include {
+  public: name, region, signup_date
+  private: *
+} extend {
+  measure: customer_count is count()
+}
+
+// A second extension with a different gate and field surface.
+#(authorize) "$REGION = 'us-west'"
+source: customers_us_west is customers_raw include {
+  public: name, region, signup_date, lifetime_value
+  private: *
+}
+```
+
+- `run: customers_raw -> …` → **403** (gate is `false`).
+- `run: customers_marketing -> …` → allowed with `$ROLE = 'analyst'`; the consumer can only touch `name`, `region`, `signup_date`.
+- `run: customers_us_west -> …` → allowed with `$REGION = 'us-west'`, on a different surface.
+
+The `include { … private: * }` layer is what controls which base columns each extension can re-expose; the extension's own `#(authorize)` gates consumer access to that curated surface. The base's `#(authorize) "false"` is a defense-in-depth backstop against a direct `run: customers_raw`.
+
+## Enforcement
+
+The gate runs, fail-closed, on every query entry point — **before** any filter injection or compilation, so a denial is a clean 403 and never masked by a later error:
+
+| Entry point | Behavior |
+| --- | --- |
+| `POST /…/query` | Gate the run-target source; deny → 403. |
+| Notebook cell `GET` | Gate each cell that runs a query. |
+| `POST /…/compile` | Gate the named source the submitted text targets (early, before compiling — so compile errors can't be used as a schema oracle — plus a compiled-source backstop). |
+| MCP `malloy_executeQuery` | Routes through the query path; a denial surfaces as `isError: true` naming the source. |
+
+**Fail-closed:** any probe error, a referenced given with no supplied value, a missing/null result, or a non-`true` result all **deny**.
+
+### Validation
+
+Authorize expressions are validated at **model load** (compile-only, no execution). A malformed annotation (missing quotes), an unknown given, or a source-field reference fails the load with **HTTP 424** (`ModelCompilationError`), naming the source and the underlying reason. Fix the model before it serves.
+
+### Error contract & redaction
+
+- **Runtime 403** names only the source — `{"code":403,"message":"Access denied for source \"orders\"."}` — never the authorize expression. Gate logic is not leaked to (potentially untrusted) query callers.
+- **Model-load 424** *keeps* the full expression in its message — it is author-facing at package load and you need it to fix a malformed annotation.
+
+## Security model
+
+`#(authorize)` evaluates expressions over **request-supplied givens**. There is no authentication in Publisher's query path: a given is whatever the caller sends. So:
+
+- **Authorize is a real boundary only behind a trusted tier.** The intended deployment is Publisher behind an embedding application that authenticates end users and sets givens (role, tenant, region) from its own *verified* context, with the query/MCP API network-isolated from untrusted callers. In that setup the gate enforces the trusted tier's policy.
+- **It does not defend against a caller who sets their own givens.** Exposed directly to untrusted users, anyone can send `{"ROLE":"admin"}` and pass an `$ROLE = 'admin'` gate. Do not treat `#(authorize)` as end-user authn/authz on a public endpoint.
+- **Identity-bound givens** — a verified token or trusted-proxy header populating reserved "system givens" the caller cannot override — is a planned milestone that would make authorize a standalone boundary. It is not implemented yet.
+
+## Known limitations
+
+- **Not inherited / not joined** (see [above](#top-level-source-only-not-inherited-not-joined)) — pair locked bases with access modifiers.
+- **`/compile` raw SQL is not gated.** The gate covers named Malloy sources; `/compile` still compiles unrestricted, so a caller could read a gated table's schema/SQL via raw `duckdb.sql(...)`. Closing this (restricted compilation on `/compile`, as on `/query`) is tracked as a follow-up; until then keep `/compile` behind the trusted tier.
+- **No per-request caching.** Each gate runs a fresh probe against bundled DuckDB (microseconds); a security decision is intentionally not memoized.
+
+## Worked example
+
+```malloy
+##! experimental.givens
+
+given:
+  ROLE :: string
+
+#(authorize) "$ROLE = 'analyst'"
+source: orders is duckdb.table('orders.parquet') extend {
+  measure: order_count is count()
+}
+```
+
+```bash
+# Denied (no satisfying given) → 403
+curl -X POST .../models/orders.malloy/query \
+  -H 'content-type: application/json' \
+  -d '{"query":"run: orders -> { aggregate: order_count }","givens":{}}'
+#   → {"code":403,"message":"Access denied for source \"orders\"."}
+
+# Allowed → 200
+curl -X POST .../models/orders.malloy/query \
+  -H 'content-type: application/json' \
+  -d '{"query":"run: orders -> { aggregate: order_count }","givens":{"ROLE":"analyst"}}'
+```

--- a/docs/authorize.md
+++ b/docs/authorize.md
@@ -2,7 +2,7 @@
 
 `#(authorize)` annotations gate query access to a Malloy source based on the request's [givens](givens.md). Before Publisher runs any query that reads a gated source, it evaluates the source's in-scope authorize expressions against the supplied givens; if **at least one** returns `true` the request proceeds, otherwise it is rejected with **HTTP 403**. A source with no in-scope annotations is unrestricted.
 
-Authorize is evaluated by Publisher (not core Malloy) using a synthetic 0-row probe query, so the expression language is Malloy's, but the gate runs entirely over `given:` values — it never touches your warehouse data.
+Authorize is evaluated by Publisher (not core Malloy) using a synthetic probe query against bundled DuckDB (a one-row `SELECT 1`), so the expression language is Malloy's, but the gate runs entirely over `given:` values — it never touches your warehouse data.
 
 > ⚠️ **Read [Security model](#security-model) before deploying this as an access control.** Givens are **caller-asserted**: anyone who can reach the query API can claim a favorable given. `#(authorize)` is only a real boundary when the API sits behind a trusted tier that sets givens from its own verified context. It is not, on its own, end-user authentication.
 
@@ -39,7 +39,7 @@ The expression is any Malloy boolean expression over `$given` references and lit
 #(authorize) "$TENANT = 'acme'"
 ```
 
-**No source-field references.** The gate is a 0-row probe — it has no row context, so an expression may reference only givens and literals, never a column of the gated source. A field reference fails at model load (see [Validation](#validation)).
+**No source-field references.** The probe evaluates your expression against its own synthetic one-column row, not against your source, so an expression may reference only givens and literals — a column of the gated source isn't in scope and fails at model load (see [Validation](#validation)).
 
 Embedded quotes follow Malloy string rules: write inner string literals with single quotes inside the double-quoted annotation, e.g. `#(authorize) "$ROLE = 'analyst'"`.
 
@@ -81,9 +81,9 @@ Authorize is checked **only on the source the query directly runs against**. It 
 - **Extend footgun:** a source that extends a locked base is governed *solely by its own* annotations. `source: b is a extend { … }` does **not** inherit `a`'s gate — if `b` declares none, `b` is unrestricted even if `a` is `#(authorize) "false"`.
 - **Joins:** a gate on a source reached only via `join_*` does not fire; the gate applies to the run target, not its joins.
 
-To keep a locked base's data from leaking through an extension or join, pair the gate with Malloy [access modifiers](https://docs.malloydata.dev/documentation/experiments/include) (`include { public: …, private: * }`) so the extension re-exposes only a curated column surface. See the [recommended pattern](#recommended-pattern-locked-base--curated-extensions).
+To keep a locked base's data from leaking through an extension or join, pair the gate with Malloy [access modifiers](https://docs.malloydata.dev/documentation/experiments/include) (`include { public: …, private: * }`) so the extension re-exposes only a curated column surface. See the [recommended pattern](#recommended-pattern-locked-base-and-curated-extensions).
 
-## Recommended pattern: locked base + curated extensions
+## Recommended pattern: locked base and curated extensions
 
 Lock sensitive base sources with `#(authorize) "false"` and re-expose curated subsets through extension sources, each with its own gate and access modifiers:
 
@@ -135,7 +135,7 @@ The gate runs, fail-closed, on every query entry point — **before** any filter
 | `POST /…/compile` | Gate the named source the submitted text targets (early, before compiling — so compile errors can't be used as a schema oracle — plus a compiled-source backstop). |
 | MCP `malloy_executeQuery` | Routes through the query path; a denial surfaces as `isError: true` naming the source. |
 
-**Fail-closed:** any probe error, a referenced given with no supplied value, a missing/null result, or a non-`true` result all **deny**.
+**Fail-closed, evaluated as a disjunction.** Each in-scope expression is probed independently; a branch that errors, references an unset given, or returns null / non-`true` is treated as *not granting*, and the next branch is tried. The request is denied only when **no** branch returns `true`. So a single-gate source with an unset given is denied, but a source whose *other* gate is satisfied still grants — the skip keeps OR semantics intact.
 
 ### Validation
 

--- a/docs/authorize_annotations_state.md
+++ b/docs/authorize_annotations_state.md
@@ -27,7 +27,7 @@ Running status + known-gap list for the `#(authorize)` / `##(authorize)` access-
 
 1. **Extend footgun** — an extension of a locked base with no gate of its own is unrestricted. Mitigation: access modifiers (`include { … private: * }`). Pinned by `authorize_integration` ("does NOT inherit … through extend").
 2. **Join bypass** — a gated source reached only via `join_*` is not gated (gate applies to the run target). Documented top-level-only boundary.
-3. **`/compile` raw SQL not gated** — the gate covers named Malloy sources; `/compile` compiles unrestricted, so raw `duckdb.sql(...)` can read a gated table's schema/SQL. **Follow-up:** extend `#807`-style restricted compilation to `/compile`. Bounded by the trusted-tier model; keep `/compile` behind the trusted tier until closed.
+3. **`/compile` raw SQL not gated** — the gate covers named Malloy sources; `/compile` compiles unrestricted, so raw `duckdb.sql(...)` can read a gated table's schema/SQL. **Follow-up:** apply #807's restricted-mode technique (which hardened `/query`) to `/compile`. Bounded by the trusted-tier model; keep `/compile` behind the trusted tier until closed.
 4. **MCP integration test gap** — no full `callTool` integration test against a gated model; the MCP E2E harness (`mcpApp`-only, process-singleton env, no reload) can't seed a gated package per-test without ordering fragility. The transform is covered piecewise (unit + HTTP e2e + `handler_utils` branch). **Follow-up:** make the MCP E2E harness seedable, then add the `callTool` test.
 
 ## Deferred (not started)

--- a/docs/authorize_annotations_state.md
+++ b/docs/authorize_annotations_state.md
@@ -1,0 +1,40 @@
+# Authorize Annotations — Implementation State
+
+Running status + known-gap list for the `#(authorize)` / `##(authorize)` access-gate feature. User-facing reference is [authorize.md](authorize.md); the original design is [authorize-annotations-plan.md](authorize-annotations-plan.md).
+
+## Status
+
+| Area | Status | Landed in |
+| --- | --- | --- |
+| Parse + surface annotations on the API | ✅ | #804 |
+| Compile-time validation (malformed / unknown given / field ref → 424) | ✅ | #805 |
+| Runtime gate on `POST /query` + notebook cells | ✅ | #806 |
+| Gate on `POST /compile` (early + compiled-source backstop) | ✅ | #814 |
+| MCP `malloy_executeQuery` denial → `isError` naming the source | ✅ | #814 |
+| HTTP 403 / 424 error mapping + redaction split | ✅ | #814 |
+| Docs (`authorize.md`, this file, givens cross-link, release notes) | ✅ | this change |
+| End-to-end sample + Playwright + filter×given×authorize compose | ⬜ | follow-up |
+
+## Behavior (as shipped)
+
+- **OR semantics:** file-level `##(authorize)` + a source's own `#(authorize)` are one disjunction; any `true` grants. Empty → unrestricted. Stacking widens access.
+- **File-level is a model-wide override:** a permissive `##(authorize)` unlocks every source in the file.
+- **Top-level-source only:** not inherited through `extend`, not walked through joins.
+- **Fail-closed:** probe error / missing given / null / non-true → deny (403).
+- **Redaction:** runtime 403 names the source only; model-load 424 keeps the expression (author-facing).
+
+## Known gaps (intentional, documented)
+
+1. **Extend footgun** — an extension of a locked base with no gate of its own is unrestricted. Mitigation: access modifiers (`include { … private: * }`). Pinned by `authorize_integration` ("does NOT inherit … through extend").
+2. **Join bypass** — a gated source reached only via `join_*` is not gated (gate applies to the run target). Documented top-level-only boundary.
+3. **`/compile` raw SQL not gated** — the gate covers named Malloy sources; `/compile` compiles unrestricted, so raw `duckdb.sql(...)` can read a gated table's schema/SQL. **Follow-up:** extend `#807`-style restricted compilation to `/compile`. Bounded by the trusted-tier model; keep `/compile` behind the trusted tier until closed.
+4. **MCP integration test gap** — no full `callTool` integration test against a gated model; the MCP E2E harness (`mcpApp`-only, process-singleton env, no reload) can't seed a gated package per-test without ordering fragility. The transform is covered piecewise (unit + HTTP e2e + `handler_utils` branch). **Follow-up:** make the MCP E2E harness seedable, then add the `callTool` test.
+
+## Deferred (not started)
+
+- **Identity-bound givens** — verified token / trusted-proxy header populating reserved "system givens" the caller cannot override; turns authorize into a standalone boundary not dependent on the trusted-tier assumption. See [authorize.md § Security model](authorize.md#security-model).
+- **Per-request probe memoization** — declined; microsecond DuckDB cost, stale-allow risk.
+
+## Trust model (must stay loud in the docs)
+
+Givens are **caller-asserted**; there is no auth in Publisher's query path. `#(authorize)` is a real boundary **only behind a trusted middle tier** that sets givens from verified context, with the query/MCP API network-isolated from untrusted callers. This is stated prominently at the top of [authorize.md](authorize.md) and in its Security model section.

--- a/docs/givens.md
+++ b/docs/givens.md
@@ -6,6 +6,8 @@ Givens replace the older `#(filter)` annotation path. New models should declare 
 
 For the authoritative Malloy reference (semantics, supported types, scoping rules), see [Malloy: Givens](https://docs.malloydata.dev/documentation/experiments/givens).
 
+To gate *access* to a source based on these givens, see [Authorize (source access gates)](authorize.md).
+
 ## Declaring Givens
 
 Givens are an experimental Malloy feature. Enable them once at the top of the model, then declare each given as a top-level statement before the source that uses it:


### PR DESCRIPTION
The `#(authorize)` gate is functionally complete across `/query`, notebook cells, and `/compile` (#804, #805, #806, #814) but had no user-facing docs. This adds them.

### What it does
- **`docs/authorize.md`** — the reference. Syntax (`#(authorize)` source-level, `##(authorize)` file-level), the expression language (givens-only, no source-field refs — it's a 0-row probe), and the semantics readers get wrong:
  - **OR semantics** — stacking gates *widens* access (any-true-passes).
  - **File-level is a model-wide override** — a permissive `##(authorize)` unlocks every source in the file.
  - **Top-level-source only** — not inherited through `extend`, not walked through joins; the extend footgun + the access-modifier mitigation.
  - The recommended **locked-base + curated-extension** pattern, the enforcement table, the **403/424 error contract + redaction split**, and a prominent **Security model** section: givens are caller-asserted, so authorize is a real boundary only **behind a trusted tier** — not end-user authn.
  - Known limitations (extend, join, the deferred restricted-`/compile` gap) and the identity-bound-givens milestone.
- **`docs/authorize_annotations_state.md`** — implementation status table + the running gap list (extend, join, `/compile` raw-SQL, MCP integration-test gap) and deferred items.
- **`docs/givens.md`** — cross-link to authorize.md.
- **`RELEASE_NOTES.md`** — an Unreleased entry leading with the trusted-tier caveat.

### Tested
Docs only. The gate behavior shown in the examples is verified by the merged work (`authorize_integration`, `compile_authorize*`, and the live manual run on #814); the locked-base/access-modifier example is lifted from the reviewed design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)