### PR TITLE
feat(server): explore visibility + query boundary via publisher.json explores

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ The two compose: `explores` decides which files are listed, and `export { … }`
   For gradual migration, use `explores` with `queryableSources: "all"` to curate listings while keeping every source queryable by name; switch to `"declared"` when ready to enforce the boundary.
 
 > **`explores`/`export {}` are a discovery filter; `queryableSources` decides if they also gate queries; `#(authorize)` is the identity gate.** With `queryableSources: "all"`, hiding a source only removes it from listings — it stays queryable by name. To restrict *who* can query (as opposed to *what* is queryable), gate the source with `#(authorize)` (see [docs/authorize.md](docs/authorize.md)); those gates are enforced against the complete source set and are never weakened by listing or boundary curation.
+>
+> The `queryableSources` boundary applies to the *query* surface (`getQueryResults`, the MCP query tool, and `/compile`). It does **not** cover raw retrieval by exact path — a hidden model's file text and its compiled metadata are still fetchable by path — by design; use `#(authorize)` when the contents themselves must be protected, not just removed from discovery.
 
 Validation is asymmetric by design: **publishing** a package with an `explores` entry that doesn't resolve to a real model is rejected with a `400`, while at **startup/reload** the package still serves but hides the unresolved entry (it never falls back to listing everything) and surfaces the reason in the package's `exploresWarnings` field.
 

--- a/README.md
+++ b/README.md
@@ -299,6 +299,38 @@ A package can ship a `public/` directory of web files (an `index.html` plus CSS,
 
 For local development, start the server with `--watch-env <env>` (or `PUBLISHER_WATCH=<env>`). Publisher then mounts that environment's local-dir packages in place and watches them: editing a `.malloy` recompiles the package, editing an asset refreshes the page, and open pages live-reload over a server-sent-events stream at `GET .../packages/<pkg>/events`. See `examples/html-data-app/` for a worked example, and [docs/html-data-apps.md](docs/html-data-apps.md) for the full authoring reference (the `Publisher.query` / `Publisher.embed` API, the page and event contracts, and the security model).
 
+## Controlling the discovery surface
+
+Declaring `explores` in `publisher.json` is the **single opt-in** for curated discovery. When absent or empty, every model is listed with its full source set — today's backward-compatible behavior.
+
+A package's manifest can scope which models and sources appear in listings (the surface that drives discovery and chat), at two granularities that **both apply only after `explores` is declared**:
+
+- **File level — `explores`.** An optional `string[]` of `.malloy` file paths (relative to the package root) that form the package's public surface. When present, only those models are returned by `listModels()`; every other `.malloy` file still compiles for import/join resolution and stays queryable, but is hidden from listings. When absent or empty, every model is listed. Notebooks are always listed regardless of this field (they can't be imported, so they have nothing to hide behind).
+
+  ```json
+  {
+    "name": "sales",
+    "description": "Sales models",
+    "explores": ["index.malloy"]
+  }
+  ```
+
+- **Within a file — `export { … }`.** Once `explores` is declared, the discovery accessors list only the model's re-export closure (`modelDef.exports`), matching what Malloy's `modelInfo`/`sourceInfos` expose. A model with no `export { … }` exports all of its locally-declared top-level sources; declaring `export { customers }` lists only `customers` and keeps imported/internal helpers out.
+
+The two compose: `explores` decides which files are listed, and `export { … }` decides which sources within a listed file are shown.
+
+- **Query boundary — `queryableSources`.** Controls whether that discovery surface is *also* a query boundary. `"declared"` (the default) makes **queryable == discoverable**: when `explores` is declared, only `explores` files — and within them only the `export {}` closure — are valid top-level query targets; every other source still compiles, imports, joins, and extends, but a direct query against it is denied with a `404` (indistinguishable from a non-existent target). `"all"` decouples the axes — `explores`/`export {}` gate discovery only and every compiled source stays directly queryable. When `explores` is absent there is no curated surface, so both modes are equivalent (everything queryable).
+
+  ```json
+  { "name": "sales", "explores": ["index.malloy"], "queryableSources": "all" }
+  ```
+
+  For gradual migration, use `explores` with `queryableSources: "all"` to curate listings while keeping every source queryable by name; switch to `"declared"` when ready to enforce the boundary.
+
+> **`explores`/`export {}` are a discovery filter; `queryableSources` decides if they also gate queries; `#(authorize)` is the identity gate.** With `queryableSources: "all"`, hiding a source only removes it from listings — it stays queryable by name. To restrict *who* can query (as opposed to *what* is queryable), gate the source with `#(authorize)` (see [docs/authorize.md](docs/authorize.md)); those gates are enforced against the complete source set and are never weakened by listing or boundary curation.
+
+Validation is asymmetric by design: **publishing** a package with an `explores` entry that doesn't resolve to a real model is rejected with a `400`, while at **startup/reload** the package still serves but hides the unresolved entry (it never falls back to listing everything) and surfaces the reason in the package's `exploresWarnings` field.
+
 ## Community
 
 - Join the [Malloy Slack](https://join.slack.com/t/malloy-community/shared_invite/zt-1kgfwgi5g-CrsdaRqs81QY67QW0~t_uw)

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -1429,6 +1429,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Package"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "500":
@@ -1526,6 +1528,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Package"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -2661,6 +2665,50 @@ components:
           type: string
           description: Package location, can be an absolute path or URI (e.g. github, s3,
             gcs, etc.)
+        explores:
+          type: array
+          items:
+            type: string
+          description: >-
+            Optional opt-in for curated discovery. When present, only these
+            model file paths (relative to the package root) are listed via
+            `listModels()`, and within-file discovery is filtered to each
+            model's `export {}` closure. When absent or empty, every model is
+            listed with its full source set (backward-compatible). Every other
+            .malloy file still compiles for import/join resolution but is
+            hidden from listings once `explores` is declared. Notebooks are
+            always listed regardless of this field.
+        exploresWarnings:
+          type: array
+          readOnly: true
+          items:
+            type: string
+          description: >-
+            Actionable messages for declared explores that do not resolve to
+            a real model in this package (e.g. a misspelled path, or a notebook
+            listed as an explore). Server-computed and read-only: it is
+            ignored on create/update requests and only ever returned in
+            responses. Present only when there are such problems. Loading is
+            fail-safe — the unresolved entry simply lists nothing rather than
+            exposing everything — so this is the signal that a package is
+            misconfigured; publishing such a package is rejected.
+        queryableSources:
+          type: string
+          enum:
+            - declared
+            - all
+          description: >-
+            Controls whether the discovery surface is also a query boundary.
+            `"declared"` (the default) makes queryable == discoverable: when
+            `explores` is declared, only `explores` model files — and within
+            them only the `export {}` closure — are valid top-level query
+            targets; every other source still compiles, imports, joins, and
+            extends but is not directly queryable (denied with 404). `"all"`
+            decouples them: `explores`/`export {}` gate discovery only and every
+            compiled source stays directly queryable. When `explores` is absent
+            there is no curated surface, so both modes are equivalent
+            (everything queryable). Invalid values fall back to `"declared"`.
+            Identity-based access is a separate concern — see `#(authorize)`.
 
     Model:
       type: object

--- a/packages/sdk/src/components/Model/Model.tsx
+++ b/packages/sdk/src/components/Model/Model.tsx
@@ -45,6 +45,22 @@ export default function Model({
    const [sharedSourceIndex, setSharedSourceIndex] = React.useState(0);
    const [copyMessage, setCopyMessage] = useState("");
 
+   // Whether the model imports other files — drives the empty-state hint for
+   // import-only models, whose discovery surface is legitimately empty (no
+   // local sources, no export{}) but whose page would otherwise render blank.
+   // `modelDef` is returned by the server but intentionally absent from the
+   // typed CompiledModel schema (internal compiler blob), hence the cast.
+   const modelDefJson = (data as { modelDef?: string } | undefined)?.modelDef;
+   const hasImports = React.useMemo(() => {
+      if (!modelDefJson) return false;
+      try {
+         const def = JSON.parse(modelDefJson) as { imports?: unknown[] };
+         return Array.isArray(def.imports) && def.imports.length > 0;
+      } catch {
+         return false;
+      }
+   }, [modelDefJson]);
+
    if (isLoading) {
       return <Loading text="Fetching Model..." />;
    }
@@ -195,6 +211,29 @@ export default function Model({
                   ))}
                </Stack>
             )}
+
+            {/* Empty discovery surface: nothing exported, nothing to render.
+                For import-only models, say why and how to fix it — otherwise
+                the page reads as broken. */}
+            {(!Array.isArray(data?.sourceInfos) ||
+               data.sourceInfos.length === 0) &&
+               !(data?.queries && data.queries.length > 0) && (
+                  <Box sx={{ textAlign: "center", py: 6 }}>
+                     <Typography
+                        variant="body1"
+                        sx={{ color: "text.secondary", marginBottom: "8px" }}
+                     >
+                        This model exposes no sources or queries.
+                     </Typography>
+                     {hasImports && (
+                        <Typography variant="body2" color="text.secondary">
+                           It imports other files but re-exports nothing. Add{" "}
+                           <code>export {"{ source_name }"}</code> to surface
+                           imported sources here.
+                        </Typography>
+                     )}
+                  </Box>
+               )}
 
             {/* Model Explorer Dialog */}
             <ModelExplorerDialog

--- a/packages/server/src/constants.ts
+++ b/packages/server/src/constants.ts
@@ -5,6 +5,18 @@ export const PUBLISHER_CONFIG_NAME = "publisher.config.json";
 export const PACKAGE_MANIFEST_NAME = "publisher.json";
 export const MODEL_FILE_SUFFIX = ".malloy";
 export const NOTEBOOK_FILE_SUFFIX = ".malloynb";
+
+/**
+ * Normalize a package-relative model path so author-written `explores`
+ * entries compare equal to the paths produced by `listPackageFiles`
+ * (forward slashes, no leading "./"). Shared by every input channel — the
+ * worker's on-disk parse and the API publish/update path — so a manifest
+ * behaves the same whether it's loaded from disk or written via the API.
+ */
+export function normalizeModelPath(p: string): string {
+   return p.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
 /**
  * Default row cap applied to Malloy model queries (the `runnable.run`
  * path used by `getQueryResults` and notebook cell execution) when

--- a/packages/server/src/controller/package.controller.spec.ts
+++ b/packages/server/src/controller/package.controller.spec.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import sinon from "sinon";
+
+import { BadRequestError } from "../errors";
+import type { EnvironmentStore } from "../service/environment_store";
+import type { ManifestService } from "../service/manifest_service";
+import { PackageController } from "./package.controller";
+
+describe("PackageController.addPackage explores validation", () => {
+   afterEach(() => {
+      sinon.restore();
+   });
+
+   it("no-location: rejects invalid explores and rolls back via unloadPackage (NOT deletePackage)", async () => {
+      // The no-location path registers a PRE-EXISTING user directory, so a bad
+      // manifest must unload it from memory — never deletePackage, which would
+      // delete the user's files.
+      const invalidMsg =
+         "Invalid explores entry 'missing.malloy' in publisher.json: file not found";
+      const mockPackage = {
+         formatInvalidExplores: () => invalidMsg,
+      };
+      const unloadPackage = sinon.stub().resolves(undefined);
+      const deletePackage = sinon.stub().resolves(undefined);
+      const addPackage = sinon.stub().resolves(mockPackage);
+      const environment = { addPackage, unloadPackage, deletePackage };
+      const getEnvironment = sinon.stub().resolves(environment);
+      const addPackageToDatabase = sinon.stub().resolves(undefined);
+      const environmentStore = {
+         publisherConfigIsFrozen: false,
+         getEnvironment,
+         addPackageToDatabase,
+      } as unknown as EnvironmentStore;
+
+      const controller = new PackageController(
+         environmentStore,
+         {} as ManifestService,
+      );
+
+      await expect(
+         controller.addPackage("env", {
+            name: "pkg",
+            description: "test",
+            explores: ["missing.malloy"],
+         }),
+      ).rejects.toBeInstanceOf(BadRequestError);
+
+      expect(unloadPackage.calledOnceWith("pkg")).toBe(true);
+      expect(deletePackage.called).toBe(false);
+      expect(addPackageToDatabase.called).toBe(false);
+   });
+
+   it("location: validation runs inside installPackage's rollback window, not as a controller delete", async () => {
+      // For the location path the tree was freshly downloaded, so validation is
+      // delegated to installPackage (which rolls the swap back on failure). The
+      // controller passes a validator and does NOT call delete/unload itself.
+      const invalidMsg =
+         "Invalid explores entry 'missing.malloy' in publisher.json: file not found";
+      const mockPackage = { formatInvalidExplores: () => invalidMsg };
+      // installPackage mimics the real contract: invoke the validator and, if it
+      // returns a message, throw BadRequestError (after its internal rollback).
+      const installPackage = sinon
+         .stub()
+         .callsFake(
+            async (
+               _name: string,
+               _downloader: unknown,
+               validate?: (pkg: unknown) => string | undefined,
+            ) => {
+               const msg = validate?.(mockPackage);
+               if (msg) throw new BadRequestError(msg);
+               return mockPackage;
+            },
+         );
+      const unloadPackage = sinon.stub().resolves(undefined);
+      const deletePackage = sinon.stub().resolves(undefined);
+      const environment = { installPackage, unloadPackage, deletePackage };
+      const getEnvironment = sinon.stub().resolves(environment);
+      const addPackageToDatabase = sinon.stub().resolves(undefined);
+      const environmentStore = {
+         publisherConfigIsFrozen: false,
+         getEnvironment,
+         addPackageToDatabase,
+      } as unknown as EnvironmentStore;
+
+      const controller = new PackageController(
+         environmentStore,
+         {} as ManifestService,
+      );
+
+      await expect(
+         controller.addPackage("env", {
+            name: "pkg",
+            description: "test",
+            location: "gs://bucket/pkg.zip",
+            explores: ["missing.malloy"],
+         }),
+      ).rejects.toBeInstanceOf(BadRequestError);
+
+      expect(installPackage.calledOnce).toBe(true);
+      expect(typeof installPackage.firstCall.args[2]).toBe("function");
+      expect(deletePackage.called).toBe(false);
+      expect(unloadPackage.called).toBe(false);
+      expect(addPackageToDatabase.called).toBe(false);
+   });
+
+   it("persists when explores are valid (no-location)", async () => {
+      const mockPackage = {
+         formatInvalidExplores: () => "",
+      };
+      const addPackage = sinon.stub().resolves(mockPackage);
+      const getEnvironment = sinon.stub().resolves({ addPackage });
+      const addPackageToDatabase = sinon.stub().resolves(undefined);
+      const environmentStore = {
+         publisherConfigIsFrozen: false,
+         getEnvironment,
+         addPackageToDatabase,
+      } as unknown as EnvironmentStore;
+
+      const controller = new PackageController(
+         environmentStore,
+         {} as ManifestService,
+      );
+
+      await controller.addPackage("env", {
+         name: "pkg",
+         description: "test",
+         explores: ["index.malloy"],
+      });
+
+      expect(addPackageToDatabase.calledOnceWith("env", "pkg")).toBe(true);
+   });
+});
+
+describe("PackageController.updatePackage explores validation", () => {
+   afterEach(() => {
+      sinon.restore();
+   });
+
+   it("location update: validates the EFFECTIVE explores (body override) before the swap commits", async () => {
+      // body.location triggers a reinstall (atomic swap). The effective explores
+      // — the body override here — must be validated inside installPackage so a
+      // bad update rolls back to the previous tree instead of swapping in the
+      // rejected one and 400-ing after the fact.
+      const invalidMsg =
+         "Invalid explores entry 'nope.malloy' in publisher.json: file not found";
+      // The mock package validates whatever override it's handed.
+      const mockPackage = {
+         formatInvalidExplores: (override?: string[]) =>
+            override?.includes("nope.malloy") ? invalidMsg : "",
+      };
+      const installPackage = sinon
+         .stub()
+         .callsFake(
+            async (
+               _name: string,
+               _downloader: unknown,
+               validate?: (pkg: unknown) => string | undefined,
+            ) => {
+               const msg = validate?.(mockPackage);
+               if (msg) throw new BadRequestError(msg);
+               return mockPackage;
+            },
+         );
+      const updatePackage = sinon.stub().resolves(mockPackage);
+      const environment = { installPackage, updatePackage };
+      const getEnvironment = sinon.stub().resolves(environment);
+      const addPackageToDatabase = sinon.stub().resolves(undefined);
+      const environmentStore = {
+         publisherConfigIsFrozen: false,
+         getEnvironment,
+         addPackageToDatabase,
+      } as unknown as EnvironmentStore;
+
+      const controller = new PackageController(
+         environmentStore,
+         {} as ManifestService,
+      );
+
+      await expect(
+         controller.updatePackage("env", "pkg", {
+            name: "pkg",
+            location: "gs://bucket/pkg.zip",
+            explores: ["nope.malloy"],
+         }),
+      ).rejects.toBeInstanceOf(BadRequestError);
+
+      // The rejected swap never reached the metadata-apply / persist steps.
+      expect(updatePackage.called).toBe(false);
+      expect(addPackageToDatabase.called).toBe(false);
+   });
+});

--- a/packages/server/src/controller/package.controller.ts
+++ b/packages/server/src/controller/package.controller.ts
@@ -1,4 +1,5 @@
 import { components } from "../api";
+import { normalizeModelPath } from "../constants";
 import { BadRequestError, FrozenConfigError } from "../errors";
 import { logger } from "../logger";
 import { EnvironmentStore } from "../service/environment_store";
@@ -231,7 +232,10 @@ export class PackageController {
                   bodyLocation,
                   stagingPath,
                ),
-            (pkg) => pkg.formatInvalidExplores(body.explores),
+            (pkg) =>
+               pkg.formatInvalidExplores(
+                  body.explores?.map(normalizeModelPath),
+               ),
          );
       }
       // Apply metadata changes (publisher.json) under the same per-package

--- a/packages/server/src/controller/package.controller.ts
+++ b/packages/server/src/controller/package.controller.ts
@@ -86,20 +86,53 @@ export class PackageController {
          environmentName,
          false,
       );
+      // Strict at publish: the author is in the loop here, so reject a bad
+      // explores with an actionable 400 instead of silently serving a hidden
+      // surface. (At startup/reload we fail safe and only warn — see
+      // Package.loadViaWorker.) The rollback differs by path so a rejected
+      // publish never destroys user content:
+      //   - location: the tree was just downloaded into a fresh canonical, so
+      //     validation runs inside installPackage's swap window and a failure
+      //     wipes that download (the existing rollback) — nothing pre-existing
+      //     to lose.
+      //   - no-location: addPackage registered a *pre-existing* user directory,
+      //     so we validate after the fact and `unloadPackage` (evict from
+      //     memory, keep the files) rather than delete it.
       let result;
       if (body.location) {
          const bodyLocation = body.location;
-         result = await environment.installPackage(packageName, (stagingPath) =>
-            this.downloadInto(
-               environmentName,
-               packageName,
-               bodyLocation,
-               stagingPath,
-            ),
+         result = await environment.installPackage(
+            packageName,
+            (stagingPath) =>
+               this.downloadInto(
+                  environmentName,
+                  packageName,
+                  bodyLocation,
+                  stagingPath,
+               ),
+            (pkg) => pkg.formatInvalidExplores(),
          );
       } else {
          result = await environment.addPackage(packageName);
       }
+
+      // `addPackage`/`installPackage` are typed `Package | undefined`; a missing
+      // result here is a should-never-happen internal fault. Fail loudly rather
+      // than letting optional chaining silently skip the validation below.
+      if (!result) {
+         throw new Error(`Failed to create package ${packageName}`);
+      }
+
+      if (!body.location) {
+         const invalidMsg = result.formatInvalidExplores();
+         if (invalidMsg) {
+            await environment.unloadPackage(packageName).catch(() => {
+               /* best-effort; the package is not persisted below */
+            });
+            throw new BadRequestError(invalidMsg);
+         }
+      }
+
       await this.environmentStore.addPackageToDatabase(
          environmentName,
          packageName,
@@ -184,15 +217,21 @@ export class PackageController {
       );
       if (body.location) {
          // Re-install: stream the new content into a staging dir (no lock)
-         // and atomically swap it in (under the lock).
+         // and atomically swap it in (under the lock). Validate the effective
+         // explores (the body override, else the new tree's own manifest)
+         // INSIDE the swap window, so a rejected update rolls back to the
+         // previous tree instead of swapping the bad one in and 400-ing after.
          const bodyLocation = body.location;
-         await environment.installPackage(packageName, (stagingPath) =>
-            this.downloadInto(
-               environmentName,
-               packageName,
-               bodyLocation,
-               stagingPath,
-            ),
+         await environment.installPackage(
+            packageName,
+            (stagingPath) =>
+               this.downloadInto(
+                  environmentName,
+                  packageName,
+                  bodyLocation,
+                  stagingPath,
+               ),
+            (pkg) => pkg.formatInvalidExplores(body.explores),
          );
       }
       // Apply metadata changes (publisher.json) under the same per-package

--- a/packages/server/src/dto/package.dto.ts
+++ b/packages/server/src/dto/package.dto.ts
@@ -1,4 +1,10 @@
-import { IsString, IsNotEmpty } from "class-validator";
+import {
+   IsString,
+   IsNotEmpty,
+   IsOptional,
+   IsArray,
+   IsIn,
+} from "class-validator";
 import { ApiPackage } from "../service/package";
 
 export class PackageDto implements ApiPackage {
@@ -9,4 +15,13 @@ export class PackageDto implements ApiPackage {
    @IsString()
    @IsNotEmpty()
    description: string;
+
+   @IsOptional()
+   @IsArray()
+   @IsString({ each: true })
+   explores?: string[];
+
+   @IsOptional()
+   @IsIn(["declared", "all"])
+   queryableSources?: "declared" | "all";
 }

--- a/packages/server/src/errors.spec.ts
+++ b/packages/server/src/errors.spec.ts
@@ -6,6 +6,7 @@ import {
    ConnectionError,
    internalErrorToHttpError,
    ModelCompilationError,
+   NotQueryableError,
    PayloadTooLargeError,
    QueryTimeoutError,
    ServiceUnavailableError,
@@ -39,6 +40,17 @@ describe("internalErrorToHttpError", () => {
       expect(json).toEqual({
          code: 403,
          message: 'Access denied for source "gated".',
+      });
+   });
+
+   it("maps NotQueryableError to 404 (explore boundary)", () => {
+      const { status, json } = internalErrorToHttpError(
+         new NotQueryableError('No queryable source "hidden".'),
+      );
+      expect(status).toBe(404);
+      expect(json).toEqual({
+         code: 404,
+         message: 'No queryable source "hidden".',
       });
    });
 

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -14,6 +14,8 @@ export function internalErrorToHttpError(error: Error) {
       return httpError(404, error.message);
    } else if (error instanceof ModelNotFoundError) {
       return httpError(404, error.message);
+   } else if (error instanceof NotQueryableError) {
+      return httpError(404, error.message);
    } else if (error instanceof MalloyError) {
       return httpError(400, error.message);
    } else if (error instanceof ConnectionNotFoundError) {
@@ -125,6 +127,22 @@ export class AccessDeniedError extends Error {
    constructor(message: string) {
       super(message);
       this.name = "AccessDeniedError";
+   }
+}
+
+/**
+ * A query targeted a source/model that is not part of the package's queryable
+ * surface under `queryableSources: "declared"` (a non-`explores` model file, or
+ * a source not in a model's `export {}` closure). Mapped to HTTP **404**, not
+ * 403, and with a deliberately generic message: unlike `#(authorize)` (which is
+ * identity-scoped and answers "who"), the explore boundary is identity-free and
+ * answers "what is queryable" — so a hidden target should be indistinguishable
+ * from a non-existent one (no enumeration / existence oracle).
+ */
+export class NotQueryableError extends Error {
+   constructor(message: string) {
+      super(message);
+      this.name = "NotQueryableError";
    }
 }
 

--- a/packages/server/src/health.spec.ts
+++ b/packages/server/src/health.spec.ts
@@ -25,6 +25,18 @@ describe("performGracefulShutdownAfterDrain: shutdown ordering", () => {
    const originalExit = process.exit;
    let callOrder: string[];
 
+   afterAll(async () => {
+      // performGracefulShutdownAfterDrain drains the package-load worker pool
+      // via getPackageLoadPool().shutdown() — which lazily CREATES the global
+      // singleton and leaves it installed in its shut-down state. In prod the
+      // process exits right after, so that's fine; in this shared test process
+      // it poisons every later spec that touches the worker path
+      // (Package.create → "PackageLoadPool is shutting down"), with failures
+      // that come and go with bun's platform-dependent file order. Reset the
+      // singleton so the next user lazily creates a fresh pool.
+      await __setPackageLoadPoolForTests(null);
+   });
+
    beforeEach(() => {
       callOrder = [];
 

--- a/packages/server/src/package_load/package_load_pool.ts
+++ b/packages/server/src/package_load/package_load_pool.ts
@@ -248,7 +248,7 @@ export interface LoadPackageOutcome {
 // ──────────────────────────────────────────────────────────────────────
 
 /**
- * Locate the worker explore. In production builds it's bundled to
+ * Locate the worker entrypoint. In production builds it's bundled to
  * `dist/package_load_worker.mjs` next to `server.mjs`. In dev
  * (bun --watch) the source `.ts` next to this file loads directly —
  * Bun supports `new Worker(<ts-url>)`. The .ts fallback also keeps

--- a/packages/server/src/package_load/package_load_pool.ts
+++ b/packages/server/src/package_load/package_load_pool.ts
@@ -228,7 +228,12 @@ export interface LoadPackageJob {
  * don't allocate a Map for models the caller never looks at.
  */
 export interface LoadPackageOutcome {
-   packageMetadata: { name?: string; description?: string };
+   packageMetadata: {
+      name?: string;
+      description?: string;
+      explores?: string[];
+      queryableSources?: "declared" | "all";
+   };
    models: Array<
       Omit<SerializedModel, "modelDef" | "sourceInfos"> & {
          modelDef?: ModelDef;
@@ -243,7 +248,7 @@ export interface LoadPackageOutcome {
 // ──────────────────────────────────────────────────────────────────────
 
 /**
- * Locate the worker entrypoint. In production builds it's bundled to
+ * Locate the worker explore. In production builds it's bundled to
  * `dist/package_load_worker.mjs` next to `server.mjs`. In dev
  * (bun --watch) the source `.ts` next to this file loads directly —
  * Bun supports `new Worker(<ts-url>)`. The .ts fallback also keeps

--- a/packages/server/src/package_load/package_load_worker.ts
+++ b/packages/server/src/package_load/package_load_worker.ts
@@ -75,6 +75,7 @@ import { fileURLToPath, pathToFileURL } from "url";
 
 import {
    MODEL_FILE_SUFFIX,
+   normalizeModelPath,
    NOTEBOOK_FILE_SUFFIX,
    PACKAGE_MANIFEST_NAME,
 } from "../constants";
@@ -414,16 +415,10 @@ function filterModelPaths(allRelative: string[]): string[] {
    );
 }
 
-// Normalize a package-relative model path so author-written `explores`
-// entries compare equal to the paths produced by `listPackageFiles`
-// (forward slashes, no leading "./"). Normalization is one-sided: it runs
-// here at parse time so the keys stored in Package.models are already
-// normalized, and listModels()/getInvalidExplores() compare explores
-// against those keys directly — there is no second normalization to keep in
-// sync on the listing side.
-function normalizeModelPath(p: string): string {
-   return p.replace(/\\/g, "/").replace(/^\.\//, "");
-}
+// `normalizeModelPath` (shared, from ../constants) runs here at parse time so
+// the keys stored in Package.models are already normalized, and the API
+// publish/update path normalizes its `explores` input through the same helper —
+// so on-disk and API-written manifests share one representation.
 
 // explores validation is intentionally NOT done here. The worker is the
 // shared load path (startup, reload, AND publish), but the policy differs by

--- a/packages/server/src/package_load/package_load_worker.ts
+++ b/packages/server/src/package_load/package_load_worker.ts
@@ -375,16 +375,30 @@ function buildWorkerMalloyConfig(job: LoadPackageRequest): MalloyConfig {
 // stays decoupled from the main-thread service module graph)
 // ──────────────────────────────────────────────────────────────────────
 
-async function readPackageMetadata(
-   packagePath: string,
-): Promise<{ name?: string; description?: string }> {
+async function readPackageMetadata(packagePath: string): Promise<{
+   name?: string;
+   description?: string;
+   explores?: string[];
+   queryableSources?: "declared" | "all";
+}> {
    const manifestPath = path.join(packagePath, PACKAGE_MANIFEST_NAME);
    const contents = await fs.promises.readFile(manifestPath, "utf8");
    const parsed = JSON.parse(contents) as {
       name?: string;
       description?: string;
+      explores?: string[];
+      queryableSources?: unknown;
    };
-   return { name: parsed.name, description: parsed.description };
+   return {
+      name: parsed.name,
+      description: parsed.description,
+      explores: Array.isArray(parsed.explores)
+         ? parsed.explores.map(normalizeModelPath)
+         : undefined,
+      // Default + invalid fall back to "declared" (fail-safe: queryable ==
+      // discoverable). Only an explicit "all" opts out of the query boundary.
+      queryableSources: parsed.queryableSources === "all" ? "all" : "declared",
+   };
 }
 
 async function listPackageFiles(packagePath: string): Promise<string[]> {
@@ -399,6 +413,24 @@ function filterModelPaths(allRelative: string[]): string[] {
       (p) => p.endsWith(MODEL_FILE_SUFFIX) || p.endsWith(NOTEBOOK_FILE_SUFFIX),
    );
 }
+
+// Normalize a package-relative model path so author-written `explores`
+// entries compare equal to the paths produced by `listPackageFiles`
+// (forward slashes, no leading "./"). Normalization is one-sided: it runs
+// here at parse time so the keys stored in Package.models are already
+// normalized, and listModels()/getInvalidExplores() compare explores
+// against those keys directly — there is no second normalization to keep in
+// sync on the listing side.
+function normalizeModelPath(p: string): string {
+   return p.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+// explores validation is intentionally NOT done here. The worker is the
+// shared load path (startup, reload, AND publish), but the policy differs by
+// context — strict-reject at publish, warn-and-fail-safe at load — so it lives
+// on the main thread (see Package.getInvalidExplores / loadViaWorker and the
+// publish path in package.controller). An unmatched entry simply lists nothing
+// (listModels filters by set membership), which is the fail-safe outcome.
 
 // ──────────────────────────────────────────────────────────────────────
 // Model compile (mirrors service/model.ts but produces SerializedModel)
@@ -558,6 +590,10 @@ async function compileMalloyModel(
       modelDef,
       modelInfo: modelDefToModelInfo(modelDef),
       sourceInfos,
+      // `sources`/`queries` ship complete (authorize + filter enforcement and
+      // join resolution read the full set); the Model's discovery accessors
+      // filter them down to the export closure (`modelDef.exports`) to match
+      // `modelInfo`/`sourceInfos`.
       sources,
       queries,
       filterMap: Array.from(filterMap.entries()),
@@ -800,6 +836,7 @@ async function loadPackage(
 
    const allFiles = await listPackageFiles(job.packagePath);
    const modelPaths = filterModelPaths(allFiles);
+
    const models = await Promise.all(
       modelPaths.map((modelPath) =>
          compileOneModel(job, malloyConfig, modelPath),

--- a/packages/server/src/package_load/protocol.ts
+++ b/packages/server/src/package_load/protocol.ts
@@ -173,7 +173,12 @@ export interface SerializedNotebookCell {
 export interface LoadPackageResult {
    type: "load-package-result";
    requestId: string;
-   packageMetadata: { name?: string; description?: string };
+   packageMetadata: {
+      name?: string;
+      description?: string;
+      explores?: string[];
+      queryableSources?: "declared" | "all";
+   };
    models: SerializedModel[];
    /** Wall-clock ms inside the worker for the full package load. */
    loadDurationMs: number;

--- a/packages/server/src/service/environment.ts
+++ b/packages/server/src/service/environment.ts
@@ -9,6 +9,7 @@ import { pathToFileURL } from "url";
 import { components } from "../api";
 import { API_PREFIX, README_NAME } from "../constants";
 import {
+   BadRequestError,
    ConnectionNotFoundError,
    EnvironmentNotFoundError,
    PackageNotFoundError,
@@ -365,6 +366,14 @@ export class Environment {
          // and compilation surfaces its own error.
          const gateModel = pkg.getModel(modelName);
          if (gateModel) {
+            // Query boundary first (the *what* axis): /compile compiles ad-hoc
+            // text against a model, so gate it like an ad-hoc query — a
+            // non-`explores` model file, or text whose surface-resolved target
+            // is a non-curated model source (under queryableSources:
+            // "declared"), is rejected with a generic 404 before compilation
+            // can leak schema/SQL. Text the early gate can't pin is settled by
+            // the compiled backstop below.
+            gateModel.assertQueryBoundaryEarly(undefined, undefined, source);
             await gateModel.assertAuthorizedForText(source, givens ?? {});
          }
 
@@ -392,8 +401,8 @@ export class Environment {
                // gate or extract beyond the early text gate already applied.
             }
 
-            // Compiled-source backstop — runs REGARDLESS of includeSql. It gates
-            // the source the COMPILED final query actually reads, closing
+            // Compiled-source backstops — run REGARDLESS of includeSql. They
+            // gate the source the COMPILED final query actually reads, closing
             // named-query / multi-statement indirection the early surface-syntax
             // gate misses (e.g. `run: ungated\nrun: gated` — the early gate only
             // matches the FIRST `run:`, but the LAST statement is what executes).
@@ -401,9 +410,26 @@ export class Environment {
             // (field-not-found errors leak its columns), so this must not be
             // conditional on SQL extraction. (A `source: x is gated` alias makes
             // a new ungated source — that's the documented "extend doesn't
-            // inherit authorize" footgun, the same as the query path.) Only run
-            // when the model declares gates so ungated compiles don't pay for
-            // the extra final-query compile.
+            // inherit authorize" footgun, the same as the query path.)
+
+            // Boundary backstop (the *what* axis, 404) before the authorize
+            // one (the *who* axis, 403). /compile text is always ad-hoc — the
+            // early gate can only positively deny, never fully clear — so the
+            // compiled final query's run target is the authority. Self-gates
+            // internally (no-ops when the boundary is inert: "all" / no
+            // explores), so it is deliberately NOT guarded by hasAuthorize().
+            // Text that compiles only source definitions (no final query) has
+            // no run target and nothing to gate.
+            if (queryMaterializer && gateModel) {
+               await gateModel.assertQueryBoundaryForRunnable(
+                  queryMaterializer,
+                  source,
+               );
+            }
+
+            // Authorize backstop (the *who* axis, 403). Only run when the model
+            // declares gates so ungated compiles don't pay for the extra
+            // final-query compile.
             if (queryMaterializer && gateModel?.hasAuthorize()) {
                await gateModel.assertAuthorizedForRunnable(
                   queryMaterializer,
@@ -897,6 +923,7 @@ export class Environment {
    public async installPackage(
       packageName: string,
       downloader: (stagingPath: string) => Promise<void>,
+      validate?: (pkg: Package) => string | undefined,
    ): Promise<Package> {
       assertSafePackageName(packageName);
       const stagingPath = this.allocateStagingPath(packageName);
@@ -963,6 +990,15 @@ export class Environment {
                canonicalPath,
                () => this.malloyConfig.malloyConfig,
             );
+            // Strict-reject hook (publish/update only — reload passes no
+            // validator and stays fail-safe). Throw INSIDE the try so the
+            // catch below rolls the swap back: the just-installed tree is
+            // wiped and the retired tree (if any) is restored, so a rejected
+            // publish/update never leaves the bad tree served on disk.
+            const validationMsg = validate?.(newPackage);
+            if (validationMsg) {
+               throw new BadRequestError(validationMsg);
+            }
             logger.debug("install.phase2.committed", {
                environmentName: this.environmentName,
                packageName,
@@ -1086,7 +1122,12 @@ export class Environment {
 
    private async writePackageManifest(
       packageName: string,
-      metadata: { name: string; description?: string },
+      metadata: {
+         name: string;
+         description?: string;
+         explores?: string[];
+         queryableSources?: "declared" | "all";
+      },
    ): Promise<void> {
       const packagePath = safeJoinUnderRoot(this.environmentPath, packageName);
       const manifestPath = safeJoinUnderRoot(packagePath, "publisher.json");
@@ -1101,11 +1142,20 @@ export class Environment {
             logger.warn(`Could not read manifest for ${packageName}`);
          }
 
-         // Update with new metadata
+         // Update with new metadata. `explores`/`queryableSources` are only
+         // overwritten when the caller explicitly provides them; otherwise the
+         // existing on-disk value is preserved via the spread (an undefined here
+         // must not erase it).
          const updatedManifest = {
             ...existingManifest,
             name: metadata.name,
             description: metadata.description,
+            ...(metadata.explores !== undefined
+               ? { explores: metadata.explores }
+               : {}),
+            ...(metadata.queryableSources !== undefined
+               ? { queryableSources: metadata.queryableSources }
+               : {}),
          };
 
          // Write back to file
@@ -1132,16 +1182,44 @@ export class Environment {
          if (body.name) {
             _package.setName(body.name);
          }
+         // Preserve `explores` across a metadata PATCH. `setPackageMetadata`
+         // replaces the whole object, so a name/description-only update must
+         // carry the existing discovery surface through — otherwise the
+         // in-memory `explores` is wiped and `listModels()` silently starts
+         // serving every model until the next reload. When the body explicitly
+         // carries `explores`, honor the new set instead.
+         const existing = _package.getPackageMetadata();
+         const explores =
+            body.explores !== undefined ? body.explores : existing.explores;
+         const queryableSources =
+            body.queryableSources !== undefined
+               ? body.queryableSources
+               : existing.queryableSources;
          _package.setPackageMetadata({
             name: body.name,
             description: body.description,
             resource: body.resource,
             location: body.location,
+            explores,
+            queryableSources,
          });
+
+         // Strict-reject, symmetric with the publish path
+         // (package.controller.addPackage): validate the resulting explores
+         // against the live model set and restore the prior metadata before
+         // rejecting, so a bad update neither persists nor mutates the served
+         // surface.
+         const invalidMsg = _package.formatInvalidExplores();
+         if (invalidMsg) {
+            _package.setPackageMetadata(existing);
+            throw new BadRequestError(invalidMsg);
+         }
 
          await this.writePackageManifest(packageName, {
             name: packageName,
             description: body.description,
+            explores: body.explores,
+            queryableSources: body.queryableSources,
          });
 
          return _package.getPackageMetadata();
@@ -1242,6 +1320,38 @@ export class Environment {
                   });
             });
          }
+      });
+   }
+
+   /**
+    * Evict a package from the in-memory caches WITHOUT touching its on-disk
+    * directory — the non-destructive counterpart to {@link deletePackage}.
+    *
+    * Used to roll back a no-location `addPackage` (which registers a
+    * *pre-existing*, user-owned directory) when post-load validation rejects
+    * it: deleting the tree there would destroy content the publisher never
+    * created. This still drains and closes the connections the just-created
+    * `Package` opened, so the duckdb handle isn't leaked.
+    */
+   public async unloadPackage(packageName: string): Promise<void> {
+      assertSafePackageName(packageName);
+      return this.withPackageLock(packageName, async () => {
+         const _package = this.packages.get(packageName);
+         if (!_package) {
+            return;
+         }
+         if (
+            this.packageStatuses.get(packageName)?.status ===
+            PackageStatus.SERVING
+         ) {
+            this.setPackageStatus(packageName, PackageStatus.UNLOADING);
+         }
+         // Same 30s connection drain as deletePackage — just no fs rename/rm.
+         this.retireConnectionGeneration(`package ${packageName}`, () =>
+            _package.getMalloyConfig().shutdown("close"),
+         );
+         this.packages.delete(packageName);
+         this.packageStatuses.delete(packageName);
       });
    }
 

--- a/packages/server/src/service/environment.ts
+++ b/packages/server/src/service/environment.ts
@@ -7,7 +7,12 @@ import * as fs from "fs";
 import * as path from "path";
 import { pathToFileURL } from "url";
 import { components } from "../api";
-import { API_PREFIX, normalizeModelPath, README_NAME } from "../constants";
+import {
+   API_PREFIX,
+   normalizeModelPath,
+   NOTEBOOK_FILE_SUFFIX,
+   README_NAME,
+} from "../constants";
 import {
    BadRequestError,
    ConnectionNotFoundError,
@@ -297,6 +302,17 @@ export class Environment {
    ): Promise<{ problems: LogMessage[]; sql?: string }> {
       assertSafePackageName(packageName);
       assertSafeRelativeModelPath(modelName);
+      // /compile appends the submitted source to the TARGET MODEL's content for
+      // namespace context. A notebook (.malloynb) is markdown + cells, not a
+      // model, so compiling against it only yields a confusing parse error —
+      // reject it up front with an actionable message. (Notebooks remain public
+      // for discovery/query; this is specific to the compile context.)
+      if (modelName.endsWith(NOTEBOOK_FILE_SUFFIX)) {
+         throw new BadRequestError(
+            `Cannot compile against a notebook ("${modelName}"). ` +
+               `/compile takes a .malloy model path for namespace context.`,
+         );
+      }
       // Hold the per-package mutex for the duration of every disk read —
       // both the explicit `fs.readFile(modelPath)` below and the implicit
       // import resolution that `runtime.loadModel` does through the URL

--- a/packages/server/src/service/environment.ts
+++ b/packages/server/src/service/environment.ts
@@ -7,7 +7,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { pathToFileURL } from "url";
 import { components } from "../api";
-import { API_PREFIX, README_NAME } from "../constants";
+import { API_PREFIX, normalizeModelPath, README_NAME } from "../constants";
 import {
    BadRequestError,
    ConnectionNotFoundError,
@@ -1189,8 +1189,15 @@ export class Environment {
          // serving every model until the next reload. When the body explicitly
          // carries `explores`, honor the new set instead.
          const existing = _package.getPackageMetadata();
+         // Normalize API-body explores through the same helper the worker uses
+         // for on-disk explores, so `["./index.malloy"]` / backslash paths
+         // validate and persist identically regardless of input channel (no
+         // misleading publish-time 400, no publish-vs-reload divergence).
+         const normalizedExplores = body.explores?.map(normalizeModelPath);
          const explores =
-            body.explores !== undefined ? body.explores : existing.explores;
+            normalizedExplores !== undefined
+               ? normalizedExplores
+               : existing.explores;
          const queryableSources =
             body.queryableSources !== undefined
                ? body.queryableSources
@@ -1218,7 +1225,7 @@ export class Environment {
          await this.writePackageManifest(packageName, {
             name: packageName,
             description: body.description,
-            explores: body.explores,
+            explores: normalizedExplores,
             queryableSources: body.queryableSources,
          });
 

--- a/packages/server/src/service/explore_visibility.spec.ts
+++ b/packages/server/src/service/explore_visibility.spec.ts
@@ -1,0 +1,434 @@
+/**
+ * Integration test: Explore Visibility.
+ *
+ * Drives `Package.create` through the package-load worker pool (same harness as
+ * package_worker_path.spec.ts) and verifies, end-to-end, the listing rule:
+ *
+ *   - `explores` in publisher.json hides non-entry .malloy models from
+ *     `listModels()` while they still compile for import/join resolution.
+ *   - Within an explore, only the re-export closure (`export { … }`) is
+ *     listed as sources — imported helpers stay out.
+ *   - A query that joins through a hidden module still resolves.
+ *   - Notebooks are always listed regardless of `explores`.
+ *   - Absent/empty `explores` → every model is listed with the full source set
+ *     (backward compatible; no within-file `export {}` curation).
+ *   - Within-file curation applies only when `explores` is declared.
+ *   - A bogus `explores` path is fail-safe at load (warn + hide, no throw);
+ *     the publish path rejects it (package.controller.spec.ts).
+ */
+import {
+   afterAll,
+   afterEach,
+   beforeAll,
+   beforeEach,
+   describe,
+   expect,
+   it,
+} from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+   PackageLoadPool,
+   __setPackageLoadPoolForTests,
+} from "../package_load/package_load_pool";
+import { Package } from "./package";
+
+const ORIGINAL_ENV = process.env.PACKAGE_LOAD_WORKERS;
+
+describe("Explore Visibility via worker pool", () => {
+   let tempDir: string;
+   let pool: PackageLoadPool;
+
+   beforeAll(async () => {
+      process.env.PACKAGE_LOAD_WORKERS = "1";
+      pool = new PackageLoadPool(1);
+      await __setPackageLoadPoolForTests(pool);
+   });
+
+   afterAll(async () => {
+      await __setPackageLoadPoolForTests(null);
+      if (ORIGINAL_ENV === undefined) delete process.env.PACKAGE_LOAD_WORKERS;
+      else process.env.PACKAGE_LOAD_WORKERS = ORIGINAL_ENV;
+   });
+
+   beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "publisher-explores-"));
+   });
+
+   afterEach(() => {
+      if (tempDir) {
+         try {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+         } catch {
+            /* already gone */
+         }
+         tempDir = "";
+      }
+   });
+
+   async function makeMalloyConfig(): Promise<{
+      malloyConfig: import("@malloydata/malloy").MalloyConfig;
+      duckdb: { close: () => Promise<void> };
+   }> {
+      const { MalloyConfig, FixedConnectionMap } = await import(
+         "@malloydata/malloy"
+      );
+      const { DuckDBConnection } = await import("@malloydata/db-duckdb");
+      const duckdb = new DuckDBConnection("duckdb", ":memory:");
+      const connections = new FixedConnectionMap(
+         new Map([["duckdb", duckdb]]),
+         "duckdb",
+      );
+      const malloyConfig = new MalloyConfig({ connections: {} });
+      malloyConfig.wrapConnections(() => connections);
+      return { malloyConfig, duckdb };
+   }
+
+   function writeManifest(extra: Record<string, unknown> = {}): void {
+      fs.writeFileSync(
+         path.join(tempDir, "publisher.json"),
+         JSON.stringify({ name: "pkg", description: "test package", ...extra }),
+      );
+   }
+
+   // A base module (never an explore) plus a curated index that imports it,
+   // joins through it, and re-exports only `customers`. `helper` is a second
+   // local source the index does NOT export — used to prove within-file curation.
+   function writeLayeredModels(): void {
+      fs.writeFileSync(
+         path.join(tempDir, "base.malloy"),
+         `source: base_source is duckdb.sql("select 1 as id, 'x' as label")`,
+      );
+      fs.writeFileSync(
+         path.join(tempDir, "index.malloy"),
+         `import "base.malloy"
+source: helper is duckdb.sql("select 1 as id")
+source: customers is duckdb.sql("select 1 as id, 100 as amt") extend {
+  join_one: b is base_source on id = b.id
+  measure: total is amt.sum()
+  view: v is { aggregate: total }
+}
+export { customers }`,
+      );
+      fs.writeFileSync(
+         path.join(tempDir, "report.malloynb"),
+         `>>>markdown\n# Sales Report\nA report that is always public.`,
+      );
+   }
+
+   async function listedModelPaths(pkg: Package): Promise<string[]> {
+      return (await pkg.listModels()).map((m) => m.path as string).sort();
+   }
+
+   it("hides non-entry models, curates exports, keeps join-through, lists notebooks", async () => {
+      writeManifest({ explores: ["index.malloy"] });
+      writeLayeredModels();
+
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+
+         // Listing surface: only the explore, not base.malloy.
+         expect(await listedModelPaths(pkg)).toEqual(["index.malloy"]);
+
+         // Within-file curation: only the re-exported `customers`, not the
+         // un-exported `helper`, and not the imported `base_source`.
+         const apiModel = (await pkg.getModel("index.malloy")!.getModel()) as {
+            sources?: { name?: string }[];
+         };
+         expect((apiModel.sources ?? []).map((s) => s.name).sort()).toEqual([
+            "customers",
+         ]);
+
+         // The hidden base module still resolves: index.malloy compiled (above)
+         // and a query that joins through base_source executes.
+         const { result } = await pkg
+            .getModel("index.malloy")!
+            .getQueryResults("customers", "v", undefined);
+         expect(result.data).toBeDefined();
+
+         // Notebooks are always public regardless of explores.
+         expect((await pkg.listNotebooks()).map((n) => n.path)).toEqual([
+            "report.malloynb",
+         ]);
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("keeps enforcing a hidden source's authorize gate (curation ≠ access)", async () => {
+      // base_source is hidden from index.malloy's listing (not re-exported),
+      // but it carries its own #(authorize) gate. Curation must not drop that
+      // gate: getAuthorize reads the COMPLETE source list, not the curated view.
+      writeManifest({ explores: ["index.malloy"] });
+      fs.writeFileSync(
+         path.join(tempDir, "base.malloy"),
+         `#(authorize) "1 = 1"
+source: base_source is duckdb.sql("select 1 as id")`,
+      );
+      fs.writeFileSync(
+         path.join(tempDir, "index.malloy"),
+         `import "base.malloy"
+source: customers is duckdb.sql("select 1 as id, 100 as amt") extend {
+  measure: total is amt.sum()
+}
+export { customers }`,
+      );
+
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const model = pkg.getModel("index.malloy")!;
+
+         // Discovery: base_source is hidden, customers is listed.
+         const apiModel = (await model.getModel()) as {
+            sources?: { name?: string }[];
+         };
+         expect((apiModel.sources ?? []).map((s) => s.name).sort()).toEqual([
+            "customers",
+         ]);
+
+         // Enforcement: the hidden source's gate is still in force.
+         expect(model.getAuthorize("base_source")).toEqual(["1 = 1"]);
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("lists every model and full sources when explores is absent (backward compatible)", async () => {
+      writeManifest();
+      writeLayeredModels();
+
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         expect(await listedModelPaths(pkg)).toEqual([
+            "base.malloy",
+            "index.malloy",
+         ]);
+
+         // No `explores` ⇒ export{} curation off; non-exported `helper` listed.
+         const apiModel = (await pkg.getModel("index.malloy")!.getModel()) as {
+            sources?: { name?: string }[];
+         };
+         const names = (apiModel.sources ?? []).map((s) => s.name).sort();
+         expect(names).toContain("customers");
+         expect(names).toContain("helper");
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("does not curate by export{} without explores; curates once explores is declared", async () => {
+      writeManifest(); // no explores
+      fs.writeFileSync(
+         path.join(tempDir, "model.malloy"),
+         `source: public_orders is duckdb.sql("select 1 as id")
+source: internal_scratch is duckdb.sql("select 1 as id")
+export { public_orders }`,
+      );
+
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const api = (await pkg.getModel("model.malloy")!.getModel()) as {
+            sources?: { name?: string }[];
+            modelInfo?: string;
+         };
+         let sourceNames = (api.sources ?? []).map((s) => s.name).sort();
+         expect(sourceNames).toEqual(["internal_scratch", "public_orders"]);
+
+         // Opt in via explores ⇒ export closure only, aligned with modelInfo.
+         pkg.setPackageMetadata({
+            ...pkg.getPackageMetadata(),
+            explores: ["model.malloy"],
+         });
+         const curated = (await pkg.getModel("model.malloy")!.getModel()) as {
+            sources?: { name?: string }[];
+            modelInfo?: string;
+         };
+         sourceNames = (curated.sources ?? []).map((s) => s.name).sort();
+         expect(sourceNames).toEqual(["public_orders"]);
+         const mi = JSON.parse(curated.modelInfo ?? "{}");
+         const infoNames = (mi.entries ?? [])
+            .filter((e: { kind: string }) => e.kind === "source")
+            .map((e: { name: string }) => e.name)
+            .sort();
+         expect(sourceNames).toEqual(infoNames);
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("import-only barrel lists imported sources without explores; empty once explores lists it", async () => {
+      writeManifest(); // no explores
+      fs.writeFileSync(
+         path.join(tempDir, "base.malloy"),
+         `source: base_source is duckdb.sql("select 1 as id, 100 as amt") extend {
+  measure: total is amt.sum()
+  view: v is { aggregate: total }
+}`,
+      );
+      fs.writeFileSync(
+         path.join(tempDir, "consumer.malloy"),
+         `import "base.malloy"
+run: base_source -> v`,
+      );
+
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const api = (await pkg.getModel("consumer.malloy")!.getModel()) as {
+            sources?: { name?: string }[];
+         };
+         expect((api.sources ?? []).map((s) => s.name).sort()).toEqual([
+            "base_source",
+         ]);
+         expect(pkg.emptyDiscoveryWarnings()).toEqual([]);
+
+         pkg.setPackageMetadata({
+            ...pkg.getPackageMetadata(),
+            explores: ["consumer.malloy"],
+            queryableSources: "all",
+         });
+         const curated = (await pkg
+            .getModel("consumer.malloy")!
+            .getModel()) as {
+            sources?: { name?: string }[];
+            modelInfo?: string;
+         };
+         const sourceNames = (curated.sources ?? []).map((s) => s.name).sort();
+         expect(sourceNames).toEqual([]);
+         const mi = JSON.parse(curated.modelInfo ?? "{}");
+         const infoNames = (mi.entries ?? [])
+            .filter((e: { kind: string }) => e.kind === "source")
+            .map((e: { name: string }) => e.name)
+            .sort();
+         expect(sourceNames).toEqual(infoNames);
+
+         // Soft migration: queryableSources "all" keeps hidden files queryable.
+         const { result } = await pkg
+            .getModel("base.malloy")!
+            .getQueryResults("base_source", "v", undefined);
+         expect(result.data).toBeDefined();
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("direct getModel on a hidden file succeeds and uses package-wide curation", async () => {
+      writeManifest({ explores: ["index.malloy"] });
+      fs.writeFileSync(
+         path.join(tempDir, "base.malloy"),
+         `source: pub is duckdb.sql("select 1 as id")
+source: hidden is duckdb.sql("select 2 as id")
+export { pub }`,
+      );
+      fs.writeFileSync(
+         path.join(tempDir, "index.malloy"),
+         `import "base.malloy"
+source: customers is duckdb.sql("select 1 as id")
+export { customers }`,
+      );
+
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         expect(await listedModelPaths(pkg)).toEqual(["index.malloy"]);
+
+         const hidden = (await pkg.getModel("base.malloy")!.getModel()) as {
+            sources?: { name?: string }[];
+         };
+         expect((hidden.sources ?? []).map((s) => s.name)).toEqual(["pub"]);
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("warns for a LISTED import-only model (blank page), not for a hidden one", async () => {
+      writeManifest({ explores: ["consumer.malloy"] });
+      fs.writeFileSync(
+         path.join(tempDir, "base.malloy"),
+         `source: base_source is duckdb.sql("select 1 as id")`,
+      );
+      fs.writeFileSync(
+         path.join(tempDir, "consumer.malloy"),
+         `import "base.malloy"\nrun: base_source -> { group_by: id }`,
+      );
+
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const warnings = pkg.emptyDiscoveryWarnings();
+         expect(warnings.length).toBe(1);
+         expect(warnings[0]).toBe(
+            `Model "consumer.malloy" is listed but exposes nothing: it only ` +
+               `imports other files and re-exports none of their sources. ` +
+               `Add e.g. 'export { source_name }' to surface sources on ` +
+               `this model.`,
+         );
+         expect(pkg.formatInvalidExplores()).toBe("");
+
+         fs.writeFileSync(
+            path.join(tempDir, "consumer.malloy"),
+            `import "base.malloy"\nexport { base_source }`,
+         );
+         await pkg.reloadAllModels({});
+         expect(pkg.emptyDiscoveryWarnings()).toEqual([]);
+
+         fs.writeFileSync(
+            path.join(tempDir, "consumer.malloy"),
+            `import "base.malloy"\nrun: base_source -> { group_by: id }`,
+         );
+         writeManifest({ explores: ["base.malloy"] });
+         await pkg.reloadAllModels({});
+         expect(pkg.emptyDiscoveryWarnings()).toEqual([]);
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("load is fail-safe on an unknown explores path: warns, hides, does not throw", async () => {
+      writeManifest({ explores: ["does-not-exist.malloy"] });
+      writeLayeredModels();
+
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         expect(await listedModelPaths(pkg)).toEqual([]);
+         expect(pkg.formatInvalidExplores()).toMatch(
+            /does-not-exist\.malloy.*not found/s,
+         );
+         const warnings = pkg.getPackageMetadata().exploresWarnings ?? [];
+         expect(warnings.length).toBe(1);
+         expect(warnings[0]).toBe(
+            `Invalid explores entry 'does-not-exist.malloy' in ` +
+               `publisher.json: file not found in the package. Fix: list a ` +
+               `.malloy file relative to the package root ` +
+               `(e.g. "index.malloy").`,
+         );
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("flags a notebook listed as an explore; valid entries still resolve", async () => {
+      writeManifest({ explores: ["index.malloy", "report.malloynb"] });
+      writeLayeredModels();
+
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         expect(await listedModelPaths(pkg)).toEqual(["index.malloy"]);
+         expect(pkg.getInvalidExplores().map((p) => p.entry)).toEqual([
+            "report.malloynb",
+         ]);
+         expect(pkg.formatInvalidExplores()).toMatch(
+            /report\.malloynb.*notebooks are always public/s,
+         );
+      } finally {
+         await duckdb.close();
+      }
+   });
+});

--- a/packages/server/src/service/exports_probe.spec.ts
+++ b/packages/server/src/service/exports_probe.spec.ts
@@ -1,0 +1,107 @@
+// Contract test for the Malloy property explore visibility relies on when
+// `explores` is declared: `ModelDef.exports`. The within-file curation in
+// service/model.ts lists only the names in `exports`, so if a Malloy upgrade
+// changes this behavior the curation silently breaks — pin it here against
+// the real compiler (not a re-implementation). See explore_visibility.spec.ts
+// for the end-to-end wiring through Package/Model.
+import { DuckDBConnection } from "@malloydata/db-duckdb";
+import {
+   FixedConnectionMap,
+   InMemoryURLReader,
+   Runtime,
+} from "@malloydata/malloy";
+import { beforeAll, describe, expect, it } from "bun:test";
+
+const ROOT = "file:///probe/";
+let connections: FixedConnectionMap;
+
+beforeAll(() => {
+   const duckdb = new DuckDBConnection("duckdb", ":memory:");
+   connections = new FixedConnectionMap(
+      new Map([["duckdb", duckdb]]),
+      "duckdb",
+   );
+});
+
+async function modelDefOf(
+   files: Record<string, string>,
+   entry: string,
+): Promise<{ exports: string[]; contents: string[] }> {
+   const urlReader = new InMemoryURLReader(
+      new Map(
+         Object.entries(files).map(([name, text]) => [`${ROOT}${name}`, text]),
+      ),
+   );
+   const runtime = new Runtime({ urlReader, connections });
+   const model = await runtime
+      .loadModel(new URL(`${ROOT}${entry}`), { importBaseURL: new URL(ROOT) })
+      .getModel();
+   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+   const def = (model as any)._modelDef;
+   return {
+      exports: [...(def.exports as string[])],
+      contents: Object.keys(def.contents),
+   };
+}
+
+describe("Malloy ModelDef.exports contract (curation depends on this)", () => {
+   it("no export{}: exports = all locally-declared top-level sources", async () => {
+      const { exports } = await modelDefOf(
+         {
+            "m.malloy": `source: a is duckdb.sql("select 1 as x")
+                         source: b is duckdb.sql("select 2 as y")`,
+         },
+         "m.malloy",
+      );
+      expect(exports.sort()).toEqual(["a", "b"]);
+   });
+
+   it("export{a}: exports narrows to the listed name", async () => {
+      const { exports } = await modelDefOf(
+         {
+            "m.malloy": `source: a is duckdb.sql("select 1 as x")
+                         source: b is duckdb.sql("select 2 as y")
+                         export { a }`,
+         },
+         "m.malloy",
+      );
+      expect(exports).toEqual(["a"]);
+   });
+
+   it("imported sources are in contents but NOT in exports unless re-exported", async () => {
+      const { exports, contents } = await modelDefOf(
+         {
+            "base.malloy": `source: base_source is duckdb.sql("select 1 as x")`,
+            "index.malloy": `import "base.malloy"
+               source: customers is base_source extend { dimension: two is 2 }
+               export { customers }`,
+         },
+         "index.malloy",
+      );
+      // The imported base_source is resolvable (in contents) — so joins work —
+      // but it is not part of the re-export closure, so it must not be listed.
+      expect(contents).toContain("base_source");
+      expect(exports).toEqual(["customers"]);
+   });
+
+   it("import without export{}: imported name is excluded from exports", async () => {
+      const { exports } = await modelDefOf(
+         {
+            "base.malloy": `source: base_source is duckdb.sql("select 1 as x")`,
+            "user.malloy": `import "base.malloy"
+               source: local_one is duckdb.sql("select 2 as y")`,
+         },
+         "user.malloy",
+      );
+      // Even with no explicit export{}, `exports` lists only locally-declared
+      // names — the imported `base_source` is omitted. This is the raw Malloy
+      // `exports` behavior (mirrored by modelDefToModelInfo's modelInfo/
+      // sourceInfos) that publisher's discovery curation relies on when it is
+      // active: a model that declares `explores` lists only this export
+      // closure (Model.curateForDiscovery), while every source stays
+      // resolvable for joins and fully queryable. (Without `explores`, curation
+      // is off and publisher lists the uncurated source set — see
+      // explore_visibility.spec.)
+      expect(exports).toEqual(["local_one"]);
+   });
+});

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -42,6 +42,7 @@ import {
    BadRequestError,
    ModelCompilationError,
    ModelNotFoundError,
+   NotQueryableError,
    PayloadTooLargeError,
 } from "../errors";
 import { logger } from "../logger";
@@ -135,6 +136,21 @@ export class Model {
    /** Model-wide `##(authorize)` expressions; apply to every query in the
     *  model, including ad-hoc inline sources not declared in the model. */
    private fileLevelAuthorize: string[] = [];
+   /** Whether discovery accessors curate to the `export {}` closure. Pushed
+    *  down by the owning Package (see Package.applyDiscoveryPolicyToModels):
+    *  true only when the package declares `explores` in publisher.json.
+    *  Defaults to false (legacy listings) so a Model created outside a
+    *  Package matches pre-opt-in behavior. */
+   private discoveryCurationEnabled = false;
+   /** Per-package query-boundary policy, pushed down by the owning Package
+    *  (see `Package.applyQueryBoundaryToModels`). Defaults are inert (mode
+    *  "all" / not declared) so a Model created outside a Package — or before
+    *  the policy is applied — never spuriously denies. */
+   private queryBoundary: {
+      mode: "declared" | "all";
+      exploresDeclared: boolean;
+      isQueryEntryPoint: boolean;
+   } = { mode: "all", exploresDeclared: false, isQueryEntryPoint: true };
    private meter = metrics.getMeter("publisher");
    private queryExecutionHistogram = this.meter.createHistogram(
       "malloy_model_query_duration",
@@ -401,14 +417,7 @@ export class Model {
       const target = this.extractSourceName(query);
       if (!target || !query) return undefined;
 
-      // Map each ad-hoc source name to the base it derives from
-      // (`source: NAME is BASE ...` → NAME → BASE).
-      const aliasOf = new Map<string, string>();
-      const declRe = /source\s*:\s*(\w+)\s+is\s+(\w+)/g;
-      let match: RegExpExecArray | null;
-      while ((match = declRe.exec(query)) !== null) {
-         aliasOf.set(match[1], match[2]);
-      }
+      const aliasOf = Model.buildAliasMap(query);
 
       // Walk the derivation chain until we hit a protected source or run out.
       let current: string | undefined = target;
@@ -700,16 +709,253 @@ export class Model {
       return this.modelType;
    }
 
+   /**
+    * Restrict a list of named objects to the model's re-export closure
+    * (`modelDef.exports`) for discovery. This mirrors what Malloy's stable
+    * `modelDefToModelInfo` already does for `modelInfo`/`sourceInfos` (and what
+    * the app renders), so the publisher-extracted `sources`/`queries` stay
+    * consistent with `modelInfo` within a single response. A model with no
+    * `export { … }` has `exports` = all top-level names, so this is a no-op
+    * there. Only active when the package declares `explores` (see
+    * `discoveryCurationEnabled`). `this.sources`/`this.queries` stay complete so
+    * #(authorize)/filter enforcement and join/extend resolution are unaffected.
+    * Whether a non-exported source is also non-*queryable* depends on the
+    * package's `queryableSources` policy — see {@link assertQueryBoundaryEarly}.
+    */
+   private curateForDiscovery<T extends { name?: string }>(
+      items: T[] | undefined,
+   ): T[] | undefined {
+      if (!items) return items;
+      if (!this.discoveryCurationEnabled) return items;
+      const exports = this.modelDef?.exports;
+      if (!Array.isArray(exports)) return items;
+      const exported = new Set(exports);
+      return items.filter(
+         (item) => item.name !== undefined && exported.has(item.name),
+      );
+   }
+
+   /** Set by the owning Package; see {@link curateForDiscovery}. */
+   public setDiscoveryCuration(enabled: boolean): void {
+      this.discoveryCurationEnabled = enabled;
+   }
+
    public getSources(): ApiSource[] | undefined {
-      return this.sources;
+      return this.curateForDiscovery(this.sources);
    }
 
    public getSourceInfos(): Malloy.SourceInfo[] | undefined {
-      return this.sourceInfos;
+      return this.curateForDiscovery(this.sourceInfos);
    }
 
    public getQueries(): ApiQuery[] | undefined {
-      return this.queries;
+      return this.curateForDiscovery(this.queries);
+   }
+
+   /**
+    * True when this is an import-only model: it imports other files but
+    * declares and re-exports nothing of its own, so `modelDef.exports` is
+    * empty and its discovery surface lists no sources or queries. Legitimate
+    * as plumbing, but confusing when the model is *listed* — the page renders
+    * blank. Used by the load-time warning (Package.emptyDiscoveryWarnings);
+    * the fix is to re-export what should be visible (`export { name }`).
+    */
+   public hasEmptyDiscoverySurface(): boolean {
+      // No curation (no `explores`) ⇒ legacy listings include imported sources.
+      if (!this.discoveryCurationEnabled) return false;
+      if (this.modelType !== "model" || !this.modelDef) return false;
+      const exports = this.modelDef.exports;
+      if (!Array.isArray(exports) || exports.length > 0) return false;
+      return (this.modelDef.imports?.length ?? 0) > 0;
+   }
+
+   /** Set by the owning Package; see {@link assertQueryBoundaryEarly}. */
+   public setQueryBoundary(policy: {
+      mode: "declared" | "all";
+      exploresDeclared: boolean;
+      isQueryEntryPoint: boolean;
+   }): void {
+      this.queryBoundary = policy;
+   }
+
+   /**
+    * Query boundary, step 1 of 2 — the PRE-compilation gate. Enforces the rule
+    * "queryable == discoverable": a source is a valid top-level query target
+    * only if it is in the package's discovery surface (`explores` files +
+    * their `export {}` closure). This is the *what* axis (identity-free);
+    * `#(authorize)` is the orthogonal *who* axis, and both must pass. Denials
+    * are a generic 404 ({@link NotQueryableError}) so a hidden target is
+    * indistinguishable from a non-existent one. Inert unless `explores` is
+    * declared AND mode is "declared" (the default). Notebooks are exempt
+    * (always public) and never call this.
+    *
+    * This step runs before compilation so a denied target can't be probed via
+    * compile errors (schema oracle), and it only POSITIVELY denies — explicit
+    * names it can check, and ad-hoc text whose surface-resolved target is a
+    * model-declared non-curated source. Anything it can't pin returns
+    * "deferred" for {@link assertQueryBoundaryCompiled} to settle against the
+    * compiled run target. "cleared" admissions (explicit curated names) skip
+    * the backstop: an exported named query may read hidden sources internally —
+    * that is the author's deliberate exposure, and re-deriving its source from
+    * the compiled query must not re-deny it.
+    */
+   public assertQueryBoundaryEarly(
+      sourceName?: string,
+      queryName?: string,
+      query?: string,
+   ): "cleared" | "deferred" {
+      const { mode, exploresDeclared, isQueryEntryPoint } = this.queryBoundary;
+      // No opt-in surface (no explores) or explicitly decoupled ("all") ⇒ the
+      // boundary is discovery-only; everything compiled stays queryable.
+      if (mode === "all" || !exploresDeclared) return "cleared";
+
+      // File-level: a non-`explores` model file is not a query entry point.
+      // This is the robust line — the file is named by the request URL, so
+      // there is nothing to resolve and nothing to evade.
+      if (!isQueryEntryPoint) {
+         throw new NotQueryableError(`No queryable model "${this.modelPath}".`);
+      }
+
+      const curatedSources = this.curatedSourceNames();
+      const curatedQueries = new Set(
+         (this.getQueries() ?? []).map((q) => q.name).filter(Boolean),
+      );
+
+      // A named query/view is an author-exported entry point (the author chose
+      // to expose it, even if it reads hidden sources internally) — admit it on
+      // its own name, or on the explicitly-named curated source it runs against.
+      if (queryName && !query) {
+         // The exported-query fast-path admits a *pure* named query (`run: q`)
+         // on its own name. It must NOT fire when a source is also named: a
+         // request is `run: <sourceName>-><queryName>`, so a hidden source
+         // could otherwise be reached via a view whose name happens to collide
+         // with an exported top-level query (and clearing skips the compiled
+         // backstop). With a source prefix, only the named source's curation
+         // gates the request.
+         if (!sourceName && curatedQueries.has(queryName)) return "cleared";
+         if (sourceName && curatedSources.has(sourceName)) return "cleared";
+         throw new NotQueryableError(`No queryable query "${queryName}".`);
+      }
+
+      // An explicitly-named source: admit iff curated.
+      if (sourceName) {
+         if (curatedSources.has(sourceName)) return "cleared";
+         throw new NotQueryableError(`No queryable source "${sourceName}".`);
+      }
+
+      // Ad-hoc text: positively deny only a surface-resolved target that is a
+      // model-declared source outside the curated surface (and doesn't derive
+      // from a curated one) — pre-compile, so its compile errors can't leak
+      // schema. Everything else (inline derivations, multi-statement, forms
+      // the regex can't read) defers to the compiled backstop.
+      if (query) {
+         const target = this.extractSourceName(query);
+         if (
+            target &&
+            !curatedSources.has(target) &&
+            !this.derivesFromCurated(target, query) &&
+            this.sources?.some((s) => s.name === target)
+         ) {
+            throw new NotQueryableError(`No queryable source "${target}".`);
+         }
+      }
+      return "deferred";
+   }
+
+   /**
+    * Query boundary, step 2 of 2 — the POST-compilation backstop for
+    * "deferred" admissions. `compiledSource` is the run target read off the
+    * compiled query's `structRef` (see
+    * {@link resolveAuthorizeSourceFromRunnable}) — the source Malloy actually
+    * executes, surviving named-query indirection, multi-statement forms (the
+    * LAST `run:` wins), and derivation. This inspects compiler *output* only;
+    * compilation itself is never altered or restricted.
+    *
+    * Admit iff the compiled target is curated, or is an ad-hoc alias that
+    * derives from a curated source (`source: x is customers extend { … }` →
+    * `run: x` — composing over a queryable source is itself queryable). FAIL
+    * CLOSED otherwise, including when the target can't be resolved at all.
+    * (Raw inline `conn.sql(...)` never reaches here on the query path —
+    * restricted-mode compilation rejects it first.)
+    */
+   public assertQueryBoundaryCompiled(
+      compiledSource: string | undefined,
+      query?: string,
+   ): void {
+      const { mode, exploresDeclared, isQueryEntryPoint } = this.queryBoundary;
+      if (mode === "all" || !exploresDeclared) return;
+      if (!isQueryEntryPoint) {
+         throw new NotQueryableError(`No queryable model "${this.modelPath}".`);
+      }
+      if (compiledSource) {
+         if (this.curatedSourceNames().has(compiledSource)) return;
+         if (query && this.derivesFromCurated(compiledSource, query)) return;
+      }
+      throw new NotQueryableError("Query target is not queryable.");
+   }
+
+   /**
+    * The /compile-path wrapper: resolve the compiled run target from the
+    * materializer and apply the boundary backstop. No-ops when the boundary is
+    * inert, so the resolution work is skipped for unaffected packages.
+    */
+   public async assertQueryBoundaryForRunnable(
+      runnable: { getPreparedQuery(): Promise<unknown> },
+      query?: string,
+   ): Promise<void> {
+      const { mode, exploresDeclared } = this.queryBoundary;
+      if (mode === "all" || !exploresDeclared) return;
+      this.assertQueryBoundaryCompiled(
+         await this.resolveAuthorizeSourceFromRunnable(runnable),
+         query,
+      );
+   }
+
+   /** Source names in the export-curated discovery surface (= the directly
+    *  queryable set under the "declared" boundary). */
+   private curatedSourceNames(): Set<string> {
+      return new Set(
+         (this.getSources() ?? [])
+            .map((s) => s.name)
+            .filter((n): n is string => n !== undefined),
+      );
+   }
+
+   /** True if `name` reaches a curated source by walking the ad-hoc text's
+    *  `source: NAME is BASE` derivation declarations — composition over a
+    *  queryable source is itself queryable. */
+   private derivesFromCurated(name: string, query: string): boolean {
+      const curated = this.curatedSourceNames();
+      const aliasOf = Model.buildAliasMap(query);
+      let current: string | undefined = name;
+      const seen = new Set<string>();
+      while (current && !seen.has(current)) {
+         if (curated.has(current)) return true;
+         seen.add(current);
+         current = aliasOf.get(current);
+      }
+      return false;
+   }
+
+   /** Map each ad-hoc source alias to the base it derives from
+    *  (`source: NAME is BASE …` → NAME → BASE). Shared by filter inheritance
+    *  ({@link resolveFilterSource}) and the query boundary, which both walk
+    *  derivation chains in caller-authored query text. */
+   private static buildAliasMap(query: string): Map<string, string> {
+      const aliasOf = new Map<string, string>();
+      // Match a bare `\w+` or a backtick-quoted Malloy identifier on BOTH sides
+      // (a hyphenated source like `customer-orders` needs quoting), same pattern
+      // as `extractSourceName`. The quoted capture returns the inner name (no
+      // backticks), keeping aliases keyed the way `curatedSourceNames()` and the
+      // compiled run target are — otherwise a derivation over a quoted source
+      // wouldn't walk back to the curated set and would be falsely denied.
+      const declRe =
+         /source\s*:\s*(?:`([^`]+)`|(\w+))\s+is\s+(?:`([^`]+)`|(\w+))/g;
+      let match: RegExpExecArray | null;
+      while ((match = declRe.exec(query)) !== null) {
+         aliasOf.set(match[1] ?? match[2], match[3] ?? match[4]);
+      }
+      return aliasOf;
    }
 
    /**
@@ -877,6 +1123,18 @@ export class Model {
       if (!this.modelMaterializer || !this.modelDef || !this.modelInfo)
          throw new BadRequestError("Model has no queryable entities.");
 
+      // Query boundary FIRST (the *what* axis): reject a target that isn't in
+      // the package's queryable surface with a generic 404, before authorize
+      // (the *who* axis) and before compilation — so a non-queryable source is
+      // indistinguishable from a non-existent one and can't be probed.
+      // "deferred" means the early gate couldn't pin the target; the compiled
+      // backstop below settles it against the source the query actually runs.
+      const boundary = this.assertQueryBoundaryEarly(
+         sourceName,
+         queryName,
+         query,
+      );
+
       // Early fast-path authorize gate (before loadQuery). Resolve the source
       // from surface syntax; gate if it names one. This runs BEFORE compilation
       // so the gate can't be used as a schema oracle — without it, a denied
@@ -993,6 +1251,16 @@ export class Model {
       // AccessDeniedError stays a 403; independent of bypassFilters.
       const compiledSource =
          await this.resolveAuthorizeSourceFromRunnable(runnable);
+
+      // Boundary backstop (the *what* axis, 404) BEFORE the authorize gate
+      // (the *who* axis, 403): settle "deferred" early-gate admissions against
+      // the compiled run target. Skipped for "cleared" admissions — an
+      // explicitly-named exported query may read hidden sources internally
+      // (the author's deliberate exposure), and must not be re-denied here.
+      if (boundary === "deferred") {
+         this.assertQueryBoundaryCompiled(compiledSource, query);
+      }
+
       // Run unless it's the redundant re-probe of the exact named source the
       // early gate already cleared. When compiledSource is unknown/unresolved,
       // this still runs and assertAuthorized applies the model-wide file-level
@@ -1101,8 +1369,11 @@ export class Model {
          sourceInfos: this.getSourceInfos()?.map((sourceInfo) =>
             JSON.stringify(sourceInfo),
          ),
-         sources: this.sources,
-         queries: this.queries,
+         // Discovery surface: an explore lists only its export closure
+         // (getSources/getQueries curate); `this.sources` stays complete for
+         // enforcement and resolution.
+         sources: this.getSources(),
+         queries: this.getQueries(),
          givens: this.givens,
       } as ApiCompiledModel;
    }
@@ -1158,6 +1429,10 @@ export class Model {
          modelPath: this.modelPath,
          malloyVersion: MALLOY_VERSION,
          modelInfo: JSON.stringify(this.modelInfo ?? {}),
+         // Raw-notebook view is uncurated (complete `this.sources`/`this.queries`,
+         // not the export-filtered `getSources`/`getQueries`): notebooks can't be
+         // imported, so their in-file sources have no internal/import-only role to
+         // hide — they're always public. Model files curate; notebooks don't.
          sources: this.modelDef && this.sources,
          queries: this.modelDef && this.queries,
          annotations: allAnnotations,

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -804,6 +804,9 @@ export class Model {
       queryName?: string,
       query?: string,
    ): "cleared" | "deferred" {
+      // Notebooks are always public — they can't be explores and are never
+      // gated by the boundary, even when reached via the /compile path.
+      if (this.modelPath.endsWith(NOTEBOOK_FILE_SUFFIX)) return "cleared";
       const { mode, exploresDeclared, isQueryEntryPoint } = this.queryBoundary;
       // No opt-in surface (no explores) or explicitly decoupled ("all") ⇒ the
       // boundary is discovery-only; everything compiled stays queryable.
@@ -882,6 +885,8 @@ export class Model {
       compiledSource: string | undefined,
       query?: string,
    ): void {
+      // Notebooks are always public (mirrors assertQueryBoundaryEarly).
+      if (this.modelPath.endsWith(NOTEBOOK_FILE_SUFFIX)) return;
       const { mode, exploresDeclared, isQueryEntryPoint } = this.queryBoundary;
       if (mode === "all" || !exploresDeclared) return;
       if (!isQueryEntryPoint) {

--- a/packages/server/src/service/package.spec.ts
+++ b/packages/server/src/service/package.spec.ts
@@ -75,11 +75,19 @@ describe("service/package", () => {
          new Map([
             [
                "model1.malloy",
-               { getPath: () => "model1.malloy" } as unknown as Model,
+               {
+                  getPath: () => "model1.malloy",
+                  setDiscoveryCuration: () => {},
+                  setQueryBoundary: () => {},
+               } as unknown as Model,
             ],
             [
                "model2.malloynb",
-               { getPath: () => "model2.malloynb" } as unknown as Model,
+               {
+                  getPath: () => "model2.malloynb",
+                  setDiscoveryCuration: () => {},
+                  setQueryBoundary: () => {},
+               } as unknown as Model,
             ],
          ]),
       );
@@ -294,17 +302,21 @@ describe("service/package", () => {
                      {
                         getPath: () => "model1.malloy",
                         getModel: () => "foo",
+                        setDiscoveryCuration: () => {},
+                        setQueryBoundary: () => {},
                      } as unknown as Model,
                   ],
                   [
                      "model2.malloynb",
                      {
                         getPath: () => "model2.malloynb",
+                        setDiscoveryCuration: () => {},
                         getNotebookError: () => {
                            return {
                               message: "This is the error",
                            };
                         },
+                        setQueryBoundary: () => {},
                      } as unknown as Model,
                   ],
                ]),

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -83,6 +83,53 @@ export class Package {
       this.databases = databases;
       this.models = models;
       this.malloyConfig = malloyConfig;
+      this.applyDiscoveryPolicyToModels();
+      this.applyQueryBoundaryToModels();
+   }
+
+   /**
+    * Push the discovery-curation policy down onto each Model. Curation (file
+    * listing via `explores` and within-file `export {}` filtering) is enabled
+    * only when `explores` is declared in publisher.json — absent/empty
+    * `explores` preserves legacy listings. Re-derived on reload and metadata
+    * PATCH (the inputs can change there).
+    */
+   private applyDiscoveryPolicyToModels(): void {
+      const explores = this.packageMetadata.explores;
+      const exploresDeclared = !!(explores && explores.length > 0);
+      const curationEnabled = exploresDeclared;
+      for (const model of this.models.values()) {
+         model.setDiscoveryCuration(curationEnabled);
+      }
+   }
+
+   /**
+    * Push the package-level query-boundary policy down onto each Model so the
+    * query chokepoints can enforce it without a back-reference to the Package:
+    * `Model.getQueryResults` (the HTTP query route and the MCP tool) and the
+    * `/compile` path (via `assertQueryBoundaryForRunnable`). Derived once here
+    * (and on reload) rather than per query: the policy only changes when the
+    * manifest is (re)read.
+    *
+    * Policy: queryable == discoverable. The boundary is inert unless `explores`
+    * is declared (no curated surface ⇒ nothing to restrict) AND
+    * `queryableSources` is "declared" (the default; "all" decouples the axes).
+    * When active, a model file is a query entry point only if it is listed in
+    * `explores`; within-file curation (`export {}`) is read off each Model.
+    */
+   private applyQueryBoundaryToModels(): void {
+      const explores = this.packageMetadata.explores;
+      const exploresDeclared = !!(explores && explores.length > 0);
+      const exploreSet = exploresDeclared ? new Set(explores) : null;
+      const mode =
+         this.packageMetadata.queryableSources === "all" ? "all" : "declared";
+      for (const [modelPath, model] of this.models) {
+         model.setQueryBoundary({
+            mode,
+            exploresDeclared,
+            isQueryEntryPoint: exploreSet ? exploreSet.has(modelPath) : true,
+         });
+      }
    }
 
    static async create(
@@ -251,6 +298,8 @@ export class Package {
          name: outcome.packageMetadata.name,
          description: outcome.packageMetadata.description,
          resource: `${API_PREFIX}/environments/${environmentName}/packages/${packageName}`,
+         explores: outcome.packageMetadata.explores,
+         queryableSources: outcome.packageMetadata.queryableSources,
       };
 
       // Build live `Model`s from worker output. Any per-model compile
@@ -297,7 +346,7 @@ export class Package {
          duration: formatDuration(executionTime),
       });
 
-      return new Package(
+      const pkg = new Package(
          environmentName,
          packageName,
          packagePath,
@@ -306,6 +355,21 @@ export class Package {
          models,
          malloyConfig,
       );
+
+      // Fail-safe at load: a bad explores entry doesn't fail the package
+      // (its models still load and listModels hides the unmatched entry — it
+      // never falls back to listing everything). Warn so the misconfig is
+      // visible; the publish path rejects it outright (see package.controller).
+      const invalidMsg = pkg.formatInvalidExplores();
+      if (invalidMsg) {
+         logger.warn(`Package ${packageName} has invalid explores`, {
+            packageName,
+            detail: invalidMsg,
+         });
+      }
+      pkg.logEmptyDiscoveryWarnings();
+
+      return pkg;
    }
 
    public getPackageName(): string {
@@ -313,7 +377,111 @@ export class Package {
    }
 
    public getPackageMetadata(): ApiPackage {
-      return this.packageMetadata;
+      // Surface explores misconfig so consumers/UI can show it (loading is
+      // fail-safe — the package still serves with the bad entry hidden — so this
+      // is the only non-log signal that it's broken). Computed fresh against the
+      // current models; absent when everything resolves. Returns a copy in that
+      // case so the added field never mutates the stored metadata.
+      const warnings = this.exploreWarnings();
+      if (warnings.length === 0) return this.packageMetadata;
+      return { ...this.packageMetadata, exploresWarnings: warnings };
+   }
+
+   /**
+    * Declared `explores` (publisher.json) that don't resolve to a real
+    * `.malloy` model in this package, each with an actionable reason. Empty
+    * when explores is absent/empty or every entry resolves.
+    *
+    * The listing already fails safe — a non-resolving entry matches no model in
+    * `listModels`, so it hides rather than exposes. This surfaces *why*, so the
+    * load path can warn and the publish path can reject (see package.controller).
+    */
+   public getInvalidExplores(
+      exploresOverride?: string[],
+   ): { entry: string; reason: string }[] {
+      const declared = exploresOverride ?? this.packageMetadata.explores;
+      if (!declared || declared.length === 0) return [];
+      const malloyModels = new Set(
+         Array.from(this.models.keys()).filter((p) =>
+            p.endsWith(MODEL_FILE_SUFFIX),
+         ),
+      );
+      const problems: { entry: string; reason: string }[] = [];
+      for (const entry of declared) {
+         if (entry.endsWith(NOTEBOOK_FILE_SUFFIX)) {
+            problems.push({
+               entry,
+               reason:
+                  `notebooks are always public and cannot be explores. ` +
+                  `Fix: remove it, and list a ${MODEL_FILE_SUFFIX} model file instead.`,
+            });
+         } else if (!malloyModels.has(entry)) {
+            problems.push({
+               entry,
+               reason:
+                  `file not found in the package. Fix: list a ${MODEL_FILE_SUFFIX} ` +
+                  `file relative to the package root (e.g. "index.malloy").`,
+            });
+         }
+      }
+      return problems;
+   }
+
+   /** One actionable message per invalid entry (empty when all resolve). */
+   public exploreWarnings(exploresOverride?: string[]): string[] {
+      return this.getInvalidExplores(exploresOverride).map(
+         (p) =>
+            `Invalid explores entry '${p.entry}' in ${PACKAGE_MANIFEST_NAME}: ${p.reason}`,
+      );
+   }
+
+   /**
+    * The {@link exploreWarnings} joined into one string, or "" if none.
+    * Newline-separated so multiple invalid entries stay one-per-line in the
+    * 400 message rather than running together.
+    */
+   public formatInvalidExplores(exploresOverride?: string[]): string {
+      return this.exploreWarnings(exploresOverride).join("\n");
+   }
+
+   /**
+    * One message per LISTED model whose discovery surface is empty because it
+    * is import-only (imports other files, declares/re-exports nothing). Such a
+    * model renders a blank page, which reads as broken; the fix is an explicit
+    * re-export. Log-only (see loadViaWorker/reloadAllModels) — deliberately
+    * NOT part of exploreWarnings, which is strict-at-publish: import-only
+    * files are a legitimate pattern and must not block a publish. Hidden
+    * (non-listed) models are skipped — nobody browses them, so an empty
+    * surface there is just normal plumbing.
+    */
+   public emptyDiscoveryWarnings(): string[] {
+      const explores = this.packageMetadata.explores;
+      const exploreSet =
+         explores && explores.length > 0 ? new Set(explores) : null;
+      const warnings: string[] = [];
+      for (const [modelPath, model] of this.models) {
+         if (!modelPath.endsWith(MODEL_FILE_SUFFIX)) continue;
+         if (exploreSet && !exploreSet.has(modelPath)) continue;
+         if (model.hasEmptyDiscoverySurface()) {
+            warnings.push(
+               `Model "${modelPath}" is listed but exposes nothing: it only ` +
+                  `imports other files and re-exports none of their sources. ` +
+                  `Add e.g. 'export { source_name }' to surface sources on ` +
+                  `this model.`,
+            );
+         }
+      }
+      return warnings;
+   }
+
+   /** Log {@link emptyDiscoveryWarnings}; shared by load and reload. */
+   private logEmptyDiscoveryWarnings(): void {
+      for (const warning of this.emptyDiscoveryWarnings()) {
+         logger.warn(`Package ${this.packageName} has a blank-looking model`, {
+            packageName: this.packageName,
+            detail: warning,
+         });
+      }
    }
 
    public listDatabases(): ApiDatabase[] {
@@ -448,6 +616,25 @@ export class Package {
          }
       }
       this.models = nextModels;
+      // A reload re-reads publisher.json in the worker; pick up any change to
+      // the explore set and query-boundary mode so listModels()/the gate
+      // reflect edited explores without a full Package.create.
+      this.packageMetadata.explores = outcome.packageMetadata.explores;
+      this.packageMetadata.queryableSources =
+         outcome.packageMetadata.queryableSources;
+      this.applyDiscoveryPolicyToModels();
+      this.applyQueryBoundaryToModels();
+      // Re-run the fail-safe warning against the refreshed model set: an edit
+      // to publisher.json that introduces a bad entry should surface in the
+      // logs on reload too, not only at initial load (loadViaWorker).
+      const invalidMsg = this.formatInvalidExplores();
+      if (invalidMsg) {
+         logger.warn(`Package ${this.packageName} has invalid explores`, {
+            packageName: this.packageName,
+            detail: invalidMsg,
+         });
+      }
+      this.logEmptyDiscoveryWarnings();
    }
 
    public async getModelFileText(modelPath: string): Promise<string> {
@@ -459,10 +646,19 @@ export class Package {
    }
 
    public async listModels(): Promise<ApiModel[]> {
+      // When `explores` is declared in publisher.json, only those models
+      // form the public surface; every other .malloy file still compiles for
+      // import/join resolution but is hidden from the listing. Absent/empty →
+      // every model is listed (backward-compatible default). Notebooks are
+      // unaffected (see listNotebooks) — they are always public.
+      const explores = this.packageMetadata.explores;
+      const exploreSet =
+         explores && explores.length > 0 ? new Set(explores) : null;
       const values = await Promise.all(
          Array.from(this.models.keys())
             .filter((modelPath) => {
-               return modelPath.endsWith(MODEL_FILE_SUFFIX);
+               if (!modelPath.endsWith(MODEL_FILE_SUFFIX)) return false;
+               return exploreSet ? exploreSet.has(modelPath) : true;
             })
             .map(async (modelPath) => {
                let error: string | undefined;
@@ -664,5 +860,7 @@ export class Package {
 
    public setPackageMetadata(packageMetadata: ApiPackage) {
       this.packageMetadata = packageMetadata;
+      this.applyDiscoveryPolicyToModels();
+      this.applyQueryBoundaryToModels();
    }
 }

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -94,10 +94,22 @@ export class Package {
     * `explores` preserves legacy listings. Re-derived on reload and metadata
     * PATCH (the inputs can change there).
     */
-   private applyDiscoveryPolicyToModels(): void {
+   /** True when the package opts into curated discovery via a non-empty
+    *  `explores`. Single source of truth so the curation/boundary/listing
+    *  derivations can't drift out of sync. */
+   private exploresDeclared(): boolean {
       const explores = this.packageMetadata.explores;
-      const exploresDeclared = !!(explores && explores.length > 0);
-      const curationEnabled = exploresDeclared;
+      return !!(explores && explores.length > 0);
+   }
+
+   /** The declared explore set, or null when discovery is uncurated. */
+   private exploreSet(): Set<string> | null {
+      const explores = this.packageMetadata.explores;
+      return explores && explores.length > 0 ? new Set(explores) : null;
+   }
+
+   private applyDiscoveryPolicyToModels(): void {
+      const curationEnabled = this.exploresDeclared();
       for (const model of this.models.values()) {
          model.setDiscoveryCuration(curationEnabled);
       }
@@ -118,9 +130,8 @@ export class Package {
     * `explores`; within-file curation (`export {}`) is read off each Model.
     */
    private applyQueryBoundaryToModels(): void {
-      const explores = this.packageMetadata.explores;
-      const exploresDeclared = !!(explores && explores.length > 0);
-      const exploreSet = exploresDeclared ? new Set(explores) : null;
+      const exploresDeclared = this.exploresDeclared();
+      const exploreSet = this.exploreSet();
       const mode =
          this.packageMetadata.queryableSources === "all" ? "all" : "declared";
       for (const [modelPath, model] of this.models) {
@@ -455,9 +466,7 @@ export class Package {
     * surface there is just normal plumbing.
     */
    public emptyDiscoveryWarnings(): string[] {
-      const explores = this.packageMetadata.explores;
-      const exploreSet =
-         explores && explores.length > 0 ? new Set(explores) : null;
+      const exploreSet = this.exploreSet();
       const warnings: string[] = [];
       for (const [modelPath, model] of this.models) {
          if (!modelPath.endsWith(MODEL_FILE_SUFFIX)) continue;
@@ -651,9 +660,7 @@ export class Package {
       // import/join resolution but is hidden from the listing. Absent/empty →
       // every model is listed (backward-compatible default). Notebooks are
       // unaffected (see listNotebooks) — they are always public.
-      const explores = this.packageMetadata.explores;
-      const exploreSet =
-         explores && explores.length > 0 ? new Set(explores) : null;
+      const exploreSet = this.exploreSet();
       const values = await Promise.all(
          Array.from(this.models.keys())
             .filter((modelPath) => {

--- a/packages/server/src/service/package_rollback.spec.ts
+++ b/packages/server/src/service/package_rollback.spec.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+
+import { BadRequestError } from "../errors";
+import { Environment } from "./environment";
+
+/**
+ * Regression tests for explores-validation ROLLBACK, guarding against the two
+ * data-loss bugs a code review found:
+ *
+ *  1. No-location create rollback must NOT delete a pre-existing user
+ *     directory. The controller now `unloadPackage`s (evict from memory, keep
+ *     files) instead of `deletePackage` (which renames + rm's the tree).
+ *
+ *  2. A location update/reinstall with invalid explores must roll back to the
+ *     PREVIOUS tree rather than swapping the rejected one in and 400-ing after.
+ *     Validation now happens inside `installPackage`'s swap window.
+ *
+ * Both run against a real `Environment` + real `Package.create` over temp dirs.
+ */
+describe("explores-validation rollback (real Environment)", () => {
+   let rootDir: string;
+   let envPath: string;
+
+   const GOOD_MODEL = `source: ones is duckdb.sql("SELECT 1 as x")\n`;
+   const BAD_MODEL = `source: twos is duckdb.sql("SELECT 2 as y")\n`;
+
+   async function writePackageDir(
+      dir: string,
+      manifest: Record<string, unknown>,
+      model: string,
+   ): Promise<void> {
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(
+         path.join(dir, "publisher.json"),
+         JSON.stringify({
+            name: "pkg",
+            description: "rollback fixture",
+            ...manifest,
+         }),
+      );
+      await fs.writeFile(path.join(dir, "model.malloy"), model);
+   }
+
+   async function copyDir(src: string, dst: string): Promise<void> {
+      await fs.mkdir(dst, { recursive: true });
+      await fs.cp(src, dst, { recursive: true });
+   }
+
+   beforeEach(async () => {
+      rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "publisher-rollback-"));
+      envPath = path.join(rootDir, "env");
+      await fs.mkdir(envPath, { recursive: true });
+   });
+
+   afterEach(async () => {
+      await fs.rm(rootDir, { recursive: true, force: true }).catch(() => {});
+   });
+
+   it("Fix 1: unloadPackage evicts from memory but keeps the on-disk directory", async () => {
+      // Mimics the no-location create path: a pre-existing package directory is
+      // registered, then rolled back. unloadPackage must not touch the files.
+      const env = await Environment.create("testEnv", envPath, []);
+      const pkgDir = path.join(envPath, "pkg");
+      await writePackageDir(pkgDir, {}, GOOD_MODEL);
+
+      await env.addPackage("pkg");
+      expect(env.getPackageStatus("pkg")).toBeDefined();
+
+      await env.unloadPackage("pkg");
+
+      // Evicted from memory...
+      expect(env.getPackageStatus("pkg")).toBeUndefined();
+      // ...but the user's files are untouched.
+      const modelText = await fs.readFile(
+         path.join(pkgDir, "model.malloy"),
+         "utf-8",
+      );
+      expect(modelText).toBe(GOOD_MODEL);
+   });
+
+   it("Fix 2: a rejected location reinstall restores the previous tree", async () => {
+      const env = await Environment.create("testEnv", envPath, []);
+
+      const goodFixture = path.join(rootDir, "good");
+      const badFixture = path.join(rootDir, "bad");
+      await writePackageDir(goodFixture, {}, GOOD_MODEL);
+      await writePackageDir(
+         badFixture,
+         { explores: ["missing.malloy"] },
+         BAD_MODEL,
+      );
+
+      // First install: the good tree is served.
+      await env.installPackage("pkg", (stagingPath) =>
+         copyDir(goodFixture, stagingPath),
+      );
+      expect(await env.getModelFileText("pkg", "model.malloy")).toBe(
+         GOOD_MODEL,
+      );
+
+      // Reinstall with an invalid-explores tree, validated inside the swap.
+      await expect(
+         env.installPackage(
+            "pkg",
+            (stagingPath) => copyDir(badFixture, stagingPath),
+            (pkg) => pkg.formatInvalidExplores(),
+         ),
+      ).rejects.toBeInstanceOf(BadRequestError);
+
+      // The previous (good) tree is still the one on disk — the rejected tree
+      // was rolled back, not swapped in.
+      expect(await env.getModelFileText("pkg", "model.malloy")).toBe(
+         GOOD_MODEL,
+      );
+   });
+
+   it("a valid location reinstall still succeeds (no false rollback)", async () => {
+      const env = await Environment.create("testEnv", envPath, []);
+      const goodFixture = path.join(rootDir, "good");
+      const nextFixture = path.join(rootDir, "next");
+      await writePackageDir(goodFixture, {}, GOOD_MODEL);
+      await writePackageDir(
+         nextFixture,
+         { explores: ["model.malloy"] },
+         BAD_MODEL,
+      );
+
+      await env.installPackage("pkg", (stagingPath) =>
+         copyDir(goodFixture, stagingPath),
+      );
+      await env.installPackage(
+         "pkg",
+         (stagingPath) => copyDir(nextFixture, stagingPath),
+         (pkg) => pkg.formatInvalidExplores(),
+      );
+      expect(await env.getModelFileText("pkg", "model.malloy")).toBe(BAD_MODEL);
+   });
+});

--- a/packages/server/src/service/package_rollback.spec.ts
+++ b/packages/server/src/service/package_rollback.spec.ts
@@ -138,4 +138,27 @@ describe("explores-validation rollback (real Environment)", () => {
       );
       expect(await env.getModelFileText("pkg", "model.malloy")).toBe(BAD_MODEL);
    });
+
+   it("updatePackage normalizes a ./-prefixed body explores (no false 400, persists normalized)", async () => {
+      // API-body explores must go through the same normalization the worker
+      // applies to on-disk explores, so `./model.malloy` validates and persists
+      // as `model.malloy` rather than being rejected with a misleading 404.
+      const env = await Environment.create("testEnv", envPath, []);
+      const pkgDir = path.join(envPath, "pkg");
+      await writePackageDir(pkgDir, {}, GOOD_MODEL);
+      await env.addPackage("pkg");
+
+      const updated = await env.updatePackage("pkg", {
+         name: "pkg",
+         explores: ["./model.malloy"],
+      });
+
+      // Accepted (no BadRequestError) and stored in normalized form...
+      expect(updated.explores).toEqual(["model.malloy"]);
+      // ...both in memory and on disk.
+      const manifest = JSON.parse(
+         await fs.readFile(path.join(pkgDir, "publisher.json"), "utf-8"),
+      );
+      expect(manifest.explores).toEqual(["model.malloy"]);
+   });
 });

--- a/packages/server/src/service/package_rollback.spec.ts
+++ b/packages/server/src/service/package_rollback.spec.ts
@@ -161,4 +161,30 @@ describe("explores-validation rollback (real Environment)", () => {
       );
       expect(manifest.explores).toEqual(["model.malloy"]);
    });
+
+   it("compileSource rejects a notebook path; a model path still compiles", async () => {
+      // /compile appends source to the target MODEL's content for context; a
+      // notebook isn't a valid target and must be rejected up front (not left to
+      // a confusing downstream parse error).
+      const env = await Environment.create("testEnv", envPath, []);
+      const pkgDir = path.join(envPath, "pkg");
+      await writePackageDir(pkgDir, {}, GOOD_MODEL);
+      await fs.writeFile(
+         path.join(pkgDir, "report.malloynb"),
+         `>>>markdown\n# Report\n`,
+      );
+      await env.addPackage("pkg");
+
+      await expect(
+         env.compileSource("pkg", "report.malloynb", "run: ones"),
+      ).rejects.toBeInstanceOf(BadRequestError);
+
+      // The .malloy model still compiles ad-hoc source (no regression).
+      const { problems } = await env.compileSource(
+         "pkg",
+         "model.malloy",
+         "run: ones -> { select: x }",
+      );
+      expect(problems.some((p) => p.severity === "error")).toBe(false);
+   });
 });

--- a/packages/server/src/service/query_boundary.spec.ts
+++ b/packages/server/src/service/query_boundary.spec.ts
@@ -1,0 +1,447 @@
+/**
+ * Integration test: Query Boundary (`queryableSources`).
+ *
+ * Drives `Package.create` through the package-load worker pool and verifies the
+ * rule "queryable == discoverable": under the default `queryableSources:
+ * "declared"`, only the discovery surface (`explores` files + their `export {}`
+ * closure) is a valid top-level query target. Everything else still compiles,
+ * imports, joins, and extends, but is denied a direct query with a generic 404
+ * (`NotQueryableError`). `"all"` decouples the axes (the prior behavior), and a
+ * package with no `explores` is unaffected in either mode.
+ *
+ * Enforcement is two-step (mirroring the authorize gate): an early
+ * pre-compilation gate that positively denies what it can resolve (schema-
+ * oracle defense), and a compiled backstop that settles everything else
+ * against the run target Malloy actually executes (read off the prepared
+ * query's structRef — inspecting compiler output, never altering compilation).
+ * Ad-hoc derivation over a curated source is admitted via the same alias walk
+ * filters use; an unresolvable target fails closed.
+ *
+ * This is the *what* axis; `#(authorize)` (the *who* axis) is orthogonal and
+ * tested in explore_visibility.spec.ts / the authorize specs. Notebooks are
+ * always public and never gated.
+ */
+import {
+   afterAll,
+   afterEach,
+   beforeAll,
+   beforeEach,
+   describe,
+   expect,
+   it,
+} from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+   PackageLoadPool,
+   __setPackageLoadPoolForTests,
+} from "../package_load/package_load_pool";
+import { NotQueryableError } from "../errors";
+import { Package } from "./package";
+
+const ORIGINAL_ENV = process.env.PACKAGE_LOAD_WORKERS;
+
+describe("Query Boundary (queryableSources) via worker pool", () => {
+   let tempDir: string;
+   let pool: PackageLoadPool;
+
+   beforeAll(async () => {
+      process.env.PACKAGE_LOAD_WORKERS = "1";
+      pool = new PackageLoadPool(1);
+      await __setPackageLoadPoolForTests(pool);
+   });
+
+   afterAll(async () => {
+      await __setPackageLoadPoolForTests(null);
+      if (ORIGINAL_ENV === undefined) delete process.env.PACKAGE_LOAD_WORKERS;
+      else process.env.PACKAGE_LOAD_WORKERS = ORIGINAL_ENV;
+   });
+
+   beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "publisher-qbound-"));
+   });
+
+   afterEach(() => {
+      if (tempDir) {
+         try {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+         } catch {
+            /* already gone */
+         }
+         tempDir = "";
+      }
+   });
+
+   async function makeMalloyConfig(): Promise<{
+      malloyConfig: import("@malloydata/malloy").MalloyConfig;
+      duckdb: { close: () => Promise<void> };
+   }> {
+      const { MalloyConfig, FixedConnectionMap } = await import(
+         "@malloydata/malloy"
+      );
+      const { DuckDBConnection } = await import("@malloydata/db-duckdb");
+      const duckdb = new DuckDBConnection("duckdb", ":memory:");
+      const connections = new FixedConnectionMap(
+         new Map([["duckdb", duckdb]]),
+         "duckdb",
+      );
+      const malloyConfig = new MalloyConfig({ connections: {} });
+      malloyConfig.wrapConnections(() => connections);
+      return { malloyConfig, duckdb };
+   }
+
+   function writeManifest(extra: Record<string, unknown> = {}): void {
+      fs.writeFileSync(
+         path.join(tempDir, "publisher.json"),
+         JSON.stringify({ name: "pkg", description: "test package", ...extra }),
+      );
+   }
+
+   // base.malloy (a building block, never an explore) + index.malloy (the
+   // explore) which imports/joins it, exports only `customers`, and keeps a
+   // local `helper` source it does NOT export. Each runnable source carries a
+   // view so it can actually be queried.
+   function writeLayeredModels(): void {
+      fs.writeFileSync(
+         path.join(tempDir, "base.malloy"),
+         `source: base_source is duckdb.sql("select 1 as id, 5 as n") extend {
+  measure: total_n is n.sum()
+  view: v is { aggregate: total_n }
+}`,
+      );
+      fs.writeFileSync(
+         path.join(tempDir, "index.malloy"),
+         `import "base.malloy"
+source: helper is duckdb.sql("select 1 as id") extend {
+  measure: c is count()
+  view: hv is { aggregate: c }
+}
+source: customers is duckdb.sql("select 1 as id, 100 as amt") extend {
+  join_one: b is base_source on id = b.id
+  measure: total is amt.sum()
+  view: v is { aggregate: total }
+}
+export { customers }`,
+      );
+      fs.writeFileSync(
+         path.join(tempDir, "report.malloynb"),
+         `>>>markdown\n# Report\nAlways public.`,
+      );
+   }
+
+   // -- default mode ("declared") -----------------------------------------
+
+   it("declared: exported source in an explores file IS queryable (incl. join-through)", async () => {
+      writeManifest({ explores: ["index.malloy"] }); // queryableSources defaults to "declared"
+      writeLayeredModels();
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const { result } = await pkg
+            .getModel("index.malloy")!
+            .getQueryResults("customers", "v", undefined);
+         expect(result.data).toBeDefined();
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("declared: a non-explores model file is not queryable (file-level, 404)", async () => {
+      writeManifest({ explores: ["index.malloy"] });
+      writeLayeredModels();
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         // base.malloy is hidden (not an explore) → not a query entry point.
+         await expect(
+            pkg
+               .getModel("base.malloy")!
+               .getQueryResults("base_source", "v", undefined),
+         ).rejects.toBeInstanceOf(NotQueryableError);
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("declared: a non-exported source inside an explores file is not queryable", async () => {
+      writeManifest({ explores: ["index.malloy"] });
+      writeLayeredModels();
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         // `helper` compiles and is joinable, but is not in index's export{}.
+         await expect(
+            pkg.getModel("index.malloy")!.getQueryResults("helper", "hv"),
+         ).rejects.toBeInstanceOf(NotQueryableError);
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("declared: ad-hoc query is admitted for a curated source, denied for a hidden one", async () => {
+      writeManifest({ explores: ["index.malloy"] });
+      writeLayeredModels();
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const model = pkg.getModel("index.malloy")!;
+
+         const { result } = await model.getQueryResults(
+            undefined,
+            undefined,
+            "run: customers -> { aggregate: total }",
+         );
+         expect(result.data).toBeDefined();
+
+         await expect(
+            model.getQueryResults(
+               undefined,
+               undefined,
+               "run: helper -> { aggregate: c }",
+            ),
+         ).rejects.toBeInstanceOf(NotQueryableError);
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("declared: multi-statement is settled by the COMPILED run target (last statement wins)", async () => {
+      writeManifest({ explores: ["index.malloy"] });
+      writeLayeredModels();
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const model = pkg.getModel("index.malloy")!;
+
+         // Curated decoy first, hidden real target last. The early gate only
+         // sees the first `run:` (curated → defers); the compiled backstop
+         // resolves the LAST statement — the one Malloy actually executes —
+         // and denies it. This is the case the structRef read exists for.
+         await expect(
+            model.getQueryResults(
+               undefined,
+               undefined,
+               "run: customers -> { aggregate: total }\nrun: helper -> { aggregate: c }",
+            ),
+         ).rejects.toBeInstanceOf(NotQueryableError);
+
+         // Hidden target FIRST is positively denied by the early gate, before
+         // compilation — its compile errors can't be used as a schema oracle.
+         await expect(
+            model.getQueryResults(
+               undefined,
+               undefined,
+               "run: helper -> { aggregate: c }\nrun: customers -> { aggregate: total }",
+            ),
+         ).rejects.toBeInstanceOf(NotQueryableError);
+
+         // All-curated multi-statement is legitimate and admitted (no false
+         // denial from the old fail-closed-on-shape heuristic).
+         const { result } = await model.getQueryResults(
+            undefined,
+            undefined,
+            "run: customers -> { aggregate: total }\nrun: customers -> { group_by: id }",
+         );
+         expect(result.data).toBeDefined();
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("declared: ad-hoc derivation over a curated source is queryable; over a hidden one is not", async () => {
+      writeManifest({ explores: ["index.malloy"] });
+      writeLayeredModels();
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const model = pkg.getModel("index.malloy")!;
+
+         // Composing over a queryable source is itself queryable: the compiled
+         // structRef names the ad-hoc alias `x`, and the derivation walk maps
+         // x → customers (curated).
+         const { result } = await model.getQueryResults(
+            undefined,
+            undefined,
+            "source: x is customers extend { measure: m is count() }\nrun: x -> { aggregate: m }",
+         );
+         expect(result.data).toBeDefined();
+
+         // Laundering a hidden source through an ad-hoc alias is denied: the
+         // chain y → helper never reaches the curated surface.
+         await expect(
+            model.getQueryResults(
+               undefined,
+               undefined,
+               "source: y is helper extend { measure: m is count() }\nrun: y -> { aggregate: m }",
+            ),
+         ).rejects.toBeInstanceOf(NotQueryableError);
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("declared: an exported named query reading a hidden source is admitted by name", async () => {
+      // Exporting a query is the author's deliberate exposure of a result,
+      // even when the source it reads stays hidden. The explicit queryName
+      // request is cleared by the early gate and the compiled backstop is
+      // skipped — re-deriving the underlying (hidden) source must not re-deny
+      // the author's chosen entry point.
+      writeManifest({ explores: ["index.malloy"] });
+      fs.writeFileSync(
+         path.join(tempDir, "index.malloy"),
+         `source: helper is duckdb.sql("select 1 as id") extend {
+  measure: c is count()
+}
+source: customers is duckdb.sql("select 1 as id, 100 as amt") extend {
+  measure: total is amt.sum()
+}
+query: helper_stats is helper -> { aggregate: c }
+export { customers, helper_stats }`,
+      );
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const model = pkg.getModel("index.malloy")!;
+
+         const { result } = await model.getQueryResults(
+            undefined,
+            "helper_stats",
+            undefined,
+         );
+         expect(result.data).toBeDefined();
+
+         // …while the hidden source itself stays non-queryable directly.
+         await expect(
+            model.getQueryResults(
+               undefined,
+               undefined,
+               "run: helper -> { aggregate: c }",
+            ),
+         ).rejects.toBeInstanceOf(NotQueryableError);
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("declared: a hidden source is not queryable via a view whose name collides with an exported query (regression)", async () => {
+      // Guards the early-gate fast-path. An exported top-level query named
+      // `stats` must admit the pure named query `run: stats`, but must NOT clear
+      // `run: helper->stats` where `helper` is hidden and `stats` is also a view
+      // on it. Clearing on the bare queryName (ignoring the source prefix) would
+      // skip the compiled backstop and let the hidden source be read through the
+      // name collision — so the source-prefixed form is gated on the *source*
+      // being curated, not on the query name.
+      writeManifest({ explores: ["index.malloy"] });
+      fs.writeFileSync(
+         path.join(tempDir, "index.malloy"),
+         `source: helper is duckdb.sql("select 1 as id") extend {
+  measure: c is count()
+  view: stats is { aggregate: c }
+}
+source: customers is duckdb.sql("select 1 as id, 100 as amt") extend {
+  measure: total is amt.sum()
+}
+query: stats is customers -> { aggregate: total }
+export { customers, stats }`,
+      );
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const model = pkg.getModel("index.malloy")!;
+
+         // The exported top-level query is reachable on its own name.
+         const { result } = await model.getQueryResults(
+            undefined,
+            "stats",
+            undefined,
+         );
+         expect(result.data).toBeDefined();
+
+         // …but the hidden source is NOT reachable through the colliding view
+         // name when explicitly targeted as the run source.
+         await expect(
+            model.getQueryResults("helper", "stats", undefined),
+         ).rejects.toBeInstanceOf(NotQueryableError);
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("declared: ad-hoc derivation over a backtick-quoted exported source is queryable", async () => {
+      // A source whose name needs backticks (a hyphen) must still be walkable
+      // by the derivation alias map — otherwise composing over it returns a
+      // false 404. Guards buildAliasMap's quoted-identifier handling.
+      writeManifest({ explores: ["index.malloy"] });
+      fs.writeFileSync(
+         path.join(tempDir, "index.malloy"),
+         `source: \`customer-orders\` is duckdb.sql("select 1 as id, 100 as amt") extend {
+  measure: total is amt.sum()
+}
+export { \`customer-orders\` }`,
+      );
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const model = pkg.getModel("index.malloy")!;
+
+         const { result } = await model.getQueryResults(
+            undefined,
+            undefined,
+            "source: x is `customer-orders` extend { measure: m is count() }\nrun: x -> { aggregate: m }",
+         );
+         expect(result.data).toBeDefined();
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   // -- "all" mode (decoupled) --------------------------------------------
+
+   it("all: explores gates discovery only — hidden file/source stay queryable", async () => {
+      writeManifest({ explores: ["index.malloy"], queryableSources: "all" });
+      writeLayeredModels();
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+
+         // Listing is still curated to the explore.
+         const listed = (await pkg.listModels()).map((m) => m.path);
+         expect(listed).toEqual(["index.malloy"]);
+
+         // …but the non-explores file and the non-exported source are queryable.
+         const base = await pkg
+            .getModel("base.malloy")!
+            .getQueryResults("base_source", "v", undefined);
+         expect(base.result.data).toBeDefined();
+         const helper = await pkg
+            .getModel("index.malloy")!
+            .getQueryResults("helper", "hv", undefined);
+         expect(helper.result.data).toBeDefined();
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   // -- no explores declared (boundary inert) -----------------------------
+
+   it("declared default + no explores: everything stays queryable (backward compatible)", async () => {
+      writeManifest(); // no explores → no curated surface to enforce
+      writeLayeredModels();
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const base = await pkg
+            .getModel("base.malloy")!
+            .getQueryResults("base_source", "v", undefined);
+         expect(base.result.data).toBeDefined();
+         // `helper` is non-exported, but with no explores there is no boundary.
+         const helper = await pkg
+            .getModel("index.malloy")!
+            .getQueryResults("helper", "hv", undefined);
+         expect(helper.result.data).toBeDefined();
+      } finally {
+         await duckdb.close();
+      }
+   });
+});

--- a/packages/server/src/service/query_boundary.spec.ts
+++ b/packages/server/src/service/query_boundary.spec.ts
@@ -396,6 +396,29 @@ export { \`customer-orders\` }`,
       }
    });
 
+   it("declared: a notebook is exempt from the boundary (always public)", async () => {
+      // The /compile path runs assertQueryBoundaryEarly against the target
+      // model; a notebook is never in `explores`, so without an explicit
+      // exemption it would 404 — contradicting "notebooks are always public".
+      writeManifest({ explores: ["index.malloy"] });
+      writeLayeredModels();
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const notebook = pkg.getModel("report.malloynb");
+         expect(notebook).toBeDefined();
+         // Boundary is inert for notebooks even though it's not an explore.
+         expect(
+            notebook!.assertQueryBoundaryEarly(undefined, undefined, "run: x"),
+         ).toBe("cleared");
+         expect(() =>
+            notebook!.assertQueryBoundaryCompiled("anything", "run: x"),
+         ).not.toThrow();
+      } finally {
+         await duckdb.close();
+      }
+   });
+
    // -- "all" mode (decoupled) --------------------------------------------
 
    it("all: explores gates discovery only — hidden file/source stay queryable", async () => {


### PR DESCRIPTION
> **Supersedes #823.** GitHub stopped syncing that PR's head to the branch — it stayed pinned at the old `fea90809` commit while the branch advanced to `57589657`, so no CI would run. Three real pushes and a close/reopen didn't recover it. This is a fresh PR from the same branch (`jswir/entry-point-visibility`) so the head resolves correctly and checks run. Same commit, same content; #823's discussion and Kyle's approval live there.

## What

An opt-in `explores` field in `publisher.json` designating which `.malloy` files
form a package's public discovery surface, plus an optional `queryableSources`
boundary that turns that surface into an enforced one. Everything is gated on
declaring `explores`: **with no `explores`, discovery and querying behave exactly
as they do today** — all models listed, full source set, nothing blocked. Opt-in
and backward compatible by default.

This lets customers build layered models (base/bridge sources in their own files)
without those internals showing up in chat/discovery, and optionally stops them
being queried directly.

## How it works

### Discovery surface — gated on `explores`

Two granularities, both active **only when `explores` is declared**:

- **File level — `explores`**: `listModels()` returns only the listed files;
  other `.malloy` files still compile and stay joinable but are hidden. Absent/
  empty → every file listed (today's behavior). Notebooks always listed.
- **Within a file — `export {}`**: accessors list only `modelDef.exports`,
  matching Malloy's export-aware `modelInfo`/`sourceInfos`.

The complete source/query set is retained internally, so `#(filter)`/`#(authorize)`
and join/extend resolution are unaffected. Discovery hiding is not access control
on its own.

### Query boundary — `queryableSources` (`declared` | `all`, default `declared`)

Once `explores` is declared, the surface can also bound what's directly queryable:
- `declared` (default): queryable == discoverable. Hidden files/sources → 404
  (`NotQueryableError`), indistinguishable from non-existent.
- `all`: discovery curated, everything stays queryable by name (softer migration).

With **no `explores`, the boundary is inert** in both modes. Enforcement mirrors
the authorize gate (early pre-compile gate + compiled backstop). The early gate
only takes the exported-query fast-path for a *pure* named query (no source
prefix); a source-prefixed request is gated on the named source's curation, so a
hidden source can't be reached via a view whose name collides with an exported
top-level query.

## Rollout — opt-in, no flag

The earlier revision shipped `export {}` curation unconditionally plus a temporary
`PUBLISHER_LEGACY_DISCOVERY` env flag. That's been **dropped** in favor of gating
all curation on `explores`: a flag only protects non-adopters while every
deployment remembers to set it, which doesn't hold for packages we don't own or
control. Gating on `explores` makes "no `explores` = today's behavior" true
structurally.

## Non-destructive validation rollback

Strict-at-publish `explores` validation rejects a bad manifest with a `400`
without destroying content:

- **No-location create** registers a *pre-existing* user directory, so a bad
  manifest unloads it from memory (`unloadPackage`) instead of `deletePackage`
  (which would delete the user's files).
- **Location install/update** validates the *effective* explores INSIDE
  `installPackage`'s swap window, so a rejected update rolls back to the previous
  tree instead of swapping the bad one in and 400-ing after. Reload passes no
  validator and stays fail-safe.

## Tested

- Server unit suite: **899 pass / 0 fail**; typecheck + lint clean.
- `explore_visibility.spec` / `query_boundary.spec`: legacy behavior without
  `explores`; file + `export {}` curation; `declared` vs `all`; multi-statement
  settled by the compiled run target; ad-hoc-derivation laundering denied; the
  collision regression (hidden source not reachable via a view name colliding
  with an exported query); backtick-quoted exported source still queryable.
- `package_rollback.spec` (real `Environment` + temp dirs): `unloadPackage` keeps
  the on-disk dir; a rejected location reinstall restores the previous tree; a
  valid reinstall still swaps.
- `package.controller.spec`: no-location invalid → `unloadPackage` not
  `deletePackage`; location paths pass a validator; update validates effective
  explores. `errors.spec`: `NotQueryableError` → 404. Contract test pins Malloy's
  `ModelDef.exports`.

## Docs

- README "Controlling the discovery surface": `explores` + `export {}`,
  `queryableSources`, discovery-vs-access-control, publish-vs-load policy.
- `api-doc.yaml`: `explores`/`queryableSources` documented; `exploresWarnings`
  `readOnly`.

## Downstream

- Consumers use `explores` / `exploresWarnings` / `queryableSources`.
- Retiring Credible's `.malloy_hidden` / `#(agent-hidden)` lives in separate
  Credible repos; this PR is the upstream source of truth.
