### PR TITLE
feat(server): validate renderer tags at package load

### DIFF
--- a/packages/server/src/package_load/package_load_pool.spec.ts
+++ b/packages/server/src/package_load/package_load_pool.spec.ts
@@ -201,6 +201,72 @@ describe("PackageLoadPool (real worker)", () => {
       }
    });
 
+   it("fails the load when a view carries an invalid renderer tag", async () => {
+      writeManifest(tempDir);
+      // `# big_value { sparkline=... }` is a child-only renderer config placed
+      // on the view itself, with no activating big_value. The renderer declines
+      // to match it; without compile-time validation it renders as
+      // "[object Object]" at query time. The package load must reject it.
+      fs.writeFileSync(
+         path.join(tempDir, "bad_render.malloy"),
+         `source: nums is duckdb.sql("select 1 as a, 2 as b") extend {
+  measure: total is a.sum()
+  # big_value { sparkline=trend }
+  view: card is {
+    aggregate: total
+    nest:
+      # line_chart { size=spark }
+      trend is { group_by: a; aggregate: total }
+  }
+}`,
+      );
+
+      const { malloyConfig, duckdb } = await buildConfig();
+      try {
+         const outcome = await pool.loadPackage({
+            packagePath: tempDir,
+            packageName: "pkg",
+            malloyConfig,
+            defaultConnectionName: "duckdb",
+         });
+         expect(outcome.models).toHaveLength(1);
+         const m = outcome.models[0];
+         expect(m.compilationError).toBeDefined();
+         expect(m.compilationError?.message).toContain(
+            "Invalid renderer configuration",
+         );
+         expect(m.compilationError?.message).toContain("nums -> card");
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("loads a view whose renderer tags are valid", async () => {
+      writeManifest(tempDir);
+      fs.writeFileSync(
+         path.join(tempDir, "good_render.malloy"),
+         `source: nums is duckdb.sql("select 1 as a, 2 as b") extend {
+  measure: total is a.sum()
+  # bar_chart
+  view: chart is { group_by: a; aggregate: total }
+}`,
+      );
+
+      const { malloyConfig, duckdb } = await buildConfig();
+      try {
+         const outcome = await pool.loadPackage({
+            packagePath: tempDir,
+            packageName: "pkg",
+            malloyConfig,
+            defaultConnectionName: "duckdb",
+         });
+         expect(outcome.models).toHaveLength(1);
+         expect(outcome.models[0].compilationError).toBeUndefined();
+      } finally {
+         await duckdb.close();
+      }
+   });
+
    it("ignores embedded csv/parquet files (database probing is a main-thread concern)", async () => {
       // The worker is pure-CPU: it reads the manifest and compiles
       // .malloy files only. Database probing stays on the main thread

--- a/packages/server/src/package_load/package_load_worker.ts
+++ b/packages/server/src/package_load/package_load_worker.ts
@@ -79,6 +79,7 @@ import {
    PACKAGE_MANIFEST_NAME,
 } from "../constants";
 import { HackyDataStylesAccumulator } from "../data_styles";
+import { validateRenderTags } from "@malloydata/render-validator";
 import { ModelCompilationError } from "../errors";
 import { validateAuthorizeProbes } from "../service/authorize";
 import { type FilterDefinition } from "../service/filter";
@@ -511,6 +512,67 @@ function buildRuntimeForModel(
    return { runtime, urlReader };
 }
 
+/**
+ * Validate renderer tags (e.g. `# big_value`, `# line_chart`) on every named
+ * query/view in a model at compile time, so a misconfigured tag fails the
+ * package load with a `ModelCompilationError` (424) instead of rendering as
+ * "[object Object]" or an inline error only when the view is queried.
+ *
+ * Each view is prepared (compiled, NOT executed) to obtain its stable result
+ * schema; `validateRenderTags` then runs the renderer's tag validation against
+ * that schema headlessly. Only error-severity findings are fatal -- warnings
+ * (e.g. unread tags) are left for the query-time `renderLogs` surface so a
+ * benign lint never blocks a package load.
+ */
+async function validateModelRenderTags(
+   mm: ModelMaterializer,
+   sources: ApiSourceWire[],
+   queries: ApiQueryWire[],
+): Promise<void> {
+   // Build the runnable query string for each renderable target: top-level
+   // named queries (`run: <name>`) and every view declared on a source
+   // (`run: <source> -> <view>`). Source views are where render tags like
+   // `# big_value` usually live, and they are NOT in `queries`.
+   const targets: { label: string; queryString: string }[] = [];
+   for (const query of queries) {
+      if (query.name) {
+         targets.push({ label: query.name, queryString: `run: ${query.name}` });
+      }
+   }
+   for (const source of sources) {
+      for (const view of source.views ?? []) {
+         targets.push({
+            label: `${source.name} -> ${view.name}`,
+            queryString: `run: ${source.name} -> ${view.name}`,
+         });
+      }
+   }
+
+   for (const target of targets) {
+      let result: Malloy.Result;
+      try {
+         const prepared = await mm
+            .loadQuery(target.queryString)
+            .getPreparedResult();
+         result = prepared.toStableResult();
+      } catch {
+         // A view/query that fails to prepare is reported by the normal compile
+         // path; don't mask that with a render-tag error.
+         continue;
+      }
+      const errors = validateRenderTags(result).filter(
+         (log) => log.severity === "error",
+      );
+      if (errors.length > 0) {
+         throw new ModelCompilationError({
+            message: `Invalid renderer configuration on '${target.label}': ${errors
+               .map((e) => e.message)
+               .join("; ")}`,
+         });
+      }
+   }
+}
+
 async function compileMalloyModel(
    job: LoadPackageRequest,
    malloyConfig: MalloyConfig,
@@ -551,6 +613,9 @@ async function compileMalloyModel(
    // on an unknown given / source-field reference; compileOneModel's catch
    // turns it into this model's compilationError.
    await validateAuthorizeProbes(mm, sources);
+   // Validate renderer tags at compile time so a misconfigured render tag fails
+   // the load instead of producing garbage at render time.
+   await validateModelRenderTags(mm, sources, queries);
 
    return {
       modelPath,
@@ -732,6 +797,9 @@ async function compileNotebookModel(
       finalQueries = extractQueries(finalModelDef);
       // Validate #(authorize) at compile time (shared with Model.create).
       await validateAuthorizeProbes(mm, finalSources);
+      // Validate renderer tags at compile time so a misconfigured render tag
+      // fails the load instead of producing garbage at render time.
+      await validateModelRenderTags(mm, finalSources, finalQueries);
    }
 
    return {

--- a/packages/server/src/service/package_worker_path.spec.ts
+++ b/packages/server/src/service/package_worker_path.spec.ts
@@ -304,6 +304,14 @@ source: gated is duckdb.sql("select 1 as id")`,
          ).rejects.toBeInstanceOf(ServiceUnavailableError);
       } finally {
          await duckdb.close();
+         // Replace the singleton with a fresh, live pool immediately. The
+         // outer afterAll also resets to null, but restoring here ensures the
+         // shut-down pool never outlives this test -- otherwise, under serial
+         // execution, a later spec file that lazily reuses the singleton via
+         // getPackageLoadPool() could observe the dead pool before afterAll
+         // runs and fail with "PackageLoadPool is shutting down".
+         pool = new PackageLoadPool(1);
+         await __setPackageLoadPoolForTests(pool);
       }
    });
 });


### PR DESCRIPTION
Renderer tags (for example `# big_value`, `# line_chart`) are validated by the renderer at render time, but a misconfigured tag was previously invisible until a view was queried -- and could render as "[object Object]". One case: a child-only big_value config such as `# big_value { sparkline=... }` placed on a view with no activating big_value. The renderer declines to match it, and the result falls through to a String() coercion.

Validate renderer tags during the package-load compile pass instead, alongside the existing #(authorize) check. For each top-level query and each source view, prepare the query (compile only, no execution), take its stable result schema, and run the renderer's headless `validateRenderTags`. Any error-severity finding throws a ModelCompilationError, which the worker reports as the model's compilationError (HTTP 424) -- so a bad tag fails the load with a clear message rather than producing garbage at render time.

Only error-severity findings are fatal; warnings remain on the query-time `renderLogs` surface so a benign render lint never blocks a package load.