### PR TITLE
ci(release): scope changelog to the previous stable release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,11 +173,34 @@ jobs:
             exit 0
           fi
 
+          # Pin the changelog base to the immediately preceding release tag.
+          # Each release is cut from a fresh release/sdk-* branch that is never
+          # merged back to main, so prior release tags are not ancestors of this
+          # release's commit. Left to --generate-notes alone, GitHub's ancestor
+          # walk skips every diverged sibling tag and lands on the last tag still
+          # in the mainline ancestry, producing a changelog spanning hundreds of
+          # PRs. Selecting the previous tag by version sort and passing it as the
+          # explicit start tag scopes the notes to just this release's changes.
+          # Prerelease tags (containing a hyphen) are excluded so the base is
+          # always the last stable release, consistent with the prerelease skip
+          # above.
+          git fetch --tags --force
+          PREV_TAG="$(git tag -l 'v[0-9]*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | grep -vx "$TAG" | tail -1)"
+
+          NOTES_START_ARGS=()
+          if [ -n "$PREV_TAG" ]; then
+            echo "::notice title=Changelog::Generating notes from ${PREV_TAG} to ${TAG}"
+            NOTES_START_ARGS=(--notes-start-tag "$PREV_TAG")
+          else
+            echo "::notice title=Changelog::No previous tag found; using default note generation"
+          fi
+
           gh release create "$TAG" \
             --target "$BRANCH" \
             --title "v${VERSION}" \
             --notes-file "$NOTES_FILE" \
-            --generate-notes
+            --generate-notes \
+            "${NOTES_START_ARGS[@]}"
 
           echo "## 🏷️ GitHub Release" >> $GITHUB_STEP_SUMMARY
           echo "Created release [\`${TAG}\`](https://github.com/${{ github.repository }}/releases/tag/${TAG})" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Problem

Every auto-generated release note compares the new release all the way back to `v0.0.46`, producing a "Full Changelog: v0.0.46...vX" link and a PR list spanning hundreds of PRs. For example, v0.0.208's notes listed 162 PRs.

## Root cause

Each release is cut from a fresh `release/sdk-<version>` branch that is created off `main` and never merged back. The release tag (`vX`) is planted on that short-lived branch, so prior release tags are not ancestors of the new release's commit -- `compare/v0.0.207...v0.0.208` reports `diverged`, not a clean ancestry.

`gh release create --generate-notes` picks the changelog base by walking the target commit's ancestry for the most recent reachable tag. Since none of the recent release tags are ancestors, the walk skips every diverged sibling tag and lands on the last tag still in the mainline ancestry: `v0.0.46` (the last release before this branch-per-release flow began).

## Fix

Compute the previous stable release tag explicitly by version sort and pass it as `--notes-start-tag`, which anchors the changelog base instead of relying on the ancestry walk:

- `git fetch --tags --force` then select the previous tag with `git tag -l 'v[0-9]*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V`.
- Prerelease tags (containing a hyphen) are excluded, consistent with the existing prerelease skip in this job, so the base is always the last stable release.
- When no previous stable tag exists (first release), the start-tag argument is omitted and generation falls back to the default behavior.

## Verification

- The GitHub Release Notes API was exercised against this repo with an explicit non-ancestor `previous_tag_name=v0.0.207`; it returned a scoped 3-PR changelog and `compare/v0.0.207...v0.0.208`, confirming the explicit start tag overrides the ancestry walk.
- The tag picker was dry-run against the repo's tag list and against lists seeded with stray higher prerelease tags; it selects the correct previous stable tag in each case and returns empty (default notes) when no stable tag exists.
- The grep pattern is a positive match for `vMAJOR.MINOR.PATCH`, portable across GNU grep, BSD grep, and ugrep.

## Note

This scopes the displayed changelog correctly. The underlying branch divergence is unchanged, so `compare/vPREV...vNEW` will still report "diverged". Making the ancestry itself linear (merging release branches back, or tagging on `main`) is a larger process change left out of this PR.
