### PR TITLE
fix(sdk): givens UI correctness (mid-run, empty/boolean overrides, date dedup) + e2e authorize coverage

### DIFF
--- a/packages/app/tests/playwright/notebook-authorize.spec.ts
+++ b/packages/app/tests/playwright/notebook-authorize.spec.ts
@@ -107,14 +107,27 @@ test.describe("notebook-authorize", () => {
    }
 
    test("UI: result is gated until the given is supplied", async ({ page }) => {
+      // Wait on the actual denied cell response, not a fixed delay: the gated
+      // cell runs on load (role unset) and returns 403. Arm the wait before
+      // opening so we can't miss it. A fixed timeout would either flake on a
+      // slow runner or — worse — let the `role` fill land while the notebook is
+      // still executing, where the change is recorded but not re-run.
+      const deniedResponse = page.waitForResponse(
+         (r) =>
+            /\/notebooks\/.*authz_gate_notebook\.malloynb\/cells\/0/.test(
+               r.url(),
+            ) && r.request().method() === "GET",
+         { timeout: 30_000 },
+      );
       await openNotebook(page);
+      expect((await deniedResponse).status()).toBe(403);
 
-      // Gate denies on load (role unset) — the cell renders no result. Let the
-      // initial execution settle, then confirm the spotlight result is absent.
-      await page.waitForTimeout(2500);
+      // Execution finished (no spinner) and, denied, rendered no result.
+      await expect(page.getByRole("progressbar")).toHaveCount(0);
       await expect(page.getByText("Southwest Airlines")).toHaveCount(0);
 
-      // Supplying the satisfying given re-executes and the result appears.
+      // With the notebook idle, supplying the satisfying given re-executes and
+      // the result appears.
       await page.getByLabel("role").fill("analyst");
       await expect(page.getByText("Southwest Airlines").first()).toBeVisible();
    });

--- a/packages/app/tests/playwright/notebook-authorize.spec.ts
+++ b/packages/app/tests/playwright/notebook-authorize.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "@playwright/test";
+import * as fs from "fs/promises";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { DEFAULT_ENV, PACKAGES } from "./helpers/fixtures";
+import { gotoHome, openEnvironment, openPackage } from "./helpers/navigation";
+
+/**
+ * End-to-end coverage for `#(authorize)` source gates in a notebook. The
+ * malloy-samples fixtures ship no gated model, so the spec writes its own
+ * .malloy + .malloynb into the `faa` package, reloads, and cleans up.
+ *
+ * The gated source requires `$role = 'analyst'`; `role` has no default, so the
+ * gate denies on load (HTTP 403, no cell result) and grants once the user
+ * supplies `role = analyst` in the Parameters panel. The query spotlights
+ * carrier WN → "Southwest Airlines", the visible signal that the gate passed.
+ */
+
+const FIXTURE_MODEL = "authz_gate.malloy";
+const FIXTURE_NOTEBOOK = "authz_gate_notebook.malloynb";
+
+const FAA_DIR = path.resolve(
+   path.dirname(fileURLToPath(import.meta.url)),
+   "../../../server/publisher_data/malloy-samples/faa",
+);
+
+const MODEL_SOURCE = `##! experimental.givens
+
+given: role :: string
+
+#(authorize) "$role = 'analyst'"
+source: gated_carriers is duckdb.table('data/carriers.parquet') extend {
+  primary_key: code
+  view: spotlight is {
+    where: code = 'WN'
+    select: code, name
+    limit: 1
+  }
+}
+`;
+
+// Single malloy cell (index 0) so the cell-GET index is unambiguous. The cell
+// enables `experimental.givens` in its own compile scope: authorize validation
+// compiles a `$role` probe against the notebook model, which needs the flag set
+// here even though `role` itself is declared in the imported model.
+const NOTEBOOK_SOURCE = `>>>malloy
+##! experimental.givens
+import "authz_gate.malloy"
+run: gated_carriers -> spotlight
+`;
+
+async function reloadFaaPackage(baseURL: string): Promise<void> {
+   const url = `${baseURL}/api/v0/environments/${DEFAULT_ENV}/packages/${PACKAGES.faa}?reload=true`;
+   const res = await fetch(url);
+   if (!res.ok) {
+      throw new Error(`Package reload failed: ${res.status} ${res.statusText}`);
+   }
+}
+
+test.describe("notebook-authorize", () => {
+   test.beforeAll(async ({ baseURL }) => {
+      await fs.writeFile(path.join(FAA_DIR, FIXTURE_MODEL), MODEL_SOURCE);
+      await fs.writeFile(path.join(FAA_DIR, FIXTURE_NOTEBOOK), NOTEBOOK_SOURCE);
+      await reloadFaaPackage(baseURL!);
+   });
+
+   test.afterAll(async ({ baseURL }) => {
+      await fs.unlink(path.join(FAA_DIR, FIXTURE_MODEL)).catch(() => undefined);
+      await fs
+         .unlink(path.join(FAA_DIR, FIXTURE_NOTEBOOK))
+         .catch(() => undefined);
+      await reloadFaaPackage(baseURL!).catch(() => undefined);
+   });
+
+   const cellUrl = (baseURL: string, givens?: Record<string, string>) => {
+      const base = `${baseURL}/api/v0/environments/${DEFAULT_ENV}/packages/${PACKAGES.faa}/notebooks/${FIXTURE_NOTEBOOK}/cells/0`;
+      return givens
+         ? `${base}?givens=${encodeURIComponent(JSON.stringify(givens))}`
+         : base;
+   };
+
+   test("notebook cell is denied (403) without the gate-passing given", async ({
+      baseURL,
+   }) => {
+      const res = await fetch(cellUrl(baseURL!));
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as { message?: string };
+      // Names the source; never the gate expression.
+      expect(body.message).toContain("gated_carriers");
+      expect(body.message ?? "").not.toContain("analyst");
+   });
+
+   test("notebook cell succeeds (200) with role = analyst", async ({
+      baseURL,
+   }) => {
+      const res = await fetch(cellUrl(baseURL!, { role: "analyst" }));
+      expect(res.status).toBe(200);
+   });
+
+   async function openNotebook(page: import("@playwright/test").Page) {
+      await gotoHome(page);
+      await openEnvironment(page, DEFAULT_ENV);
+      await openPackage(page, DEFAULT_ENV, PACKAGES.faa);
+      await page.getByText(FIXTURE_NOTEBOOK, { exact: true }).click();
+      await expect(page).toHaveURL(/authz_gate_notebook\.malloynb/);
+      await expect(page.getByLabel("role")).toBeVisible();
+   }
+
+   test("UI: result is gated until the given is supplied", async ({ page }) => {
+      await openNotebook(page);
+
+      // Gate denies on load (role unset) — the cell renders no result. Let the
+      // initial execution settle, then confirm the spotlight result is absent.
+      await page.waitForTimeout(2500);
+      await expect(page.getByText("Southwest Airlines")).toHaveCount(0);
+
+      // Supplying the satisfying given re-executes and the result appears.
+      await page.getByLabel("role").fill("analyst");
+      await expect(page.getByText("Southwest Airlines").first()).toBeVisible();
+   });
+});

--- a/packages/app/tests/playwright/notebook-authorize.spec.ts
+++ b/packages/app/tests/playwright/notebook-authorize.spec.ts
@@ -131,4 +131,34 @@ test.describe("notebook-authorize", () => {
       await page.getByLabel("role").fill("analyst");
       await expect(page.getByText("Southwest Airlines").first()).toBeVisible();
    });
+
+   test("UI: a given supplied mid-execution is applied once the run finishes", async ({
+      page,
+   }) => {
+      // Hold the first (denied) cell GET so the notebook stays executing while
+      // we fill `role`. This is the window where a given change used to be
+      // recorded but never re-run. Only the first /cells/0 request is held.
+      let held = false;
+      await page.route(/\/cells\/0/, async (route) => {
+         if (!held) {
+            held = true;
+            await new Promise((r) => setTimeout(r, 5000));
+         }
+         await route.continue();
+      });
+
+      // Wait until the held request is actually in flight (notebook executing),
+      // then fill — a deterministic "mid-execution" signal, no fixed delay.
+      const firstCellRequest = page.waitForRequest(
+         (r) => /\/cells\/0/.test(r.url()),
+         { timeout: 30_000 },
+      );
+      await openNotebook(page);
+      await firstCellRequest;
+      await page.getByLabel("role").fill("analyst");
+
+      // Once the held run finishes, the mid-flight given must be picked up and
+      // re-executed — the result appears without any further interaction.
+      await expect(page.getByText("Southwest Airlines").first()).toBeVisible();
+   });
 });

--- a/packages/app/tests/playwright/notebook-givens.spec.ts
+++ b/packages/app/tests/playwright/notebook-givens.spec.ts
@@ -26,6 +26,7 @@ const MODEL_SOURCE = `##! experimental.givens
 #(description="Two-letter IATA carrier code")
 given: target_code :: string is 'WN'
 given: cutoff :: date is @2024-01-01
+given: include_x :: boolean is true
 
 source: carriers_with_given is duckdb.table('data/carriers.parquet') extend {
   primary_key: code
@@ -96,6 +97,7 @@ test.describe("notebook-givens", () => {
       const names = givens.map((g) => g.name);
       expect(names).toContain("target_code");
       expect(names).toContain("cutoff");
+      expect(names).toContain("include_x");
    });
 
    test("Parameters panel renders one input per declared given", async ({
@@ -108,6 +110,7 @@ test.describe("notebook-givens", () => {
       ).toBeVisible();
       await expect(page.getByLabel("target_code")).toBeVisible();
       await expect(page.getByLabel("cutoff")).toBeVisible();
+      await expect(page.getByLabel("include_x")).toBeVisible();
    });
 
    test("description annotation surfaces as helper text", async ({ page }) => {
@@ -172,5 +175,55 @@ test.describe("notebook-givens", () => {
       await expect(input).toHaveValue("");
       await expect(resetBtn).toBeHidden();
       await expect(page.getByText("Southwest Airlines").first()).toBeVisible();
+   });
+
+   test("empty string is a deliberate override, distinct from revert-to-default", async ({
+      page,
+   }) => {
+      await openGivensNotebook(page);
+      const input = page.getByLabel("target_code");
+
+      // Default WN → Southwest.
+      await expect(page.getByText("Southwest Airlines").first()).toBeVisible();
+
+      // Explicit AA → American.
+      await input.fill("AA");
+      await expect(page.getByText("American Airlines").first()).toBeVisible();
+
+      // Typing the field empty is an explicit "" override, NOT a revert: the
+      // cell re-runs with "" (no carrier matches), so American disappears and
+      // the default (WN/Southwest) does not come back.
+      await input.fill("");
+      await expect(page.getByText("American Airlines")).toHaveCount(0);
+      await expect(page.getByText("Southwest Airlines")).toHaveCount(0);
+
+      // The × is present even though the field is empty — an override is active,
+      // distinct from unset. Clicking it reverts to the model default.
+      const clearBtn = page.getByRole("button", { name: "clear value" });
+      await expect(clearBtn).toBeVisible();
+      await clearBtn.click();
+      await expect(page.getByText("Southwest Airlines").first()).toBeVisible();
+   });
+
+   test("boolean reflects the default when unset, and toggles/reverts as an explicit override", async ({
+      page,
+   }) => {
+      await openGivensNotebook(page);
+      const box = page.getByLabel("include_x");
+
+      // Unset → reflects the model default (`is true`), so the box shows what
+      // the query actually runs with. No override yet, so no Reset.
+      await expect(box).toBeChecked();
+      await expect(page.getByRole("button", { name: "Reset" })).toBeHidden();
+
+      // Toggle → explicit `false` override (a real value, not "unset").
+      await box.uncheck();
+      await expect(box).not.toBeChecked();
+      await expect(page.getByRole("button", { name: "Reset" })).toBeVisible();
+
+      // Revert (×) → drop the override, back to the default (checked).
+      await page.getByRole("button", { name: "clear value" }).click();
+      await expect(box).toBeChecked();
+      await expect(page.getByRole("button", { name: "Reset" })).toBeHidden();
    });
 });

--- a/packages/sdk/src/components/Notebook/Notebook.tsx
+++ b/packages/sdk/src/components/Notebook/Notebook.tsx
@@ -443,7 +443,11 @@ export default function Notebook({
    const prevInputsRef = useRef<string>("");
 
    useEffect(() => {
-      // Serialize activeFilters + givenValues to detect actual value changes
+      // Serialize activeFilters + givenValues to detect actual value changes.
+      // Encode dates to the same YYYY-MM-DD granularity buildGivens sends on the
+      // wire — otherwise JSON.stringify renders Date as a full ISO timestamp, so
+      // two times on the same day would look like a change and trigger a
+      // redundant re-run even though the sent value is identical.
       const serialized = JSON.stringify({
          filters: activeFilters.map((f) => ({
             dim: f.dimensionName,
@@ -451,9 +455,12 @@ export default function Notebook({
             val: f.value,
             val2: f.value2,
          })),
-         givens: Array.from(givenValues.entries()).sort(([a], [b]) =>
-            a.localeCompare(b),
-         ),
+         givens: Array.from(givenValues.entries())
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([name, v]) => [
+               name,
+               v instanceof Date ? v.toISOString().slice(0, 10) : v,
+            ]),
       });
 
       // Skip if no actual change

--- a/packages/sdk/src/components/Notebook/Notebook.tsx
+++ b/packages/sdk/src/components/Notebook/Notebook.tsx
@@ -471,12 +471,18 @@ export default function Notebook({
          return;
       }
 
-      prevInputsRef.current = serialized;
-
-      // Re-execute with current filters and givens (or empty if cleared)
-      if (!isExecuting) {
-         executeCells(activeFilters, givenValues);
+      // Don't consume the change until we can act on it. If a run is already in
+      // flight, leave prevInputsRef stale and bail: this effect re-runs when
+      // isExecuting flips back to false (it's a dependency), and will then pick
+      // up the latest inputs. Updating prevInputsRef here instead would mark the
+      // change "seen" and drop it — a given/filter edited mid-run would never
+      // re-execute.
+      if (isExecuting) {
+         return;
       }
+
+      prevInputsRef.current = serialized;
+      executeCells(activeFilters, givenValues);
    }, [activeFilters, givenValues, isExecuting, executeCells]);
 
    // Handle filter change using composite key

--- a/packages/sdk/src/components/given/GivenInput.tsx
+++ b/packages/sdk/src/components/given/GivenInput.tsx
@@ -7,6 +7,7 @@ import {
    FormHelperText,
    IconButton,
    InputAdornment,
+   Stack,
    TextField,
 } from "@mui/material";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
@@ -61,16 +62,21 @@ function annotationHelperText(given: Given): string | undefined {
  * Renders an input widget appropriate for the declared given type.
  * Unknown / unrecognized types fall back to a plain text input.
  *
- * For text-based inputs (string, number, filter, default), a clear (×)
- * adornment appears when the field has a value. DatePicker, Checkbox, and
- * multi-Autocomplete have their own native clear affordances.
+ * Three states, distinguished so a deliberate empty/false override is not
+ * confused with "use the model default":
+ *   - unset (`value === undefined`) → the given is omitted from the request and
+ *     the server applies the model default. Text widgets show the default as a
+ *     ghost placeholder; the boolean checkbox reflects the default's value.
+ *   - explicit override (any concrete value, INCLUDING `""` and `false`) → sent
+ *     verbatim. A clear (×) affordance appears whenever a value is overridden —
+ *     including an empty string — so typing the field empty (a deliberate `""`)
+ *     is distinguishable from unset by the × being present.
+ *   - revert → the × affordance calls `onChange(null)`, which drops the override
+ *     (useGivensForm deletes the key) and returns the widget to its unset state.
  *
- * A given's model default (if any) is surfaced as an always-visible
+ * A given's model default (if any) is also surfaced as an always-visible
  * `Default: …` helper line on every widget — including the boolean checkbox,
- * which gets a wrapping FormControl for the slot — plus a ghost placeholder on
- * the text widgets (a bonus MUI only reveals on focus, since the floating label
- * sits in the placeholder's spot at rest). The value itself stays empty, so
- * leaving the field blank still means "use the model default".
+ * which gets a wrapping FormControl for the slot.
  */
 export function GivenInput({ given, value, onChange }: GivenInputProps) {
    const label = given.name ?? "";
@@ -98,24 +104,36 @@ export function GivenInput({ given, value, onChange }: GivenInputProps) {
       ) : undefined;
 
    if (type === "boolean") {
-      const checked = value === true;
-      // A checkbox has no helperText slot of its own and no "unset" visual, so
-      // wrap it in a FormControl to carry the annotation + `Default: …` line.
-      // This matters most for a `boolean is true` given: the box reads unchecked
-      // when untouched, but the query runs with the default, so the caption is
-      // what tells the user that. (The deeper "no unset state" checkbox quirk is
-      // a pre-existing givens limitation, not specific to defaults.)
+      // Three states for a boolean. When unset, reflect the model DEFAULT so the
+      // box shows what the query will actually run with (not a misleading
+      // unchecked). A toggle is an explicit true/false override; the revert (×)
+      // — shown only when overridden — drops the override back to the default.
+      const isOverridden = typeof value === "boolean";
+      const defaultChecked = given.default?.trim() === "true";
+      const checked = isOverridden ? value : defaultChecked;
       return (
          <FormControl>
-            <FormControlLabel
-               control={
-                  <Checkbox
-                     checked={checked}
-                     onChange={(e) => onChange(e.target.checked)}
-                  />
-               }
-               label={label}
-            />
+            <Stack direction="row" alignItems="center">
+               <FormControlLabel
+                  control={
+                     <Checkbox
+                        checked={checked}
+                        onChange={(e) => onChange(e.target.checked)}
+                     />
+                  }
+                  label={label}
+               />
+               {isOverridden && (
+                  <IconButton
+                     size="small"
+                     aria-label="clear value"
+                     onClick={() => onChange(null)}
+                     edge="end"
+                  >
+                     <ClearIcon fontSize="small" />
+                  </IconButton>
+               )}
+            </Stack>
             {helperNode && <FormHelperText>{helperNode}</FormHelperText>}
          </FormControl>
       );
@@ -195,23 +213,28 @@ export function GivenInput({ given, value, onChange }: GivenInputProps) {
       );
    }
 
-   // Default: string, filter<...>, or unknown types — plain text input
+   // Default: string, filter<...>, or unknown types — plain text input.
+   // An empty field is a deliberate `""` override, NOT a revert: typing the
+   // field empty sends "" (so gates like `$region != ''` are expressible). Only
+   // the × reverts to the model default. The default ghost shows just for the
+   // unset state, so an empty override (× present, no ghost) reads differently.
    const str = typeof value === "string" ? value : "";
+   const isOverridden = value !== undefined && value !== null;
    return (
       <TextField
          label={label}
          value={str}
-         onChange={(e) => {
-            const v = e.target.value;
-            onChange(v === "" ? null : v);
-         }}
+         onChange={(e) => onChange(e.target.value)}
          placeholder={
-            defaultDisplay ?? (type.startsWith("filter<") ? type : undefined)
+            isOverridden
+               ? undefined
+               : (defaultDisplay ??
+                 (type.startsWith("filter<") ? type : undefined))
          }
          helperText={helperNode}
          slotProps={{
             input: {
-               endAdornment: str !== "" && (
+               endAdornment: isOverridden && (
                   <ClearAdornment onClear={() => onChange(null)} />
                ),
             },

--- a/packages/sdk/src/hooks/useGivensForm.ts
+++ b/packages/sdk/src/hooks/useGivensForm.ts
@@ -22,8 +22,6 @@ export interface UseGivensFormResult {
    givenValues: Map<string, GivenValue>;
    /** Update a given's value. Pass `null` to revert to model default. */
    updateGiven: (name: string, value: GivenValue) => void;
-   /** Remove a single given override. */
-   clearGiven: (name: string) => void;
    /** Remove all overrides. */
    clearAll: () => void;
    /** Map of just the givens that have a user-supplied (non-null) override. */
@@ -74,15 +72,6 @@ export function useGivensForm(givens: Given[]): UseGivensFormResult {
       });
    }, []);
 
-   const clearGiven = useCallback((name: string) => {
-      setGivenValues((prev) => {
-         if (!prev.has(name)) return prev;
-         const next = new Map(prev);
-         next.delete(name);
-         return next;
-      });
-   }, []);
-
    const clearAll = useCallback(() => {
       setGivenValues((prev) => (prev.size === 0 ? prev : new Map()));
    }, []);
@@ -103,7 +92,6 @@ export function useGivensForm(givens: Given[]): UseGivensFormResult {
    return {
       givenValues,
       updateGiven,
-      clearGiven,
       clearAll,
       getActiveGivens,
    };

--- a/packages/server/src/service/authorize_integration.spec.ts
+++ b/packages/server/src/service/authorize_integration.spec.ts
@@ -930,3 +930,70 @@ source: declared is duckdb.table('customers') extend { measure: c is count() }
       ).resolves.toBeUndefined();
    });
 });
+
+// A given can be both a runtime query parameter (substituted into a view's
+// `where`) AND the subject of an `#(authorize)` gate on the same source. These
+// two layers compose: the gate fires first (before any filtering), and once it
+// passes the parameterized filter applies to the result. This is the layered
+// case the end-to-end story rests on.
+describe("authorize composes with given parameters", () => {
+   // `ROLE` gates access; `REGION` is a runtime filter parameter on the view.
+   const COMPOSED = `##! experimental.givens
+
+given:
+  ROLE :: string
+  REGION :: string
+
+#(authorize) "$ROLE = 'analyst'"
+source: regional is duckdb.table('customers') extend {
+  measure: c is count()
+  view: in_region is {
+    where: region = $REGION
+    aggregate: c
+  }
+}
+`;
+
+   async function runComposed(givens: Record<string, GivenValue>) {
+      await writeModel("compose.malloy", COMPOSED);
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "compose.malloy",
+         getConnections(),
+      );
+      return model.getQueryResults(
+         undefined,
+         undefined,
+         "run: regional -> in_region",
+         undefined,
+         undefined,
+         givens,
+      );
+   }
+
+   function countOf(compactResult: unknown): number {
+      const rows = compactResult as Array<Record<string, unknown>>;
+      return Number(rows[0]?.c);
+   }
+
+   it("denies before filtering when the gate fails, even with the filter given supplied", async () => {
+      await expect(runComposed({ REGION: "us-west" })).rejects.toBeInstanceOf(
+         AccessDeniedError,
+      );
+   });
+
+   it("applies the parameterized filter once the gate passes", async () => {
+      // Seed: one 'us-west' customer, one 'us-east'.
+      const west = await runComposed({ ROLE: "analyst", REGION: "us-west" });
+      expect(countOf(west.compactResult)).toBe(1);
+
+      const east = await runComposed({ ROLE: "analyst", REGION: "us-east" });
+      expect(countOf(east.compactResult)).toBe(1);
+
+      // A region matching no rows proves the given genuinely filters (not a
+      // gate-only pass-through).
+      const none = await runComposed({ ROLE: "analyst", REGION: "nowhere" });
+      expect(countOf(none.compactResult)).toBe(0);
+   });
+});


### PR DESCRIPTION
Started as end-to-end validation for the `#(authorize)` series, then picked up a cluster of givens UI fixes that review surfaced along the way.

## Authorize coverage
- Playwright spec writes a gated model + notebook into the `faa` package and proves the gate at the notebook-cell HTTP surface (403 naming the source, redacted; 200 with the satisfying given) and through the UI (result hidden until `role` is supplied, then renders).
- Integration block proves a given can be both a runtime query parameter and the subject of an `#(authorize)` gate on the same source: gate fires before filtering; once it passes, the parameterized filter applies.

## Givens UI fixes
- **Apply changes made mid-execution.** The re-execution effect recorded the latest inputs before the `isExecuting` guard, then skipped the run — so a given/filter edited while cells were running was silently dropped. Now the change isn't consumed until it can be acted on; the effect re-runs when execution finishes with the latest inputs. (Surfaced by Codex review.)
- **Empty-string and boolean overrides.** Givens used absence/`null` to mean "use the model default," and the inputs collapsed an empty string and an untoggled boolean into that same state — so a deliberate `""` (matters for gates like `$region != ''`) and an explicit boolean couldn't be expressed. `GivenInput` now models three states: unset (omitted, server default), explicit override (any concrete value incl. `""`/`false`, sent verbatim), and revert (the × drops the override). The boolean reflects the model default when unset and gains a revert affordance.
- **Date dedup key.** The change-detection effect serialized dates as full ISO while the wire sends `YYYY-MM-DD`, so two times on the same day triggered a redundant re-run. The dedup key now uses the same granularity as the payload.
- **Remove dead `clearGiven`** from `useGivensForm` (exported, never wired).

### Tested
- `tsc` + `eslint` clean (server, sdk, app)
- `authorize_integration` 40/40 (incl. the compose block)
- Playwright `notebook-authorize` 4/4 and `notebook-givens` 9/9 against a local stack on malloy 0.0.405 (new tests cover the mid-execution re-run, empty-string override, and boolean default/toggle/revert; the mid-execution test is confirmed to fail without its fix)
- Drove the authorize flow in a real browser: no result with `role` unset, `WN` / Southwest Airlines once `role=analyst` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)