### PR TITLE
feat(materialization): auto-run all phases by default

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -621,55 +621,7 @@ paths:
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
 
-  # TODO: Remove this endpoint.
   /environments/{environmentName}/connections/{connectionName}/sqlSource:
-    get:
-      tags:
-        - connections
-      operationId: get-sqlsource
-      deprecated: true
-      summary: Get SQL source (deprecated)
-      description: |
-        **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
-        Use the POST version instead for better security and functionality.
-
-        Creates a Malloy source from a SQL statement using the specified connection.
-        The SQL statement is executed to generate a source definition that can be used in Malloy models.
-      parameters:
-        - name: environmentName
-          in: path
-          description: Name of the environment
-          required: true
-          schema:
-            $ref: "#/components/schemas/IdentifierPattern"
-        - name: connectionName
-          in: path
-          description: Name of the connection
-          required: true
-          schema:
-            $ref: "#/components/schemas/IdentifierPattern"
-        - name: sqlStatement
-          in: query
-          description: SQL statement
-          required: false
-          schema:
-            type: string
-      responses:
-        "200":
-          description: SQL source information
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SqlSource"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
-
     post:
       tags:
         - connections
@@ -746,13 +698,6 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/IdentifierPattern"
-        - name: options
-          in: query
-          description: Options (deprecated; pass in body instead)
-          deprecated: true
-          required: false
-          schema:
-            type: string
       requestBody:
         description: SQL statement to execute
         required: true
@@ -818,55 +763,6 @@ paths:
               properties:
                 sqlStatement:
                   type: string
-      responses:
-        "200":
-          description: Temporary table information
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TemporaryTable"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
-
-  # TODO: Remove this endpoint.
-  /environments/{environmentName}/connections/{connectionName}/temporaryTable:
-    get:
-      tags:
-        - connections
-      operationId: get-temporarytable
-      deprecated: true
-      summary: Create temporary table (deprecated)
-      description: |
-        **DEPRECATED**: This endpoint is deprecated and may be removed in future versions.
-        Use the POST version instead for better security and functionality.
-
-        Creates a temporary table from a SQL statement using the specified connection.
-        Temporary tables are useful for storing intermediate results during complex queries.
-      parameters:
-        - name: environmentName
-          in: path
-          description: Name of the environment
-          required: true
-          schema:
-            $ref: "#/components/schemas/IdentifierPattern"
-        - name: connectionName
-          in: path
-          description: Name of the connection
-          required: true
-          schema:
-            $ref: "#/components/schemas/IdentifierPattern"
-        - name: sqlStatement
-          in: query
-          description: SQL statement
-          required: false
-          schema:
-            type: string
       responses:
         "200":
           description: Temporary table information
@@ -1067,60 +963,7 @@ paths:
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
 
-  # TODO: Remove the GET (deprecated) form once clients migrate.
   /environments/{environmentName}/packages/{packageName}/connections/{connectionName}/sqlSource:
-    get:
-      tags:
-        - connections
-      operationId: get-sqlsource-in-package
-      deprecated: true
-      summary: Get SQL source (per-package, deprecated)
-      description: |
-        **DEPRECATED**: Use the POST version instead.
-
-        Creates a Malloy source from a SQL statement using the specified
-        connection, resolved in the context of the named package.
-      parameters:
-        - name: environmentName
-          in: path
-          description: Name of the environment
-          required: true
-          schema:
-            $ref: "#/components/schemas/IdentifierPattern"
-        - name: packageName
-          in: path
-          description: Name of the package whose connection context to use
-          required: true
-          schema:
-            $ref: "#/components/schemas/IdentifierPattern"
-        - name: connectionName
-          in: path
-          description: Name of the connection
-          required: true
-          schema:
-            $ref: "#/components/schemas/IdentifierPattern"
-        - name: sqlStatement
-          in: query
-          description: SQL statement
-          required: false
-          schema:
-            type: string
-      responses:
-        "200":
-          description: SQL source information
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SqlSource"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
-
     post:
       tags:
         - connections
@@ -1205,13 +1048,6 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/IdentifierPattern"
-        - name: options
-          in: query
-          description: Options (deprecated; pass in body instead)
-          deprecated: true
-          required: false
-          schema:
-            type: string
       requestBody:
         description: SQL statement to execute
         required: true
@@ -1283,60 +1119,6 @@ paths:
               properties:
                 sqlStatement:
                   type: string
-      responses:
-        "200":
-          description: Temporary table information
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TemporaryTable"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
-
-  # TODO: Remove this endpoint.
-  /environments/{environmentName}/packages/{packageName}/connections/{connectionName}/temporaryTable:
-    get:
-      tags:
-        - connections
-      operationId: get-temporarytable-in-package
-      deprecated: true
-      summary: Create temporary table (per-package, deprecated)
-      description: |
-        **DEPRECATED**: Use the POST version instead.
-
-        Creates a temporary table from a SQL statement using the specified
-        connection, resolved in the context of the named package.
-      parameters:
-        - name: environmentName
-          in: path
-          description: Name of the environment
-          required: true
-          schema:
-            $ref: "#/components/schemas/IdentifierPattern"
-        - name: packageName
-          in: path
-          description: Name of the package whose connection context to use
-          required: true
-          schema:
-            $ref: "#/components/schemas/IdentifierPattern"
-        - name: connectionName
-          in: path
-          description: Name of the connection
-          required: true
-          schema:
-            $ref: "#/components/schemas/IdentifierPattern"
-        - name: sqlStatement
-          in: query
-          description: SQL statement
-          required: false
-          schema:
-            type: string
       responses:
         "200":
           description: Temporary table information
@@ -3539,24 +3321,6 @@ components:
         source:
           type: string
           description: Table source as a JSON string.
-        columns:
-          description: Table fields
-          type: array
-          items:
-            $ref: "#/components/schemas/Column"
-
-    # TODO: Remove this. Replaced by Table
-    TableSource:
-      type: object
-      deprecated: true
-      properties:
-        resource:
-          type: string
-          description: Resource path to the table source.
-        # Pass source as an opaque JSON string that is malloyVersion dependent.
-        # TODO: Remove this once we update the Malloy Publisher connection.
-        source:
-          type: string
         columns:
           description: Table fields
           type: array

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3732,8 +3732,20 @@ components:
 
     CreateMaterializationRequest:
       type: object
-      description: Options for starting a two-round materialization (Round 1).
+      description:
+        Options for starting a materialization. Auto-run by default; opt into the
+        two-round control-plane-driven flow with pauseBetweenPhases.
       properties:
+        pauseBetweenPhases:
+          type: boolean
+          default: false
+          description:
+            When false (default) the publisher runs all phases in one pass —
+            self-assigns table names (the "#@ persist name=" value, else the
+            source name), builds with realization=COPY, assembles the manifest,
+            and auto-loads it into the package models. When true it pauses at
+            BUILD_PLAN_READY for the control plane to send Round 2 build
+            instructions.
         forceRefresh:
           type: boolean
           default: false
@@ -3767,6 +3779,11 @@ components:
           type: string
         packageName:
           type: string
+        pauseBetweenPhases:
+          type: boolean
+          description:
+            Echoes the create-time flag. False (default) = auto-run all phases;
+            true = pause at BUILD_PLAN_READY for control-plane-driven Round 2.
         status:
           $ref: "#/components/schemas/MaterializationStatus"
         buildPlan:

--- a/packages/app/tests/playwright/package-materializations.spec.ts
+++ b/packages/app/tests/playwright/package-materializations.spec.ts
@@ -10,14 +10,11 @@ import { getPublisherStatus } from "./helpers/publisherStatus";
 
 const PKG = PACKAGES.ecommerce;
 
-// A materialization that has settled as far as the publisher can drive it.
-// Round 1 reaches BUILD_PLAN_READY; the control plane (absent in E2E) would
-// drive Round 2 to MANIFEST_FILE_READY. A stopped run is CANCELLED, a broken
-// package is FAILED.
-const SETTLED_STATUS =
-   /^(BUILD_PLAN_READY|MANIFEST_FILE_READY|FAILED|CANCELLED)$/;
-// Terminal states are the only ones a publisher record can be deleted from.
-const TERMINAL_STATUS = /^(MANIFEST_FILE_READY|FAILED|CANCELLED)$/;
+// The runs list shows friendly status labels: in-progress phases read as
+// "Pending", the terminal success state as "Done", and failures/cancellations
+// keep their own labels. Auto-run drives every phase to a terminal state on its
+// own. Terminal states are the only ones a record can be deleted from.
+const TERMINAL_STATUS = /^(Done|Failed|Cancelled)$/;
 
 test.describe("package-materializations: read", () => {
    test("package page exposes a Materializations entry", async ({ page }) => {
@@ -51,7 +48,7 @@ test.describe("package-materializations: mutable", () => {
       test.skip(!mutable, "publisher is read-only");
    });
 
-   test("New materialization dialog opens with plan options", async ({
+   test("New materialization dialog defaults to a full run", async ({
       page,
    }) => {
       await openMaterializations(page, DEFAULT_ENV, PKG);
@@ -62,15 +59,17 @@ test.describe("package-materializations: mutable", () => {
       await expect(
          dialog.getByText("Force refresh (rebuild even if unchanged)"),
       ).toBeVisible();
+      // The dialog always runs every phase — there is no two-round toggle.
+      await expect(dialog.getByLabel(/Pause between phases/)).toHaveCount(0);
       await expect(
-         dialog.getByRole("button", { name: "Create plan" }),
+         dialog.getByRole("button", { name: "Materialize" }),
       ).toBeVisible();
 
       await dialog.getByRole("button", { name: "Cancel" }).click();
       await expect(dialog).toBeHidden();
    });
 
-   test("create plan (Round 1) → reach a terminal state → delete", async ({
+   test("auto-run drives to a terminal state on its own → delete", async ({
       page,
    }) => {
       test.setTimeout(120_000);
@@ -80,30 +79,21 @@ test.describe("package-materializations: mutable", () => {
          name: /Materialization actions for/,
       });
 
-      // --- Create (Round 1: compile + plan) ---
+      // --- Materialize (auto-run: compile + plan + build + load) ---
       await page.getByRole("button", { name: "New materialization" }).click();
       const dialog = page.getByRole("dialog", { name: "New materialization" });
       await expect(dialog).toBeVisible();
-      await dialog.getByRole("button", { name: "Create plan" }).click();
+      await dialog.getByRole("button", { name: "Materialize" }).click();
       await expect(dialog).toBeHidden({ timeout: 15_000 });
 
-      // A run row appears in the table while Round 1 runs.
+      // A run row appears in the table while the run progresses.
       const row = page.locator('table tbody tr[role="button"]').first();
       await expect(row).toBeVisible({ timeout: 30_000 });
 
-      // --- Drive it to a terminal state ---
-      // The publisher only runs Round 1 (settles at BUILD_PLAN_READY, which is
-      // still cancellable), so we Stop it to force a terminal CANCELLED state we
-      // can delete. If it already failed it's terminal; just close the menu.
-      await actions.first().click();
-      const stopItem = page.getByRole("menuitem", {
-         name: /Stop materialization/,
-      });
-      if (await stopItem.isVisible().catch(() => false)) {
-         await stopItem.click();
-      } else {
-         await page.keyboard.press("Escape");
-      }
+      // --- Auto-run settles itself ---
+      // Unlike the two-round flow, the publisher drives every phase without
+      // pausing, so the run reaches a terminal state (MANIFEST_FILE_READY on
+      // success, FAILED on a broken package) with no manual Round 2.
       await expect(page.getByText(TERMINAL_STATUS).first()).toBeVisible({
          timeout: 90_000,
       });
@@ -137,18 +127,18 @@ test.describe("package-materializations: mutable", () => {
          const create = page.getByRole("dialog", {
             name: "New materialization",
          });
-         await create.getByRole("button", { name: "Create plan" }).click();
+         await create.getByRole("button", { name: "Materialize" }).click();
          await create.waitFor({ state: "hidden" });
          await row.waitFor({ timeout: 30_000 });
       }
-      // Wait for a settled state so the run list stops polling and the detail
+      // Wait for a terminal state so the run list stops polling and the detail
       // content is stable before we assert against it.
-      await expect(page.getByText(SETTLED_STATUS).first()).toBeVisible({
+      await expect(page.getByText(TERMINAL_STATUS).first()).toBeVisible({
          timeout: 90_000,
       });
 
       // The run row is a keyboard-operable button (role + tabindex), and Enter
-      // opens the detail dialog, which shows the Round 1 build plan.
+      // opens the detail dialog, which always renders a "Build plan" section.
       await expect(row).toHaveAttribute("tabindex", "0");
       await row.focus();
       await page.keyboard.press("Enter");

--- a/packages/cli/src/commands/materializations.ts
+++ b/packages/cli/src/commands/materializations.ts
@@ -2,16 +2,19 @@ import { PublisherClient } from "../api/client.js";
 import Table from "cli-table3";
 import { logSuccess, logInfo, logOutput, truncate } from "../utils/logger.js";
 
-// Round 1 (compile + plan) settles at BUILD_PLAN_READY or a failure. Round 2
-// (the build) is driven by the control plane with build instructions only it
-// holds, so a publisher-only client cannot await MANIFEST_FILE_READY.
-const SETTLED_STATUSES = [
+// Auto-run (default) settles at MANIFEST_FILE_READY (the full build + load
+// completed) or a failure. In pauseBetweenPhases mode the publisher pauses at
+// BUILD_PLAN_READY for the control plane to drive Round 2, so that is also a
+// settled (success) state for a publisher-only client.
+const AUTO_SETTLED_STATUSES = ["MANIFEST_FILE_READY", "FAILED", "CANCELLED"];
+const AUTO_SUCCESS_STATUSES = ["MANIFEST_FILE_READY"];
+const PAUSE_SETTLED_STATUSES = [
   "BUILD_PLAN_READY",
   "MANIFEST_FILE_READY",
   "FAILED",
   "CANCELLED",
 ];
-const SUCCESS_STATUSES = ["BUILD_PLAN_READY", "MANIFEST_FILE_READY"];
+const PAUSE_SUCCESS_STATUSES = ["BUILD_PLAN_READY", "MANIFEST_FILE_READY"];
 
 export async function listMaterializations(
   client: PublisherClient,
@@ -63,11 +66,11 @@ export async function getMaterialization(
 }
 
 /**
- * Create a materialization: Round 1 (compile + plan). The control plane drives
- * Round 2 (the build) from the resulting build plan, so there is no "start"
- * here. With `wait`, poll until Round 1 settles (BUILD_PLAN_READY, or
- * FAILED/CANCELLED); without it, return immediately with a hint for checking
- * status.
+ * Create a materialization. By default (auto-run) the publisher runs all phases
+ * — compile, plan, self-assign table names, build, and auto-load the manifest —
+ * settling at MANIFEST_FILE_READY. With `pauseBetweenPhases`, it pauses at
+ * BUILD_PLAN_READY for the control plane to drive Round 2. With `wait`, poll
+ * until the run settles; without it, return immediately with a status hint.
  */
 export async function materialize(
   client: PublisherClient,
@@ -75,6 +78,7 @@ export async function materialize(
   packageName: string,
   options: {
     forceRefresh?: boolean;
+    pauseBetweenPhases?: boolean;
     wait?: boolean;
     pollIntervalMs?: number;
     timeoutMs?: number;
@@ -83,7 +87,10 @@ export async function materialize(
   const created = await client.createMaterialization(
     environmentName,
     packageName,
-    { forceRefresh: options.forceRefresh },
+    {
+      forceRefresh: options.forceRefresh,
+      pauseBetweenPhases: options.pauseBetweenPhases,
+    },
   );
   const id = created.id as string | undefined;
   if (!id) {
@@ -98,12 +105,19 @@ export async function materialize(
     return;
   }
 
+  const settledStatuses = options.pauseBetweenPhases
+    ? PAUSE_SETTLED_STATUSES
+    : AUTO_SETTLED_STATUSES;
+  const successStatuses = options.pauseBetweenPhases
+    ? PAUSE_SUCCESS_STATUSES
+    : AUTO_SUCCESS_STATUSES;
+
   const pollIntervalMs = options.pollIntervalMs ?? 2000;
   const timeoutMs = options.timeoutMs ?? 120000;
   const deadline = Date.now() + timeoutMs;
 
   let current = created;
-  while (!SETTLED_STATUSES.includes(current.status) && Date.now() < deadline) {
+  while (!settledStatuses.includes(current.status) && Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
     current = await client.getMaterialization(environmentName, packageName, id);
   }
@@ -111,7 +125,7 @@ export async function materialize(
   // Always print the final record for visibility.
   logOutput(JSON.stringify(current, null, 2));
 
-  if (SUCCESS_STATUSES.includes(current.status)) {
+  if (successStatuses.includes(current.status)) {
     logSuccess(`Materialization ${id} ready: ${current.status}`);
     return;
   }
@@ -119,11 +133,11 @@ export async function materialize(
   // Non-success: throw so the CLI exits non-zero. The index.ts action's catch
   // turns a thrown error into logError + process.exit(1), which is what a
   // CI/automation caller relying on --wait's exit code needs.
-  if (!SETTLED_STATUSES.includes(current.status)) {
+  if (!settledStatuses.includes(current.status)) {
     throw new Error(
       `Timed out waiting for materialization ${id} after ${Math.round(
         timeoutMs / 1000,
-      )}s (last status: ${current.status}). Round 1 may still be running.`,
+      )}s (last status: ${current.status}). The build may still be running.`,
     );
   }
   throw new Error(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -435,11 +435,17 @@ program
 // the build from the resulting plan)
 program
   .command("materialize")
-  .description("Create a materialization build plan (Round 1) for a package")
+  .description(
+    "Materialize a package: by default run all phases (build + load); use --pause-between-phases for the control-plane two-round flow",
+  )
   .requiredOption("--environment <n>", "Environment name")
   .requiredOption("--package <n>", "Package name")
   .option("--force-refresh", "Rebuild all sources, ignoring existing build IDs")
-  .option("--wait", "Poll until the build plan is ready or the run settles")
+  .option(
+    "--pause-between-phases",
+    "Pause at BUILD_PLAN_READY for the control plane to drive Round 2 (default: run all phases)",
+  )
+  .option("--wait", "Poll until the run settles (build complete, or paused)")
   .option(
     "--timeout <seconds>",
     "With --wait, seconds to wait before giving up (default 120)",
@@ -462,6 +468,7 @@ program
         options.package,
         {
           forceRefresh: options.forceRefresh,
+          pauseBetweenPhases: options.pauseBetweenPhases,
           wait: options.wait,
           timeoutMs: timeoutSec !== undefined ? timeoutSec * 1000 : undefined,
           pollIntervalMs: pollSec !== undefined ? pollSec * 1000 : undefined,

--- a/packages/cli/src/tests/materializations.test.ts
+++ b/packages/cli/src/tests/materializations.test.ts
@@ -68,7 +68,7 @@ describe("Materialization Commands", () => {
     );
   });
 
-  test("materialize creates Round 1 plan, no poll without wait", async () => {
+  test("materialize creates a run, no poll without wait", async () => {
     const mockClient = {
       createMaterialization: mock(() =>
         Promise.resolve({ id: "m1", status: "PENDING" }),
@@ -86,6 +86,7 @@ describe("Materialization Commands", () => {
       "pkg",
       {
         forceRefresh: true,
+        pauseBetweenPhases: undefined,
       },
     );
     // Round 2 (build) is control-plane driven; the CLI never starts a build.
@@ -93,7 +94,54 @@ describe("Materialization Commands", () => {
     expect(mockClient.getMaterialization).not.toHaveBeenCalled();
   });
 
-  test("materialize with wait polls until the build plan is ready", async () => {
+  test("materialize forwards pauseBetweenPhases for the two-round flow", async () => {
+    const mockClient = {
+      createMaterialization: mock(() =>
+        Promise.resolve({ id: "m1", status: "PENDING" }),
+      ),
+    } as unknown as PublisherClient;
+
+    await materializationCommands.materialize(mockClient, "env", "pkg", {
+      pauseBetweenPhases: true,
+    });
+
+    expect(mockClient.createMaterialization).toHaveBeenCalledWith(
+      "env",
+      "pkg",
+      {
+        forceRefresh: undefined,
+        pauseBetweenPhases: true,
+      },
+    );
+  });
+
+  test("materialize (auto-run) with wait polls past BUILD_PLAN_READY to MANIFEST_FILE_READY", async () => {
+    let calls = 0;
+    const mockClient = {
+      createMaterialization: mock(() =>
+        Promise.resolve({ id: "m1", status: "PENDING" }),
+      ),
+      getMaterialization: mock(() => {
+        calls += 1;
+        // Auto-run does not settle at BUILD_PLAN_READY; it must keep polling
+        // until MANIFEST_FILE_READY.
+        return Promise.resolve({
+          id: "m1",
+          status: calls >= 3 ? "MANIFEST_FILE_READY" : "BUILD_PLAN_READY",
+        });
+      }),
+    } as unknown as PublisherClient;
+
+    await materializationCommands.materialize(mockClient, "env", "pkg", {
+      wait: true,
+      pollIntervalMs: 1,
+      timeoutMs: 1000,
+    });
+
+    expect(calls).toBeGreaterThanOrEqual(3);
+  });
+
+  test("materialize (pause) with wait settles at BUILD_PLAN_READY", async () => {
     let calls = 0;
     const mockClient = {
       createMaterialization: mock(() =>
@@ -109,6 +157,7 @@ describe("Materialization Commands", () => {
     } as unknown as PublisherClient;
 
     await materializationCommands.materialize(mockClient, "env", "pkg", {
+      pauseBetweenPhases: true,
       wait: true,
       pollIntervalMs: 1,
       timeoutMs: 1000,

--- a/packages/sdk/src/components/Materializations/CreateMaterializationDialog.tsx
+++ b/packages/sdk/src/components/Materializations/CreateMaterializationDialog.tsx
@@ -14,10 +14,7 @@ import {
 import { useState } from "react";
 
 type CreateMaterializationDialogProps = {
-   onSubmit: (opts: {
-      forceRefresh: boolean;
-      pauseBetweenPhases: boolean;
-   }) => Promise<unknown>;
+   onSubmit: (opts: { forceRefresh: boolean }) => Promise<unknown>;
    isSubmitting: boolean;
    disabled?: boolean;
    disabledReason?: string;
@@ -31,13 +28,12 @@ export default function CreateMaterializationDialog({
 }: CreateMaterializationDialogProps) {
    const [open, setOpen] = useState(false);
    const [forceRefresh, setForceRefresh] = useState(false);
-   const [pauseBetweenPhases, setPauseBetweenPhases] = useState(false);
 
    const handleClose = () => setOpen(false);
 
    const handleRun = async () => {
       try {
-         await onSubmit({ forceRefresh, pauseBetweenPhases });
+         await onSubmit({ forceRefresh });
          setOpen(false);
       } catch {
          // The mutation surfaces the error through the caller's Snackbar;
@@ -81,9 +77,7 @@ export default function CreateMaterializationDialog({
                <DialogContentText sx={{ mb: 2 }}>
                   Materialize every persist source in this package: compile,
                   build the tables, and load them so queries serve from the
-                  materialized tables. Enable &ldquo;Pause between phases&rdquo;
-                  to stop at the build plan for a control plane to drive the
-                  build instead.
+                  materialized tables.
                </DialogContentText>
                <FormGroup>
                   <FormControlLabel
@@ -97,17 +91,6 @@ export default function CreateMaterializationDialog({
                      }
                      label="Force refresh (rebuild even if unchanged)"
                   />
-                  <FormControlLabel
-                     control={
-                        <Switch
-                           checked={pauseBetweenPhases}
-                           onChange={(event) =>
-                              setPauseBetweenPhases(event.target.checked)
-                           }
-                        />
-                     }
-                     label="Pause between phases (control-plane two-round flow)"
-                  />
                </FormGroup>
             </DialogContent>
             <DialogActions>
@@ -117,7 +100,7 @@ export default function CreateMaterializationDialog({
                   loading={isSubmitting}
                   onClick={handleRun}
                >
-                  {pauseBetweenPhases ? "Create plan" : "Materialize"}
+                  Materialize
                </Button>
             </DialogActions>
          </Dialog>

--- a/packages/sdk/src/components/Materializations/CreateMaterializationDialog.tsx
+++ b/packages/sdk/src/components/Materializations/CreateMaterializationDialog.tsx
@@ -14,7 +14,10 @@ import {
 import { useState } from "react";
 
 type CreateMaterializationDialogProps = {
-   onSubmit: (opts: { forceRefresh: boolean }) => Promise<unknown>;
+   onSubmit: (opts: {
+      forceRefresh: boolean;
+      pauseBetweenPhases: boolean;
+   }) => Promise<unknown>;
    isSubmitting: boolean;
    disabled?: boolean;
    disabledReason?: string;
@@ -28,12 +31,13 @@ export default function CreateMaterializationDialog({
 }: CreateMaterializationDialogProps) {
    const [open, setOpen] = useState(false);
    const [forceRefresh, setForceRefresh] = useState(false);
+   const [pauseBetweenPhases, setPauseBetweenPhases] = useState(false);
 
    const handleClose = () => setOpen(false);
 
    const handleRun = async () => {
       try {
-         await onSubmit({ forceRefresh });
+         await onSubmit({ forceRefresh, pauseBetweenPhases });
          setOpen(false);
       } catch {
          // The mutation surfaces the error through the caller's Snackbar;
@@ -75,9 +79,11 @@ export default function CreateMaterializationDialog({
             </DialogTitle>
             <DialogContent>
                <DialogContentText sx={{ mb: 2 }}>
-                  Compile this package and produce a build plan for every
-                  persist source. The control plane assigns table identities and
-                  drives the build from the plan.
+                  Materialize every persist source in this package: compile,
+                  build the tables, and load them so queries serve from the
+                  materialized tables. Enable &ldquo;Pause between phases&rdquo;
+                  to stop at the build plan for a control plane to drive the
+                  build instead.
                </DialogContentText>
                <FormGroup>
                   <FormControlLabel
@@ -91,6 +97,17 @@ export default function CreateMaterializationDialog({
                      }
                      label="Force refresh (rebuild even if unchanged)"
                   />
+                  <FormControlLabel
+                     control={
+                        <Switch
+                           checked={pauseBetweenPhases}
+                           onChange={(event) =>
+                              setPauseBetweenPhases(event.target.checked)
+                           }
+                        />
+                     }
+                     label="Pause between phases (control-plane two-round flow)"
+                  />
                </FormGroup>
             </DialogContent>
             <DialogActions>
@@ -100,7 +117,7 @@ export default function CreateMaterializationDialog({
                   loading={isSubmitting}
                   onClick={handleRun}
                >
-                  Create plan
+                  {pauseBetweenPhases ? "Create plan" : "Materialize"}
                </Button>
             </DialogActions>
          </Dialog>

--- a/packages/sdk/src/components/Materializations/ManifestView.tsx
+++ b/packages/sdk/src/components/Materializations/ManifestView.tsx
@@ -1,5 +1,6 @@
 import {
    Box,
+   Stack,
    Table,
    TableBody,
    TableCell,
@@ -9,25 +10,36 @@ import {
 } from "@mui/material";
 import { ManifestEntry } from "../../client";
 import { MONO_FONT_FAMILY } from "../styles";
+import { formatTimestamp } from "./utils";
 
 type ManifestViewProps = {
    entries: { [buildId: string]: ManifestEntry } | undefined;
+   builtAt?: string;
 };
 
 /**
- * Read-only view of a materialization's Round 2 build manifest: the physical
- * tables the control plane produced from the build plan. The publisher no longer
- * brokers a package-level manifest; this renders the manifest carried on a
- * single materialization resource.
+ * Read-only view of a materialization's build manifest: the physical tables
+ * produced from the build plan, carried on the materialization resource.
  */
-export default function ManifestView({ entries }: ManifestViewProps) {
+export default function ManifestView({ entries, builtAt }: ManifestViewProps) {
    const rows = Object.entries(entries ?? {});
 
    return (
       <Box>
-         <Typography variant="subtitle2" gutterBottom>
-            Build manifest
-         </Typography>
+         <Stack
+            direction="row"
+            alignItems="baseline"
+            justifyContent="space-between"
+         >
+            <Typography variant="subtitle2" gutterBottom>
+               Build manifest
+            </Typography>
+            {builtAt && (
+               <Typography variant="caption" color="text.secondary">
+                  Built {formatTimestamp(builtAt)}
+               </Typography>
+            )}
+         </Stack>
          {rows.length === 0 ? (
             <Typography
                variant="body2"
@@ -42,6 +54,8 @@ export default function ManifestView({ entries }: ManifestViewProps) {
                   <TableRow>
                      <TableCell>Source</TableCell>
                      <TableCell>Table name</TableCell>
+                     <TableCell>Connection</TableCell>
+                     <TableCell>Realization</TableCell>
                      <TableCell align="right">Rows</TableCell>
                   </TableRow>
                </TableHead>
@@ -54,6 +68,10 @@ export default function ManifestView({ entries }: ManifestViewProps) {
                         <TableCell sx={{ fontFamily: MONO_FONT_FAMILY }}>
                            {entry.physicalTableName ?? "-"}
                         </TableCell>
+                        <TableCell sx={{ fontFamily: MONO_FONT_FAMILY }}>
+                           {entry.connectionName ?? "-"}
+                        </TableCell>
+                        <TableCell>{entry.realization ?? "-"}</TableCell>
                         <TableCell align="right">
                            {entry.rowCount ?? "-"}
                         </TableCell>

--- a/packages/sdk/src/components/Materializations/MaterializationDetailDialog.tsx
+++ b/packages/sdk/src/components/Materializations/MaterializationDetailDialog.tsx
@@ -19,9 +19,10 @@ import { MONO_FONT_FAMILY } from "../styles";
 import ManifestView from "./ManifestView";
 import {
    formatDuration,
-   formatRelativeTime,
+   formatTimestamp,
    parseMetadata,
    statusColor,
+   statusLabel,
 } from "./utils";
 
 type MaterializationDetailDialogProps = {
@@ -50,7 +51,7 @@ export default function MaterializationDetailDialog({
                   <Stack direction="row" alignItems="center" spacing={1.5}>
                      <Chip
                         size="small"
-                        label={materialization.status ?? "UNKNOWN"}
+                        label={statusLabel(materialization.status)}
                         color={statusColor(materialization.status)}
                      />
                      <Typography
@@ -69,13 +70,41 @@ export default function MaterializationDetailDialog({
                   </IconButton>
                </DialogTitle>
                <DialogContent dividers>
-                  <Stack direction="row" spacing={4} sx={{ mb: 3 }}>
+                  <Box
+                     sx={{
+                        display: "grid",
+                        gridTemplateColumns:
+                           "repeat(auto-fit, minmax(150px, 1fr))",
+                        gap: 2,
+                        mb: 3,
+                     }}
+                  >
+                     <DetailField
+                        label="Package"
+                        value={materialization.packageName ?? "—"}
+                     />
+                     <DetailField
+                        label="Mode"
+                        value={
+                           materialization.pauseBetweenPhases
+                              ? "Two-round"
+                              : "Auto-run"
+                        }
+                     />
+                     <DetailField
+                        label="Force refresh"
+                        value={meta.forceRefresh ? "Yes" : "No"}
+                     />
                      <DetailField
                         label="Started"
-                        value={formatRelativeTime(
+                        value={formatTimestamp(
                            materialization.startedAt ??
                               materialization.createdAt,
                         )}
+                     />
+                     <DetailField
+                        label="Completed"
+                        value={formatTimestamp(materialization.completedAt)}
                      />
                      <DetailField
                         label="Duration"
@@ -92,7 +121,15 @@ export default function MaterializationDetailDialog({
                         label="Sources skipped"
                         value={`${meta.sourcesSkipped ?? 0}`}
                      />
-                  </Stack>
+                     <DetailField
+                        label="Created"
+                        value={formatTimestamp(materialization.createdAt)}
+                     />
+                     <DetailField
+                        label="Updated"
+                        value={formatTimestamp(materialization.updatedAt)}
+                     />
+                  </Box>
 
                   {materialization.error && (
                      <Box sx={{ mb: 3 }}>
@@ -134,6 +171,7 @@ export default function MaterializationDetailDialog({
                                  <TableCell>Source</TableCell>
                                  <TableCell>Connection</TableCell>
                                  <TableCell>Dialect</TableCell>
+                                 <TableCell align="right">Columns</TableCell>
                                  <TableCell>Build ID</TableCell>
                               </TableRow>
                            </TableHead>
@@ -153,8 +191,16 @@ export default function MaterializationDetailDialog({
                                     <TableCell>
                                        {source.dialect ?? "-"}
                                     </TableCell>
+                                    <TableCell align="right">
+                                       {source.columns?.length ?? 0}
+                                    </TableCell>
                                     <TableCell
-                                       sx={{ fontFamily: MONO_FONT_FAMILY }}
+                                       sx={{
+                                          fontFamily: MONO_FONT_FAMILY,
+                                          fontSize: "0.75rem",
+                                          wordBreak: "break-all",
+                                          maxWidth: 220,
+                                       }}
                                     >
                                        {source.buildId}
                                     </TableCell>
@@ -165,7 +211,10 @@ export default function MaterializationDetailDialog({
                      )}
                   </Box>
 
-                  <ManifestView entries={materialization.manifest?.entries} />
+                  <ManifestView
+                     entries={materialization.manifest?.entries}
+                     builtAt={materialization.manifest?.builtAt}
+                  />
                </DialogContent>
             </>
          )}

--- a/packages/sdk/src/components/Materializations/MaterializationRunsList.tsx
+++ b/packages/sdk/src/components/Materializations/MaterializationRunsList.tsx
@@ -27,6 +27,7 @@ import {
    isTerminalStatus,
    parseMetadata,
    statusColor,
+   statusLabel,
 } from "./utils";
 
 type MaterializationRunsListProps = {
@@ -141,7 +142,7 @@ function MaterializationRow({
             <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
                <Chip
                   size="small"
-                  label={materialization.status ?? "UNKNOWN"}
+                  label={statusLabel(materialization.status)}
                   color={statusColor(materialization.status)}
                   variant={active ? "filled" : "outlined"}
                />

--- a/packages/sdk/src/components/Materializations/Materializations.tsx
+++ b/packages/sdk/src/components/Materializations/Materializations.tsx
@@ -75,20 +75,15 @@ export default function Materializations({
          queryKey: ["materializations", environmentName, packageName],
       });
 
-   // Round 1 only: ask the publisher to compile and produce a build plan. The
-   // control plane drives Round 2 (the build) from that plan, so there is no
-   // "start" call here.
+   // Auto-run: the publisher compiles, builds every persist source, and loads
+   // the resulting manifest in a single pass.
    const createMaterialization = useMutationWithApiError({
-      mutationFn: (opts: {
-         forceRefresh: boolean;
-         pauseBetweenPhases: boolean;
-      }) =>
+      mutationFn: (opts: { forceRefresh: boolean }) =>
          apiClients.materializations.createMaterialization(
             environmentName,
             packageName,
             {
                forceRefresh: opts.forceRefresh,
-               pauseBetweenPhases: opts.pauseBetweenPhases,
             },
          ),
       onSuccess() {
@@ -186,8 +181,8 @@ export default function Materializations({
                      Materializations
                   </Typography>
                   <Typography variant="body2" color="text.secondary">
-                     Plan persist sources for {packageName}; the control plane
-                     drives the build and produces the manifest
+                     Materialize the persist sources in {packageName} into
+                     tables and serve queries from them
                   </Typography>
                </Box>
                {mutable && (

--- a/packages/sdk/src/components/Materializations/Materializations.tsx
+++ b/packages/sdk/src/components/Materializations/Materializations.tsx
@@ -79,14 +79,20 @@ export default function Materializations({
    // control plane drives Round 2 (the build) from that plan, so there is no
    // "start" call here.
    const createMaterialization = useMutationWithApiError({
-      mutationFn: (opts: { forceRefresh: boolean }) =>
+      mutationFn: (opts: {
+         forceRefresh: boolean;
+         pauseBetweenPhases: boolean;
+      }) =>
          apiClients.materializations.createMaterialization(
             environmentName,
             packageName,
-            { forceRefresh: opts.forceRefresh },
+            {
+               forceRefresh: opts.forceRefresh,
+               pauseBetweenPhases: opts.pauseBetweenPhases,
+            },
          ),
       onSuccess() {
-         setNotificationMessage("Build plan requested");
+         setNotificationMessage("Materialization requested");
          invalidateList();
       },
       onError(error) {

--- a/packages/sdk/src/components/Materializations/utils.ts
+++ b/packages/sdk/src/components/Materializations/utils.ts
@@ -22,6 +22,29 @@ export function isTerminalStatus(status?: MaterializationStatus): boolean {
    );
 }
 
+/**
+ * Human-friendly status label. The publisher drives every phase automatically,
+ * so the intermediate protocol states (PENDING / BUILD_PLAN_READY /
+ * MANIFEST_ROWS_READY) all read as "Pending" and the terminal success state
+ * reads as "Done". Failures and cancellations keep their own labels.
+ */
+export function statusLabel(status?: MaterializationStatus): string {
+   switch (status) {
+      case MaterializationStatus.ManifestFileReady:
+         return "Done";
+      case MaterializationStatus.Failed:
+         return "Failed";
+      case MaterializationStatus.Cancelled:
+         return "Cancelled";
+      case MaterializationStatus.Pending:
+      case MaterializationStatus.BuildPlanReady:
+      case MaterializationStatus.ManifestRowsReady:
+         return "Pending";
+      default:
+         return "Unknown";
+   }
+}
+
 type ChipColor = "default" | "info" | "success" | "error" | "warning";
 
 export function statusColor(status?: MaterializationStatus): ChipColor {
@@ -77,6 +100,20 @@ export function formatDuration(
    const hours = Math.floor(minutes / 60);
    const remMinutes = minutes % 60;
    return `${hours}h ${remMinutes}m`;
+}
+
+/** Absolute, locale-formatted timestamp (e.g. "Jun 19, 2026, 3:33 PM"). */
+export function formatTimestamp(iso?: string | null): string {
+   if (!iso) return "—";
+   const date = new Date(iso);
+   if (Number.isNaN(date.getTime())) return "—";
+   return date.toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+   });
 }
 
 /** Compact relative timestamp, e.g. "just now", "5m ago", "2h ago", "3d ago". */

--- a/packages/server/src/controller/materialization.controller.ts
+++ b/packages/server/src/controller/materialization.controller.ts
@@ -20,8 +20,19 @@ export class MaterializationController {
    private validateCreateBody(body: Record<string, unknown>): {
       forceRefresh?: boolean;
       sourceNames?: string[];
+      pauseBetweenPhases?: boolean;
    } {
-      const result: { forceRefresh?: boolean; sourceNames?: string[] } = {};
+      const result: {
+         forceRefresh?: boolean;
+         sourceNames?: string[];
+         pauseBetweenPhases?: boolean;
+      } = {};
+      if (body.pauseBetweenPhases !== undefined) {
+         if (typeof body.pauseBetweenPhases !== "boolean") {
+            throw new BadRequestError("pauseBetweenPhases must be a boolean");
+         }
+         result.pauseBetweenPhases = body.pauseBetweenPhases;
+      }
       if (body.forceRefresh !== undefined) {
          if (typeof body.forceRefresh !== "boolean") {
             throw new BadRequestError("forceRefresh must be a boolean");

--- a/packages/server/src/materialization_metrics.ts
+++ b/packages/server/src/materialization_metrics.ts
@@ -15,7 +15,7 @@
 
 import { metrics, type Counter, type Histogram } from "@opentelemetry/api";
 
-export type MaterializationRound = "round1" | "round2";
+export type MaterializationRound = "round1" | "round2" | "auto";
 export type MaterializationOutcome = "success" | "failed" | "cancelled";
 
 let roundCounter: Counter | null = null;
@@ -31,7 +31,7 @@ function ensureTelemetry(): { counter: Counter; duration: Histogram } {
          "publisher_materialization_rounds_total",
          {
             description:
-               "Materialization rounds completed. Labels: round ('round1'|'round2'), outcome ('success'|'failed'|'cancelled').",
+               "Materialization rounds completed. Labels: round ('round1'|'round2'|'auto'), outcome ('success'|'failed'|'cancelled').",
          },
       );
    }
@@ -40,7 +40,7 @@ function ensureTelemetry(): { counter: Counter; duration: Histogram } {
          "publisher_materialization_round_duration_ms",
          {
             description:
-               "Wall-clock duration of a materialization round. Label: round ('round1'|'round2').",
+               "Wall-clock duration of a materialization round. Label: round ('round1'|'round2'|'auto').",
             unit: "ms",
          },
       );

--- a/packages/server/src/server-old.ts
+++ b/packages/server/src/server-old.ts
@@ -376,26 +376,7 @@ export function registerLegacyRoutes(
       },
    );
 
-   // sqlSource (deprecated GET + supported POST), per-project + per-package
-   app.get(
-      `${LEGACY_API_PREFIX}/projects/:projectName/connections/:connectionName/sqlSource`,
-      async (req, res) => {
-         try {
-            res.status(200).json(
-               await connectionController.getConnectionSqlSource(
-                  req.params.projectName,
-                  req.params.connectionName,
-                  req.query.sqlStatement as string,
-               ),
-            );
-         } catch (error) {
-            logger.error(error);
-            const { json, status } = internalErrorToHttpError(error as Error);
-            res.status(status).json(json);
-         }
-      },
-   );
-
+   // sqlSource (POST), per-project + per-package
    app.post(
       `${LEGACY_API_PREFIX}/projects/:projectName/connections/:connectionName/sqlSource`,
       async (req, res) => {
@@ -405,26 +386,6 @@ export function registerLegacyRoutes(
                   req.params.projectName,
                   req.params.connectionName,
                   req.body.sqlStatement as string,
-               ),
-            );
-         } catch (error) {
-            logger.error(error);
-            const { json, status } = internalErrorToHttpError(error as Error);
-            res.status(status).json(json);
-         }
-      },
-   );
-
-   app.get(
-      `${LEGACY_API_PREFIX}/projects/:projectName/packages/:packageName/connections/:connectionName/sqlSource`,
-      async (req, res) => {
-         try {
-            res.status(200).json(
-               await connectionController.getConnectionSqlSource(
-                  req.params.projectName,
-                  req.params.connectionName,
-                  req.query.sqlStatement as string,
-                  req.params.packageName,
                ),
             );
          } catch (error) {
@@ -564,48 +525,7 @@ export function registerLegacyRoutes(
       },
    );
 
-   // temporaryTable (deprecated GET) + sqlTemporaryTable (supported POST)
-   app.get(
-      `${LEGACY_API_PREFIX}/projects/:projectName/connections/:connectionName/temporaryTable`,
-      queryConcurrency(),
-      async (req, res) => {
-         try {
-            res.status(200).json(
-               await connectionController.getConnectionTemporaryTable(
-                  req.params.projectName,
-                  req.params.connectionName,
-                  req.query.sqlStatement as string,
-               ),
-            );
-         } catch (error) {
-            logger.error(error);
-            const { json, status } = internalErrorToHttpError(error as Error);
-            res.status(status).json(json);
-         }
-      },
-   );
-
-   app.get(
-      `${LEGACY_API_PREFIX}/projects/:projectName/packages/:packageName/connections/:connectionName/temporaryTable`,
-      queryConcurrency(),
-      async (req, res) => {
-         try {
-            res.status(200).json(
-               await connectionController.getConnectionTemporaryTable(
-                  req.params.projectName,
-                  req.params.connectionName,
-                  req.query.sqlStatement as string,
-                  req.params.packageName,
-               ),
-            );
-         } catch (error) {
-            logger.error(error);
-            const { json, status } = internalErrorToHttpError(error as Error);
-            res.status(status).json(json);
-         }
-      },
-   );
-
+   // sqlTemporaryTable (POST), per-project + per-package
    app.post(
       `${LEGACY_API_PREFIX}/projects/:projectName/connections/:connectionName/sqlTemporaryTable`,
       queryConcurrency(),

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -8,7 +8,6 @@ import * as http from "http";
 import { createProxyMiddleware } from "http-proxy-middleware";
 import { AddressInfo } from "net";
 import * as path from "path";
-import { ParsedQs } from "qs";
 import { fileURLToPath } from "url";
 import { CompileController } from "./controller/compile.controller";
 import { ConnectionController } from "./controller/connection.controller";
@@ -1043,28 +1042,6 @@ app.get(
    },
 );
 
-/**
- * @deprecated Use /environments/:environmentName/connections/:connectionName/sqlSource POST method instead
- */
-app.get(
-   `${API_PREFIX}/environments/:environmentName/connections/:connectionName/sqlSource`,
-   async (req, res) => {
-      try {
-         res.status(200).json(
-            await connectionController.getConnectionSqlSource(
-               req.params.environmentName,
-               req.params.connectionName,
-               req.query.sqlStatement as string,
-            ),
-         );
-      } catch (error) {
-         logger.error(error);
-         const { json, status } = internalErrorToHttpError(error as Error);
-         res.status(status).json(json);
-      }
-   },
-);
-
 app.post(
    `${API_PREFIX}/environments/:environmentName/connections/:connectionName/sqlSource`,
    async (req, res) => {
@@ -1085,26 +1062,6 @@ app.post(
 );
 
 // Per-package versions
-app.get(
-   `${API_PREFIX}/environments/:environmentName/packages/:packageName/connections/:connectionName/sqlSource`,
-   async (req, res) => {
-      try {
-         res.status(200).json(
-            await connectionController.getConnectionSqlSource(
-               req.params.environmentName,
-               req.params.connectionName,
-               req.query.sqlStatement as string,
-               req.params.packageName,
-            ),
-         );
-      } catch (error) {
-         logger.error(error);
-         const { json, status } = internalErrorToHttpError(error as Error);
-         res.status(status).json(json);
-      }
-   },
-);
-
 app.post(
    `${API_PREFIX}/environments/:environmentName/packages/:packageName/connections/:connectionName/sqlSource`,
    async (req, res) => {
@@ -1139,21 +1096,12 @@ app.post(
    queryConcurrency(),
    async (req, res) => {
       try {
-         let options: string | ParsedQs | (string | ParsedQs)[] | undefined;
-
-         // Support both body and query parameters for options for backwards compatibility
-         // TODO: To be removed in the future
-         if (req.body?.options) {
-            options = req.body.options;
-         } else {
-            options = req.query.options;
-         }
          res.status(200).json(
             await connectionController.getConnectionQueryData(
                req.params.environmentName,
                req.params.connectionName,
                req.body.sqlStatement as string,
-               options as string,
+               req.body?.options as string,
             ),
          );
       } catch (error) {
@@ -1169,65 +1117,12 @@ app.post(
    queryConcurrency(),
    async (req, res) => {
       try {
-         let options: string | ParsedQs | (string | ParsedQs)[] | undefined;
-         if (req.body?.options) {
-            options = req.body.options;
-         } else {
-            options = req.query.options;
-         }
          res.status(200).json(
             await connectionController.getConnectionQueryData(
                req.params.environmentName,
                req.params.connectionName,
                req.body.sqlStatement as string,
-               options as string,
-               req.params.packageName,
-            ),
-         );
-      } catch (error) {
-         logger.error(error);
-         const { json, status } = internalErrorToHttpError(error as Error);
-         res.status(status).json(json);
-      }
-   },
-);
-
-/**
- * @deprecated Use environments/:environmentName/connections/:connectionName/sqlTemporaryTable POST method instead
- */
-app.get(
-   `${API_PREFIX}/environments/:environmentName/connections/:connectionName/temporaryTable`,
-   queryConcurrency(),
-   async (req, res) => {
-      try {
-         res.status(200).json(
-            await connectionController.getConnectionTemporaryTable(
-               req.params.environmentName,
-               req.params.connectionName,
-               req.query.sqlStatement as string,
-            ),
-         );
-      } catch (error) {
-         logger.error(error);
-         const { json, status } = internalErrorToHttpError(error as Error);
-         res.status(status).json(json);
-      }
-   },
-);
-
-/**
- * @deprecated Use /environments/:environmentName/packages/:packageName/connections/:connectionName/sqlTemporaryTable
- */
-app.get(
-   `${API_PREFIX}/environments/:environmentName/packages/:packageName/connections/:connectionName/temporaryTable`,
-   queryConcurrency(),
-   async (req, res) => {
-      try {
-         res.status(200).json(
-            await connectionController.getConnectionTemporaryTable(
-               req.params.environmentName,
-               req.params.connectionName,
-               req.query.sqlStatement as string,
+               req.body?.options as string,
                req.params.packageName,
             ),
          );

--- a/packages/server/src/service/materialization_service.spec.ts
+++ b/packages/server/src/service/materialization_service.spec.ts
@@ -27,6 +27,7 @@ function makeMaterialization(
       id: "mat-1",
       environmentId: "env-1",
       packageName: "pkg",
+      pauseBetweenPhases: false,
       status: "PENDING",
       buildPlan: null,
       manifest: null,
@@ -178,7 +179,11 @@ describe("MaterializationService", () => {
          const result = await ctx.service.createMaterialization(
             "my-env",
             "pkg",
-            { forceRefresh: true, sourceNames: ["orders"] },
+            {
+               forceRefresh: true,
+               sourceNames: ["orders"],
+               pauseBetweenPhases: true,
+            },
          );
 
          expect(result.status).toBe("PENDING");
@@ -186,8 +191,29 @@ describe("MaterializationService", () => {
             "env-1",
             "pkg",
             "PENDING",
-            { forceRefresh: true, sourceNames: ["orders"] },
+            {
+               forceRefresh: true,
+               sourceNames: ["orders"],
+               pauseBetweenPhases: true,
+            },
          ]);
+      });
+
+      it("defaults pauseBetweenPhases to false (auto-run) in metadata", async () => {
+         ctx.repository.getActiveMaterialization.resolves(null);
+         ctx.repository.createMaterialization.resolves(
+            makeMaterialization({ status: "PENDING" }),
+         );
+
+         await ctx.service.createMaterialization("my-env", "pkg", {});
+
+         expect(ctx.repository.createMaterialization.firstCall.args[3]).toEqual(
+            {
+               forceRefresh: false,
+               sourceNames: null,
+               pauseBetweenPhases: false,
+            },
+         );
       });
 
       it("rejects when an active materialization already exists", async () => {
@@ -215,9 +241,27 @@ describe("MaterializationService", () => {
    });
 
    describe("buildMaterialization (Round 2)", () => {
+      it("rejects action=build on an auto-run materialization", async () => {
+         ctx.repository.getMaterializationById.resolves(
+            makeMaterialization({
+               status: "BUILD_PLAN_READY",
+               pauseBetweenPhases: false,
+               buildPlan: makeBuildPlan(),
+            }),
+         );
+         await expect(
+            ctx.service.buildMaterialization("my-env", "pkg", "mat-1", [
+               makeInstruction(),
+            ]),
+         ).rejects.toThrow(InvalidStateTransitionError);
+      });
+
       it("rejects when not at BUILD_PLAN_READY", async () => {
          ctx.repository.getMaterializationById.resolves(
-            makeMaterialization({ status: "PENDING" }),
+            makeMaterialization({
+               status: "PENDING",
+               pauseBetweenPhases: true,
+            }),
          );
          await expect(
             ctx.service.buildMaterialization("my-env", "pkg", "mat-1", [
@@ -230,6 +274,7 @@ describe("MaterializationService", () => {
          ctx.repository.getMaterializationById.resolves(
             makeMaterialization({
                status: "BUILD_PLAN_READY",
+               pauseBetweenPhases: true,
                buildPlan: makeBuildPlan(),
             }),
          );
@@ -244,6 +289,7 @@ describe("MaterializationService", () => {
          ctx.repository.getMaterializationById.resolves(
             makeMaterialization({
                status: "BUILD_PLAN_READY",
+               pauseBetweenPhases: true,
                buildPlan: makeBuildPlan(),
             }),
          );
@@ -257,6 +303,7 @@ describe("MaterializationService", () => {
       it("accepts a valid build and returns the record (202)", async () => {
          const m = makeMaterialization({
             status: "BUILD_PLAN_READY",
+            pauseBetweenPhases: true,
             buildPlan: makeBuildPlan(),
          });
          ctx.repository.getMaterializationById.resolves(m);

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -20,6 +20,7 @@ import {
 } from "../materialization_metrics";
 import {
    BuildInstruction,
+   BuildManifest,
    BuildManifestResult,
    BuildPlan,
    Materialization,
@@ -74,6 +75,22 @@ function flattenDependsOn(node: {
    dependsOn: { sourceID: string }[];
 }): string[] {
    return node.dependsOn.map((d) => d.sourceID);
+}
+
+/**
+ * Physical table name the publisher self-assigns in auto-run mode: the
+ * `#@ persist name=<table>` value if present, else the Malloy source name.
+ * The author owns quoting the `name=` value for the dialect.
+ */
+function selfAssignTableName(persistSource: PersistSource): string {
+   try {
+      return (
+         persistSource.annotations.parseAsTag("@").tag.text("name") ||
+         persistSource.name
+      );
+   } catch {
+      return persistSource.name;
+   }
 }
 
 /** Classify a thrown round error as cancelled (cooperative abort) or failed. */
@@ -225,7 +242,11 @@ export class MaterializationService {
    async createMaterialization(
       environmentName: string,
       packageName: string,
-      options: { forceRefresh?: boolean; sourceNames?: string[] } = {},
+      options: {
+         forceRefresh?: boolean;
+         sourceNames?: string[];
+         pauseBetweenPhases?: boolean;
+      } = {},
    ): Promise<Materialization> {
       const environmentId = await this.resolveEnvironmentId(environmentName);
 
@@ -245,9 +266,12 @@ export class MaterializationService {
          );
       }
 
+      const pauseBetweenPhases = options.pauseBetweenPhases ?? false;
+      const forceRefresh = options.forceRefresh ?? false;
       const metadata = {
-         forceRefresh: options.forceRefresh ?? false,
+         forceRefresh,
          sourceNames: options.sourceNames ?? null,
+         pauseBetweenPhases,
       };
 
       let created: Materialization;
@@ -273,13 +297,26 @@ export class MaterializationService {
          throw err;
       }
 
-      this.runInBackground(created.id, () =>
-         this.runRound1(
-            created.id,
-            environmentName,
-            packageName,
-            options.sourceNames,
-         ),
+      // Default (auto-run): compile, self-assign names, build, and auto-load in
+      // one pass. Opt-in two-round: pause at BUILD_PLAN_READY for the control
+      // plane to drive Round 2.
+      this.runInBackground(created.id, (signal) =>
+         pauseBetweenPhases
+            ? this.runRound1(
+                 created.id,
+                 environmentName,
+                 packageName,
+                 options.sourceNames,
+                 signal,
+              )
+            : this.runAuto(
+                 created.id,
+                 environmentName,
+                 packageName,
+                 options.sourceNames,
+                 forceRefresh,
+                 signal,
+              ),
       );
 
       return created;
@@ -331,6 +368,230 @@ export class MaterializationService {
       }
    }
 
+   // ==================== AUTO-RUN (DEFAULT) ====================
+
+   /**
+    * Auto-run (default, pauseBetweenPhases=false). Compile + plan, then
+    * self-assign physical table names (the `#@ persist name=` value, else the
+    * source name) with realization=COPY, skip sources whose buildId is
+    * unchanged since the most recent successful manifest (unless forceRefresh),
+    * build the rest, assemble the manifest, and auto-load it into the package
+    * models so subsequent queries resolve to the materialized tables. No pause,
+    * no second round.
+    */
+   private async runAuto(
+      id: string,
+      environmentName: string,
+      packageName: string,
+      sourceNames: string[] | undefined,
+      forceRefresh: boolean,
+      signal: AbortSignal,
+   ): Promise<void> {
+      logger.info("Materialization auto-run: compile + build + load", {
+         materializationId: id,
+         packageName,
+      });
+      const startedAt = Date.now();
+
+      try {
+         const environmentId = await this.resolveEnvironmentId(environmentName);
+         const environment = await this.environmentStore.getEnvironment(
+            environmentName,
+            false,
+         );
+         const pkg = await environment.getPackage(packageName, false);
+
+         const compiled = await environment.withPackageLock(packageName, () =>
+            this.compilePackageBuildPlan(pkg, signal),
+         );
+
+         const buildPlan = this.deriveBuildPlan(
+            compiled.graphs,
+            compiled.sources,
+            compiled.connectionDigests,
+            sourceNames,
+         );
+         await this.transition(id, "BUILD_PLAN_READY", { buildPlan });
+
+         // Skip-if-unchanged: reuse tables from the most recent successful
+         // manifest for sources whose buildId is unchanged, unless forceRefresh.
+         const priorEntries = forceRefresh
+            ? {}
+            : await this.getMostRecentManifestEntries(
+                 environmentId,
+                 packageName,
+                 id,
+              );
+         const { instructions, carried } = this.deriveSelfInstructions(
+            compiled,
+            sourceNames,
+            priorEntries,
+         );
+
+         const entries = await this.executeInstructedBuild(
+            compiled,
+            instructions,
+            carried,
+            signal,
+         );
+
+         await this.transition(id, "MANIFEST_ROWS_READY");
+
+         const manifestResult: BuildManifestResult = {
+            builtAt: new Date().toISOString(),
+            entries,
+            strict: false,
+         };
+         const durationMs = Date.now() - startedAt;
+         await this.transition(id, "MANIFEST_FILE_READY", {
+            completedAt: new Date(),
+            manifest: manifestResult,
+            metadata: {
+               forceRefresh,
+               sourceNames: sourceNames ?? null,
+               pauseBetweenPhases: false,
+               sourcesBuilt: instructions.length,
+               sourcesReused: Object.keys(carried).length,
+               durationMs,
+            },
+         });
+
+         await this.autoLoadManifest(environment, packageName, entries);
+
+         this.recordRound("auto", "success", startedAt);
+         logger.info("Materialization auto-run complete", {
+            materializationId: id,
+            packageName,
+            sourcesBuilt: instructions.length,
+            sourcesReused: Object.keys(carried).length,
+            durationMs,
+         });
+      } catch (err) {
+         this.recordRound("auto", outcomeFor(err, signal), startedAt);
+         throw err;
+      }
+   }
+
+   /**
+    * Derive the publisher's own build instructions for auto-run. Each persist
+    * source (respecting the optional sourceNames filter) gets a self-assigned
+    * physical table name and COPY realization, unless its buildId is unchanged
+    * since `priorEntries` — those are carried forward (reused) instead of
+    * rebuilt.
+    */
+   private deriveSelfInstructions(
+      compiled: {
+         graphs: MalloyBuildGraph[];
+         sources: Record<string, PersistSource>;
+         connectionDigests: Record<string, string>;
+      },
+      sourceNames: string[] | undefined,
+      priorEntries: Record<string, ManifestEntry>,
+   ): {
+      instructions: BuildInstruction[];
+      carried: Record<string, ManifestEntry>;
+   } {
+      const include = sourceNames ? new Set(sourceNames) : null;
+      const instructions: BuildInstruction[] = [];
+      const carried: Record<string, ManifestEntry> = {};
+      const seen = new Set<string>();
+
+      for (const graph of compiled.graphs) {
+         for (const level of graph.nodes) {
+            for (const node of level) {
+               const persistSource = compiled.sources[node.sourceID];
+               if (!persistSource) continue;
+               if (include && !include.has(persistSource.name)) continue;
+
+               const buildId = persistSource.makeBuildId(
+                  compiled.connectionDigests[persistSource.connectionName],
+                  persistSource.getSQL(),
+               );
+               if (seen.has(buildId)) continue;
+               seen.add(buildId);
+
+               const prior = priorEntries[buildId];
+               if (prior && prior.physicalTableName) {
+                  carried[buildId] = prior;
+                  continue;
+               }
+
+               instructions.push({
+                  buildId,
+                  materializedTableId: `local-${buildId.substring(
+                     0,
+                     STAGING_BUILD_ID_LEN,
+                  )}`,
+                  physicalTableName: selfAssignTableName(persistSource),
+                  realization: "COPY",
+               });
+            }
+         }
+      }
+
+      return { instructions, carried };
+   }
+
+   /**
+    * Entries of the most recent successful (MANIFEST_FILE_READY) materialization
+    * for this package, used for skip-if-unchanged. Excludes the in-flight run.
+    */
+   private async getMostRecentManifestEntries(
+      environmentId: string,
+      packageName: string,
+      excludeId: string,
+   ): Promise<Record<string, ManifestEntry>> {
+      const list = await this.repository.listMaterializations(
+         environmentId,
+         packageName,
+      );
+      for (const m of list) {
+         if (m.id === excludeId) continue;
+         if (m.status === "MANIFEST_FILE_READY" && m.manifest?.entries) {
+            return m.manifest.entries;
+         }
+      }
+      return {};
+   }
+
+   /**
+    * Load a freshly produced manifest into the package's models so persist
+    * references resolve to the materialized tables. Best-effort: a load failure
+    * is logged, not fatal (the run already reached MANIFEST_FILE_READY).
+    */
+   private async autoLoadManifest(
+      environment: {
+         reloadAllModelsForPackage(
+            packageName: string,
+            manifest: BuildManifest["entries"],
+         ): Promise<void>;
+      },
+      packageName: string,
+      entries: Record<string, ManifestEntry>,
+   ): Promise<void> {
+      const manifestEntries: BuildManifest["entries"] = {};
+      for (const [buildId, entry] of Object.entries(entries)) {
+         if (entry.physicalTableName) {
+            manifestEntries[buildId] = { tableName: entry.physicalTableName };
+         }
+      }
+      try {
+         await environment.reloadAllModelsForPackage(
+            packageName,
+            manifestEntries,
+         );
+         logger.info("Auto-run: loaded manifest into package models", {
+            packageName,
+            entryCount: Object.keys(manifestEntries).length,
+         });
+      } catch (err) {
+         logger.warn("Auto-run: failed to load manifest into package models", {
+            packageName,
+            error: err instanceof Error ? err.message : String(err),
+         });
+      }
+   }
+
    // ==================== ROUND 2: BUILD ====================
 
    /**
@@ -346,6 +607,11 @@ export class MaterializationService {
    ): Promise<Materialization> {
       const m = await this.getMaterialization(environmentName, packageName, id);
 
+      if (!m.pauseBetweenPhases) {
+         throw new InvalidStateTransitionError(
+            `Materialization ${id} is an auto-run materialization; action=build does not apply (set pauseBetweenPhases=true for the two-round flow)`,
+         );
+      }
       if (m.status !== "BUILD_PLAN_READY") {
          throw new InvalidStateTransitionError(
             `Materialization ${id} is ${m.status}, expected BUILD_PLAN_READY`,
@@ -412,52 +678,16 @@ export class MaterializationService {
          );
          const pkg = await environment.getPackage(packageName, false);
 
-         const { graphs, sources, connectionDigests, connections } =
-            await environment.withPackageLock(packageName, () =>
-               this.compilePackageBuildPlan(pkg, signal),
-            );
+         const compiled = await environment.withPackageLock(packageName, () =>
+            this.compilePackageBuildPlan(pkg, signal),
+         );
 
-         const byBuildId = new Map<string, BuildInstruction>();
-         for (const instruction of instructions) {
-            byBuildId.set(instruction.buildId, instruction);
-         }
-
-         // Accumulates physical names as sources are built so downstream sources
-         // resolve their upstream references to the freshly-assigned tables.
-         const manifest = new Manifest();
-         const entries: Record<string, ManifestEntry> = {};
-
-         for (const graph of graphs) {
-            const connection = connections.get(graph.connectionName);
-            if (!connection) {
-               throw new BadRequestError(
-                  `Connection '${graph.connectionName}' not found`,
-               );
-            }
-            for (const level of graph.nodes) {
-               for (const node of level) {
-                  if (signal.aborted) throw new Error("Build cancelled");
-                  const persistSource = sources[node.sourceID];
-                  if (!persistSource) continue;
-
-                  const buildId = persistSource.makeBuildId(
-                     connectionDigests[persistSource.connectionName],
-                     persistSource.getSQL(),
-                  );
-                  const instruction = byBuildId.get(buildId);
-                  if (!instruction) continue;
-
-                  const entry = await this.buildOneSource(
-                     persistSource,
-                     instruction,
-                     connection,
-                     connectionDigests,
-                     manifest,
-                  );
-                  entries[buildId] = entry;
-               }
-            }
-         }
+         const entries = await this.executeInstructedBuild(
+            compiled,
+            instructions,
+            {},
+            signal,
+         );
 
          await this.transition(id, "MANIFEST_ROWS_READY");
 
@@ -490,7 +720,79 @@ export class MaterializationService {
    }
 
    /**
-    * Build a single instructed source into its CP-assigned physical table.
+    * Shared build loop for both auto-run and Round 2. Seeds the manifest with
+    * carried-forward (reused) upstream entries so downstream references resolve,
+    * then builds each instructed source in dependency order. Returns the full
+    * entry map (carried + freshly built). The package was compiled by the
+    * caller; this runs outside the package lock.
+    */
+   private async executeInstructedBuild(
+      compiled: {
+         graphs: MalloyBuildGraph[];
+         sources: Record<string, PersistSource>;
+         connectionDigests: Record<string, string>;
+         connections: Map<string, MalloyConnection>;
+      },
+      instructions: BuildInstruction[],
+      seedEntries: Record<string, ManifestEntry>,
+      signal: AbortSignal,
+   ): Promise<Record<string, ManifestEntry>> {
+      const { graphs, sources, connectionDigests, connections } = compiled;
+
+      const byBuildId = new Map<string, BuildInstruction>();
+      for (const instruction of instructions) {
+         byBuildId.set(instruction.buildId, instruction);
+      }
+
+      // Accumulates physical names as sources are built so downstream sources
+      // resolve their upstream references to the freshly-assigned tables. Seed
+      // it with carried-forward entries so reused upstreams resolve too.
+      const manifest = new Manifest();
+      const entries: Record<string, ManifestEntry> = {};
+      for (const [buildId, entry] of Object.entries(seedEntries)) {
+         if (entry.physicalTableName) {
+            manifest.update(buildId, { tableName: entry.physicalTableName });
+         }
+         entries[buildId] = entry;
+      }
+
+      for (const graph of graphs) {
+         const connection = connections.get(graph.connectionName);
+         if (!connection) {
+            throw new BadRequestError(
+               `Connection '${graph.connectionName}' not found`,
+            );
+         }
+         for (const level of graph.nodes) {
+            for (const node of level) {
+               if (signal.aborted) throw new Error("Build cancelled");
+               const persistSource = sources[node.sourceID];
+               if (!persistSource) continue;
+
+               const buildId = persistSource.makeBuildId(
+                  connectionDigests[persistSource.connectionName],
+                  persistSource.getSQL(),
+               );
+               const instruction = byBuildId.get(buildId);
+               if (!instruction) continue;
+
+               const entry = await this.buildOneSource(
+                  persistSource,
+                  instruction,
+                  connection,
+                  connectionDigests,
+                  manifest,
+               );
+               entries[buildId] = entry;
+            }
+         }
+      }
+
+      return entries;
+   }
+
+   /**
+    * Build a single instructed source into its assigned physical table.
     * COPY uses a staging table + atomic rename for crash-safety; the staging
     * name derives from the buildId. Records and returns the manifest entry.
     */

--- a/packages/server/src/storage/DatabaseInterface.ts
+++ b/packages/server/src/storage/DatabaseInterface.ts
@@ -122,6 +122,11 @@ export interface Materialization {
    id: string;
    environmentId: string;
    packageName: string;
+   /**
+    * Echoes the create-time flag (read from metadata). False (default) =
+    * auto-run all phases; true = pause at BUILD_PLAN_READY for Round 2.
+    */
+   pauseBetweenPhases: boolean;
    status: MaterializationStatus;
    /** Round 1 output. Null until status >= BUILD_PLAN_READY. */
    buildPlan: BuildPlan | null;

--- a/packages/server/src/storage/duckdb/MaterializationRepository.ts
+++ b/packages/server/src/storage/duckdb/MaterializationRepository.ts
@@ -232,14 +232,16 @@ export class MaterializationRepository {
    }
 
    private mapRow(row: Record<string, unknown>): Materialization {
+      const metadata = parseJsonColumn<Record<string, unknown>>(row.metadata);
       return {
          id: row.id as string,
          environmentId: row.environment_id as string,
          packageName: row.package_name as string,
+         pauseBetweenPhases: metadata?.pauseBetweenPhases === true,
          status: row.status as MaterializationStatus,
          buildPlan: parseJsonColumn<BuildPlan>(row.build_plan),
          manifest: parseJsonColumn<BuildManifestResult>(row.manifest),
-         metadata: parseJsonColumn<Record<string, unknown>>(row.metadata),
+         metadata,
          startedAt: row.started_at ? new Date(row.started_at as string) : null,
          completedAt: row.completed_at
             ? new Date(row.completed_at as string)

--- a/packages/server/tests/integration/materialization/materialization_lifecycle.integration.spec.ts
+++ b/packages/server/tests/integration/materialization/materialization_lifecycle.integration.spec.ts
@@ -21,7 +21,7 @@ const SETTLED_STATUSES = [
 ];
 const TERMINAL_STATUSES = ["MANIFEST_FILE_READY", "FAILED", "CANCELLED"];
 
-describe("Materialization two-round REST API (E2E)", () => {
+describe("Materialization REST API: auto-run + two-round (E2E)", () => {
    let env: (RestE2EEnv & { stop(): Promise<void> }) | null = null;
    let baseUrl: string;
 
@@ -91,13 +91,16 @@ describe("Materialization two-round REST API (E2E)", () => {
       return `${baseUrl}${API}${p}`;
    }
 
+   // Most tests here exercise the control-plane two-round flow, so default to
+   // pauseBetweenPhases=true (pause at BUILD_PLAN_READY). The auto-run group
+   // overrides this with pauseBetweenPhases=false.
    async function createMaterialization(
       body: Record<string, unknown> = {},
    ): Promise<Response> {
       return fetch(url("/materializations"), {
          method: "POST",
          headers: { "Content-Type": "application/json" },
-         body: JSON.stringify(body),
+         body: JSON.stringify({ pauseBetweenPhases: true, ...body }),
       });
    }
 
@@ -161,6 +164,95 @@ describe("Materialization two-round REST API (E2E)", () => {
       expect(values.length).toBeGreaterThan(0);
       return values[0];
    }
+
+   // ── Group A0: Auto-run lifecycle (default) ───────────────────────
+
+   describe("auto-run lifecycle (default)", () => {
+      it(
+         "runs all phases on create, self-assigns names, and auto-loads",
+         async () => {
+            // pauseBetweenPhases=false (default): the publisher runs compile +
+            // plan + build + load in one pass with no Round 2.
+            const createRes = await createMaterialization({
+               pauseBetweenPhases: false,
+            });
+            expect(createRes.status).toBe(201);
+            const created = (await createRes.json()) as Record<string, unknown>;
+            expect(created.status).toBe("PENDING");
+            expect(created.pauseBetweenPhases).toBe(false);
+            const id = created.id as string;
+
+            // It settles at MANIFEST_FILE_READY without any build instruction.
+            const built = await pollUntil(
+               id,
+               (s) => TERMINAL_STATUSES.includes(s),
+               90_000,
+            );
+            expect(built.status).toBe("MANIFEST_FILE_READY");
+
+            // The manifest carries the self-assigned physical table name (from
+            // `#@ persist name="order_summary"`).
+            const manifest = built.manifest as Record<string, unknown>;
+            expect(manifest).toBeDefined();
+            const entries = manifest.entries as Record<
+               string,
+               Record<string, unknown>
+            >;
+            const values = Object.values(entries);
+            expect(values.length).toBe(1);
+            expect(values[0].physicalTableName).toBe("order_summary");
+            expect(values[0].sourceName).toBe("order_summary");
+            expect(values[0].realization).toBe("COPY");
+
+            // Cleanup: delete the record and drop the self-built table.
+            const deleteRes = await fetch(
+               url(`/materializations/${id}?dropTables=true`),
+               { method: "DELETE" },
+            );
+            expect(deleteRes.status).toBe(204);
+         },
+         { timeout: 120_000 },
+      );
+
+      it("rejects action=build on an auto-run materialization (409)", async () => {
+         // Force a pause so we can observe a BUILD_PLAN_READY record, but mark it
+         // auto-run via metadata by creating a real auto-run and racing build is
+         // flaky; instead assert the guard on a freshly created auto-run that we
+         // immediately try to build. Auto-run never needs Round 2.
+         const createRes = await createMaterialization({
+            pauseBetweenPhases: false,
+         });
+         expect(createRes.status).toBe(201);
+         const { id } = (await createRes.json()) as { id: string };
+
+         // Drive to terminal so there is no in-flight round, then assert build
+         // is rejected (auto-run records never accept action=build).
+         await pollUntil(id, (s) => TERMINAL_STATUSES.includes(s), 90_000);
+
+         const buildRes = await fetch(
+            url(`/materializations/${id}?action=build`),
+            {
+               method: "POST",
+               headers: { "Content-Type": "application/json" },
+               body: JSON.stringify({
+                  sources: [
+                     {
+                        buildId: "x",
+                        materializedTableId: "mt",
+                        physicalTableName: "t",
+                        realization: "COPY",
+                     },
+                  ],
+               }),
+            },
+         );
+         expect(buildRes.status).toBe(409);
+
+         await fetch(url(`/materializations/${id}?dropTables=true`), {
+            method: "DELETE",
+         });
+      });
+   });
 
    // ── Group A: Full two-round lifecycle (happy path) ────────────────
 


### PR DESCRIPTION
## Summary

- Creating a materialization now **runs all phases automatically by default** (`pauseBetweenPhases=false`): compile + plan → self-assign physical table names (`#@ persist name=`, else the source name) with `realization=COPY` → skip-if-unchanged by `buildId` (unless `forceRefresh`) → build → assemble manifest → auto-load into the package models, ending at `MANIFEST_FILE_READY` with no second round.
- The control-plane **two-round flow is preserved behind opt-in `pauseBetweenPhases=true`**, which pauses at `BUILD_PLAN_READY` for the CP to drive Round 2 with assigned names. CP-owned identity/naming/reuse/GC are unaffected in that mode.
- Implements the approach documented in the v0 persistence ADRs (standalone auto-run default + orchestrated two-round).

### Changes by layer
- **Spec** (`api-doc.yaml`): add `pauseBetweenPhases` to `CreateMaterializationRequest` and `Materialization`; regenerated clients.
- **Server**: `runAuto` + a shared `executeInstructedBuild` loop (reused by Round 2), self-instruction derivation, skip-if-unchanged via the most recent successful manifest, and manifest auto-load; `action=build` is rejected on auto-run records; `pauseBetweenPhases` surfaced from metadata.
- **CLI**: `materialize` defaults to a full run, adds `--pause-between-phases`, and uses mode-aware settle/success states for `--wait`.
- **SDK**: `CreateMaterializationDialog` gains a "Pause between phases" toggle and a context-aware button label ("Materialize" / "Create plan"); the flag is threaded through `Materializations.tsx`.

## Test plan

- [x] `tsc --noEmit` clean: server, CLI, SDK
- [x] Server unit suite passing
- [x] CLI tests passing (auto vs. pause `--wait` behavior, flag forwarding)
- [x] E2E (`materialization_lifecycle.integration.spec.ts`) passing — new auto-run group builds `order_summary`, self-assigns the name, auto-loads, and rejects `action=build`
- [x] ESLint + Prettier clean on changed files

Made with [Cursor](https://cursor.com)