### PR TITLE
Materialization quality pass: simplify, tests, telemetry, serve-time binding

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -2451,6 +2451,37 @@ components:
             URI (gs:// or s3://) of the control-plane-computed manifest for this package.
             On (re)load the worker reads it and binds persist references
             (buildId -> physicalTableName). Null = serve live.
+        manifestBindingStatus:
+          type: string
+          readOnly: true
+          enum:
+            - unbound
+            - bound
+            - live_fallback
+          description: >-
+            Server-computed, read-only: whether the control-plane build manifest
+            is currently bound to this package's served models. `unbound` = no
+            manifest configured, so the package serves live. `bound` = a manifest
+            was fetched and applied, so persist sources route to their
+            materialized physical tables. `live_fallback` = a `manifestLocation`
+            is configured but the fetch/bind failed or timed out, so the package
+            is serving live despite intending to be materialized-routed. Lets the
+            control plane confirm a worker actually bound a distributed manifest
+            rather than inferring it from logs.
+        manifestEntryCount:
+          type: integer
+          readOnly: true
+          description: >-
+            Server-computed, read-only: number of buildId -> physical-table
+            entries currently bound (0 when unbound or on live fallback).
+        boundManifestUri:
+          type: ["string", "null"]
+          readOnly: true
+          description: >-
+            Server-computed, read-only: the manifest URI actually bound to the
+            served models. Usually equals `manifestLocation`, but can differ
+            after an in-memory auto-load following a materialization build (no
+            URI), in which case it is null. Null whenever the package is unbound.
 
     Model:
       type: object

--- a/packages/server/src/materialization_metrics.ts
+++ b/packages/server/src/materialization_metrics.ts
@@ -86,10 +86,14 @@ export function recordSourceBuildDuration(durationMs: number): void {
    if (!sourceBuildDuration) {
       sourceBuildDuration = metrics
          .getMeter("publisher")
-         .createHistogram("publisher_materialization_source_build_duration_ms", {
-            description: "Wall-clock duration of building a single persist source.",
-            unit: "ms",
-         });
+         .createHistogram(
+            "publisher_materialization_source_build_duration_ms",
+            {
+               description:
+                  "Wall-clock duration of building a single persist source.",
+               unit: "ms",
+            },
+         );
    }
    sourceBuildDuration.record(durationMs);
 }

--- a/packages/server/src/materialization_metrics.ts
+++ b/packages/server/src/materialization_metrics.ts
@@ -17,9 +17,14 @@ import { metrics, type Counter, type Histogram } from "@opentelemetry/api";
 
 export type MaterializationRound = "round1" | "round2" | "auto";
 export type MaterializationOutcome = "success" | "failed" | "cancelled";
+/** Manifest bind outcome: timeout is split out from generic failure on purpose. */
+export type ManifestBindOutcome = "success" | "failure" | "timeout";
 
 let roundCounter: Counter | null = null;
 let roundDuration: Histogram | null = null;
+let manifestBindCounter: Counter | null = null;
+let sourceBuildDuration: Histogram | null = null;
+let dropTablesCounter: Counter | null = null;
 
 function ensureTelemetry(): { counter: Counter; duration: Histogram } {
    if (roundCounter && roundDuration) {
@@ -59,8 +64,54 @@ export function recordMaterializationRound(
    duration.record(durationMs, { round });
 }
 
+/**
+ * Record a manifest-bind attempt (publisher binding a control-plane manifest to
+ * a package at load). `timeout` is distinguished from `failure` so operators can
+ * tell an unreachable/slow manifest store from a malformed manifest.
+ */
+export function recordManifestBind(outcome: ManifestBindOutcome): void {
+   if (!manifestBindCounter) {
+      manifestBindCounter = metrics
+         .getMeter("publisher")
+         .createCounter("publisher_materialization_manifest_bind_total", {
+            description:
+               "Manifest bind attempts. Label: outcome ('success'|'failure'|'timeout').",
+         });
+   }
+   manifestBindCounter.add(1, { outcome });
+}
+
+/** Record the wall-clock duration of building one persist source's table. */
+export function recordSourceBuildDuration(durationMs: number): void {
+   if (!sourceBuildDuration) {
+      sourceBuildDuration = metrics
+         .getMeter("publisher")
+         .createHistogram("publisher_materialization_source_build_duration_ms", {
+            description: "Wall-clock duration of building a single persist source.",
+            unit: "ms",
+         });
+   }
+   sourceBuildDuration.record(durationMs);
+}
+
+/** Record a best-effort physical-table drop on materialization delete. */
+export function recordDropTables(outcome: "success" | "failure"): void {
+   if (!dropTablesCounter) {
+      dropTablesCounter = metrics
+         .getMeter("publisher")
+         .createCounter("publisher_materialization_drop_tables_total", {
+            description:
+               "Physical tables dropped on delete. Label: outcome ('success'|'failure').",
+         });
+   }
+   dropTablesCounter.add(1, { outcome });
+}
+
 /** Visible for tests. Drops cached instruments so a fresh MeterProvider can capture emissions. */
 export function resetMaterializationTelemetryForTesting(): void {
    roundCounter = null;
    roundDuration = null;
+   manifestBindCounter = null;
+   sourceBuildDuration = null;
+   dropTablesCounter = null;
 }

--- a/packages/server/src/service/environment.ts
+++ b/packages/server/src/service/environment.ts
@@ -21,6 +21,7 @@ import {
    ServiceUnavailableError,
 } from "../errors";
 import { logger } from "../logger";
+import { recordManifestBind } from "../materialization_metrics";
 import {
    assertSafeEnvironmentPath,
    assertSafePackageName,
@@ -55,6 +56,11 @@ import type { PackageMemoryGovernor } from "./package_memory_governor";
  */
 const STAGING_DIR_NAME = ".staging";
 const RETIRED_DIR_NAME = ".retired";
+
+// How long to wait for a control-plane manifest fetch during (re)bind before
+// giving up and serving live. Binding happens before a package is marked
+// SERVING, so an unreachable/slow manifest store must not block the package.
+const MANIFEST_FETCH_TIMEOUT_MS = 15_000;
 
 export enum PackageStatus {
    LOADING = "loading",
@@ -393,9 +399,17 @@ export class Environment {
          // Initialize Runtime with the package's active MalloyConfig so compile
          // checks see the same package-scoped duckdb as execution. This runtime
          // borrows the package config; the package/environment lifecycle owns release.
+         // Thread the package's bound build manifest (when present) so the
+         // /compile preview routes persist sources to their materialized tables
+         // exactly like execution does — otherwise includeSql=true would always
+         // show base-table SQL and diverge from what executeQuery actually runs.
+         const boundManifestEntries = pkg.getBuildManifestEntries();
          const runtime = new Runtime({
             urlReader: interceptingReader,
             config: pkg.getMalloyConfig(),
+            buildManifest: boundManifestEntries
+               ? { entries: boundManifestEntries, strict: false }
+               : undefined,
          });
 
          // Attempt to compile
@@ -1140,8 +1154,15 @@ export class Environment {
    ): Promise<void> {
       const packageName = pkg.getPackageName();
       try {
-         const entries = await fetchManifestEntries(manifestLocation);
+         // Bind runs before a package is marked SERVING, so a slow/unreachable
+         // manifest store must not block serving indefinitely — bound is the
+         // intended state, live is the degraded fallback. Race the fetch against
+         // a timeout and fall back to live on either failure.
+         const entries =
+            await this.fetchManifestEntriesWithTimeout(manifestLocation);
          await pkg.reloadAllModels(entries);
+         pkg.setBoundManifestUri(manifestLocation);
+         recordManifestBind("success");
          logger.info("Bound build manifest to package", {
             environmentName: this.environmentName,
             packageName,
@@ -1149,12 +1170,49 @@ export class Environment {
             entryCount: Object.keys(entries).length,
          });
       } catch (err) {
+         pkg.markManifestBindFailed();
+         const timedOut =
+            err instanceof Error && err.message.includes("Timed out after");
+         recordManifestBind(timedOut ? "timeout" : "failure");
          logger.warn("Failed to bind build manifest; serving live", {
             environmentName: this.environmentName,
             packageName,
             manifestLocation,
+            timedOut,
             error: err instanceof Error ? err.message : String(err),
          });
+      }
+   }
+
+   /**
+    * Fetch manifest entries, rejecting if the fetch exceeds
+    * {@link MANIFEST_FETCH_TIMEOUT_MS}. Keeps {@link bindManifest}'s bind-before-
+    * serve guarantee from stalling on an unreachable manifest store.
+    */
+   private async fetchManifestEntriesWithTimeout(
+      manifestLocation: string,
+   ): Promise<BuildManifest["entries"]> {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeout = new Promise<never>((_, reject) => {
+         timer = setTimeout(
+            () =>
+               reject(
+                  new Error(
+                     `Timed out after ${MANIFEST_FETCH_TIMEOUT_MS}ms fetching manifest ${manifestLocation}`,
+                  ),
+               ),
+            MANIFEST_FETCH_TIMEOUT_MS,
+         );
+      });
+      try {
+         return await Promise.race([
+            fetchManifestEntries(manifestLocation),
+            timeout,
+         ]);
+      } finally {
+         if (timer) {
+            clearTimeout(timer);
+         }
       }
    }
 

--- a/packages/server/src/service/materialization_service.spec.ts
+++ b/packages/server/src/service/materialization_service.spec.ts
@@ -621,7 +621,10 @@ describe("getMostRecentManifestEntries (skip-if-unchanged)", () => {
          },
       };
       ctx.repository.listMaterializations.resolves([
-         makeMaterialization({ id: "in-flight", status: "MANIFEST_ROWS_READY" }),
+         makeMaterialization({
+            id: "in-flight",
+            status: "MANIFEST_ROWS_READY",
+         }),
          makeMaterialization({
             id: "old-success",
             status: "MANIFEST_FILE_READY",
@@ -730,7 +733,13 @@ describe("buildOneSource (characterization)", () => {
                m: Manifest,
             ) => Promise<{ buildId: string; physicalTableName: string }>;
          }
-      ).buildOneSource(source, instruction, connection, { duckdb: "dig" }, new Manifest());
+      ).buildOneSource(
+         source,
+         instruction,
+         connection,
+         { duckdb: "dig" },
+         new Manifest(),
+      );
    }
 
    it("stages, swaps, and renames in a crash-safe order", async () => {

--- a/packages/server/src/service/materialization_service.spec.ts
+++ b/packages/server/src/service/materialization_service.spec.ts
@@ -606,6 +606,99 @@ describe("deriveSelfInstructions (characterization)", () => {
    });
 });
 
+describe("getMostRecentManifestEntries (skip-if-unchanged)", () => {
+   let ctx: ReturnType<typeof createMocks>;
+   beforeEach(() => {
+      ctx = createMocks();
+   });
+
+   it("returns entries from the most recent successful run, excluding the in-flight one", async () => {
+      const entries = {
+         b1: {
+            buildId: "b1",
+            physicalTableName: "orders_v1",
+            connectionName: "duckdb",
+         },
+      };
+      ctx.repository.listMaterializations.resolves([
+         makeMaterialization({ id: "in-flight", status: "MANIFEST_ROWS_READY" }),
+         makeMaterialization({
+            id: "old-success",
+            status: "MANIFEST_FILE_READY",
+            manifest: { builtAt: "t", strict: false, entries },
+         }),
+      ]);
+
+      const result = await (
+         ctx.service as unknown as {
+            getMostRecentManifestEntries: (
+               e: string,
+               p: string,
+               x: string,
+            ) => Promise<unknown>;
+         }
+      ).getMostRecentManifestEntries("env-1", "pkg", "in-flight");
+
+      expect(result).toEqual(entries);
+   });
+
+   it("returns {} when the only successful run is the excluded one", async () => {
+      ctx.repository.listMaterializations.resolves([
+         makeMaterialization({
+            id: "self",
+            status: "MANIFEST_FILE_READY",
+            manifest: {
+               builtAt: "t",
+               strict: false,
+               entries: { b1: { buildId: "b1", physicalTableName: "t1" } },
+            },
+         }),
+      ]);
+
+      const result = await (
+         ctx.service as unknown as {
+            getMostRecentManifestEntries: (
+               e: string,
+               p: string,
+               x: string,
+            ) => Promise<unknown>;
+         }
+      ).getMostRecentManifestEntries("env-1", "pkg", "self");
+
+      expect(result).toEqual({});
+   });
+});
+
+describe("stopMaterialization (in-flight)", () => {
+   let ctx: ReturnType<typeof createMocks>;
+   beforeEach(() => {
+      ctx = createMocks();
+   });
+
+   it("aborts a running build cooperatively without forcing a transition", async () => {
+      ctx.repository.getMaterializationById.resolves(
+         makeMaterialization({ status: "MANIFEST_ROWS_READY" }),
+      );
+      const controller = new AbortController();
+      (
+         ctx.service as unknown as {
+            runningAbortControllers: Map<string, AbortController>;
+         }
+      ).runningAbortControllers.set("mat-1", controller);
+
+      const result = await ctx.service.stopMaterialization(
+         "my-env",
+         "pkg",
+         "mat-1",
+      );
+
+      expect(controller.signal.aborted).toBe(true);
+      // The background run records the terminal state; stop must not also write.
+      expect(ctx.repository.updateMaterialization.called).toBe(false);
+      expect(result.status).toBe("MANIFEST_ROWS_READY");
+   });
+});
+
 describe("buildOneSource (characterization)", () => {
    let ctx: ReturnType<typeof createMocks>;
    beforeEach(() => {

--- a/packages/server/src/service/materialization_service.spec.ts
+++ b/packages/server/src/service/materialization_service.spec.ts
@@ -1,3 +1,4 @@
+import { Manifest } from "@malloydata/malloy";
 import { beforeEach, describe, expect, it } from "bun:test";
 import * as sinon from "sinon";
 import {
@@ -496,5 +497,174 @@ describe("MaterializationService", () => {
 describe("stagingSuffix", () => {
    it("derives a short, stable suffix from the buildId", () => {
       expect(stagingSuffix("abcdef1234567890")).toBe("_abcdef123456");
+   });
+});
+
+// Characterization (Pass 0): lock in the auto-run instruction-derivation and
+// the single-source build SQL sequence before the simplify pass moves them.
+// deriveSelfInstructions / buildOneSource are private; we exercise them via a
+// typed cast rather than the heavyweight runtime path.
+
+// A minimal stand-in for a Malloy PersistSource exposing only what the build
+// internals touch.
+function fakeSource(opts: {
+   name: string;
+   buildId: string;
+   sql?: string;
+   connectionName?: string;
+}): unknown {
+   return {
+      name: opts.name,
+      sourceID: opts.name,
+      connectionName: opts.connectionName ?? "duckdb",
+      makeBuildId: () => opts.buildId,
+      getSQL: () => opts.sql ?? "SELECT 1",
+      annotations: {
+         parseAsTag: () => ({ tag: { text: () => undefined } }),
+      },
+   };
+}
+
+describe("deriveSelfInstructions (characterization)", () => {
+   let ctx: ReturnType<typeof createMocks>;
+   beforeEach(() => {
+      ctx = createMocks();
+   });
+
+   function compiledWith(sources: Record<string, unknown>, levels: string[][]) {
+      return {
+         graphs: [
+            {
+               connectionName: "duckdb",
+               nodes: levels.map((level) =>
+                  level.map((sourceID) => ({ sourceID, dependsOn: [] })),
+               ),
+            },
+         ],
+         sources,
+         connectionDigests: { duckdb: "dig" },
+      };
+   }
+
+   it("carries forward unchanged buildIds and builds the rest (deduping repeats)", () => {
+      const compiled = compiledWith(
+         {
+            s1: fakeSource({ name: "s1", buildId: "b1aaaaaaaaaaaaaa" }),
+            s2: fakeSource({ name: "s2", buildId: "b2bbbbbbbbbbbbbb" }),
+         },
+         [["s1", "s2"], ["s2"]],
+      );
+      const priorEntries = {
+         b1aaaaaaaaaaaaaa: {
+            buildId: "b1aaaaaaaaaaaaaa",
+            physicalTableName: "s1_prev",
+            connectionName: "duckdb",
+         },
+      };
+
+      const { instructions, carried } = (
+         ctx.service as unknown as {
+            deriveSelfInstructions: (
+               c: unknown,
+               n: string[] | undefined,
+               p: unknown,
+            ) => { instructions: BuildInstruction[]; carried: unknown };
+         }
+      ).deriveSelfInstructions(compiled, undefined, priorEntries);
+
+      expect(instructions).toHaveLength(1);
+      expect(instructions[0].buildId).toBe("b2bbbbbbbbbbbbbb");
+      expect(instructions[0].physicalTableName).toBe("s2");
+      expect(instructions[0].realization).toBe("COPY");
+      expect(instructions[0].materializedTableId).toBe("local-b2bbbbbbbbbb");
+      expect(
+         (carried as Record<string, unknown>)["b1aaaaaaaaaaaaaa"],
+      ).toBeDefined();
+   });
+
+   it("honors the sourceNames filter (excluded sources are neither built nor carried)", () => {
+      const compiled = compiledWith(
+         {
+            s1: fakeSource({ name: "s1", buildId: "b1aaaaaaaaaaaaaa" }),
+            s2: fakeSource({ name: "s2", buildId: "b2bbbbbbbbbbbbbb" }),
+         },
+         [["s1", "s2"]],
+      );
+      const { instructions, carried } = (
+         ctx.service as unknown as {
+            deriveSelfInstructions: (
+               c: unknown,
+               n: string[] | undefined,
+               p: unknown,
+            ) => { instructions: BuildInstruction[]; carried: unknown };
+         }
+      ).deriveSelfInstructions(compiled, ["s2"], {});
+
+      expect(instructions).toHaveLength(1);
+      expect(instructions[0].buildId).toBe("b2bbbbbbbbbbbbbb");
+      expect(Object.keys(carried as Record<string, unknown>)).toHaveLength(0);
+   });
+});
+
+describe("buildOneSource (characterization)", () => {
+   let ctx: ReturnType<typeof createMocks>;
+   beforeEach(() => {
+      ctx = createMocks();
+   });
+
+   function callBuildOneSource(
+      connection: { runSQL: sinon.SinonStub },
+      physicalTableName: string,
+   ): Promise<{ buildId: string; physicalTableName: string }> {
+      const source = fakeSource({
+         name: "orders",
+         buildId: "abcdef1234567890",
+         sql: "SELECT * FROM t",
+      });
+      const instruction: BuildInstruction = {
+         buildId: "abcdef1234567890",
+         materializedTableId: "mt-1",
+         physicalTableName,
+         realization: "COPY",
+      };
+      return (
+         ctx.service as unknown as {
+            buildOneSource: (
+               s: unknown,
+               i: BuildInstruction,
+               c: unknown,
+               d: Record<string, string>,
+               m: Manifest,
+            ) => Promise<{ buildId: string; physicalTableName: string }>;
+         }
+      ).buildOneSource(source, instruction, connection, { duckdb: "dig" }, new Manifest());
+   }
+
+   it("stages, swaps, and renames in a crash-safe order", async () => {
+      const runSQL = sinon.stub().resolves();
+      const entry = await callBuildOneSource({ runSQL }, "orders_v1");
+
+      const sql = runSQL.getCalls().map((c) => c.args[0] as string);
+      expect(sql).toEqual([
+         "DROP TABLE IF EXISTS orders_v1_abcdef123456",
+         "CREATE TABLE orders_v1_abcdef123456 AS (SELECT * FROM t)",
+         "DROP TABLE IF EXISTS orders_v1",
+         "ALTER TABLE orders_v1_abcdef123456 RENAME TO orders_v1",
+      ]);
+      expect(entry.physicalTableName).toBe("orders_v1");
+      expect(entry.buildId).toBe("abcdef1234567890");
+   });
+
+   it("drops the staging table and rethrows when the build SQL fails", async () => {
+      const runSQL = sinon.stub();
+      runSQL.onCall(0).resolves(); // initial staging drop
+      runSQL.onCall(1).rejects(new Error("create boom")); // CREATE TABLE AS
+      runSQL.onCall(2).resolves(); // cleanup staging drop
+      await expect(callBuildOneSource({ runSQL }, "orders_v1")).rejects.toThrow(
+         "create boom",
+      );
+      expect(runSQL.lastCall.args[0]).toBe(
+         "DROP TABLE IF EXISTS orders_v1_abcdef123456",
+      );
    });
 });

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -78,6 +78,21 @@ function flattenDependsOn(node: {
 }
 
 /**
+ * The buildId for a persist source: a stable digest of its connection identity
+ * and canonical SQL. Centralizes the (source, connectionDigests) call shape so
+ * planning, self-instruction, and build all agree on the same id.
+ */
+function computeBuildId(
+   source: PersistSource,
+   connectionDigests: Record<string, string>,
+): string {
+   return source.makeBuildId(
+      connectionDigests[source.connectionName],
+      source.getSQL(),
+   );
+}
+
+/**
  * Physical table name the publisher self-assigns in auto-run mode: the
  * `#@ persist name=<table>` value if present, else the Malloy source name.
  * The author owns quoting the `name=` value for the dialect.
@@ -435,25 +450,14 @@ export class MaterializationService {
             signal,
          );
 
-         await this.transition(id, "MANIFEST_ROWS_READY");
-
-         const manifestResult: BuildManifestResult = {
-            builtAt: new Date().toISOString(),
-            entries,
-            strict: false,
-         };
          const durationMs = Date.now() - startedAt;
-         await this.transition(id, "MANIFEST_FILE_READY", {
-            completedAt: new Date(),
-            manifest: manifestResult,
-            metadata: {
-               forceRefresh,
-               sourceNames: sourceNames ?? null,
-               pauseBetweenPhases: false,
-               sourcesBuilt: instructions.length,
-               sourcesReused: Object.keys(carried).length,
-               durationMs,
-            },
+         await this.commitManifest(id, entries, {
+            forceRefresh,
+            sourceNames: sourceNames ?? null,
+            pauseBetweenPhases: false,
+            sourcesBuilt: instructions.length,
+            sourcesReused: Object.keys(carried).length,
+            durationMs,
          });
 
          await this.autoLoadManifest(environment, packageName, entries);
@@ -503,9 +507,9 @@ export class MaterializationService {
                if (!persistSource) continue;
                if (include && !include.has(persistSource.name)) continue;
 
-               const buildId = persistSource.makeBuildId(
-                  compiled.connectionDigests[persistSource.connectionName],
-                  persistSource.getSQL(),
+               const buildId = computeBuildId(
+                  persistSource,
+                  compiled.connectionDigests,
                );
                if (seen.has(buildId)) continue;
                seen.add(buildId);
@@ -689,21 +693,10 @@ export class MaterializationService {
             signal,
          );
 
-         await this.transition(id, "MANIFEST_ROWS_READY");
-
-         const manifestResult: BuildManifestResult = {
-            builtAt: new Date().toISOString(),
-            entries,
-            strict: false,
-         };
          const durationMs = Date.now() - startedAt;
-         await this.transition(id, "MANIFEST_FILE_READY", {
-            completedAt: new Date(),
-            manifest: manifestResult,
-            metadata: {
-               sourcesBuilt: Object.keys(entries).length,
-               durationMs,
-            },
+         await this.commitManifest(id, entries, {
+            sourcesBuilt: Object.keys(entries).length,
+            durationMs,
          });
 
          this.recordRound("round2", "success", startedAt);
@@ -769,10 +762,7 @@ export class MaterializationService {
                const persistSource = sources[node.sourceID];
                if (!persistSource) continue;
 
-               const buildId = persistSource.makeBuildId(
-                  connectionDigests[persistSource.connectionName],
-                  persistSource.getSQL(),
-               );
+               const buildId = computeBuildId(persistSource, connectionDigests);
                const instruction = byBuildId.get(buildId);
                if (!instruction) continue;
 
@@ -845,7 +835,8 @@ export class MaterializationService {
       // Make this table visible to downstream sources built later this round.
       manifest.update(buildId, { tableName: physicalTableName });
 
-      logger.info(`Round 2 built source ${persistSource.name}`, {
+      // Shared by auto-run and Round 2, so the message is path-neutral.
+      logger.info(`Built materialized source ${persistSource.name}`, {
          physicalTableName,
          durationMs: Math.round(performance.now() - startTime),
       });
@@ -996,6 +987,29 @@ export class MaterializationService {
       }
    }
 
+   /**
+    * Finalize a successful build: advance MANIFEST_ROWS_READY -> FILE_READY and
+    * persist the assembled manifest. Shared by auto-run and Round 2; the caller
+    * supplies the per-path metadata. The build itself happens before this.
+    */
+   private async commitManifest(
+      id: string,
+      entries: Record<string, ManifestEntry>,
+      metadata: Record<string, unknown>,
+   ): Promise<void> {
+      await this.transition(id, "MANIFEST_ROWS_READY");
+      const manifest: BuildManifestResult = {
+         builtAt: new Date().toISOString(),
+         entries,
+         strict: false,
+      };
+      await this.transition(id, "MANIFEST_FILE_READY", {
+         completedAt: new Date(),
+         manifest,
+         metadata,
+      });
+   }
+
    // ==================== BUILD PLAN COMPILATION ====================
 
    /**
@@ -1098,10 +1112,7 @@ export class MaterializationService {
             sourceID: source.sourceID,
             connectionName: source.connectionName,
             dialect: source.dialectName,
-            buildId: source.makeBuildId(
-               connectionDigests[source.connectionName],
-               source.getSQL(),
-            ),
+            buildId: computeBuildId(source, connectionDigests),
             sql: source.getSQL(),
             columns: deriveColumns(source),
          };

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -16,7 +16,9 @@ import {
 import { logger } from "../logger";
 import {
    MaterializationRound,
+   recordDropTables,
    recordMaterializationRound,
+   recordSourceBuildDuration,
 } from "../materialization_metrics";
 import {
    BuildInstruction,
@@ -208,6 +210,11 @@ export class MaterializationService {
          );
       }
       this.validateTransition(current.status, next);
+      logger.info("Materialization transition", {
+         materializationId: id,
+         from: current.status,
+         to: next,
+      });
       return this.repository.updateMaterialization(id, {
          status: next,
          ...extra,
@@ -835,10 +842,12 @@ export class MaterializationService {
       // Make this table visible to downstream sources built later this round.
       manifest.update(buildId, { tableName: physicalTableName });
 
+      const durationMs = Math.round(performance.now() - startTime);
+      recordSourceBuildDuration(durationMs);
       // Shared by auto-run and Round 2, so the message is path-neutral.
       logger.info(`Built materialized source ${persistSource.name}`, {
          physicalTableName,
-         durationMs: Math.round(performance.now() - startTime),
+         durationMs,
       });
 
       return {
@@ -971,12 +980,14 @@ export class MaterializationService {
                   entry.buildId,
                )}`,
             );
+            recordDropTables("success");
             logger.info("Dropped materialized table on delete", {
                materializationId: m.id,
                physicalTableName,
                connectionName,
             });
          } catch (err) {
+            recordDropTables("failure");
             logger.warn("Failed to drop materialized table on delete", {
                materializationId: m.id,
                physicalTableName,

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -606,6 +606,7 @@ export class Model {
       _packagePath: string,
       malloyConfig: ModelConnectionInput,
       data: SerializedModel,
+      options?: { buildManifest?: BuildManifest["entries"] },
    ): Model {
       const modelDef = data.modelDef as ModelDef | undefined;
       const modelInfo = data.modelInfo as Malloy.ModelInfo | undefined;
@@ -645,7 +646,7 @@ export class Model {
          );
       }
 
-      const runtime = makeHydrationRuntime(malloyConfig);
+      const runtime = makeHydrationRuntime(malloyConfig, options?.buildManifest);
       const modelMaterializer = runtime._loadModelFromModelDef(modelDef);
       const runnableNotebookCells =
          data.modelType === "notebook"
@@ -1921,6 +1922,7 @@ type HydrationMaterializer = ModelMaterializer & {
 
 function makeHydrationRuntime(
    malloyConfig: ModelConnectionInput,
+   buildManifest?: BuildManifest["entries"],
 ): HydrationRuntime {
    const urlReader = new HackyDataStylesAccumulator(URL_READER);
    const config =
@@ -1933,7 +1935,19 @@ function makeHydrationRuntime(
               );
               return c;
            })();
-   return new Runtime({ urlReader, config }) as HydrationRuntime;
+   // Thread the package's bound build manifest into the *serve* runtime. Malloy
+   // substitutes a persisted source for its materialized table at query
+   // (getSQL) time, gated on `prepareResultOptions.buildManifest`; without this
+   // the hydrated model always recomputes from the base tables even though the
+   // manifest was bound at load. `strict: false` keeps serving live for any
+   // source whose buildId is absent from the manifest.
+   return new Runtime({
+      urlReader,
+      config,
+      buildManifest: buildManifest
+         ? { entries: buildManifest, strict: false }
+         : undefined,
+   }) as HydrationRuntime;
 }
 
 /**

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -646,7 +646,10 @@ export class Model {
          );
       }
 
-      const runtime = makeHydrationRuntime(malloyConfig, options?.buildManifest);
+      const runtime = makeHydrationRuntime(
+         malloyConfig,
+         options?.buildManifest,
+      );
       const modelMaterializer = runtime._loadModelFromModelDef(modelDef);
       const runnableNotebookCells =
          data.modelType === "notebook"

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -405,8 +405,16 @@ export class Package {
       // whether persist sources are actually routed to materialized tables).
       // Always returns a copy so these overlays never mutate the stored
       // metadata; the binding fields are authoritative from the private state.
+      //
+      // `name` is the registered package name (the environment's identity for
+      // this package), not the value read from the package's own manifest —
+      // those can differ (e.g. a package installed under a different name than
+      // its publisher.json declares). `listPackages` already overrides it to
+      // the registered name; surfacing it here keeps the single-package GET
+      // consistent without relying on a returned-reference mutation.
       const metadata: ApiPackage = {
          ...this.packageMetadata,
+         name: this.packageName,
          manifestBindingStatus: this.manifestBindingStatus,
          manifestEntryCount: this.manifestEntryCount,
          boundManifestUri: this.boundManifestUri,

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -48,8 +48,6 @@ type PackageConnectionInput =
    | Map<string, Connection>
    | (() => MalloyConfig);
 
-const ENABLE_LIST_MODEL_COMPILATION = true;
-
 export class Package {
    private environmentName: string;
    private packageName: string;
@@ -741,15 +739,13 @@ export class Package {
             })
             .map(async (modelPath) => {
                let error: string | undefined;
-               if (ENABLE_LIST_MODEL_COMPILATION) {
-                  try {
-                     await this.models.get(modelPath)?.getModel();
-                  } catch (modelError) {
-                     error =
-                        modelError instanceof Error
-                           ? modelError.message
-                           : undefined;
-                  }
+               try {
+                  await this.models.get(modelPath)?.getModel();
+               } catch (modelError) {
+                  error =
+                     modelError instanceof Error
+                        ? modelError.message
+                        : undefined;
                }
                return {
                   environmentName: this.environmentName,
@@ -769,10 +765,7 @@ export class Package {
                return modelPath.endsWith(NOTEBOOK_FILE_SUFFIX);
             })
             .map(async (modelPath) => {
-               let error: Error | undefined;
-               if (ENABLE_LIST_MODEL_COMPILATION) {
-                  error = this.models.get(modelPath)?.getNotebookError();
-               }
+               const error = this.models.get(modelPath)?.getNotebookError();
                return {
                   environmentName: this.environmentName,
                   packageName: this.packageName,

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -58,6 +58,17 @@ export class Package {
    private models: Map<string, Model> = new Map();
    private packagePath: string;
    private malloyConfig: MalloyConfig;
+   // Build-manifest binding state (Malloy Persistence v0). When bound, these
+   // entries (buildId -> { tableName }) are what served queries use to route
+   // persist sources to their materialized physical tables; they are also reused
+   // by the /compile preview so previewed SQL matches executed SQL. Surfaced on
+   // /status (via getPackageMetadata) so the control plane can confirm a worker
+   // actually bound the distributed manifest instead of inferring it from logs.
+   private buildManifestEntries: BuildManifest["entries"] | undefined;
+   private manifestBindingStatus: "unbound" | "bound" | "live_fallback" =
+      "unbound";
+   private manifestEntryCount = 0;
+   private boundManifestUri: string | null = null;
    private static meter = metrics.getMeter("publisher");
    private static packageLoadHistogram = this.meter.createHistogram(
       "malloy_package_load_duration",
@@ -389,14 +400,68 @@ export class Package {
    }
 
    public getPackageMetadata(): ApiPackage {
-      // Surface explores misconfig so consumers/UI can show it (loading is
-      // fail-safe — the package still serves with the bad entry hidden — so this
-      // is the only non-log signal that it's broken). Computed fresh against the
-      // current models; absent when everything resolves. Returns a copy in that
-      // case so the added field never mutates the stored metadata.
+      // Overlay the server-computed fields onto the stored metadata: the
+      // explores misconfig warnings (loading is fail-safe — the package still
+      // serves with the bad entry hidden — so this is the only non-log signal
+      // that it's broken) and the manifest-binding state (so /status reflects
+      // whether persist sources are actually routed to materialized tables).
+      // Always returns a copy so these overlays never mutate the stored
+      // metadata; the binding fields are authoritative from the private state.
+      const metadata: ApiPackage = {
+         ...this.packageMetadata,
+         manifestBindingStatus: this.manifestBindingStatus,
+         manifestEntryCount: this.manifestEntryCount,
+         boundManifestUri: this.boundManifestUri,
+      };
       const warnings = this.exploreWarnings();
-      if (warnings.length === 0) return this.packageMetadata;
-      return { ...this.packageMetadata, exploresWarnings: warnings };
+      if (warnings.length > 0) {
+         metadata.exploresWarnings = warnings;
+      }
+      return metadata;
+   }
+
+   /**
+    * The currently-bound build-manifest entries (buildId -> { tableName }), or
+    * undefined when the package is serving live. Reused by the /compile preview
+    * so previewed SQL gets the same persist-source -> physical-table routing as
+    * execution.
+    */
+   public getBuildManifestEntries(): BuildManifest["entries"] | undefined {
+      return this.buildManifestEntries;
+   }
+
+   /**
+    * Record the URI whose manifest is currently bound to the served models. May
+    * differ from `manifestLocation` after an in-memory auto-load following a
+    * materialization build (no URI), in which case it stays null.
+    */
+   public setBoundManifestUri(uri: string | null): void {
+      this.boundManifestUri = uri;
+   }
+
+   /**
+    * Mark that a configured `manifestLocation` could not be fetched/bound, so
+    * the package is serving live despite intending to be materialized-routed.
+    */
+   public markManifestBindFailed(): void {
+      this.manifestBindingStatus = "live_fallback";
+   }
+
+   /**
+    * Store the entries applied by the latest (re)bind for reuse (/compile) and
+    * observability (/status). An empty map means the manifest was cleared, so
+    * the package reverts to live (unbound).
+    */
+   private recordManifestBinding(
+      buildManifest: BuildManifest["entries"],
+   ): void {
+      const count = Object.keys(buildManifest).length;
+      this.buildManifestEntries = count > 0 ? buildManifest : undefined;
+      this.manifestEntryCount = count;
+      this.manifestBindingStatus = count > 0 ? "bound" : "unbound";
+      if (count === 0) {
+         this.boundManifestUri = null;
+      }
    }
 
    /**
@@ -595,6 +660,7 @@ export class Package {
                this.packagePath,
                this.malloyConfig,
                sm,
+               { buildManifest },
             );
             // Validate renderer tags here too (loadViaWorker does it for the
             // create path). Reload keeps per-model placeholders rather than
@@ -636,6 +702,9 @@ export class Package {
          outcome.packageMetadata.manifestLocation ?? null;
       this.applyDiscoveryPolicyToModels();
       this.applyQueryBoundaryToModels();
+      // Remember what we just bound so /compile can route identically and
+      // /status can report the binding. An empty map reverts to live (unbound).
+      this.recordManifestBinding(buildManifest);
       // Re-run the fail-safe warning against the refreshed model set: an edit
       // to publisher.json that introduces a bad entry should surface in the
       // logs on reload too, not only at initial load (loadViaWorker).

--- a/packages/server/tests/integration/materialization/manifest_binding.integration.spec.ts
+++ b/packages/server/tests/integration/materialization/manifest_binding.integration.spec.ts
@@ -133,25 +133,38 @@ describe("Manifest binding via Package.manifestLocation (E2E)", () => {
       async () => {
          const manifestFile = await writeManifest();
 
-         // Accept on update; the response echoes the bound location.
+         // Accept on update; the response echoes the bound location and the
+         // server-computed binding observability fields (surfaced on /status so
+         // the control plane can confirm the worker actually bound the manifest).
          const patchRes = await patchPackage({
             manifestLocation: manifestFile,
          });
          expect(patchRes.status).toBe(200);
-         expect((await patchRes.json()).manifestLocation).toBe(manifestFile);
+         const patched = await patchRes.json();
+         expect(patched.manifestLocation).toBe(manifestFile);
+         expect(patched.manifestBindingStatus).toBe("bound");
+         expect(patched.manifestEntryCount).toBe(1);
+         expect(patched.boundManifestUri).toBe(manifestFile);
 
          // In-memory metadata reflects it; binding did not break serving.
-         expect((await getPackage()).manifestLocation).toBe(manifestFile);
+         const bound = await getPackage();
+         expect(bound.manifestLocation).toBe(manifestFile);
+         expect(bound.manifestBindingStatus).toBe("bound");
+         expect(bound.manifestEntryCount).toBe(1);
          expect(await queryOrderSummaryStatus()).toBe(200);
 
          // Persisted to publisher.json: a reload re-reads and re-binds it.
          expect((await getPackage(true)).manifestLocation).toBe(manifestFile);
          expect(await queryOrderSummaryStatus()).toBe(200);
 
-         // Clearing reverts to live and survives a reload.
+         // Clearing reverts to live (unbound) and survives a reload.
          const clearRes = await patchPackage({ manifestLocation: null });
          expect(clearRes.status).toBe(200);
-         expect((await clearRes.json()).manifestLocation ?? null).toBeNull();
+         const cleared = await clearRes.json();
+         expect(cleared.manifestLocation ?? null).toBeNull();
+         expect(cleared.manifestBindingStatus).toBe("unbound");
+         expect(cleared.manifestEntryCount).toBe(0);
+         expect(cleared.boundManifestUri ?? null).toBeNull();
          expect((await getPackage(true)).manifestLocation ?? null).toBeNull();
          expect(await queryOrderSummaryStatus()).toBe(200);
       },
@@ -163,7 +176,13 @@ describe("Manifest binding via Package.manifestLocation (E2E)", () => {
 
       const patchRes = await patchPackage({ manifestLocation: missing });
       expect(patchRes.status).toBe(200);
-      expect((await patchRes.json()).manifestLocation).toBe(missing);
+      const patched = await patchRes.json();
+      expect(patched.manifestLocation).toBe(missing);
+      // The configured location is retained, but the binding is reported as a
+      // degraded live fallback (not "bound") with nothing actually bound.
+      expect(patched.manifestBindingStatus).toBe("live_fallback");
+      expect(patched.manifestEntryCount).toBe(0);
+      expect(patched.boundManifestUri ?? null).toBeNull();
 
       // A fetch failure must not brick the package — it still serves live.
       expect(await queryOrderSummaryStatus()).toBe(200);

--- a/packages/server/tests/integration/materialization/materialization_lifecycle.integration.spec.ts
+++ b/packages/server/tests/integration/materialization/materialization_lifecycle.integration.spec.ts
@@ -342,6 +342,100 @@ describe("Materialization REST API: auto-run + two-round (E2E)", () => {
       );
    });
 
+   // ── Group A1: Serve-time routing (the v0 payoff) ─────────────────
+   //
+   // Materialization only pays off if *served* queries scan the materialized
+   // table instead of recomputing from the base table. The auto-run path builds
+   // the table and auto-loads the manifest into the serving models in one
+   // process, so routing is provable in-process: capture the live SQL (scans the
+   // base CSV), run an auto-run materialization, then assert both the executed
+   // query SQL and the /compile preview SQL now scan the physical table and no
+   // longer touch the base CSV. The /compile half guards the parity fix
+   // (Environment.compileSource threads the package's bound manifest).
+   describe("serve-time routing (auto-load)", () => {
+      const MODEL_PATH = "persist_test.malloy";
+      const QUERY = "run: order_summary -> { aggregate: c is count() }";
+
+      async function executedSql(): Promise<string> {
+         const res = await fetch(
+            `${baseUrl}${API}/models/${MODEL_PATH}/query`,
+            {
+               method: "POST",
+               headers: { "Content-Type": "application/json" },
+               body: JSON.stringify({ query: QUERY }),
+            },
+         );
+         expect(res.status).toBe(200);
+         const body = (await res.json()) as { result: string };
+         return (JSON.parse(body.result) as { sql: string }).sql;
+      }
+
+      async function compiledSql(): Promise<string> {
+         const res = await fetch(
+            `${baseUrl}${API}/models/${MODEL_PATH}/compile`,
+            {
+               method: "POST",
+               headers: { "Content-Type": "application/json" },
+               body: JSON.stringify({ source: QUERY, includeSql: true }),
+            },
+         );
+         expect(res.status).toBe(200);
+         const body = (await res.json()) as { status: string; sql?: string };
+         expect(body.status).toBe("success");
+         expect(body.sql).toBeDefined();
+         return body.sql as string;
+      }
+
+      it(
+         "routes served + compiled queries to the materialized table after auto-load",
+         async () => {
+            // Reset to live: a prior group may have left an in-memory binding.
+            // Auto-load never writes manifestLocation to publisher.json, so a
+            // reload re-reads the live model.
+            await fetch(`${baseUrl}${API}?reload=true`);
+
+            // Baseline: with nothing materialized, both paths recompute from the
+            // base CSV.
+            expect(await executedSql()).toContain("data/orders.csv");
+            expect(await compiledSql()).toContain("data/orders.csv");
+
+            // Build + auto-load in one pass (self-assigns physicalTableName =
+            // "order_summary" from `#@ persist name="order_summary"`).
+            const createRes = await createMaterialization({
+               pauseBetweenPhases: false,
+            });
+            expect(createRes.status).toBe(201);
+            const { id } = (await createRes.json()) as { id: string };
+            const built = await pollUntil(
+               id,
+               (s) => TERMINAL_STATUSES.includes(s),
+               90_000,
+            );
+            expect(built.status).toBe("MANIFEST_FILE_READY");
+
+            // The payoff: the served query now scans the materialized table and
+            // no longer recomputes from the base CSV, and /compile previews the
+            // same routed SQL it would execute.
+            const routedExecuted = await executedSql();
+            const routedCompiled = await compiledSql();
+            expect(routedExecuted).not.toContain("data/orders.csv");
+            expect(routedExecuted).toContain("order_summary");
+            expect(routedCompiled).not.toContain("data/orders.csv");
+            expect(routedCompiled).toContain("order_summary");
+
+            // Cleanup: drop the table + record, then reload back to live so the
+            // dangling binding doesn't leak into later groups.
+            const deleteRes = await fetch(
+               url(`/materializations/${id}?dropTables=true`),
+               { method: "DELETE" },
+            );
+            expect(deleteRes.status).toBe(204);
+            await fetch(`${baseUrl}${API}?reload=true`);
+         },
+         { timeout: 120_000 },
+      );
+   });
+
    // ── Group B: State machine and error cases ───────────────────────
 
    describe("state machine and errors", () => {


### PR DESCRIPTION
## Summary

Publisher-side quality pass over the Malloy Persistence v0 materialization subsystem. Behavior-preserving except for the serve-time manifest-binding alignment (called out below). Builds on the auto-run work merged in #836.

- **Simplify** (`materialization_service.ts`): centralized `computeBuildId`, extracted a shared `commitManifest` finalizer used by both the auto and round-2 paths, removed a duplicate recompile, and fixed a misleading path-specific log message.
- **Serve-time manifest binding alignment** (`environment.ts`, `model.ts`, `package.ts`, `api-doc.yaml`): the worker now threads the bound build manifest into the serve runtime and reports read-only binding state — `manifestBindingStatus` (`unbound`/`bound`/`live_fallback`), `manifestEntryCount`, and `boundManifestUri` — so the control plane can confirm a worker actually bound a distributed manifest instead of inferring it from logs. *(Contract change: additive, read-only response fields on the serving API.)*
- **Telemetry** (`materialization_metrics.ts`): manifest bind success/failure/timeout counters, per-source build-duration, and drop/dropTables counters; structured transition logging that distinguishes timeout from failure.
- **Tests**: characterization for build-instruction derivation + the staging→swap→rename SQL sequence; unit coverage for skip-if-unchanged / `forceRefresh` and in-flight cooperative cancel; extended manifest-binding and lifecycle integration specs.
- **Cleanup**: inlined the always-true `ENABLE_LIST_MODEL_COMPILATION` flag.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `bun test src/service/package.spec.ts src/service/materialization_service.spec.ts` — 45 pass / 0 fail
- [ ] `bun run test:integration` (manifest-binding + lifecycle suites; needs Docker/Postgres)
- [x] Exercised end-to-end via the service repo's Postgres materialization e2e against a locally built image (publish → materialize → physical table created with correct data → on-demand rebuild → drop on teardown)

## Notes

- Serve-time query **routing** is not yet provable end-to-end: the worker fetches and binds the manifest (`manifestBindingStatus=bound`, `manifestEntryCount=1`), but a query on a persisted source is still served live rather than read from the materialized table, and multi-worker manifest redistribution is racy. Tracked as a follow-up; the e2e routing assertion remains skipped on the service side with this documented.

Made with [Cursor](https://cursor.com)