### PR TITLE
fix(sdk): make withCredentials opt-in; omit empty Authorization header

### DIFF
--- a/packages/sdk/src/components/ServerProvider.tsx
+++ b/packages/sdk/src/components/ServerProvider.tsx
@@ -60,24 +60,38 @@ export interface ServerProviderProps {
     * @default true
     */
    mutable?: boolean;
+   /** Send cookies on cross-origin API requests (XHR `withCredentials`).
+    * Enable only when the server authenticates the SDK via an ambient session
+    * cookie instead of `getAccessToken`; credentialed requests require the
+    * server to answer CORS preflights with `Access-Control-Allow-Credentials:
+    * true`. Same-origin requests always carry cookies regardless of this flag.
+    * @default false
+    */
+   withCredentials?: boolean;
 }
 
 const getApiClients = (
    baseURL?: string,
    accessToken?: () => Promise<string>,
+   withCredentials?: boolean,
 ) => {
    const basePath = `${window.location.protocol}//${window.location.host}/api/v0`;
 
    // Create a custom axios instance with proper configuration
    const axiosInstance = axios.create({
       baseURL: baseURL || basePath,
-      withCredentials: true,
+      withCredentials: withCredentials ?? false,
       timeout: 600000,
    });
 
    axiosInstance.interceptors.request.use(async (config) => {
       const token = await accessToken?.();
-      config.headers.Authorization = token || "";
+      // Omit the header entirely when there is no token: an empty-string
+      // Authorization header still counts as "header present" to servers that
+      // fall back to cookie auth only when no Authorization header is set.
+      if (token) {
+         config.headers.Authorization = token;
+      }
       return config;
    });
 
@@ -109,10 +123,11 @@ export const ServerProvider: React.FC<ServerProviderProps> = ({
    getAccessToken,
    baseURL,
    mutable: mutableProp,
+   withCredentials,
 }) => {
    const apiClients = useMemo(
-      () => getApiClients(baseURL, getAccessToken),
-      [baseURL, getAccessToken],
+      () => getApiClients(baseURL, getAccessToken, withCredentials),
+      [baseURL, getAccessToken, withCredentials],
    );
 
    const server =


### PR DESCRIPTION
## What

Two fixes to `ServerProvider`'s axios client:

1. **`withCredentials` is now opt-in (default `false`)** via a new `withCredentials` prop on `ServerProviderProps`, instead of hardcoded `true`.
2. **The Authorization header is omitted when there is no token**, instead of being sent as an empty string.

## Why

The SDK authenticates with a Bearer token from `getAccessToken` — cookies are not needed on its cross-origin requests. Hardcoding `withCredentials: true` forces every cross-origin request into credentials mode `include`, so any server that (correctly) declines credentialed wildcard CORS — `Access-Control-Allow-Credentials` unset — fails the preflight and the browser blocks the request, even though the Bearer-authenticated request would succeed without cookies. This is currently breaking SPA→dataplane calls (status polling, notebook fetches) on deployments that hardened their CORS policy to non-credentialed wildcard.

Separately, the interceptor set `config.headers.Authorization = token || ""`. Axios transmits the empty-string header, and servers that fall back to cookie auth *only when no Authorization header is present* treat it as "header present" — silently disabling cookie auth for any consumer without a token getter. Omitting the header matches what the `publisher.js` runtime's `authHeaders()` already does.

## Compatibility

- Same-origin consumers (the standalone publisher app at `packages/app`, `examples/data-app`, embedded pages) are unaffected: browsers always send cookies on same-origin requests regardless of `withCredentials`.
- Cross-origin consumers that genuinely rely on ambient cookie auth must now pass `withCredentials` explicitly — that mode also requires the server to answer preflights with `Access-Control-Allow-Credentials: true`, so it only ever worked against servers configured for it.

## Tests

- `bun run build` green; built output threads the prop (`withCredentials: prop ?? false`).
- `bun test`: 34 pass, 0 fail.
- Verified empirically that axios transmits `Authorization: ""` (server receives the empty header), motivating fix 2.