### PR TITLE
test(server): fix flaky PackageLoadPool shutdown leak across specs

### DIFF
--- a/packages/server/src/health.spec.ts
+++ b/packages/server/src/health.spec.ts
@@ -1,7 +1,16 @@
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import {
+   afterAll,
+   afterEach,
+   beforeEach,
+   describe,
+   expect,
+   it,
+   spyOn,
+} from "bun:test";
 import { Server } from "http";
 import { performGracefulShutdownAfterDrain } from "./health";
 import { logger } from "./logger";
+import { __setPackageLoadPoolForTests } from "./package_load/package_load_pool";
 
 // Regression test for the graceful-shutdown ordering bug that caused
 //   [winston] Attempt to write logs with no transports: {"message":"Waiting 50 seconds..."}
@@ -39,6 +48,18 @@ describe("performGracefulShutdownAfterDrain: shutdown ordering", () => {
 
    afterEach(() => {
       process.exit = originalExit;
+   });
+
+   // performGracefulShutdownAfterDrain lazily creates and shuts down the
+   // module-level PackageLoadPool singleton. If we leave that shut-down
+   // pool installed, sibling specs that run later in the same Bun process
+   // (e.g. package.spec.ts, package_race.spec.ts) inherit a dead pool and
+   // fail with "PackageLoadPool is shutting down". Reset the singleton so
+   // the next getPackageLoadPool() spins up a fresh one. The leaked-pool
+   // ordering is filesystem-readdir dependent, which is why it only
+   // surfaced on Linux CI.
+   afterAll(async () => {
+      await __setPackageLoadPoolForTests(null);
    });
 
    const fakeServer = (): Server => ({ listening: false }) as unknown as Server;


### PR DESCRIPTION
## Summary

Fixes a pre-existing, order-dependent test flake where 6 server unit tests fail on Linux CI with `PackageLoadPool is shutting down`. This is what's currently red on #829 (a docs-only PR), but the root cause is on `main` and unrelated to those docs.

### Root cause

- `PackageLoadPool` is a process-global lazy singleton.
- `health.spec.ts` exercises `performGracefulShutdownAfterDrain()`, which lazily creates that singleton and calls `.shutdown()` on it — but never reset the singleton back to `null`.
- `bun test src` runs the whole suite in one process, so later specs (`package.spec.ts`, `package_race.spec.ts`) call `getPackageLoadPool()` and inherit the shut-down pool, then fail every `Package.create`.
- Test-file discovery order is filesystem-`readdir` dependent, so the bad ordering only happens on Linux — hence macOS/Windows stayed green.

The two other specs that touch the singleton (`package_worker_path.spec.ts`, `package_load_pool.spec.ts`) already clean up with `__setPackageLoadPoolForTests(null)`; `health.spec.ts` was the one that didn't.

### Fix

Add an `afterAll` to `health.spec.ts` that resets the pool singleton, matching the existing cleanup convention.

## Test plan

- [x] Reproduced the failure by running `health.spec.ts` before `package.spec.ts`/`package_race.spec.ts`; all 6 tests fail without the change and pass with it.
- [x] Full `bun test src` run shows no regressions (identical pass/fail counts with and without the change).
- [ ] CI green on Linux/macOS/Windows.

Made with [Cursor](https://cursor.com)