### PR TITLE
feat(materialization): single-call builds with Package.buildPlan

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,29 @@ For releases that warrant narrative — redesigns, breaking changes, migration s
 
 ---
 
+## [0.0.208] — Single-call materialization (plan-as-artifact)
+
+**Breaking change to the materialization API.** Materialization moves from the two-round (compile-then-build) protocol to a single call. The build plan is now a compile-time property of the package, and a build is requested in one request.
+
+### What changed
+
+- **New `Package.buildPlan`.** `GET …/packages/{name}` (and every endpoint/MCP resource that returns package metadata) now includes a `buildPlan` describing the package's persist sources and their dependencies. It is `null` when the package has no persist sources. This is the artifact callers read to assemble build instructions.
+- **Single-call builds via `buildInstructions`.** `POST …/materializations` accepts an optional `buildInstructions` body. With no instructions the publisher self-assigns names and runs the full build, auto-loading the resulting manifest (auto-run). With `buildInstructions` (validated against the live `Package.buildPlan` at create time) it builds directly into the caller-assigned names and does **not** auto-load — the caller distributes via `manifestLocation` (orchestrated).
+- **Streamlined state machine.** `PENDING → MANIFEST_ROWS_READY → MANIFEST_FILE_READY` (terminal), or `FAILED` / `CANCELLED`. The transient `BUILD_PLAN_READY` status is removed.
+
+### Removed (breaking)
+
+- `pauseBetweenPhases` on `CreateMaterializationRequest`.
+- The `BUILD_PLAN_READY` value from `MaterializationStatus`.
+- `POST …/materializations/{id}?action=build` — `stop` is now the only supported action.
+- `Materialization.buildPlan` — read the plan from `Package.buildPlan` instead.
+
+### Client / UI impact
+
+- **CLI:** the `--pause-between-phases` flag is gone; `malloy-pub materialize --wait` settles on `MANIFEST_FILE_READY` / `FAILED` / `CANCELLED`.
+- **SDK UI:** the materialization detail dialog drops the "Mode" field and now renders its build-plan view from `Package.buildPlan`.
+- Regenerate any SDK/Python/k6 clients against the updated `api-doc.yaml`.
+
 ## [Unreleased] — Source access gates (`#(authorize)`)
 
 **Sources can now gate query access on givens.** A `#(authorize) "<bool expr>"` annotation (source-level) or `##(authorize)` (file-level) is evaluated against the request's [givens](docs/givens.md) before any query that reads the source runs; access is denied with **HTTP 403** unless at least one in-scope expression is `true` (OR semantics). Enforced on `POST /…/query`, the notebook-cell `GET`, `POST /…/compile`, and the MCP `malloy_executeQuery` tool. Malformed or invalid annotations fail model load with **424**.

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -2029,13 +2029,15 @@ paths:
       tags:
         - materializations
       operationId: create-materialization
-      summary: Create a materialization (Round 1)
+      summary: Create a materialization
       description: |
-        Starts Round 1 of the two-round build protocol: asynchronously compiles the package,
-        computes a build plan (per-source buildId, output columns, dependency/column lineage,
-        connection capability), and pauses at BUILD_PLAN_READY without writing any tables.
-        The control plane then issues Round 2 via
-        POST .../materializations/{materializationId}?action=build with build instructions.
+        Creates a materialization and starts building. Behavior depends on the request
+        body (see CreateMaterializationRequest):
+          * Orchestrated build — supply `buildInstructions`. The publisher builds directly
+            into the caller-assigned names derived from the package's already-compiled build
+            plan (read off `Package.buildPlan`). Returns the materialization already building.
+          * Auto-run (standalone, default) — omit `buildInstructions`; the publisher
+            self-assigns names and runs all phases in one pass.
       parameters:
         - $ref: "#/components/parameters/environmentName"
         - $ref: "#/components/parameters/packageName"
@@ -2123,11 +2125,7 @@ paths:
       description: |
         Performs an action on a materialization. The action is specified via
         the `action` query parameter:
-          * `build` - Round 2. Provide BuildInstructions (CP-assigned table id, physical
-            table name, and realization per source). Builds only the instructed sources into
-            the exact names provided and assembles the manifest. Valid only when the
-            materialization is at BUILD_PLAN_READY. Returns 202.
-          * `stop` - Cancels a PENDING, BUILD_PLAN_READY, or building materialization. Returns 200.
+          * `stop` - Cancels a PENDING or building materialization. Returns 200.
       parameters:
         - $ref: "#/components/parameters/environmentName"
         - $ref: "#/components/parameters/packageName"
@@ -2138,24 +2136,11 @@ paths:
           schema:
             type: string
             enum:
-              - build
               - stop
           description: Action to perform on the materialization
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/BuildInstructions"
       responses:
         "200":
           description: Materialization cancelled (action=stop)
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Materialization"
-        "202":
-          description: Round 2 build accepted (action=build)
           content:
             application/json:
               schema:
@@ -2178,7 +2163,7 @@ paths:
       description: |
         Deletes a terminal (MANIFEST_FILE_READY, FAILED, or CANCELLED)
         materialization record. By default this removes the publisher's record
-        only; the control plane owns table GC. Set dropTables=true to also drop
+        only; the caller owns table GC. Set dropTables=true to also drop
         the physical tables this run produced (from the materialization's
         manifest) as a best-effort cleanup.
       parameters:
@@ -2191,7 +2176,7 @@ paths:
           description: |
             When true, also drop the physical tables recorded in the
             materialization's manifest before deleting the record. Defaults to
-            false (record-only delete; the control plane owns table GC).
+            false (record-only delete; the caller owns table GC).
           schema:
             type: boolean
             default: false
@@ -2343,7 +2328,7 @@ components:
             its memory back-pressure limit and is rejecting new package loads and
             queries to stay under PUBLISHER_MAX_MEMORY_BYTES (see the memory
             governor). Already-loaded packages remain serviceable while throttled;
-            the control plane treats a throttled worker as unhealthy for new load.
+            callers can treat a throttled server as unhealthy for new load.
             Only reported when the memory governor is enabled.
         frozenConfig:
           type: boolean
@@ -2448,8 +2433,8 @@ components:
         manifestLocation:
           type: ["string", "null"]
           description: |
-            URI (gs:// or s3://) of the control-plane-computed manifest for this package.
-            On (re)load the worker reads it and binds persist references
+            URI (gs:// or s3://) of the externally-computed manifest for this package.
+            On (re)load the publisher reads it and binds persist references
             (buildId -> physicalTableName). Null = serve live.
         manifestBindingStatus:
           type: string
@@ -2459,14 +2444,14 @@ components:
             - bound
             - live_fallback
           description: >-
-            Server-computed, read-only: whether the control-plane build manifest
+            Server-computed, read-only: whether the configured build manifest
             is currently bound to this package's served models. `unbound` = no
             manifest configured, so the package serves live. `bound` = a manifest
             was fetched and applied, so persist sources route to their
             materialized physical tables. `live_fallback` = a `manifestLocation`
             is configured but the fetch/bind failed or timed out, so the package
             is serving live despite intending to be materialized-routed. Lets the
-            control plane confirm a worker actually bound a distributed manifest
+            caller confirm the publisher actually bound the configured manifest
             rather than inferring it from logs.
         manifestEntryCount:
           type: integer
@@ -2482,6 +2467,23 @@ components:
             served models. Usually equals `manifestLocation`, but can differ
             after an in-memory auto-load following a materialization build (no
             URI), in which case it is null. Null whenever the package is unbound.
+        buildPlan:
+          oneOf:
+            - $ref: "#/components/schemas/BuildPlan"
+            - type: "null"
+          readOnly: true
+          description: >-
+            Server-computed, read-only: the persist build plan for this package
+            version (per-source buildId, output columns, build SQL, dependency
+            graphs), exposed as a deterministic property of the compiled package.
+            A caller reads it directly off the load/get-package response, assigns
+            physical names/identity per source, and issues a single build call
+            (see `CreateMaterializationRequest.buildInstructions`) — no separate
+            plan round-trip. The plan is a pure function of the compiled model +
+            connection config (no warehouse access), so it is stable for a given
+            (package version, connection config). Returned by default whenever the
+            package is compiled; null only when the package declares no persist
+            source.
 
     Model:
       type: object
@@ -3549,20 +3551,25 @@ components:
 
     CreateMaterializationRequest:
       type: object
-      description:
-        Options for starting a materialization. Auto-run by default; opt into the
-        two-round control-plane-driven flow with pauseBetweenPhases.
+      description: >-
+        Options for starting a materialization. Two modes — (1) auto-run
+        (default), omit `buildInstructions` and the publisher self-assigns names
+        and runs all phases in one pass; (2) orchestrated build, supply
+        `buildInstructions` and the publisher builds directly into the
+        caller-assigned names from the package's already-compiled build plan
+        (read off `Package.buildPlan`).
       properties:
-        pauseBetweenPhases:
-          type: boolean
-          default: false
+        buildInstructions:
+          oneOf:
+            - $ref: "#/components/schemas/BuildInstructions"
+            - type: "null"
           description:
-            When false (default) the publisher runs all phases in one pass —
-            self-assigns table names (the "#@ persist name=" value, else the
-            source name), builds with realization=COPY, assembles the manifest,
-            and auto-loads it into the package models. When true it pauses at
-            BUILD_PLAN_READY for the control plane to send Round 2 build
-            instructions.
+            Orchestrated build. When present, the publisher creates the
+            materialization already building these caller-assigned sources
+            (table id, physical name, realization) into the exact names
+            provided — the caller derived these instructions from
+            `Package.buildPlan` up front. Omit for auto-run (the publisher
+            self-assigns names and builds all persist sources).
         forceRefresh:
           type: boolean
           default: false
@@ -3577,10 +3584,9 @@ components:
 
     MaterializationStatus:
       type: string
-      description: Phase-aware status of a two-round materialization run.
+      description: Phase-aware status of a materialization run.
       enum:
         - PENDING
-        - BUILD_PLAN_READY
         - MANIFEST_ROWS_READY
         - MANIFEST_FILE_READY
         - FAILED
@@ -3588,7 +3594,7 @@ components:
 
     Materialization:
       type: object
-      description: A record of one two-round materialization run for a package.
+      description: A record of one materialization run for a package.
       properties:
         id:
           type: string
@@ -3596,23 +3602,13 @@ components:
           type: string
         packageName:
           type: string
-        pauseBetweenPhases:
-          type: boolean
-          description:
-            Echoes the create-time flag. False (default) = auto-run all phases;
-            true = pause at BUILD_PLAN_READY for control-plane-driven Round 2.
         status:
           $ref: "#/components/schemas/MaterializationStatus"
-        buildPlan:
-          oneOf:
-            - $ref: "#/components/schemas/BuildPlan"
-            - type: "null"
-          description: Round 1 output. Null until status >= BUILD_PLAN_READY.
         manifest:
           oneOf:
             - $ref: "#/components/schemas/BuildManifest"
             - type: "null"
-          description: Round 2 output. Null until status = MANIFEST_FILE_READY.
+          description: Build output. Null until status = MANIFEST_FILE_READY.
         startedAt:
           type: ["string", "null"]
           format: date-time
@@ -3637,10 +3633,10 @@ components:
     BuildPlan:
       type: object
       description: |
-        Round 1 output. Mirrors Malloy's native build plan plus the minimal
-        per-source detail the control plane needs in v0 to assign
-        identity/naming/realization. Lineage, policy, and connection
-        capability are intentionally omitted until they carry real data.
+        The package's persist build plan. Mirrors Malloy's native build plan plus
+        the minimal per-source detail a caller needs to assign
+        identity/naming/realization. Lineage, policy, and connection capability
+        are intentionally omitted until they carry real data.
       required: [graphs, sources]
       properties:
         graphs:
@@ -3716,7 +3712,7 @@ components:
 
     BuildInstructions:
       type: object
-      description: Round 2 input. Per-source instructions assigned by the control plane.
+      description: Build input. Per-source instructions assigned by the caller.
       required: [sources]
       properties:
         sources:
@@ -3740,7 +3736,7 @@ components:
         materializedTableId:
           type: string
           description:
-            CP-assigned surrogate id for the materialized table about to be
+            Caller-assigned surrogate id for the materialized table about to be
             produced.
         physicalTableName:
           type: string
@@ -3753,8 +3749,8 @@ components:
     BuildManifest:
       type: object
       description:
-        Round 2 output. Maps each buildId a build produced to its physical table.
-        Returned inline; the control plane persists it.
+        Build output. Maps each buildId a build produced to its physical table.
+        Returned inline; the caller persists it.
       properties:
         builtAt:
           type: string
@@ -3779,7 +3775,7 @@ components:
           type: string
         materializedTableId:
           type: string
-          description: Echoes the CP-assigned id from the BuildInstruction.
+          description: Echoes the caller-assigned id from the BuildInstruction.
         physicalTableName:
           type: string
           description: Name of the materialized table.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/app",
    "description": "Malloy Publisher App",
-   "version": "0.0.207",
+   "version": "0.0.208",
    "type": "module",
    "main": "dist/index.cjs.js",
    "module": "dist/index.es.js",

--- a/packages/app/tests/playwright/package-materializations.spec.ts
+++ b/packages/app/tests/playwright/package-materializations.spec.ts
@@ -91,9 +91,9 @@ test.describe("package-materializations: mutable", () => {
       await expect(row).toBeVisible({ timeout: 30_000 });
 
       // --- Auto-run settles itself ---
-      // Unlike the two-round flow, the publisher drives every phase without
-      // pausing, so the run reaches a terminal state (MANIFEST_FILE_READY on
-      // success, FAILED on a broken package) with no manual Round 2.
+      // The publisher drives every phase without pausing, so the run reaches a
+      // terminal state (MANIFEST_FILE_READY on success, FAILED on a broken
+      // package) with no manual follow-up build call.
       await expect(page.getByText(TERMINAL_STATUS).first()).toBeVisible({
          timeout: 90_000,
       });
@@ -138,7 +138,8 @@ test.describe("package-materializations: mutable", () => {
       });
 
       // The run row is a keyboard-operable button (role + tabindex), and Enter
-      // opens the detail dialog, which always renders a "Build plan" section.
+      // opens the detail dialog, which always renders a "Build plan" section
+      // sourced from Package.buildPlan (compile-time persist plan).
       await expect(row).toHaveAttribute("tabindex", "0");
       await row.focus();
       await page.keyboard.press("Enter");

--- a/packages/cli/src/commands/materializations.ts
+++ b/packages/cli/src/commands/materializations.ts
@@ -2,19 +2,10 @@ import { PublisherClient } from "../api/client.js";
 import Table from "cli-table3";
 import { logSuccess, logInfo, logOutput, truncate } from "../utils/logger.js";
 
-// Auto-run (default) settles at MANIFEST_FILE_READY (the full build + load
-// completed) or a failure. In pauseBetweenPhases mode the publisher pauses at
-// BUILD_PLAN_READY for the control plane to drive Round 2, so that is also a
-// settled (success) state for a publisher-only client.
-const AUTO_SETTLED_STATUSES = ["MANIFEST_FILE_READY", "FAILED", "CANCELLED"];
-const AUTO_SUCCESS_STATUSES = ["MANIFEST_FILE_READY"];
-const PAUSE_SETTLED_STATUSES = [
-  "BUILD_PLAN_READY",
-  "MANIFEST_FILE_READY",
-  "FAILED",
-  "CANCELLED",
-];
-const PAUSE_SUCCESS_STATUSES = ["BUILD_PLAN_READY", "MANIFEST_FILE_READY"];
+// A build settles at MANIFEST_FILE_READY (the full build + load completed) or
+// a failure/cancellation.
+const SETTLED_STATUSES = ["MANIFEST_FILE_READY", "FAILED", "CANCELLED"];
+const SUCCESS_STATUSES = ["MANIFEST_FILE_READY"];
 
 export async function listMaterializations(
   client: PublisherClient,
@@ -66,11 +57,10 @@ export async function getMaterialization(
 }
 
 /**
- * Create a materialization. By default (auto-run) the publisher runs all phases
- * — compile, plan, self-assign table names, build, and auto-load the manifest —
- * settling at MANIFEST_FILE_READY. With `pauseBetweenPhases`, it pauses at
- * BUILD_PLAN_READY for the control plane to drive Round 2. With `wait`, poll
- * until the run settles; without it, return immediately with a status hint.
+ * Create a materialization (auto-run): the publisher compiles, self-assigns
+ * table names, builds every persist source, and auto-loads the manifest,
+ * settling at MANIFEST_FILE_READY. With `wait`, poll until the run settles;
+ * without it, return immediately with a status hint.
  */
 export async function materialize(
   client: PublisherClient,
@@ -78,7 +68,6 @@ export async function materialize(
   packageName: string,
   options: {
     forceRefresh?: boolean;
-    pauseBetweenPhases?: boolean;
     wait?: boolean;
     pollIntervalMs?: number;
     timeoutMs?: number;
@@ -89,7 +78,6 @@ export async function materialize(
     packageName,
     {
       forceRefresh: options.forceRefresh,
-      pauseBetweenPhases: options.pauseBetweenPhases,
     },
   );
   const id = created.id as string | undefined;
@@ -105,12 +93,8 @@ export async function materialize(
     return;
   }
 
-  const settledStatuses = options.pauseBetweenPhases
-    ? PAUSE_SETTLED_STATUSES
-    : AUTO_SETTLED_STATUSES;
-  const successStatuses = options.pauseBetweenPhases
-    ? PAUSE_SUCCESS_STATUSES
-    : AUTO_SUCCESS_STATUSES;
+  const settledStatuses = SETTLED_STATUSES;
+  const successStatuses = SUCCESS_STATUSES;
 
   const pollIntervalMs = options.pollIntervalMs ?? 2000;
   const timeoutMs = options.timeoutMs ?? 120000;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -431,21 +431,17 @@ program
 // resources with differing requirements (e.g. `list environment` needs no
 // --package), so they validate manually inside each case instead.
 
-// MATERIALIZE COMMAND (Round 1: compile + build plan; the control plane drives
-// the build from the resulting plan)
+// MATERIALIZE COMMAND (auto-run: compile, build every persist source, and
+// auto-load the resulting manifest)
 program
   .command("materialize")
   .description(
-    "Materialize a package: by default run all phases (build + load); use --pause-between-phases for the control-plane two-round flow",
+    "Materialize a package: compile, build all persist sources, and auto-load the manifest",
   )
   .requiredOption("--environment <n>", "Environment name")
   .requiredOption("--package <n>", "Package name")
   .option("--force-refresh", "Rebuild all sources, ignoring existing build IDs")
-  .option(
-    "--pause-between-phases",
-    "Pause at BUILD_PLAN_READY for the control plane to drive Round 2 (default: run all phases)",
-  )
-  .option("--wait", "Poll until the run settles (build complete, or paused)")
+  .option("--wait", "Poll until the run settles (build complete or failed)")
   .option(
     "--timeout <seconds>",
     "With --wait, seconds to wait before giving up (default 120)",
@@ -468,7 +464,6 @@ program
         options.package,
         {
           forceRefresh: options.forceRefresh,
-          pauseBetweenPhases: options.pauseBetweenPhases,
           wait: options.wait,
           timeoutMs: timeoutSec !== undefined ? timeoutSec * 1000 : undefined,
           pollIntervalMs: pollSec !== undefined ? pollSec * 1000 : undefined,

--- a/packages/cli/src/tests/materializations.test.ts
+++ b/packages/cli/src/tests/materializations.test.ts
@@ -86,36 +86,14 @@ describe("Materialization Commands", () => {
       "pkg",
       {
         forceRefresh: true,
-        pauseBetweenPhases: undefined,
       },
     );
-    // Round 2 (build) is control-plane driven; the CLI never starts a build.
+    // Without --wait the CLI never polls.
     expect(mockClient.materializationAction).not.toHaveBeenCalled();
     expect(mockClient.getMaterialization).not.toHaveBeenCalled();
   });
 
-  test("materialize forwards pauseBetweenPhases for the two-round flow", async () => {
-    const mockClient = {
-      createMaterialization: mock(() =>
-        Promise.resolve({ id: "m1", status: "PENDING" }),
-      ),
-    } as unknown as PublisherClient;
-
-    await materializationCommands.materialize(mockClient, "env", "pkg", {
-      pauseBetweenPhases: true,
-    });
-
-    expect(mockClient.createMaterialization).toHaveBeenCalledWith(
-      "env",
-      "pkg",
-      {
-        forceRefresh: undefined,
-        pauseBetweenPhases: true,
-      },
-    );
-  });
-
-  test("materialize (auto-run) with wait polls past BUILD_PLAN_READY to MANIFEST_FILE_READY", async () => {
+  test("materialize with wait polls until MANIFEST_FILE_READY", async () => {
     let calls = 0;
     const mockClient = {
       createMaterialization: mock(() =>
@@ -123,11 +101,10 @@ describe("Materialization Commands", () => {
       ),
       getMaterialization: mock(() => {
         calls += 1;
-        // Auto-run does not settle at BUILD_PLAN_READY; it must keep polling
-        // until MANIFEST_FILE_READY.
+        // The build settles only at MANIFEST_FILE_READY; keep polling until then.
         return Promise.resolve({
           id: "m1",
-          status: calls >= 3 ? "MANIFEST_FILE_READY" : "BUILD_PLAN_READY",
+          status: calls >= 3 ? "MANIFEST_FILE_READY" : "PENDING",
         });
       }),
     } as unknown as PublisherClient;
@@ -141,32 +118,7 @@ describe("Materialization Commands", () => {
     expect(calls).toBeGreaterThanOrEqual(3);
   });
 
-  test("materialize (pause) with wait settles at BUILD_PLAN_READY", async () => {
-    let calls = 0;
-    const mockClient = {
-      createMaterialization: mock(() =>
-        Promise.resolve({ id: "m1", status: "PENDING" }),
-      ),
-      getMaterialization: mock(() => {
-        calls += 1;
-        return Promise.resolve({
-          id: "m1",
-          status: calls >= 2 ? "BUILD_PLAN_READY" : "PENDING",
-        });
-      }),
-    } as unknown as PublisherClient;
-
-    await materializationCommands.materialize(mockClient, "env", "pkg", {
-      pauseBetweenPhases: true,
-      wait: true,
-      pollIntervalMs: 1,
-      timeoutMs: 1000,
-    });
-
-    expect(calls).toBeGreaterThanOrEqual(2);
-  });
-
-  test("materialize with wait throws on a FAILED plan (non-zero exit)", async () => {
+  test("materialize with wait throws on a FAILED build (non-zero exit)", async () => {
     const mockClient = {
       createMaterialization: mock(() =>
         Promise.resolve({ id: "m1", status: "PENDING" }),

--- a/packages/cli/tests/integration/cli.integration.test.ts
+++ b/packages/cli/tests/integration/cli.integration.test.ts
@@ -99,12 +99,12 @@ describe("CLI integration (real server)", () => {
     expect(r.output).toContain("No materializations");
   });
 
-  it("materializes a package and waits for the build plan (Round 1)", async () => {
-    // The publisher only drives Round 1; the control plane (absent here) would
-    // drive Round 2, so the reachable success state is BUILD_PLAN_READY.
+  it("materializes a package and waits for completion", async () => {
+    // Auto-run: the publisher compiles, builds, and auto-loads in one pass,
+    // settling at MANIFEST_FILE_READY.
     const r = await runCli(["materialize", ...SCOPE, "--wait"], baseUrl);
     expect(r.code).toBe(0);
-    expect(r.output).toContain("BUILD_PLAN_READY");
+    expect(r.output).toContain("MANIFEST_FILE_READY");
     // Capture the id this run produced so the later tests are state-agnostic.
     const id = extractMaterializationId(r.output);
     expect(id).toBeDefined();
@@ -114,7 +114,7 @@ describe("CLI integration (real server)", () => {
   it("lists the run and gets it by id", async () => {
     const list = await runCli(["list", "materialization", ...SCOPE], baseUrl);
     expect(list.code).toBe(0);
-    expect(list.output).toContain("BUILD_PLAN_READY");
+    expect(list.output).toContain("MANIFEST_FILE_READY");
     expect(list.output).toContain(createdId);
 
     const get = await runCli(
@@ -123,15 +123,6 @@ describe("CLI integration (real server)", () => {
     );
     expect(get.code).toBe(0);
     expect(get.output).toContain(createdId);
-  });
-
-  it("stops the plan-ready run (Round 1 is cancellable)", async () => {
-    const r = await runCli(
-      ["stop-materialization", createdId, ...SCOPE],
-      baseUrl,
-    );
-    expect(r.code).toBe(0);
-    expect(r.output).toContain("Stopped");
   });
 
   it("refuses to stop the now-terminal materialization (exit 1)", async () => {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/sdk",
    "description": "Malloy Publisher SDK",
-   "version": "0.0.207",
+   "version": "0.0.208",
    "type": "module",
    "main": "dist/index.cjs.js",
    "module": "dist/index.es.js",

--- a/packages/sdk/src/components/Materializations/MaterializationDetailDialog.tsx
+++ b/packages/sdk/src/components/Materializations/MaterializationDetailDialog.tsx
@@ -14,7 +14,7 @@ import {
    TableRow,
    Typography,
 } from "@mui/material";
-import { Materialization } from "../../client";
+import { BuildPlan, Materialization } from "../../client";
 import { MONO_FONT_FAMILY } from "../styles";
 import ManifestView from "./ManifestView";
 import {
@@ -27,15 +27,19 @@ import {
 
 type MaterializationDetailDialogProps = {
    materialization: Materialization | null;
+   // The compiled package's current build plan (Package.buildPlan), shown for
+   // context. It is a property of the package version, not the historical run.
+   buildPlan: BuildPlan | null;
    onClose: () => void;
 };
 
 export default function MaterializationDetailDialog({
    materialization,
+   buildPlan,
    onClose,
 }: MaterializationDetailDialogProps) {
    const meta = materialization ? parseMetadata(materialization) : {};
-   const planSources = Object.values(materialization?.buildPlan?.sources ?? {});
+   const planSources = Object.values(buildPlan?.sources ?? {});
 
    return (
       <Dialog
@@ -84,14 +88,6 @@ export default function MaterializationDetailDialog({
                         value={materialization.packageName ?? "—"}
                      />
                      <DetailField
-                        label="Mode"
-                        value={
-                           materialization.pauseBetweenPhases
-                              ? "Two-round"
-                              : "Auto-run"
-                        }
-                     />
-                     <DetailField
                         label="Force refresh"
                         value={meta.forceRefresh ? "Yes" : "No"}
                      />
@@ -118,8 +114,8 @@ export default function MaterializationDetailDialog({
                         value={`${meta.sourcesBuilt ?? 0}`}
                      />
                      <DetailField
-                        label="Sources skipped"
-                        value={`${meta.sourcesSkipped ?? 0}`}
+                        label="Sources reused"
+                        value={`${meta.sourcesReused ?? 0}`}
                      />
                      <DetailField
                         label="Created"
@@ -162,7 +158,7 @@ export default function MaterializationDetailDialog({
                            color="text.secondary"
                            sx={{ fontStyle: "italic" }}
                         >
-                           No build plan yet.
+                           This package has no persist sources.
                         </Typography>
                      ) : (
                         <Table size="small">

--- a/packages/sdk/src/components/Materializations/MaterializationRunsList.tsx
+++ b/packages/sdk/src/components/Materializations/MaterializationRunsList.tsx
@@ -108,8 +108,8 @@ function MaterializationRow({
 
    const meta = parseMetadata(materialization);
    const sourcesLabel =
-      meta.sourcesBuilt !== undefined || meta.sourcesSkipped !== undefined
-         ? `${meta.sourcesBuilt ?? 0} built, ${meta.sourcesSkipped ?? 0} skipped`
+      meta.sourcesBuilt !== undefined || meta.sourcesReused !== undefined
+         ? `${meta.sourcesBuilt ?? 0} built, ${meta.sourcesReused ?? 0} reused`
          : "-";
    const active = isActiveStatus(materialization.status);
    const terminal = isTerminalStatus(materialization.status);

--- a/packages/sdk/src/components/Materializations/Materializations.tsx
+++ b/packages/sdk/src/components/Materializations/Materializations.tsx
@@ -70,6 +70,14 @@ export default function Materializations({
       },
    });
 
+   // The build plan is a property of the compiled package (Package.buildPlan),
+   // not of a historical run, so fetch it from the package for the detail view.
+   const packageQuery = useQueryWithApiError({
+      queryKey: ["package", environmentName, packageName],
+      queryFn: () =>
+         apiClients.packages.getPackage(environmentName, packageName),
+   });
+
    const invalidateList = () =>
       queryClient.invalidateQueries({
          queryKey: ["materializations", environmentName, packageName],
@@ -234,6 +242,7 @@ export default function Materializations({
 
          <MaterializationDetailDialog
             materialization={selected}
+            buildPlan={packageQuery.data?.data?.buildPlan ?? null}
             onClose={() => setSelectedId(null)}
          />
 

--- a/packages/sdk/src/components/Materializations/utils.ts
+++ b/packages/sdk/src/components/Materializations/utils.ts
@@ -1,15 +1,13 @@
 import { Materialization, MaterializationStatus } from "../../client";
 
 /**
- * Non-terminal phases of the two-round protocol. The publisher kicks off Round 1
- * (PENDING -> BUILD_PLAN_READY); the control plane drives Round 2
- * (-> MANIFEST_ROWS_READY -> MANIFEST_FILE_READY). Any of these may be polled and
- * stopped.
+ * Non-terminal phases of a build: PENDING (building) -> MANIFEST_ROWS_READY
+ * (tables built) -> MANIFEST_FILE_READY (terminal). Any non-terminal phase may
+ * be polled and stopped.
  */
 export function isActiveStatus(status?: MaterializationStatus): boolean {
    return (
       status === MaterializationStatus.Pending ||
-      status === MaterializationStatus.BuildPlanReady ||
       status === MaterializationStatus.ManifestRowsReady
    );
 }
@@ -24,9 +22,9 @@ export function isTerminalStatus(status?: MaterializationStatus): boolean {
 
 /**
  * Human-friendly status label. The publisher drives every phase automatically,
- * so the intermediate protocol states (PENDING / BUILD_PLAN_READY /
- * MANIFEST_ROWS_READY) all read as "Pending" and the terminal success state
- * reads as "Done". Failures and cancellations keep their own labels.
+ * so the intermediate states (PENDING / MANIFEST_ROWS_READY) both read as
+ * "Pending" and the terminal success state reads as "Done". Failures and
+ * cancellations keep their own labels.
  */
 export function statusLabel(status?: MaterializationStatus): string {
    switch (status) {
@@ -37,7 +35,6 @@ export function statusLabel(status?: MaterializationStatus): string {
       case MaterializationStatus.Cancelled:
          return "Cancelled";
       case MaterializationStatus.Pending:
-      case MaterializationStatus.BuildPlanReady:
       case MaterializationStatus.ManifestRowsReady:
          return "Pending";
       default:
@@ -49,7 +46,6 @@ type ChipColor = "default" | "info" | "success" | "error" | "warning";
 
 export function statusColor(status?: MaterializationStatus): ChipColor {
    switch (status) {
-      case MaterializationStatus.BuildPlanReady:
       case MaterializationStatus.ManifestRowsReady:
          return "info";
       case MaterializationStatus.ManifestFileReady:
@@ -72,8 +68,9 @@ export function statusColor(status?: MaterializationStatus): ChipColor {
 export interface MaterializationMetadata {
    forceRefresh?: boolean;
    sourceNames?: string[];
+   mode?: "auto" | "orchestrated";
    sourcesBuilt?: number;
-   sourcesSkipped?: number;
+   sourcesReused?: number;
 }
 
 export function parseMetadata(

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/server",
    "description": "Malloy Publisher Server",
-   "version": "0.0.207",
+   "version": "0.0.208",
    "main": "dist/server.mjs",
    "bin": {
       "malloy-publisher": "dist/server.mjs"

--- a/packages/server/src/controller/materialization.controller.spec.ts
+++ b/packages/server/src/controller/materialization.controller.spec.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "bun:test";
+import * as sinon from "sinon";
+import { BadRequestError } from "../errors";
+import type { MaterializationService } from "../service/materialization_service";
+import { MaterializationController } from "./materialization.controller";
+
+/**
+ * Unit tests for {@link MaterializationController.createMaterialization}'s body
+ * validation. The service is stubbed so each test asserts the parsed options
+ * the controller forwards (or the rejection for a malformed body).
+ */
+function build() {
+   const createMaterialization = sinon.stub().resolves({ id: "m1" });
+   const service = {
+      createMaterialization,
+   } as unknown as MaterializationService;
+   const controller = new MaterializationController(service);
+   return { controller, createMaterialization };
+}
+
+/** Parsed options the controller forwards for a given request body. */
+async function parse(body: Record<string, unknown>) {
+   const { controller, createMaterialization } = build();
+   await controller.createMaterialization("env", "pkg", body);
+   return createMaterialization.firstCall.args[2];
+}
+
+describe("MaterializationController.createMaterialization validation", () => {
+   it("forwards an empty body as empty options", async () => {
+      expect(await parse({})).toEqual({});
+   });
+
+   it("passes through forceRefresh and sourceNames", async () => {
+      expect(
+         await parse({ forceRefresh: true, sourceNames: ["a", "b"] }),
+      ).toEqual({ forceRefresh: true, sourceNames: ["a", "b"] });
+   });
+
+   it("rejects a non-boolean forceRefresh", async () => {
+      const { controller } = build();
+      await expect(
+         controller.createMaterialization("env", "pkg", {
+            forceRefresh: "yes",
+         }),
+      ).rejects.toThrow(BadRequestError);
+   });
+
+   it("rejects sourceNames that is not an array of strings", async () => {
+      const { controller } = build();
+      await expect(
+         controller.createMaterialization("env", "pkg", {
+            sourceNames: [1, 2],
+         }),
+      ).rejects.toThrow(BadRequestError);
+   });
+
+   it("flattens buildInstructions.sources into the instruction list", async () => {
+      const parsed = await parse({
+         buildInstructions: {
+            sources: [
+               {
+                  buildId: "b1",
+                  sourceID: "orders@m",
+                  materializedTableId: "mt-1",
+                  physicalTableName: "orders_v1",
+                  realization: "COPY",
+               },
+            ],
+         },
+      });
+      expect(parsed).toEqual({
+         buildInstructions: [
+            {
+               buildId: "b1",
+               sourceID: "orders@m",
+               materializedTableId: "mt-1",
+               physicalTableName: "orders_v1",
+               realization: "COPY",
+            },
+         ],
+      });
+   });
+
+   it("treats null buildInstructions as absent (auto-run)", async () => {
+      expect(await parse({ buildInstructions: null })).toEqual({});
+   });
+
+   it("rejects buildInstructions without a non-empty sources array", async () => {
+      const { controller } = build();
+      await expect(
+         controller.createMaterialization("env", "pkg", {
+            buildInstructions: { sources: [] },
+         }),
+      ).rejects.toThrow(BadRequestError);
+   });
+
+   it("rejects an instruction missing a required field", async () => {
+      const { controller } = build();
+      await expect(
+         controller.createMaterialization("env", "pkg", {
+            buildInstructions: {
+               sources: [{ buildId: "b1", materializedTableId: "mt-1" }],
+            },
+         }),
+      ).rejects.toThrow(BadRequestError);
+   });
+
+   it("rejects an unrecognized realization", async () => {
+      const { controller } = build();
+      await expect(
+         controller.createMaterialization("env", "pkg", {
+            buildInstructions: {
+               sources: [
+                  {
+                     buildId: "b1",
+                     materializedTableId: "mt-1",
+                     physicalTableName: "orders_v1",
+                     realization: "MERGE",
+                  },
+               ],
+            },
+         }),
+      ).rejects.toThrow(BadRequestError);
+   });
+});

--- a/packages/server/src/controller/materialization.controller.ts
+++ b/packages/server/src/controller/materialization.controller.ts
@@ -20,18 +20,20 @@ export class MaterializationController {
    private validateCreateBody(body: Record<string, unknown>): {
       forceRefresh?: boolean;
       sourceNames?: string[];
-      pauseBetweenPhases?: boolean;
+      buildInstructions?: BuildInstruction[];
    } {
       const result: {
          forceRefresh?: boolean;
          sourceNames?: string[];
-         pauseBetweenPhases?: boolean;
+         buildInstructions?: BuildInstruction[];
       } = {};
-      if (body.pauseBetweenPhases !== undefined) {
-         if (typeof body.pauseBetweenPhases !== "boolean") {
-            throw new BadRequestError("pauseBetweenPhases must be a boolean");
-         }
-         result.pauseBetweenPhases = body.pauseBetweenPhases;
+      if (
+         body.buildInstructions !== undefined &&
+         body.buildInstructions !== null
+      ) {
+         result.buildInstructions = this.validateBuildInstructions(
+            body.buildInstructions,
+         );
       }
       if (body.forceRefresh !== undefined) {
          if (typeof body.forceRefresh !== "boolean") {
@@ -53,30 +55,24 @@ export class MaterializationController {
       return result;
    }
 
-   async buildMaterialization(
-      environmentName: string,
-      packageName: string,
-      materializationId: string,
-      body: Record<string, unknown>,
-   ) {
-      return this.materializationService.buildMaterialization(
-         environmentName,
-         packageName,
-         materializationId,
-         this.validateBuildBody(body),
-      );
-   }
-
-   private validateBuildBody(
-      body: Record<string, unknown>,
-   ): BuildInstruction[] {
-      const sources = body.sources;
+   /**
+    * Validate the orchestrated `buildInstructions` payload (BuildInstructions:
+    * `{ sources: BuildInstruction[] }`) and flatten it to the instruction list
+    * the service consumes.
+    */
+   private validateBuildInstructions(raw: unknown): BuildInstruction[] {
+      if (typeof raw !== "object" || raw === null) {
+         throw new BadRequestError("buildInstructions must be an object");
+      }
+      const sources = (raw as Record<string, unknown>).sources;
       if (!Array.isArray(sources) || sources.length === 0) {
          throw new BadRequestError(
-            "build requires a non-empty 'sources' array of BuildInstruction",
+            "buildInstructions requires a non-empty 'sources' array of BuildInstruction",
          );
       }
-      return sources.map((raw) => this.validateInstruction(raw));
+      return sources.map((instruction) =>
+         this.validateInstruction(instruction),
+      );
    }
 
    private validateInstruction(raw: unknown): BuildInstruction {

--- a/packages/server/src/materialization_metrics.ts
+++ b/packages/server/src/materialization_metrics.ts
@@ -1,12 +1,11 @@
 /**
- * Centralized telemetry for the two-round materialization protocol.
+ * Centralized telemetry for materialization builds.
  *
- * Operators need to answer "are builds completing, how long do the two
- * rounds take, and where are they failing?" without grepping logs. The
- * counter carries `round` (`round1`|`round2`) and `outcome`
- * (`success`|`failed`|`cancelled`); the histogram carries `round` so a
- * dashboard can render Round 1 (compile+plan) vs Round 2 (build) latency
- * side by side.
+ * Operators need to answer "are builds completing, how long do they take, and
+ * where are they failing?" without grepping logs. The run counter carries
+ * `mode` (`auto`|`orchestrated`) and `outcome` (`success`|`failed`|`cancelled`);
+ * the run-duration histogram carries `mode` so a dashboard can render auto-run
+ * vs orchestrated build latency side by side.
  *
  * Lazy init for the same reason as {@link ./query_cap_metrics}: instruments
  * created before `setGlobalMeterProvider` bind to a NoOp meter
@@ -15,58 +14,138 @@
 
 import { metrics, type Counter, type Histogram } from "@opentelemetry/api";
 
-export type MaterializationRound = "round1" | "round2" | "auto";
+export type MaterializationMode = "auto" | "orchestrated";
 export type MaterializationOutcome = "success" | "failed" | "cancelled";
 /** Manifest bind outcome: timeout is split out from generic failure on purpose. */
 export type ManifestBindOutcome = "success" | "failure" | "timeout";
 
-let roundCounter: Counter | null = null;
-let roundDuration: Histogram | null = null;
+let runCounter: Counter | null = null;
+let runDuration: Histogram | null = null;
+let sourcesCounter: Counter | null = null;
+let buildPlanComputeDuration: Histogram | null = null;
+let autoLoadCounter: Counter | null = null;
+let connectionDigestSkipCounter: Counter | null = null;
 let manifestBindCounter: Counter | null = null;
 let sourceBuildDuration: Histogram | null = null;
 let dropTablesCounter: Counter | null = null;
 
 function ensureTelemetry(): { counter: Counter; duration: Histogram } {
-   if (roundCounter && roundDuration) {
-      return { counter: roundCounter, duration: roundDuration };
+   if (runCounter && runDuration) {
+      return { counter: runCounter, duration: runDuration };
    }
    const meter = metrics.getMeter("publisher");
-   if (!roundCounter) {
-      roundCounter = meter.createCounter(
-         "publisher_materialization_rounds_total",
-         {
-            description:
-               "Materialization rounds completed. Labels: round ('round1'|'round2'|'auto'), outcome ('success'|'failed'|'cancelled').",
-         },
-      );
+   if (!runCounter) {
+      runCounter = meter.createCounter("publisher_materialization_runs_total", {
+         description:
+            "Materialization builds completed. Labels: mode ('auto'|'orchestrated'), outcome ('success'|'failed'|'cancelled').",
+      });
    }
-   if (!roundDuration) {
-      roundDuration = meter.createHistogram(
-         "publisher_materialization_round_duration_ms",
+   if (!runDuration) {
+      runDuration = meter.createHistogram(
+         "publisher_materialization_run_duration_ms",
          {
             description:
-               "Wall-clock duration of a materialization round. Label: round ('round1'|'round2'|'auto').",
+               "Wall-clock duration of a materialization build. Label: mode ('auto'|'orchestrated').",
             unit: "ms",
          },
       );
    }
-   return { counter: roundCounter, duration: roundDuration };
+   return { counter: runCounter, duration: runDuration };
 }
 
-/** Record the outcome and duration of a materialization round. */
-export function recordMaterializationRound(
-   round: MaterializationRound,
+/** Record the outcome and duration of a materialization build. */
+export function recordMaterializationRun(
+   mode: MaterializationMode,
    outcome: MaterializationOutcome,
    durationMs: number,
 ): void {
    const { counter, duration } = ensureTelemetry();
-   counter.add(1, { round, outcome });
-   duration.record(durationMs, { round });
+   counter.add(1, { mode, outcome });
+   duration.record(durationMs, { mode });
 }
 
 /**
- * Record a manifest-bind attempt (publisher binding a control-plane manifest to
- * a package at load). `timeout` is distinguished from `failure` so operators can
+ * Record how many persist sources a run built vs. reused (carried forward
+ * unchanged via skip-if-unchanged). Lets a dashboard show the reuse ratio,
+ * the main lever on materialization cost.
+ */
+export function recordSourcesOutcome(
+   outcome: "built" | "reused",
+   count: number,
+): void {
+   if (count <= 0) return;
+   if (!sourcesCounter) {
+      sourcesCounter = metrics
+         .getMeter("publisher")
+         .createCounter("publisher_materialization_sources_total", {
+            description:
+               "Persist sources processed by a materialization run. Label: outcome ('built'|'reused').",
+         });
+   }
+   sourcesCounter.add(count, { outcome });
+}
+
+/**
+ * Record the wall-clock cost of compiling a package's build plan
+ * (`Package.buildPlan`). This recompiles models at load, so it is worth
+ * tracking as a discrete cost separate from the build itself.
+ */
+export function recordBuildPlanComputeDuration(durationMs: number): void {
+   if (!buildPlanComputeDuration) {
+      buildPlanComputeDuration = metrics
+         .getMeter("publisher")
+         .createHistogram(
+            "publisher_materialization_build_plan_compute_duration_ms",
+            {
+               description:
+                  "Wall-clock duration of compiling a package's build plan (Package.buildPlan).",
+               unit: "ms",
+            },
+         );
+   }
+   buildPlanComputeDuration.record(durationMs);
+}
+
+/**
+ * Record an auto-run manifest auto-load attempt. Auto-load is best-effort (a
+ * failure does not fail the run), so a failure here is otherwise invisible:
+ * the run is MANIFEST_FILE_READY but queries still resolve to the old tables.
+ */
+export function recordAutoLoadOutcome(outcome: "success" | "failure"): void {
+   if (!autoLoadCounter) {
+      autoLoadCounter = metrics
+         .getMeter("publisher")
+         .createCounter("publisher_materialization_auto_load_total", {
+            description:
+               "Auto-run manifest auto-load attempts. Label: outcome ('success'|'failure').",
+         });
+   }
+   autoLoadCounter.add(1, { outcome });
+}
+
+/**
+ * Record that a connection digest could not be computed during build-plan
+ * compilation because the connection failed to resolve. The resulting buildIds
+ * are computed without a digest, so this is a correctness signal, not just noise.
+ */
+export function recordConnectionDigestSkipped(): void {
+   if (!connectionDigestSkipCounter) {
+      connectionDigestSkipCounter = metrics
+         .getMeter("publisher")
+         .createCounter(
+            "publisher_materialization_connection_digest_skipped_total",
+            {
+               description:
+                  "Connection digests skipped during build-plan compile because the connection did not resolve.",
+            },
+         );
+   }
+   connectionDigestSkipCounter.add(1);
+}
+
+/**
+ * Record a manifest-bind attempt (publisher binding a configured manifest to a
+ * package at load). `timeout` is distinguished from `failure` so operators can
  * tell an unreachable/slow manifest store from a malformed manifest.
  */
 export function recordManifestBind(outcome: ManifestBindOutcome): void {
@@ -113,8 +192,12 @@ export function recordDropTables(outcome: "success" | "failure"): void {
 
 /** Visible for tests. Drops cached instruments so a fresh MeterProvider can capture emissions. */
 export function resetMaterializationTelemetryForTesting(): void {
-   roundCounter = null;
-   roundDuration = null;
+   runCounter = null;
+   runDuration = null;
+   sourcesCounter = null;
+   buildPlanComputeDuration = null;
+   autoLoadCounter = null;
+   connectionDigestSkipCounter = null;
    manifestBindCounter = null;
    sourceBuildDuration = null;
    dropTablesCounter = null;

--- a/packages/server/src/server-old.ts
+++ b/packages/server/src/server-old.ts
@@ -944,16 +944,7 @@ export function registerLegacyRoutes(
       async (req, res) => {
          try {
             const action = req.query.action;
-            if (action === "build") {
-               const build =
-                  await materializationController.buildMaterialization(
-                     req.params.projectName,
-                     req.params.packageName,
-                     req.params.materializationId,
-                     req.body || {},
-                  );
-               res.status(202).json(remapMaterializationResponse(build));
-            } else if (action === "stop") {
+            if (action === "stop") {
                const build =
                   await materializationController.stopMaterialization(
                      req.params.projectName,
@@ -963,7 +954,7 @@ export function registerLegacyRoutes(
                res.status(200).json(remapMaterializationResponse(build));
             } else {
                throw new BadRequestError(
-                  `Unsupported action '${String(action ?? "")}'. Expected 'build' or 'stop'.`,
+                  `Unsupported action '${String(action ?? "")}'. Expected 'stop'.`,
                );
             }
          } catch (error) {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1592,15 +1592,7 @@ app.post(
    async (req, res) => {
       try {
          const action = req.query.action;
-         if (action === "build") {
-            const build = await materializationController.buildMaterialization(
-               req.params.environmentName,
-               req.params.packageName,
-               req.params.materializationId,
-               req.body || {},
-            );
-            res.status(202).json(build);
-         } else if (action === "stop") {
+         if (action === "stop") {
             const build = await materializationController.stopMaterialization(
                req.params.environmentName,
                req.params.packageName,
@@ -1609,7 +1601,7 @@ app.post(
             res.status(200).json(build);
          } else {
             throw new BadRequestError(
-               `Unsupported action '${String(action ?? "")}'. Expected 'build' or 'stop'.`,
+               `Unsupported action '${String(action ?? "")}'. Expected 'stop'.`,
             );
          }
       } catch (error) {

--- a/packages/server/src/service/build_plan.spec.ts
+++ b/packages/server/src/service/build_plan.spec.ts
@@ -1,0 +1,116 @@
+import type { PersistSource } from "@malloydata/malloy";
+import { describe, expect, it } from "bun:test";
+import * as sinon from "sinon";
+import {
+   computeBuildId,
+   computePackageBuildPlan,
+   deriveBuildPlan,
+   flattenDependsOn,
+   resolvePackageConnections,
+} from "./build_plan";
+import { fakeSource } from "./materialization_test_fixtures";
+
+describe("flattenDependsOn", () => {
+   it("maps nested dependsOn entries to a flat sourceID list", () => {
+      expect(
+         flattenDependsOn({
+            dependsOn: [{ sourceID: "a" }, { sourceID: "b" }],
+         }),
+      ).toEqual(["a", "b"]);
+   });
+});
+
+describe("computeBuildId", () => {
+   it("delegates to PersistSource.makeBuildId with the connection digest and SQL", () => {
+      const makeBuildId = sinon.stub().returns("computed-id");
+      const source = {
+         connectionName: "duckdb",
+         makeBuildId,
+         getSQL: () => "SELECT 7",
+      } as unknown as PersistSource;
+
+      const id = computeBuildId(source, { duckdb: "dig-1" });
+
+      expect(id).toBe("computed-id");
+      expect(makeBuildId.calledOnceWithExactly("dig-1", "SELECT 7")).toBe(true);
+   });
+});
+
+describe("resolvePackageConnections", () => {
+   it("resolves each unique name once and omits failures", async () => {
+      const getMalloyConnection = sinon.stub();
+      getMalloyConnection.withArgs("ok").resolves({ id: "ok-conn" });
+      getMalloyConnection.withArgs("bad").rejects(new Error("nope"));
+
+      const map = await resolvePackageConnections({ getMalloyConnection }, [
+         "ok",
+         "ok",
+         "bad",
+      ]);
+
+      expect(map.has("ok")).toBe(true);
+      expect(map.has("bad")).toBe(false);
+      // "ok" requested twice but resolved once (dedupe).
+      expect(getMalloyConnection.withArgs("ok").callCount).toBe(1);
+   });
+});
+
+describe("deriveBuildPlan", () => {
+   it("projects graphs and sources into the wire build plan", () => {
+      const orders = fakeSource({
+         name: "orders",
+         buildId: "bid-orders",
+         sql: "SELECT 1",
+      });
+      const plan = deriveBuildPlan(
+         [
+            {
+               connectionName: "duckdb",
+               nodes: [[{ sourceID: "orders@m", dependsOn: [] }]],
+            },
+         ] as unknown as Parameters<typeof deriveBuildPlan>[0],
+         { "orders@m": orders },
+         { duckdb: "dig" },
+      );
+
+      expect(plan.graphs[0].connectionName).toBe("duckdb");
+      expect(plan.sources["orders@m"]).toMatchObject({
+         name: "orders",
+         connectionName: "duckdb",
+         buildId: "bid-orders",
+         sql: "SELECT 1",
+         columns: [],
+      });
+   });
+
+   it("honors the sourceNames filter", () => {
+      const a = fakeSource({ name: "a", buildId: "bid-a" });
+      const b = fakeSource({ name: "b", buildId: "bid-b" });
+      const plan = deriveBuildPlan(
+         [
+            {
+               connectionName: "duckdb",
+               nodes: [[{ sourceID: "a@m", dependsOn: [] }]],
+            },
+         ] as unknown as Parameters<typeof deriveBuildPlan>[0],
+         { "a@m": a, "b@m": b },
+         { duckdb: "dig" },
+         ["a"],
+      );
+
+      expect(Object.keys(plan.sources)).toEqual(["a@m"]);
+   });
+});
+
+describe("computePackageBuildPlan", () => {
+   it("returns null when the package declares no persist sources", async () => {
+      const pkg = {
+         getModelPaths: () => [],
+         getPackagePath: () => "/test",
+         getMalloyConfig: () => ({}),
+         getMalloyConnection: async () => ({}),
+      } as unknown as Parameters<typeof computePackageBuildPlan>[0];
+
+      expect(await computePackageBuildPlan(pkg)).toBeNull();
+   });
+});

--- a/packages/server/src/service/build_plan.ts
+++ b/packages/server/src/service/build_plan.ts
@@ -1,0 +1,238 @@
+import type {
+   AtomicField,
+   BuildGraph as MalloyBuildGraph,
+   MalloyConfig,
+   Connection as MalloyConnection,
+   PersistSource,
+} from "@malloydata/malloy";
+import { components } from "../api";
+import { logger } from "../logger";
+import { recordConnectionDigestSkipped } from "../materialization_metrics";
+import { Model } from "./model";
+
+type WireBuildGraph = components["schemas"]["BuildGraph"];
+type WirePersistSourcePlan = components["schemas"]["PersistSourcePlan"];
+type WireColumn = components["schemas"]["Column"];
+type BuildPlan = components["schemas"]["BuildPlan"];
+
+/**
+ * Minimal surface a package must expose to compile its build plan. Both
+ * {@link Package} (for the read-only `Package.buildPlan`) and the
+ * materialization service (for auto-run and orchestrated builds) satisfy it.
+ */
+export interface BuildPlanPackage {
+   getModelPaths(): string[];
+   getPackagePath(): string;
+   getMalloyConfig(): MalloyConfig;
+   getMalloyConnection(name: string): Promise<MalloyConnection>;
+}
+
+/**
+ * Result of compiling a package's persist sources: the dependency-ordered
+ * build graphs, the persist sources keyed by sourceID, the per-connection
+ * digests, and the resolved live connections. The wire {@link BuildPlan} is a
+ * projection of this (see {@link deriveBuildPlan}); the build engine consumes
+ * the full structure.
+ */
+export interface CompiledBuildPlan {
+   graphs: MalloyBuildGraph[];
+   sources: Record<string, PersistSource>;
+   connectionDigests: Record<string, string>;
+   connections: Map<string, MalloyConnection>;
+}
+
+/** Output columns of a persist source, degrading to [] if unavailable. */
+export function deriveColumns(persistSource: PersistSource): WireColumn[] {
+   try {
+      return persistSource._explore.intrinsicFields
+         .filter((f) => f.isAtomicField())
+         .map((f) => ({
+            name: f.name,
+            type: String((f as AtomicField).type),
+         }));
+   } catch (err) {
+      logger.warn("Failed to derive columns for persist source", {
+         sourceID: persistSource.sourceID,
+         error: err instanceof Error ? err.message : String(err),
+      });
+      return [];
+   }
+}
+
+/** Flatten Malloy's nested BuildNode.dependsOn into a list of sourceIDs. */
+export function flattenDependsOn(node: {
+   dependsOn: { sourceID: string }[];
+}): string[] {
+   return node.dependsOn.map((d) => d.sourceID);
+}
+
+/**
+ * The buildId for a persist source: a stable digest of its connection identity
+ * and canonical SQL. Centralizes the (source, connectionDigests) call shape so
+ * planning, self-instruction, and build all agree on the same id.
+ */
+export function computeBuildId(
+   source: PersistSource,
+   connectionDigests: Record<string, string>,
+): string {
+   return source.makeBuildId(
+      connectionDigests[source.connectionName],
+      source.getSQL(),
+   );
+}
+
+/**
+ * Resolve a Map<name, Connection> for the names a step is about to touch.
+ * The package's MalloyConfig caches each lookup, so repeated calls are cheap.
+ * A failed lookup is logged and omitted; downstream code reports the missing
+ * connection explicitly.
+ */
+export async function resolvePackageConnections(
+   pkg: { getMalloyConnection(name: string): Promise<MalloyConnection> },
+   names: Iterable<string>,
+): Promise<Map<string, MalloyConnection>> {
+   const map = new Map<string, MalloyConnection>();
+   const seen = new Set<string>();
+   for (const name of names) {
+      if (!name || seen.has(name)) continue;
+      seen.add(name);
+      try {
+         map.set(name, await pkg.getMalloyConnection(name));
+      } catch (err) {
+         logger.warn(`Failed to resolve connection ${name}`, {
+            error: err instanceof Error ? err.message : String(err),
+         });
+      }
+   }
+   return map;
+}
+
+/**
+ * Compile every model in the package and collect the dependency-ordered
+ * build graphs, persist sources, connection digests, and resolved
+ * connections. The build plan is a pure function of the compiled model plus
+ * connection config (no warehouse access).
+ */
+export async function compilePackageBuildPlan(
+   pkg: BuildPlanPackage,
+   signal?: AbortSignal,
+): Promise<CompiledBuildPlan> {
+   const allGraphs: MalloyBuildGraph[] = [];
+   const allSources: Record<string, PersistSource> = {};
+
+   for (const modelPath of pkg.getModelPaths()) {
+      if (signal?.aborted) throw new Error("Build cancelled");
+
+      const { runtime, modelURL, importBaseURL } = await Model.getModelRuntime(
+         pkg.getPackagePath(),
+         modelPath,
+         pkg.getMalloyConfig(),
+      );
+      const malloyModel = await runtime
+         .loadModel(modelURL, { importBaseURL })
+         .getModel();
+
+      // getBuildPlan() returns empty graphs for models with no #@ persist
+      // sources, so non-persist models are simply skipped below.
+      const buildPlan = malloyModel.getBuildPlan();
+      for (const msg of buildPlan.tagParseLog) {
+         logger.warn("Persist annotation issue", {
+            modelPath,
+            message: msg.message,
+            severity: msg.severity,
+         });
+      }
+      if (buildPlan.graphs.length === 0) continue;
+
+      allGraphs.push(...buildPlan.graphs);
+      for (const [sourceID, source] of Object.entries(buildPlan.sources)) {
+         allSources[sourceID] = source;
+      }
+   }
+
+   const connections = await resolvePackageConnections(
+      pkg,
+      allGraphs.map((g) => g.connectionName),
+   );
+   const connectionDigests: Record<string, string> = {};
+   for (const graph of allGraphs) {
+      const conn = connections.get(graph.connectionName);
+      if (!conn) {
+         // The connection failed to resolve (already warned in
+         // resolvePackageConnections). Its buildIds will be computed without a
+         // digest, so surface it as a discrete correctness signal rather than
+         // skipping silently.
+         recordConnectionDigestSkipped();
+         logger.warn("Skipping connection digest; connection did not resolve", {
+            connectionName: graph.connectionName,
+         });
+         continue;
+      }
+      if (!connectionDigests[graph.connectionName]) {
+         connectionDigests[graph.connectionName] = await conn.getDigest();
+      }
+   }
+
+   return {
+      graphs: allGraphs,
+      sources: allSources,
+      connectionDigests,
+      connections,
+   };
+}
+
+/** Project the Malloy build plan into the trimmed wire BuildPlan. */
+export function deriveBuildPlan(
+   graphs: MalloyBuildGraph[],
+   sources: Record<string, PersistSource>,
+   connectionDigests: Record<string, string>,
+   sourceNames?: string[],
+): BuildPlan {
+   const include = sourceNames ? new Set(sourceNames) : null;
+
+   const wireGraphs: WireBuildGraph[] = graphs.map((graph) => ({
+      connectionName: graph.connectionName,
+      nodes: graph.nodes.map((level) =>
+         level.map((node) => ({
+            sourceID: node.sourceID,
+            dependsOn: flattenDependsOn(node),
+         })),
+      ),
+   }));
+
+   const wireSources: Record<string, WirePersistSourcePlan> = {};
+   for (const [sourceID, source] of Object.entries(sources)) {
+      if (include && !include.has(source.name)) continue;
+      wireSources[sourceID] = {
+         name: source.name,
+         sourceID: source.sourceID,
+         connectionName: source.connectionName,
+         dialect: source.dialectName,
+         buildId: computeBuildId(source, connectionDigests),
+         sql: source.getSQL(),
+         columns: deriveColumns(source),
+      };
+   }
+
+   return { graphs: wireGraphs, sources: wireSources };
+}
+
+/**
+ * Compile and project a package's build plan, or null when the package
+ * declares no persist source. Convenience for the read-only `Package.buildPlan`
+ * field, which is a deterministic property of the compiled package.
+ */
+export async function computePackageBuildPlan(
+   pkg: BuildPlanPackage,
+   signal?: AbortSignal,
+): Promise<BuildPlan | null> {
+   const compiled = await compilePackageBuildPlan(pkg, signal);
+   if (compiled.graphs.length === 0) {
+      return null;
+   }
+   return deriveBuildPlan(
+      compiled.graphs,
+      compiled.sources,
+      compiled.connectionDigests,
+   );
+}

--- a/packages/server/src/service/materialization_service.spec.ts
+++ b/packages/server/src/service/materialization_service.spec.ts
@@ -1,3 +1,4 @@
+import type { Connection as MalloyConnection } from "@malloydata/malloy";
 import { Manifest } from "@malloydata/malloy";
 import { beforeEach, describe, expect, it } from "bun:test";
 import * as sinon from "sinon";
@@ -10,72 +11,21 @@ import {
 } from "../errors";
 import {
    BuildInstruction,
-   BuildPlan,
-   Materialization,
    ResourceRepository,
 } from "../storage/DatabaseInterface";
 import { DuplicateActiveMaterializationError } from "../storage/duckdb/MaterializationRepository";
 import { EnvironmentStore } from "./environment_store";
 import {
+   compiledWith,
+   fakeSource,
+   makeBuildPlan,
+   makeInstruction,
+   makeMaterialization,
+} from "./materialization_test_fixtures";
+import {
    MaterializationService,
    stagingSuffix,
 } from "./materialization_service";
-
-function makeMaterialization(
-   overrides: Partial<Materialization> = {},
-): Materialization {
-   return {
-      id: "mat-1",
-      environmentId: "env-1",
-      packageName: "pkg",
-      pauseBetweenPhases: false,
-      status: "PENDING",
-      buildPlan: null,
-      manifest: null,
-      startedAt: null,
-      completedAt: null,
-      error: null,
-      metadata: null,
-      createdAt: new Date("2026-01-01"),
-      updatedAt: new Date("2026-01-01"),
-      ...overrides,
-   };
-}
-
-function makeBuildPlan(overrides: Partial<BuildPlan> = {}): BuildPlan {
-   return {
-      graphs: [
-         {
-            connectionName: "duckdb",
-            nodes: [[{ sourceID: "orders@m.malloy", dependsOn: [] }]],
-         },
-      ],
-      sources: {
-         "orders@m.malloy": {
-            name: "orders",
-            sourceID: "orders@m.malloy",
-            connectionName: "duckdb",
-            dialect: "duckdb",
-            buildId: "build-orders",
-            sql: "SELECT 1",
-            columns: [],
-         },
-      },
-      ...overrides,
-   };
-}
-
-function makeInstruction(
-   overrides: Partial<BuildInstruction> = {},
-): BuildInstruction {
-   return {
-      buildId: "build-orders",
-      materializedTableId: "mt-1",
-      physicalTableName: '"orders_v1"',
-      realization: "COPY",
-      ...overrides,
-   };
-}
 
 type MockRepo = sinon.SinonStubbedInstance<ResourceRepository>;
 
@@ -99,7 +49,10 @@ function createMocks() {
       getEnvironment: sandbox.stub(),
    } as unknown as EnvironmentStore;
 
-   // Default: environment resolves and yields a package.
+   // Default: environment resolves and yields a package whose build plan is
+   // empty (no persist sources). Individual tests override getBuildPlan to
+   // exercise the orchestrated path. getModelPaths()=>[] keeps the background
+   // build from touching the Malloy runtime.
    repository.getEnvironmentByName.resolves({
       id: "env-1",
       name: "my-env",
@@ -107,15 +60,32 @@ function createMocks() {
       createdAt: new Date(),
       updatedAt: new Date(),
    });
-   (environmentStore.getEnvironment as sinon.SinonStub).resolves({
-      getPackage: sinon.stub().resolves({}),
-      withPackageLock: async (_name: string, fn: () => Promise<unknown>) =>
-         fn(),
-   });
+   setPackage(environmentStore, { getBuildPlan: () => null });
 
    const service = new MaterializationService(environmentStore);
 
    return { sandbox, repository, environmentStore, service };
+}
+
+/** Point environmentStore.getEnvironment at a package with the given overrides. */
+function setPackage(
+   environmentStore: EnvironmentStore,
+   pkgOverrides: Record<string, unknown>,
+): void {
+   const pkg = {
+      getBuildPlan: () => null,
+      getModelPaths: () => [],
+      getPackagePath: () => "/test",
+      getMalloyConfig: () => ({}),
+      getMalloyConnection: async () => ({}),
+      ...pkgOverrides,
+   };
+   (environmentStore.getEnvironment as sinon.SinonStub).resolves({
+      getPackage: sinon.stub().resolves(pkg),
+      withPackageLock: async (_name: string, fn: () => Promise<unknown>) =>
+         fn(),
+      reloadAllModelsForPackage: sinon.stub().resolves(),
+   });
 }
 
 describe("MaterializationService", () => {
@@ -171,8 +141,8 @@ describe("MaterializationService", () => {
       });
    });
 
-   describe("createMaterialization (Round 1)", () => {
-      it("creates a PENDING record and persists options", async () => {
+   describe("createMaterialization (auto-run)", () => {
+      it("creates a PENDING record and persists options with mode=auto", async () => {
          ctx.repository.getActiveMaterialization.resolves(null);
          const pending = makeMaterialization({ status: "PENDING" });
          ctx.repository.createMaterialization.resolves(pending);
@@ -183,7 +153,6 @@ describe("MaterializationService", () => {
             {
                forceRefresh: true,
                sourceNames: ["orders"],
-               pauseBetweenPhases: true,
             },
          );
 
@@ -195,12 +164,12 @@ describe("MaterializationService", () => {
             {
                forceRefresh: true,
                sourceNames: ["orders"],
-               pauseBetweenPhases: true,
+               mode: "auto",
             },
          ]);
       });
 
-      it("defaults pauseBetweenPhases to false (auto-run) in metadata", async () => {
+      it("defaults to auto mode in metadata", async () => {
          ctx.repository.getActiveMaterialization.resolves(null);
          ctx.repository.createMaterialization.resolves(
             makeMaterialization({ status: "PENDING" }),
@@ -212,14 +181,17 @@ describe("MaterializationService", () => {
             {
                forceRefresh: false,
                sourceNames: null,
-               pauseBetweenPhases: false,
+               mode: "auto",
             },
          );
       });
 
       it("rejects when an active materialization already exists", async () => {
          ctx.repository.getActiveMaterialization.resolves(
-            makeMaterialization({ id: "existing", status: "BUILD_PLAN_READY" }),
+            makeMaterialization({
+               id: "existing",
+               status: "MANIFEST_ROWS_READY",
+            }),
          );
          await expect(
             ctx.service.createMaterialization("my-env", "pkg"),
@@ -241,89 +213,65 @@ describe("MaterializationService", () => {
       });
    });
 
-   describe("buildMaterialization (Round 2)", () => {
-      it("rejects action=build on an auto-run materialization", async () => {
-         ctx.repository.getMaterializationById.resolves(
-            makeMaterialization({
-               status: "BUILD_PLAN_READY",
-               pauseBetweenPhases: false,
-               buildPlan: makeBuildPlan(),
-            }),
-         );
-         await expect(
-            ctx.service.buildMaterialization("my-env", "pkg", "mat-1", [
-               makeInstruction(),
-            ]),
-         ).rejects.toThrow(InvalidStateTransitionError);
-      });
-
-      it("rejects when not at BUILD_PLAN_READY", async () => {
-         ctx.repository.getMaterializationById.resolves(
-            makeMaterialization({
-               status: "PENDING",
-               pauseBetweenPhases: true,
-            }),
-         );
-         await expect(
-            ctx.service.buildMaterialization("my-env", "pkg", "mat-1", [
-               makeInstruction(),
-            ]),
-         ).rejects.toThrow(InvalidStateTransitionError);
-      });
-
-      it("rejects instructions that reference an unknown buildId", async () => {
-         ctx.repository.getMaterializationById.resolves(
-            makeMaterialization({
-               status: "BUILD_PLAN_READY",
-               pauseBetweenPhases: true,
-               buildPlan: makeBuildPlan(),
-            }),
-         );
-         await expect(
-            ctx.service.buildMaterialization("my-env", "pkg", "mat-1", [
-               makeInstruction({ buildId: "ghost" }),
-            ]),
-         ).rejects.toThrow(BadRequestError);
-      });
-
-      it("rejects SNAPSHOT when the connection does not support it", async () => {
-         ctx.repository.getMaterializationById.resolves(
-            makeMaterialization({
-               status: "BUILD_PLAN_READY",
-               pauseBetweenPhases: true,
-               buildPlan: makeBuildPlan(),
-            }),
-         );
-         await expect(
-            ctx.service.buildMaterialization("my-env", "pkg", "mat-1", [
-               makeInstruction({ realization: "SNAPSHOT" }),
-            ]),
-         ).rejects.toThrow(BadRequestError);
-      });
-
-      it("accepts a valid build and returns the record (202)", async () => {
-         const m = makeMaterialization({
-            status: "BUILD_PLAN_READY",
-            pauseBetweenPhases: true,
-            buildPlan: makeBuildPlan(),
+   describe("createMaterialization (orchestrated)", () => {
+      it("creates a PENDING record with mode=orchestrated for valid instructions", async () => {
+         setPackage(ctx.environmentStore, {
+            getBuildPlan: () => makeBuildPlan(),
          });
-         ctx.repository.getMaterializationById.resolves(m);
-         const result = await ctx.service.buildMaterialization(
+         ctx.repository.getActiveMaterialization.resolves(null);
+         ctx.repository.createMaterialization.resolves(
+            makeMaterialization({ status: "PENDING" }),
+         );
+
+         const result = await ctx.service.createMaterialization(
             "my-env",
             "pkg",
-            "mat-1",
-            [makeInstruction()],
+            { buildInstructions: [makeInstruction()] },
          );
-         expect(result.id).toBe("mat-1");
+
+         expect(result.status).toBe("PENDING");
+         expect(
+            ctx.repository.createMaterialization.firstCall.args[3],
+         ).toMatchObject({ mode: "orchestrated" });
+      });
+
+      it("rejects instructions referencing an unknown buildId before creating", async () => {
+         setPackage(ctx.environmentStore, {
+            getBuildPlan: () => makeBuildPlan(),
+         });
+         await expect(
+            ctx.service.createMaterialization("my-env", "pkg", {
+               buildInstructions: [makeInstruction({ buildId: "ghost" })],
+            }),
+         ).rejects.toThrow(BadRequestError);
+         expect(ctx.repository.createMaterialization.called).toBe(false);
+      });
+
+      it("rejects SNAPSHOT realization", async () => {
+         setPackage(ctx.environmentStore, {
+            getBuildPlan: () => makeBuildPlan(),
+         });
+         await expect(
+            ctx.service.createMaterialization("my-env", "pkg", {
+               buildInstructions: [
+                  makeInstruction({ realization: "SNAPSHOT" }),
+               ],
+            }),
+         ).rejects.toThrow(BadRequestError);
+      });
+
+      it("rejects buildInstructions when the package has no persist sources", async () => {
+         setPackage(ctx.environmentStore, { getBuildPlan: () => null });
+         await expect(
+            ctx.service.createMaterialization("my-env", "pkg", {
+               buildInstructions: [makeInstruction()],
+            }),
+         ).rejects.toThrow(BadRequestError);
       });
    });
 
    describe("stopMaterialization", () => {
-      const cancellable = [
-         "PENDING",
-         "BUILD_PLAN_READY",
-         "MANIFEST_ROWS_READY",
-      ] as const;
+      const cancellable = ["PENDING", "MANIFEST_ROWS_READY"] as const;
 
       for (const status of cancellable) {
          it(`cancels a ${status} materialization`, async () => {
@@ -369,11 +317,7 @@ describe("MaterializationService", () => {
          });
       }
 
-      const active = [
-         "PENDING",
-         "BUILD_PLAN_READY",
-         "MANIFEST_ROWS_READY",
-      ] as const;
+      const active = ["PENDING", "MANIFEST_ROWS_READY"] as const;
       for (const status of active) {
          it(`rejects deleting a ${status} materialization`, async () => {
             ctx.repository.getMaterializationById.resolves(
@@ -500,51 +444,11 @@ describe("stagingSuffix", () => {
    });
 });
 
-// Characterization (Pass 0): lock in the auto-run instruction-derivation and
-// the single-source build SQL sequence before the simplify pass moves them.
-// deriveSelfInstructions / buildOneSource are private; we exercise them via a
-// typed cast rather than the heavyweight runtime path.
-
-// A minimal stand-in for a Malloy PersistSource exposing only what the build
-// internals touch.
-function fakeSource(opts: {
-   name: string;
-   buildId: string;
-   sql?: string;
-   connectionName?: string;
-}): unknown {
-   return {
-      name: opts.name,
-      sourceID: opts.name,
-      connectionName: opts.connectionName ?? "duckdb",
-      makeBuildId: () => opts.buildId,
-      getSQL: () => opts.sql ?? "SELECT 1",
-      annotations: {
-         parseAsTag: () => ({ tag: { text: () => undefined } }),
-      },
-   };
-}
-
-describe("deriveSelfInstructions (characterization)", () => {
+describe("deriveSelfInstructions", () => {
    let ctx: ReturnType<typeof createMocks>;
    beforeEach(() => {
       ctx = createMocks();
    });
-
-   function compiledWith(sources: Record<string, unknown>, levels: string[][]) {
-      return {
-         graphs: [
-            {
-               connectionName: "duckdb",
-               nodes: levels.map((level) =>
-                  level.map((sourceID) => ({ sourceID, dependsOn: [] })),
-               ),
-            },
-         ],
-         sources,
-         connectionDigests: { duckdb: "dig" },
-      };
-   }
 
    it("carries forward unchanged buildIds and builds the rest (deduping repeats)", () => {
       const compiled = compiledWith(
@@ -702,7 +606,98 @@ describe("stopMaterialization (in-flight)", () => {
    });
 });
 
-describe("buildOneSource (characterization)", () => {
+describe("executeInstructedBuild", () => {
+   let ctx: ReturnType<typeof createMocks>;
+   beforeEach(() => {
+      ctx = createMocks();
+   });
+
+   function callExecute(
+      compiled: unknown,
+      instructions: BuildInstruction[],
+      seed: Record<string, unknown>,
+   ): Promise<Record<string, { physicalTableName?: string }>> {
+      return (
+         ctx.service as unknown as {
+            executeInstructedBuild: (
+               c: unknown,
+               i: BuildInstruction[],
+               s: Record<string, unknown>,
+               sig: AbortSignal,
+            ) => Promise<Record<string, { physicalTableName?: string }>>;
+         }
+      ).executeInstructedBuild(
+         compiled,
+         instructions,
+         seed,
+         new AbortController().signal,
+      );
+   }
+
+   it("builds instructed sources in dependency order and seeds carried entries", async () => {
+      const runSQL = sinon.stub().resolves();
+      const connection = { runSQL } as unknown as MalloyConnection;
+      const s1 = fakeSource({ name: "s1", buildId: "b1aaaaaaaaaaaaaa" });
+      const s2 = fakeSource({ name: "s2", buildId: "b2bbbbbbbbbbbbbb" });
+      const compiled = compiledWith(
+         { s1, s2 },
+         [["s1"], ["s2"]],
+         new Map([["duckdb", connection]]),
+      );
+
+      const entries = await callExecute(
+         compiled,
+         [
+            {
+               buildId: "b1aaaaaaaaaaaaaa",
+               materializedTableId: "mt-1",
+               physicalTableName: "s1_v1",
+               realization: "COPY",
+            },
+            {
+               buildId: "b2bbbbbbbbbbbbbb",
+               materializedTableId: "mt-2",
+               physicalTableName: "s2_v1",
+               realization: "COPY",
+            },
+         ],
+         {
+            carried0: {
+               buildId: "carried0",
+               physicalTableName: "carried_tbl",
+               connectionName: "duckdb",
+            },
+         },
+      );
+
+      // Both instructed sources built, plus the carried seed entry retained.
+      expect(entries["b1aaaaaaaaaaaaaa"].physicalTableName).toBe("s1_v1");
+      expect(entries["b2bbbbbbbbbbbbbb"].physicalTableName).toBe("s2_v1");
+      expect(entries["carried0"].physicalTableName).toBe("carried_tbl");
+   });
+
+   it("throws when an instructed graph's connection is missing", async () => {
+      const s1 = fakeSource({ name: "s1", buildId: "b1aaaaaaaaaaaaaa" });
+      const compiled = compiledWith({ s1 }, [["s1"]], new Map());
+
+      await expect(
+         callExecute(
+            compiled,
+            [
+               {
+                  buildId: "b1aaaaaaaaaaaaaa",
+                  materializedTableId: "mt-1",
+                  physicalTableName: "s1_v1",
+                  realization: "COPY",
+               },
+            ],
+            {},
+         ),
+      ).rejects.toThrow(BadRequestError);
+   });
+});
+
+describe("buildOneSource", () => {
    let ctx: ReturnType<typeof createMocks>;
    beforeEach(() => {
       ctx = createMocks();
@@ -768,5 +763,214 @@ describe("buildOneSource (characterization)", () => {
       expect(runSQL.lastCall.args[0]).toBe(
          "DROP TABLE IF EXISTS orders_v1_abcdef123456",
       );
+   });
+});
+
+describe("runBuild (branch behavior)", () => {
+   let ctx: ReturnType<typeof createMocks>;
+   beforeEach(() => {
+      ctx = createMocks();
+   });
+
+   // Exercise runBuild's orchestration in isolation: the build engine and
+   // manifest commit are stubbed so the test asserts which instructions flow
+   // through and whether the manifest is auto-loaded, not how a source is built.
+   type RunBuildInternals = {
+      executeInstructedBuild: sinon.SinonStub;
+      commitManifest: sinon.SinonStub;
+      autoLoadManifest: sinon.SinonStub;
+      runBuild: (
+         id: string,
+         env: string,
+         pkg: string,
+         opts: {
+            sourceNames: string[] | undefined;
+            forceRefresh: boolean;
+            buildInstructions: BuildInstruction[] | undefined;
+         },
+         signal: AbortSignal,
+      ) => Promise<void>;
+   };
+
+   function stubEngine(): RunBuildInternals {
+      const entries = {
+         "build-orders": {
+            buildId: "build-orders",
+            physicalTableName: '"orders_v1"',
+            connectionName: "duckdb",
+         },
+      };
+      const svc = ctx.service as unknown as RunBuildInternals;
+      svc.executeInstructedBuild = sinon.stub().resolves(entries);
+      svc.commitManifest = sinon.stub().resolves();
+      svc.autoLoadManifest = sinon.stub().resolves();
+      return svc;
+   }
+
+   it("orchestrated: builds caller instructions and does not auto-load", async () => {
+      const svc = stubEngine();
+      const instructions = [makeInstruction()];
+
+      await svc.runBuild(
+         "mat-1",
+         "my-env",
+         "pkg",
+         {
+            sourceNames: undefined,
+            forceRefresh: false,
+            buildInstructions: instructions,
+         },
+         new AbortController().signal,
+      );
+
+      expect(svc.executeInstructedBuild.calledOnce).toBe(true);
+      // Caller instructions pass straight through; nothing is carried/reused.
+      expect(svc.executeInstructedBuild.firstCall.args[1]).toEqual(
+         instructions,
+      );
+      expect(svc.executeInstructedBuild.firstCall.args[2]).toEqual({});
+      expect(svc.commitManifest.firstCall.args[2]).toMatchObject({
+         mode: "orchestrated",
+         sourcesBuilt: 1,
+         sourcesReused: 0,
+      });
+      // Orchestrated leaves distribution to the caller.
+      expect(svc.autoLoadManifest.called).toBe(false);
+   });
+
+   it("auto-run: derives instructions and auto-loads the manifest", async () => {
+      const svc = stubEngine();
+
+      await svc.runBuild(
+         "mat-1",
+         "my-env",
+         "pkg",
+         {
+            sourceNames: undefined,
+            forceRefresh: true,
+            buildInstructions: undefined,
+         },
+         new AbortController().signal,
+      );
+
+      expect(svc.commitManifest.firstCall.args[2]).toMatchObject({
+         mode: "auto",
+      });
+      // Auto-run owns distribution: it loads the fresh manifest into the models.
+      expect(svc.autoLoadManifest.calledOnce).toBe(true);
+   });
+});
+
+describe("autoLoadManifest", () => {
+   let ctx: ReturnType<typeof createMocks>;
+   beforeEach(() => {
+      ctx = createMocks();
+   });
+
+   it("loads only entries with a physical table into the package models", async () => {
+      const reloadAllModelsForPackage = sinon.stub().resolves();
+      const entries = {
+         b1: {
+            buildId: "b1",
+            physicalTableName: "orders_v1",
+            connectionName: "duckdb",
+         },
+         b2: { buildId: "b2", physicalTableName: undefined },
+      };
+
+      await (
+         ctx.service as unknown as {
+            autoLoadManifest: (
+               env: { reloadAllModelsForPackage: sinon.SinonStub },
+               pkg: string,
+               entries: Record<string, unknown>,
+            ) => Promise<void>;
+         }
+      ).autoLoadManifest({ reloadAllModelsForPackage }, "pkg", entries);
+
+      expect(reloadAllModelsForPackage.calledOnce).toBe(true);
+      expect(reloadAllModelsForPackage.firstCall.args).toEqual([
+         "pkg",
+         { b1: { tableName: "orders_v1" } },
+      ]);
+   });
+
+   it("swallows a reload failure (best-effort; run already succeeded)", async () => {
+      const reloadAllModelsForPackage = sinon
+         .stub()
+         .rejects(new Error("reload boom"));
+      await expect(
+         (
+            ctx.service as unknown as {
+               autoLoadManifest: (
+                  env: { reloadAllModelsForPackage: sinon.SinonStub },
+                  pkg: string,
+                  entries: Record<string, unknown>,
+               ) => Promise<void>;
+            }
+         ).autoLoadManifest({ reloadAllModelsForPackage }, "pkg", {
+            b1: { buildId: "b1", physicalTableName: "t" },
+         }),
+      ).resolves.toBeUndefined();
+   });
+});
+
+describe("runInBackground (terminal recording)", () => {
+   let ctx: ReturnType<typeof createMocks>;
+   beforeEach(() => {
+      ctx = createMocks();
+   });
+
+   const flush = () => new Promise((r) => setTimeout(r, 20));
+
+   function background(): {
+      runInBackground: (
+         id: string,
+         run: (signal: AbortSignal) => Promise<void>,
+      ) => void;
+      runningAbortControllers: Map<string, AbortController>;
+   } {
+      return ctx.service as unknown as {
+         runInBackground: (
+            id: string,
+            run: (signal: AbortSignal) => Promise<void>,
+         ) => void;
+         runningAbortControllers: Map<string, AbortController>;
+      };
+   }
+
+   it("records FAILED with the error message when the run rejects", async () => {
+      background().runInBackground("bg-1", async () => {
+         throw new Error("boom");
+      });
+      await flush();
+
+      expect(ctx.repository.updateMaterialization.calledOnce).toBe(true);
+      expect(ctx.repository.updateMaterialization.firstCall.args[0]).toBe(
+         "bg-1",
+      );
+      expect(
+         ctx.repository.updateMaterialization.firstCall.args[1],
+      ).toMatchObject({ status: "FAILED", error: "boom" });
+   });
+
+   it("records CANCELLED when the run aborts cooperatively", async () => {
+      const bg = background();
+      bg.runInBackground("bg-2", async () => {
+         bg.runningAbortControllers.get("bg-2")!.abort();
+         throw new Error("boom");
+      });
+      await flush();
+
+      expect(
+         ctx.repository.updateMaterialization.firstCall.args[1],
+      ).toMatchObject({ status: "CANCELLED", error: "Cancelled" });
+   });
+
+   it("clears the abort controller once the run settles", async () => {
+      const bg = background();
+      bg.runInBackground("bg-3", async () => {});
+      await flush();
+      expect(bg.runningAbortControllers.has("bg-3")).toBe(false);
    });
 });

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -1,12 +1,8 @@
 import type {
-   AtomicField,
-   BuildGraph as MalloyBuildGraph,
-   MalloyConfig,
    Connection as MalloyConnection,
    PersistSource,
 } from "@malloydata/malloy";
 import { Manifest } from "@malloydata/malloy";
-import { components } from "../api";
 import {
    BadRequestError,
    InvalidStateTransitionError,
@@ -15,10 +11,12 @@ import {
 } from "../errors";
 import { logger } from "../logger";
 import {
-   MaterializationRound,
+   MaterializationMode,
+   recordAutoLoadOutcome,
    recordDropTables,
-   recordMaterializationRound,
+   recordMaterializationRun,
    recordSourceBuildDuration,
+   recordSourcesOutcome,
 } from "../materialization_metrics";
 import {
    BuildInstruction,
@@ -32,14 +30,14 @@ import {
    ResourceRepository,
 } from "../storage/DatabaseInterface";
 import { DuplicateActiveMaterializationError } from "../storage/duckdb/MaterializationRepository";
+import {
+   CompiledBuildPlan,
+   compilePackageBuildPlan,
+   computeBuildId,
+} from "./build_plan";
 import { EnvironmentStore } from "./environment_store";
-import { Model } from "./model";
 import { splitTablePath } from "./quoting";
 import { resolveEnvironmentId } from "./resolve_environment";
-
-type WireBuildGraph = components["schemas"]["BuildGraph"];
-type WirePersistSourcePlan = components["schemas"]["PersistSourcePlan"];
-type WireColumn = components["schemas"]["Column"];
 
 /**
  * Length of the buildId prefix used when synthesizing staging table names.
@@ -52,46 +50,6 @@ const STAGING_BUILD_ID_LEN = 12;
 /** Staging suffix appended to a table name while it is being built. */
 export function stagingSuffix(buildId: string): string {
    return `_${buildId.substring(0, STAGING_BUILD_ID_LEN)}`;
-}
-
-/** Output columns of a persist source, degrading to [] if unavailable. */
-function deriveColumns(persistSource: PersistSource): WireColumn[] {
-   try {
-      return persistSource._explore.intrinsicFields
-         .filter((f) => f.isAtomicField())
-         .map((f) => ({
-            name: f.name,
-            type: String((f as AtomicField).type),
-         }));
-   } catch (err) {
-      logger.warn("Failed to derive columns for persist source", {
-         sourceID: persistSource.sourceID,
-         error: err instanceof Error ? err.message : String(err),
-      });
-      return [];
-   }
-}
-
-/** Flatten Malloy's nested BuildNode.dependsOn into a list of sourceIDs. */
-function flattenDependsOn(node: {
-   dependsOn: { sourceID: string }[];
-}): string[] {
-   return node.dependsOn.map((d) => d.sourceID);
-}
-
-/**
- * The buildId for a persist source: a stable digest of its connection identity
- * and canonical SQL. Centralizes the (source, connectionDigests) call shape so
- * planning, self-instruction, and build all agree on the same id.
- */
-function computeBuildId(
-   source: PersistSource,
-   connectionDigests: Record<string, string>,
-): string {
-   return source.makeBuildId(
-      connectionDigests[source.connectionName],
-      source.getSQL(),
-   );
 }
 
 /**
@@ -110,7 +68,7 @@ function selfAssignTableName(persistSource: PersistSource): string {
    }
 }
 
-/** Classify a thrown round error as cancelled (cooperative abort) or failed. */
+/** Classify a thrown build error as cancelled (cooperative abort) or failed. */
 function outcomeFor(
    _err: unknown,
    signal: AbortSignal | undefined,
@@ -119,41 +77,16 @@ function outcomeFor(
 }
 
 /**
- * Resolve a Map<name, Connection> for the names a step is about to touch.
- * The package's MalloyConfig caches each lookup, so repeated calls are cheap.
- * A failed lookup is logged and omitted; downstream code reports the missing
- * connection explicitly.
- */
-async function resolvePackageConnections(
-   pkg: { getMalloyConnection(name: string): Promise<MalloyConnection> },
-   names: Iterable<string>,
-): Promise<Map<string, MalloyConnection>> {
-   const map = new Map<string, MalloyConnection>();
-   const seen = new Set<string>();
-   for (const name of names) {
-      if (!name || seen.has(name)) continue;
-      seen.add(name);
-      try {
-         map.set(name, await pkg.getMalloyConnection(name));
-      } catch (err) {
-         logger.warn(`Failed to resolve connection ${name}`, {
-            error: err instanceof Error ? err.message : String(err),
-         });
-      }
-   }
-   return map;
-}
-
-/**
- * Allowed status transitions for the two-round protocol. MANIFEST_FILE_READY,
- * FAILED, and CANCELLED are terminal.
+ * Allowed status transitions. The build runs without an intermediate
+ * plan-ready pause: PENDING advances straight to MANIFEST_ROWS_READY once the
+ * tables are built, then to MANIFEST_FILE_READY. MANIFEST_FILE_READY, FAILED,
+ * and CANCELLED are terminal.
  */
 const VALID_TRANSITIONS: Record<
    MaterializationStatus,
    MaterializationStatus[]
 > = {
-   PENDING: ["BUILD_PLAN_READY", "FAILED", "CANCELLED"],
-   BUILD_PLAN_READY: ["MANIFEST_ROWS_READY", "FAILED", "CANCELLED"],
+   PENDING: ["MANIFEST_ROWS_READY", "FAILED", "CANCELLED"],
    MANIFEST_ROWS_READY: ["MANIFEST_FILE_READY", "FAILED", "CANCELLED"],
    MANIFEST_FILE_READY: [],
    FAILED: [],
@@ -161,14 +94,16 @@ const VALID_TRANSITIONS: Record<
 };
 
 /**
- * Orchestrates the two-round materialization protocol.
+ * Orchestrates single-call materialization builds.
  *
- * Round 1 (on create): compile the package, compute a build plan (per-source
- * buildId, columns, lineage inputs, connection capability) and pause at
- * BUILD_PLAN_READY without writing any tables. Round 2 (action=build): build
- * only the control-plane-instructed sources into their assigned physical
- * names and assemble the manifest, which is returned inline for the control
- * plane to persist.
+ * The build plan is a deterministic property of the compiled package
+ * (`Package.buildPlan`), so there is no separate plan round-trip. On create
+ * the publisher either auto-runs (self-assigns physical names from the
+ * `#@ persist name=` annotation and builds + auto-loads every persist source)
+ * or, when the caller supplies `buildInstructions` derived from
+ * `Package.buildPlan`, builds directly into the caller-assigned names without
+ * auto-loading the manifest. Both paths build in the background and return the
+ * PENDING record immediately.
  *
  * At most one active materialization per (environment, package) is enforced
  * by the DB-level unique index on `materializations.active_key` (see
@@ -210,8 +145,15 @@ export class MaterializationService {
          );
       }
       this.validateTransition(current.status, next);
-      logger.info("Materialization transition", {
+      // Terminal transitions are operationally interesting (info); the
+      // intermediate MANIFEST_ROWS_READY hop is routine bookkeeping (debug).
+      const terminal =
+         next === "MANIFEST_FILE_READY" ||
+         next === "FAILED" ||
+         next === "CANCELLED";
+      logger[terminal ? "info" : "debug"]("Materialization transition", {
          materializationId: id,
+         packageName: current.packageName,
          from: current.status,
          to: next,
       });
@@ -255,11 +197,19 @@ export class MaterializationService {
       return m;
    }
 
-   // ==================== ROUND 1: CREATE + PLAN ====================
+   // ==================== CREATE + BUILD ====================
 
    /**
-    * Create a materialization and start Round 1 (compile + plan) in the
-    * background. Returns the PENDING record immediately.
+    * Create a materialization and build it in the background. Returns the
+    * PENDING record immediately.
+    *
+    * Auto-run (default, no `buildInstructions`): self-assign physical names and
+    * build + auto-load every persist source. Orchestrated (`buildInstructions`
+    * present): build directly into the caller-assigned names from the package's
+    * build plan, without auto-loading the manifest. When `buildInstructions` is
+    * present it is validated synchronously against the package's compiled build
+    * plan so a bad instruction is rejected at create time rather than failing
+    * the background run.
     */
    async createMaterialization(
       environmentName: string,
@@ -267,7 +217,7 @@ export class MaterializationService {
       options: {
          forceRefresh?: boolean;
          sourceNames?: string[];
-         pauseBetweenPhases?: boolean;
+         buildInstructions?: BuildInstruction[];
       } = {},
    ): Promise<Materialization> {
       const environmentId = await this.resolveEnvironmentId(environmentName);
@@ -276,7 +226,13 @@ export class MaterializationService {
          environmentName,
          false,
       );
-      await environment.getPackage(packageName, false);
+      const pkg = await environment.getPackage(packageName, false);
+
+      const buildInstructions = options.buildInstructions;
+      const orchestrated = buildInstructions !== undefined;
+      if (orchestrated) {
+         this.validateInstructions(pkg.getBuildPlan(), buildInstructions);
+      }
 
       const active = await this.repository.getActiveMaterialization(
          environmentId,
@@ -288,12 +244,11 @@ export class MaterializationService {
          );
       }
 
-      const pauseBetweenPhases = options.pauseBetweenPhases ?? false;
       const forceRefresh = options.forceRefresh ?? false;
       const metadata = {
          forceRefresh,
          sourceNames: options.sourceNames ?? null,
-         pauseBetweenPhases,
+         mode: orchestrated ? "orchestrated" : "auto",
       };
 
       let created: Materialization;
@@ -319,99 +274,48 @@ export class MaterializationService {
          throw err;
       }
 
-      // Default (auto-run): compile, self-assign names, build, and auto-load in
-      // one pass. Opt-in two-round: pause at BUILD_PLAN_READY for the control
-      // plane to drive Round 2.
       this.runInBackground(created.id, (signal) =>
-         pauseBetweenPhases
-            ? this.runRound1(
-                 created.id,
-                 environmentName,
-                 packageName,
-                 options.sourceNames,
-                 signal,
-              )
-            : this.runAuto(
-                 created.id,
-                 environmentName,
-                 packageName,
-                 options.sourceNames,
-                 forceRefresh,
-                 signal,
-              ),
+         this.runBuild(
+            created.id,
+            environmentName,
+            packageName,
+            {
+               sourceNames: options.sourceNames,
+               forceRefresh,
+               buildInstructions,
+            },
+            signal,
+         ),
       );
 
       return created;
    }
 
-   private async runRound1(
-      id: string,
-      environmentName: string,
-      packageName: string,
-      sourceNames: string[] | undefined,
-      signal?: AbortSignal,
-   ): Promise<void> {
-      logger.info("Materialization Round 1: compile + plan", {
-         materializationId: id,
-         packageName,
-      });
-      const startedAt = Date.now();
-
-      try {
-         const environment = await this.environmentStore.getEnvironment(
-            environmentName,
-            false,
-         );
-         const pkg = await environment.getPackage(packageName, false);
-
-         const { graphs, sources, connectionDigests } =
-            await environment.withPackageLock(packageName, () =>
-               this.compilePackageBuildPlan(pkg, signal),
-            );
-
-         const buildPlan = this.deriveBuildPlan(
-            graphs,
-            sources,
-            connectionDigests,
-            sourceNames,
-         );
-
-         await this.transition(id, "BUILD_PLAN_READY", { buildPlan });
-         this.recordRound("round1", "success", startedAt);
-         logger.info("Materialization Round 1 complete", {
-            materializationId: id,
-            packageName,
-            sourceCount: Object.keys(buildPlan.sources).length,
-            durationMs: Date.now() - startedAt,
-         });
-      } catch (err) {
-         this.recordRound("round1", outcomeFor(err, signal), startedAt);
-         throw err;
-      }
-   }
-
-   // ==================== AUTO-RUN (DEFAULT) ====================
-
    /**
-    * Auto-run (default, pauseBetweenPhases=false). Compile + plan, then
-    * self-assign physical table names (the `#@ persist name=` value, else the
-    * source name) with realization=COPY, skip sources whose buildId is
-    * unchanged since the most recent successful manifest (unless forceRefresh),
-    * build the rest, assemble the manifest, and auto-load it into the package
-    * models so subsequent queries resolve to the materialized tables. No pause,
-    * no second round.
+    * Single-call build, shared by auto-run and orchestrated mode. Compiles the
+    * package build plan, derives the build instructions (self-assigned for
+    * auto-run; caller-supplied for orchestrated), builds the instructed sources
+    * into their physical tables, and commits the manifest. Auto-run additionally
+    * loads the fresh manifest into the package models; orchestrated leaves
+    * distribution to the caller.
     */
-   private async runAuto(
+   private async runBuild(
       id: string,
       environmentName: string,
       packageName: string,
-      sourceNames: string[] | undefined,
-      forceRefresh: boolean,
+      opts: {
+         sourceNames: string[] | undefined;
+         forceRefresh: boolean;
+         buildInstructions: BuildInstruction[] | undefined;
+      },
       signal: AbortSignal,
    ): Promise<void> {
-      logger.info("Materialization auto-run: compile + build + load", {
+      const orchestrated = opts.buildInstructions !== undefined;
+      const mode: MaterializationMode = orchestrated ? "orchestrated" : "auto";
+      logger.info("Materialization build started", {
          materializationId: id,
          packageName,
+         mode,
       });
       const startedAt = Date.now();
 
@@ -424,31 +328,31 @@ export class MaterializationService {
          const pkg = await environment.getPackage(packageName, false);
 
          const compiled = await environment.withPackageLock(packageName, () =>
-            this.compilePackageBuildPlan(pkg, signal),
+            compilePackageBuildPlan(pkg, signal),
          );
 
-         const buildPlan = this.deriveBuildPlan(
-            compiled.graphs,
-            compiled.sources,
-            compiled.connectionDigests,
-            sourceNames,
-         );
-         await this.transition(id, "BUILD_PLAN_READY", { buildPlan });
-
-         // Skip-if-unchanged: reuse tables from the most recent successful
-         // manifest for sources whose buildId is unchanged, unless forceRefresh.
-         const priorEntries = forceRefresh
-            ? {}
-            : await this.getMostRecentManifestEntries(
-                 environmentId,
-                 packageName,
-                 id,
-              );
-         const { instructions, carried } = this.deriveSelfInstructions(
-            compiled,
-            sourceNames,
-            priorEntries,
-         );
+         let instructions: BuildInstruction[];
+         let carried: Record<string, ManifestEntry>;
+         if (orchestrated) {
+            instructions = opts.buildInstructions!;
+            carried = {};
+         } else {
+            // Skip-if-unchanged: reuse tables from the most recent successful
+            // manifest for sources whose buildId is unchanged, unless
+            // forceRefresh.
+            const priorEntries = opts.forceRefresh
+               ? {}
+               : await this.getMostRecentManifestEntries(
+                    environmentId,
+                    packageName,
+                    id,
+                 );
+            ({ instructions, carried } = this.deriveSelfInstructions(
+               compiled,
+               opts.sourceNames,
+               priorEntries,
+            ));
+         }
 
          const entries = await this.executeInstructedBuild(
             compiled,
@@ -457,28 +361,38 @@ export class MaterializationService {
             signal,
          );
 
+         const sourcesBuilt = instructions.length;
+         const sourcesReused = Object.keys(carried).length;
          const durationMs = Date.now() - startedAt;
          await this.commitManifest(id, entries, {
-            forceRefresh,
-            sourceNames: sourceNames ?? null,
-            pauseBetweenPhases: false,
-            sourcesBuilt: instructions.length,
-            sourcesReused: Object.keys(carried).length,
+            forceRefresh: opts.forceRefresh,
+            sourceNames: opts.sourceNames ?? null,
+            mode,
+            sourcesBuilt,
+            sourcesReused,
             durationMs,
          });
 
-         await this.autoLoadManifest(environment, packageName, entries);
+         // Auto-run owns distribution: load the fresh manifest into the package
+         // models so subsequent queries resolve to the materialized tables.
+         // Orchestrated leaves distribution to the caller (manifestLocation).
+         if (!orchestrated) {
+            await this.autoLoadManifest(environment, packageName, entries);
+         }
 
-         this.recordRound("auto", "success", startedAt);
-         logger.info("Materialization auto-run complete", {
+         recordSourcesOutcome("built", sourcesBuilt);
+         recordSourcesOutcome("reused", sourcesReused);
+         this.recordRun(mode, "success", startedAt);
+         logger.info("Materialization build complete", {
             materializationId: id,
             packageName,
-            sourcesBuilt: instructions.length,
-            sourcesReused: Object.keys(carried).length,
+            mode,
+            sourcesBuilt,
+            sourcesReused,
             durationMs,
          });
       } catch (err) {
-         this.recordRound("auto", outcomeFor(err, signal), startedAt);
+         this.recordRun(mode, outcomeFor(err, signal), startedAt);
          throw err;
       }
    }
@@ -491,11 +405,7 @@ export class MaterializationService {
     * rebuilt.
     */
    private deriveSelfInstructions(
-      compiled: {
-         graphs: MalloyBuildGraph[];
-         sources: Record<string, PersistSource>;
-         connectionDigests: Record<string, string>;
-      },
+      compiled: CompiledBuildPlan,
       sourceNames: string[] | undefined,
       priorEntries: Record<string, ManifestEntry>,
    ): {
@@ -591,11 +501,13 @@ export class MaterializationService {
             packageName,
             manifestEntries,
          );
+         recordAutoLoadOutcome("success");
          logger.info("Auto-run: loaded manifest into package models", {
             packageName,
             entryCount: Object.keys(manifestEntries).length,
          });
       } catch (err) {
+         recordAutoLoadOutcome("failure");
          logger.warn("Auto-run: failed to load manifest into package models", {
             packageName,
             error: err instanceof Error ? err.message : String(err),
@@ -603,51 +515,21 @@ export class MaterializationService {
       }
    }
 
-   // ==================== ROUND 2: BUILD ====================
-
    /**
-    * Round 2. Validates the instructions against the stored build plan,
-    * transitions out of BUILD_PLAN_READY, and builds the instructed sources
-    * in the background. Returns the accepted record (202).
+    * Validate caller-supplied build instructions against the package's compiled
+    * build plan: every instructed buildId must be a planned source, and only
+    * COPY realization is supported. Throws when the package declares no persist
+    * source (no plan to build against).
     */
-   async buildMaterialization(
-      environmentName: string,
-      packageName: string,
-      id: string,
-      instructions: BuildInstruction[],
-   ): Promise<Materialization> {
-      const m = await this.getMaterialization(environmentName, packageName, id);
-
-      if (!m.pauseBetweenPhases) {
-         throw new InvalidStateTransitionError(
-            `Materialization ${id} is an auto-run materialization; action=build does not apply (set pauseBetweenPhases=true for the two-round flow)`,
-         );
-      }
-      if (m.status !== "BUILD_PLAN_READY") {
-         throw new InvalidStateTransitionError(
-            `Materialization ${id} is ${m.status}, expected BUILD_PLAN_READY`,
-         );
-      }
-      const plan = m.buildPlan;
-      if (!plan) {
-         throw new InvalidStateTransitionError(
-            `Materialization ${id} has no build plan`,
-         );
-      }
-
-      this.validateInstructions(plan, instructions);
-
-      this.runInBackground(id, (signal) =>
-         this.runRound2(id, environmentName, packageName, instructions, signal),
-      );
-
-      return m;
-   }
-
    private validateInstructions(
-      plan: BuildPlan,
+      plan: BuildPlan | null,
       instructions: BuildInstruction[],
    ): void {
+      if (!plan) {
+         throw new BadRequestError(
+            "Package has no persist sources; buildInstructions cannot be applied",
+         );
+      }
       const plannedBuildIds = new Set<string>();
       for (const source of Object.values(plan.sources)) {
          plannedBuildIds.add(source.buildId);
@@ -659,80 +541,24 @@ export class MaterializationService {
                `Instruction references unknown buildId '${instruction.buildId}'`,
             );
          }
-         // v0 is COPY-only; SNAPSHOT lands once clone semantics are defined.
+         // COPY-only for now; SNAPSHOT lands once clone semantics are defined.
          if (instruction.realization === "SNAPSHOT") {
             throw new BadRequestError(
-               "realization=SNAPSHOT is not supported in v0 (COPY only)",
+               "realization=SNAPSHOT is not supported (COPY only)",
             );
          }
       }
    }
 
-   private async runRound2(
-      id: string,
-      environmentName: string,
-      packageName: string,
-      instructions: BuildInstruction[],
-      signal: AbortSignal,
-   ): Promise<void> {
-      logger.info("Materialization Round 2: build", {
-         materializationId: id,
-         packageName,
-         sourceCount: instructions.length,
-      });
-      const startedAt = Date.now();
-
-      try {
-         const environment = await this.environmentStore.getEnvironment(
-            environmentName,
-            false,
-         );
-         const pkg = await environment.getPackage(packageName, false);
-
-         const compiled = await environment.withPackageLock(packageName, () =>
-            this.compilePackageBuildPlan(pkg, signal),
-         );
-
-         const entries = await this.executeInstructedBuild(
-            compiled,
-            instructions,
-            {},
-            signal,
-         );
-
-         const durationMs = Date.now() - startedAt;
-         await this.commitManifest(id, entries, {
-            sourcesBuilt: Object.keys(entries).length,
-            durationMs,
-         });
-
-         this.recordRound("round2", "success", startedAt);
-         logger.info("Materialization Round 2 complete", {
-            materializationId: id,
-            packageName,
-            sourcesBuilt: Object.keys(entries).length,
-            durationMs,
-         });
-      } catch (err) {
-         this.recordRound("round2", outcomeFor(err, signal), startedAt);
-         throw err;
-      }
-   }
-
    /**
-    * Shared build loop for both auto-run and Round 2. Seeds the manifest with
-    * carried-forward (reused) upstream entries so downstream references resolve,
-    * then builds each instructed source in dependency order. Returns the full
-    * entry map (carried + freshly built). The package was compiled by the
-    * caller; this runs outside the package lock.
+    * Shared build loop for both auto-run and orchestrated builds. Seeds the
+    * manifest with carried-forward (reused) upstream entries so downstream
+    * references resolve, then builds each instructed source in dependency
+    * order. Returns the full entry map (carried + freshly built). The package
+    * was compiled by the caller; this runs outside the package lock.
     */
    private async executeInstructedBuild(
-      compiled: {
-         graphs: MalloyBuildGraph[];
-         sources: Record<string, PersistSource>;
-         connectionDigests: Record<string, string>;
-         connections: Map<string, MalloyConnection>;
-      },
+      compiled: CompiledBuildPlan,
       instructions: BuildInstruction[],
       seedEntries: Record<string, ManifestEntry>,
       signal: AbortSignal,
@@ -825,7 +651,7 @@ export class MaterializationService {
             await connection.runSQL(`DROP TABLE IF EXISTS ${stagingTableName}`);
          } catch (cleanupErr) {
             logger.warn(
-               "Round 2: failed to clean up staging table after a failed build; physical leak",
+               "Failed to clean up staging table after a failed build; physical leak",
                {
                   stagingTableName,
                   connectionName: persistSource.connectionName,
@@ -839,12 +665,11 @@ export class MaterializationService {
          throw err;
       }
 
-      // Make this table visible to downstream sources built later this round.
+      // Make this table visible to downstream sources built later in this run.
       manifest.update(buildId, { tableName: physicalTableName });
 
       const durationMs = Math.round(performance.now() - startTime);
       recordSourceBuildDuration(durationMs);
-      // Shared by auto-run and Round 2, so the message is path-neutral.
       logger.info(`Built materialized source ${persistSource.name}`, {
          physicalTableName,
          durationMs,
@@ -873,7 +698,6 @@ export class MaterializationService {
 
       const cancellable: MaterializationStatus[] = [
          "PENDING",
-         "BUILD_PLAN_READY",
          "MANIFEST_ROWS_READY",
       ];
       if (!cancellable.includes(m.status)) {
@@ -898,10 +722,11 @@ export class MaterializationService {
     * (MANIFEST_FILE_READY, FAILED, CANCELLED) can be deleted; an active run must
     * be stopped first.
     *
-    * By default this removes the publisher's record only — the control plane
-    * owns table GC. When `dropTables` is set, the publisher additionally drops
-    * the physical tables recorded in this run's manifest as a best-effort
-    * cleanup (a drop failure is logged, not fatal, so the record still deletes).
+    * By default this removes the publisher's record only — physical-table GC is
+    * the caller's responsibility. When `dropTables` is set, the publisher
+    * additionally drops the physical tables recorded in this run's manifest as a
+    * best-effort cleanup (a drop failure is logged, not fatal, so the record
+    * still deletes).
     */
    async deleteMaterialization(
       environmentName: string,
@@ -999,9 +824,9 @@ export class MaterializationService {
    }
 
    /**
-    * Finalize a successful build: advance MANIFEST_ROWS_READY -> FILE_READY and
-    * persist the assembled manifest. Shared by auto-run and Round 2; the caller
-    * supplies the per-path metadata. The build itself happens before this.
+    * Finalize a successful build: advance to MANIFEST_ROWS_READY then
+    * MANIFEST_FILE_READY and persist the assembled manifest. The caller
+    * supplies the per-run metadata. The build itself happens before this.
     */
    private async commitManifest(
       id: string,
@@ -1021,125 +846,14 @@ export class MaterializationService {
       });
    }
 
-   // ==================== BUILD PLAN COMPILATION ====================
-
-   /**
-    * Compile every model in the package and collect the dependency-ordered
-    * build graphs, persist sources, connection digests, and resolved
-    * connections.
-    */
-   private async compilePackageBuildPlan(
-      pkg: {
-         getModelPaths(): string[];
-         getPackagePath(): string;
-         getMalloyConfig(): MalloyConfig;
-         getMalloyConnection(name: string): Promise<MalloyConnection>;
-      },
-      signal?: AbortSignal,
-   ): Promise<{
-      graphs: MalloyBuildGraph[];
-      sources: Record<string, PersistSource>;
-      connectionDigests: Record<string, string>;
-      connections: Map<string, MalloyConnection>;
-   }> {
-      const allGraphs: MalloyBuildGraph[] = [];
-      const allSources: Record<string, PersistSource> = {};
-
-      for (const modelPath of pkg.getModelPaths()) {
-         if (signal?.aborted) throw new Error("Build cancelled");
-
-         const { runtime, modelURL, importBaseURL } =
-            await Model.getModelRuntime(
-               pkg.getPackagePath(),
-               modelPath,
-               pkg.getMalloyConfig(),
-            );
-         const malloyModel = await runtime
-            .loadModel(modelURL, { importBaseURL })
-            .getModel();
-
-         // getBuildPlan() returns empty graphs for models with no #@ persist
-         // sources, so non-persist models are simply skipped below.
-         const buildPlan = malloyModel.getBuildPlan();
-         for (const msg of buildPlan.tagParseLog) {
-            logger.warn("Persist annotation issue", {
-               modelPath,
-               message: msg.message,
-               severity: msg.severity,
-            });
-         }
-         if (buildPlan.graphs.length === 0) continue;
-
-         allGraphs.push(...buildPlan.graphs);
-         for (const [sourceID, source] of Object.entries(buildPlan.sources)) {
-            allSources[sourceID] = source;
-         }
-      }
-
-      const connections = await resolvePackageConnections(
-         pkg,
-         allGraphs.map((g) => g.connectionName),
-      );
-      const connectionDigests: Record<string, string> = {};
-      for (const graph of allGraphs) {
-         const conn = connections.get(graph.connectionName);
-         if (conn && !connectionDigests[graph.connectionName]) {
-            connectionDigests[graph.connectionName] = await conn.getDigest();
-         }
-      }
-
-      return {
-         graphs: allGraphs,
-         sources: allSources,
-         connectionDigests,
-         connections,
-      };
-   }
-
-   /** Project the Malloy build plan into the trimmed v0 wire BuildPlan. */
-   private deriveBuildPlan(
-      graphs: MalloyBuildGraph[],
-      sources: Record<string, PersistSource>,
-      connectionDigests: Record<string, string>,
-      sourceNames: string[] | undefined,
-   ): BuildPlan {
-      const include = sourceNames ? new Set(sourceNames) : null;
-
-      const wireGraphs: WireBuildGraph[] = graphs.map((graph) => ({
-         connectionName: graph.connectionName,
-         nodes: graph.nodes.map((level) =>
-            level.map((node) => ({
-               sourceID: node.sourceID,
-               dependsOn: flattenDependsOn(node),
-            })),
-         ),
-      }));
-
-      const wireSources: Record<string, WirePersistSourcePlan> = {};
-      for (const [sourceID, source] of Object.entries(sources)) {
-         if (include && !include.has(source.name)) continue;
-         wireSources[sourceID] = {
-            name: source.name,
-            sourceID: source.sourceID,
-            connectionName: source.connectionName,
-            dialect: source.dialectName,
-            buildId: computeBuildId(source, connectionDigests),
-            sql: source.getSQL(),
-            columns: deriveColumns(source),
-         };
-      }
-
-      return { graphs: wireGraphs, sources: wireSources };
-   }
-
    // ==================== HELPERS ====================
 
-   private recordRound(
-      round: MaterializationRound,
+   private recordRun(
+      mode: MaterializationMode,
       outcome: "success" | "failed" | "cancelled",
       startedAtMs: number,
    ): void {
-      recordMaterializationRound(round, outcome, Date.now() - startedAtMs);
+      recordMaterializationRun(mode, outcome, Date.now() - startedAtMs);
    }
 
    private runInBackground(

--- a/packages/server/src/service/materialization_test_fixtures.ts
+++ b/packages/server/src/service/materialization_test_fixtures.ts
@@ -1,0 +1,119 @@
+import type { PersistSource } from "@malloydata/malloy";
+import {
+   BuildInstruction,
+   BuildPlan,
+   Materialization,
+} from "../storage/DatabaseInterface";
+import { CompiledBuildPlan } from "./build_plan";
+
+/**
+ * Shared fixtures for the materialization unit specs (service, controller,
+ * build-plan). Centralizing the builders keeps the per-source stand-ins and
+ * record shapes consistent across files and avoids drift when the wire types
+ * change.
+ */
+
+/** A persisted materialization record with sensible PENDING defaults. */
+export function makeMaterialization(
+   overrides: Partial<Materialization> = {},
+): Materialization {
+   return {
+      id: "mat-1",
+      environmentId: "env-1",
+      packageName: "pkg",
+      status: "PENDING",
+      manifest: null,
+      startedAt: null,
+      completedAt: null,
+      error: null,
+      metadata: null,
+      createdAt: new Date("2026-01-01"),
+      updatedAt: new Date("2026-01-01"),
+      ...overrides,
+   };
+}
+
+/** A single-source wire BuildPlan (the `Package.buildPlan` artifact). */
+export function makeBuildPlan(overrides: Partial<BuildPlan> = {}): BuildPlan {
+   return {
+      graphs: [
+         {
+            connectionName: "duckdb",
+            nodes: [[{ sourceID: "orders@m.malloy", dependsOn: [] }]],
+         },
+      ],
+      sources: {
+         "orders@m.malloy": {
+            name: "orders",
+            sourceID: "orders@m.malloy",
+            connectionName: "duckdb",
+            dialect: "duckdb",
+            buildId: "build-orders",
+            sql: "SELECT 1",
+            columns: [],
+         },
+      },
+      ...overrides,
+   };
+}
+
+/** A caller-supplied build instruction matching {@link makeBuildPlan}. */
+export function makeInstruction(
+   overrides: Partial<BuildInstruction> = {},
+): BuildInstruction {
+   return {
+      buildId: "build-orders",
+      materializedTableId: "mt-1",
+      physicalTableName: '"orders_v1"',
+      realization: "COPY",
+      ...overrides,
+   };
+}
+
+/**
+ * A minimal stand-in for a Malloy {@link PersistSource} exposing only what the
+ * build internals touch (name/id, deterministic buildId, SQL, and the
+ * `#@ persist name=` annotation reader, defaulted to "unset").
+ */
+export function fakeSource(opts: {
+   name: string;
+   buildId: string;
+   sql?: string;
+   connectionName?: string;
+}): PersistSource {
+   return {
+      name: opts.name,
+      sourceID: opts.name,
+      connectionName: opts.connectionName ?? "duckdb",
+      makeBuildId: () => opts.buildId,
+      getSQL: () => opts.sql ?? "SELECT 1",
+      annotations: {
+         parseAsTag: () => ({ tag: { text: () => undefined } }),
+      },
+   } as unknown as PersistSource;
+}
+
+/**
+ * Assemble a {@link CompiledBuildPlan} from a sources map and dependency
+ * levels (one connection, "duckdb"). `connections` is supplied by the caller
+ * because build vs. plan-derivation tests need different connection mocks.
+ */
+export function compiledWith(
+   sources: Record<string, PersistSource>,
+   levels: string[][],
+   connections: CompiledBuildPlan["connections"] = new Map(),
+): CompiledBuildPlan {
+   return {
+      graphs: [
+         {
+            connectionName: "duckdb",
+            nodes: levels.map((level) =>
+               level.map((sourceID) => ({ sourceID, dependsOn: [] })),
+            ),
+         },
+      ] as unknown as CompiledBuildPlan["graphs"],
+      sources,
+      connectionDigests: { duckdb: "dig" },
+      connections,
+   };
+}

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -28,9 +28,11 @@ import {
    ServiceUnavailableError,
 } from "../errors";
 import { formatDuration, logger } from "../logger";
+import { recordBuildPlanComputeDuration } from "../materialization_metrics";
 import { assertSafeEnvironmentPath, safeJoinUnderRoot } from "../path_safety";
-import { BuildManifest } from "../storage/DatabaseInterface";
+import { BuildManifest, BuildPlan } from "../storage/DatabaseInterface";
 import { ignoreDotfiles } from "../utils";
+import { computePackageBuildPlan } from "./build_plan";
 import { Model } from "./model";
 
 type ApiDatabase = components["schemas"]["Database"];
@@ -67,6 +69,13 @@ export class Package {
       "unbound";
    private manifestEntryCount = 0;
    private boundManifestUri: string | null = null;
+   // The package's persist build plan: a deterministic property of the compiled
+   // package (per-source buildId, columns, build SQL, dependency graphs),
+   // computed once at load from the live (unbound) models so it is stable for a
+   // given (package version, connection config). Null when the package declares
+   // no persist source. Surfaced read-only on getPackageMetadata() so a caller
+   // can derive build instructions without a separate plan round-trip.
+   private buildPlan: BuildPlan | null = null;
    private static meter = metrics.getMeter("publisher");
    private static packageLoadHistogram = this.meter.createHistogram(
       "malloy_package_load_duration",
@@ -377,6 +386,26 @@ export class Package {
          malloyConfig,
       );
 
+      // Compute the persist build plan off the live (unbound) models, before the
+      // caller binds any configured manifest, so the surfaced plan reflects the
+      // canonical build (not the manifest-rewritten SQL). Best-effort: a plan
+      // failure is logged, not fatal — the package still serves; the plan is
+      // just absent. Recompiles the models (duplicate schema RPCs vs the worker
+      // compile); accepted for now.
+      try {
+         const buildPlanStart = Date.now();
+         pkg.buildPlan = await computePackageBuildPlan(pkg);
+         recordBuildPlanComputeDuration(Date.now() - buildPlanStart);
+      } catch (err) {
+         logger.warn(
+            `Failed to compute build plan for package ${packageName}`,
+            {
+               packageName,
+               error: err instanceof Error ? err.message : String(err),
+            },
+         );
+      }
+
       // Fail-safe at load: a bad explores entry doesn't fail the package
       // (its models still load and listModels hides the unmatched entry — it
       // never falls back to listing everything). Warn so the misconfig is
@@ -395,6 +424,16 @@ export class Package {
 
    public getPackageName(): string {
       return this.packageName;
+   }
+
+   /**
+    * The package's persist build plan (per-source buildId, columns, build SQL,
+    * dependency graphs), or null when the package declares no persist source.
+    * A deterministic property of the compiled package; callers derive build
+    * instructions from it for an orchestrated materialization.
+    */
+   public getBuildPlan(): BuildPlan | null {
+      return this.buildPlan;
    }
 
    public getPackageMetadata(): ApiPackage {
@@ -418,6 +457,7 @@ export class Package {
          manifestBindingStatus: this.manifestBindingStatus,
          manifestEntryCount: this.manifestEntryCount,
          boundManifestUri: this.boundManifestUri,
+         buildPlan: this.buildPlan,
       };
       const warnings = this.exploreWarnings();
       if (warnings.length > 0) {

--- a/packages/server/src/storage/DatabaseInterface.ts
+++ b/packages/server/src/storage/DatabaseInterface.ts
@@ -108,8 +108,8 @@ export interface Connection {
    updatedAt: Date;
 }
 
-// Wire types for the two-round build protocol, kept in sync with the OpenAPI
-// spec via the generated `api.ts`.
+// Wire types for the build protocol, kept in sync with the OpenAPI spec via
+// the generated `api.ts`.
 export type MaterializationStatus =
    components["schemas"]["MaterializationStatus"];
 export type BuildPlan = components["schemas"]["BuildPlan"];
@@ -122,15 +122,8 @@ export interface Materialization {
    id: string;
    environmentId: string;
    packageName: string;
-   /**
-    * Echoes the create-time flag (read from metadata). False (default) =
-    * auto-run all phases; true = pause at BUILD_PLAN_READY for Round 2.
-    */
-   pauseBetweenPhases: boolean;
    status: MaterializationStatus;
-   /** Round 1 output. Null until status >= BUILD_PLAN_READY. */
-   buildPlan: BuildPlan | null;
-   /** Round 2 output. Null until status = MANIFEST_FILE_READY. */
+   /** Build output. Null until status = MANIFEST_FILE_READY. */
    manifest: BuildManifestResult | null;
    startedAt: Date | null;
    completedAt: Date | null;
@@ -142,7 +135,6 @@ export interface Materialization {
 
 export interface MaterializationUpdate {
    status?: MaterializationStatus;
-   buildPlan?: BuildPlan | null;
    manifest?: BuildManifestResult | null;
    startedAt?: Date;
    completedAt?: Date;
@@ -154,8 +146,8 @@ export interface MaterializationUpdate {
  * Malloy-facing build manifest: maps a buildId to the physical table backing
  * that persist source. This is the shape the Malloy runtime consumes when
  * (re)loading models so persist references resolve to materialized tables.
- * Distinct from {@link BuildManifestResult} (the wire/Round 2 output, which
- * also carries CP bookkeeping like materializedTableId and rowCount).
+ * Distinct from {@link BuildManifestResult} (the wire build output, which also
+ * carries caller bookkeeping like materializedTableId and rowCount).
  */
 export interface BuildManifestEntry {
    tableName: string;

--- a/packages/server/src/storage/duckdb/MaterializationRepository.ts
+++ b/packages/server/src/storage/duckdb/MaterializationRepository.ts
@@ -1,6 +1,5 @@
 import {
    BuildManifestResult,
-   BuildPlan,
    Materialization,
    MaterializationStatus,
    MaterializationUpdate,
@@ -16,7 +15,6 @@ const TERMINAL_STATUSES: ReadonlySet<MaterializationStatus> = new Set([
 /** Non-terminal statuses count as "active" for the single-active guard. */
 const ACTIVE_STATUSES: readonly MaterializationStatus[] = [
    "PENDING",
-   "BUILD_PLAN_READY",
    "MANIFEST_ROWS_READY",
 ];
 
@@ -40,8 +38,9 @@ export class DuplicateActiveMaterializationError extends Error {
 /**
  * DuckDB-backed repository for package materializations.
  *
- * A Materialization tracks a single build run for an (environment, package) pair
- * through its lifecycle: PENDING -> RUNNING -> SUCCESS | FAILED | CANCELLED.
+ * A Materialization tracks a single build run for an (environment, package)
+ * pair through its lifecycle: PENDING -> MANIFEST_ROWS_READY ->
+ * MANIFEST_FILE_READY, or -> FAILED | CANCELLED.
  */
 export class MaterializationRepository {
    constructor(private db: DuckDBConnection) {}
@@ -114,8 +113,8 @@ export class MaterializationRepository {
 
       try {
          const rows = await this.db.all<Record<string, unknown>>(
-            `INSERT INTO materializations (id, environment_id, package_name, status, active_key, metadata, build_plan, manifest, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?)
+            `INSERT INTO materializations (id, environment_id, package_name, status, active_key, metadata, manifest, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?)
             RETURNING *`,
             [
                id,
@@ -181,12 +180,6 @@ export class MaterializationRepository {
             updates.metadata ? JSON.stringify(updates.metadata) : null,
          );
       }
-      if (updates.buildPlan !== undefined) {
-         setClauses.push(`build_plan = ?`);
-         params.push(
-            updates.buildPlan ? JSON.stringify(updates.buildPlan) : null,
-         );
-      }
       if (updates.manifest !== undefined) {
          setClauses.push(`manifest = ?`);
          params.push(
@@ -237,9 +230,7 @@ export class MaterializationRepository {
          id: row.id as string,
          environmentId: row.environment_id as string,
          packageName: row.package_name as string,
-         pauseBetweenPhases: metadata?.pauseBetweenPhases === true,
          status: row.status as MaterializationStatus,
-         buildPlan: parseJsonColumn<BuildPlan>(row.build_plan),
          manifest: parseJsonColumn<BuildManifestResult>(row.manifest),
          metadata,
          startedAt: row.started_at ? new Date(row.started_at as string) : null,

--- a/packages/server/src/storage/duckdb/schema.ts
+++ b/packages/server/src/storage/duckdb/schema.ts
@@ -75,15 +75,15 @@ export async function initializeSchema(
 
    // Materializations table.
    //
-   // `active_key` enforces at-most-one active (PENDING or RUNNING)
-   // materialization per (environment, package) at the DB layer. It is set to
+   // `active_key` enforces at-most-one active (non-terminal) materialization
+   // per (environment, package) at the DB layer. It is set to
    // `{environment_id}|{package_name}` while the row is active and cleared
    // to NULL on transition to any terminal state. A unique index on
    // `active_key` (see below) makes the insert-then-check race impossible —
    // a second concurrent create fails with a constraint violation, which the
    // service layer translates to `MaterializationConflictError`.
-   // `build_plan` (Round 1) and `manifest` (Round 2) are JSON blobs holding
-   // the two-round protocol payloads returned inline on the resource.
+   // `manifest` is a JSON blob holding the build output returned inline on the
+   // resource.
    await db.run(`
     CREATE TABLE IF NOT EXISTS materializations (
       id VARCHAR PRIMARY KEY,
@@ -95,7 +95,6 @@ export async function initializeSchema(
       completed_at TIMESTAMP,
       error TEXT,
       metadata JSON,
-      build_plan JSON,
       manifest JSON,
       created_at TIMESTAMP NOT NULL,
       updated_at TIMESTAMP NOT NULL,

--- a/packages/server/tests/integration/materialization/materialization_lifecycle.integration.spec.ts
+++ b/packages/server/tests/integration/materialization/materialization_lifecycle.integration.spec.ts
@@ -12,16 +12,9 @@ const PROJECT_NAME = "test-project";
 const PACKAGE_NAME = "persist-test";
 const API = `/api/v0/environments/${PROJECT_NAME}/packages/${PACKAGE_NAME}`;
 
-/** Statuses from which no background round is in flight. */
-const SETTLED_STATUSES = [
-   "BUILD_PLAN_READY",
-   "MANIFEST_FILE_READY",
-   "FAILED",
-   "CANCELLED",
-];
 const TERMINAL_STATUSES = ["MANIFEST_FILE_READY", "FAILED", "CANCELLED"];
 
-describe("Materialization REST API: auto-run + two-round (E2E)", () => {
+describe("Materialization REST API: single-call (E2E)", () => {
    let env: (RestE2EEnv & { stop(): Promise<void> }) | null = null;
    let baseUrl: string;
 
@@ -91,16 +84,13 @@ describe("Materialization REST API: auto-run + two-round (E2E)", () => {
       return `${baseUrl}${API}${p}`;
    }
 
-   // Most tests here exercise the control-plane two-round flow, so default to
-   // pauseBetweenPhases=true (pause at BUILD_PLAN_READY). The auto-run group
-   // overrides this with pauseBetweenPhases=false.
    async function createMaterialization(
       body: Record<string, unknown> = {},
    ): Promise<Response> {
       return fetch(url("/materializations"), {
          method: "POST",
          headers: { "Content-Type": "application/json" },
-         body: JSON.stringify({ pauseBetweenPhases: true, ...body }),
+         body: JSON.stringify(body),
       });
    }
 
@@ -129,10 +119,8 @@ describe("Materialization REST API: auto-run + two-round (E2E)", () => {
       throw new Error(`Materialization ${id} did not reach the expected state`);
    }
 
-   const pollUntilSettled = (id: string) =>
-      pollUntil(id, (s) => SETTLED_STATUSES.includes(s));
-   const pollUntilTerminal = (id: string) =>
-      pollUntil(id, (s) => TERMINAL_STATUSES.includes(s));
+   const pollUntilTerminal = (id: string, timeoutMs = 90_000) =>
+      pollUntil(id, (s) => TERMINAL_STATUSES.includes(s), timeoutMs);
 
    /**
     * Drive a materialization to a terminal state and delete its record so it
@@ -142,9 +130,8 @@ describe("Materialization REST API: auto-run + two-round (E2E)", () => {
       const res = await fetch(url(`/materializations/${id}`));
       if (res.status !== 200) return;
 
-      // Let any in-flight round settle before acting on it.
-      const settled = await pollUntilSettled(id);
-      if (!TERMINAL_STATUSES.includes(settled.status as string)) {
+      const current = (await res.json()) as Record<string, unknown>;
+      if (!TERMINAL_STATUSES.includes(current.status as string)) {
          await fetch(url(`/materializations/${id}?action=stop`), {
             method: "POST",
          });
@@ -153,11 +140,12 @@ describe("Materialization REST API: auto-run + two-round (E2E)", () => {
       await fetch(url(`/materializations/${id}`), { method: "DELETE" });
    }
 
-   /** First planned source from a BUILD_PLAN_READY materialization. */
-   function firstPlannedSource(
-      materialization: Record<string, unknown>,
-   ): Record<string, unknown> {
-      const plan = materialization.buildPlan as Record<string, unknown>;
+   /** Read Package.buildPlan and return its first planned source. */
+   async function firstPlanSource(): Promise<Record<string, unknown>> {
+      const res = await fetch(url(""));
+      expect(res.status).toBe(200);
+      const pkg = (await res.json()) as Record<string, unknown>;
+      const plan = pkg.buildPlan as Record<string, unknown>;
       expect(plan).toBeDefined();
       const sources = plan.sources as Record<string, Record<string, unknown>>;
       const values = Object.values(sources);
@@ -165,29 +153,22 @@ describe("Materialization REST API: auto-run + two-round (E2E)", () => {
       return values[0];
    }
 
-   // ── Group A0: Auto-run lifecycle (default) ───────────────────────
+   // ── Group A: Auto-run lifecycle (default) ────────────────────────
 
    describe("auto-run lifecycle (default)", () => {
       it(
          "runs all phases on create, self-assigns names, and auto-loads",
          async () => {
-            // pauseBetweenPhases=false (default): the publisher runs compile +
-            // plan + build + load in one pass with no Round 2.
-            const createRes = await createMaterialization({
-               pauseBetweenPhases: false,
-            });
+            // No buildInstructions: the publisher compiles, self-assigns names,
+            // builds every persist source, and auto-loads in one pass.
+            const createRes = await createMaterialization();
             expect(createRes.status).toBe(201);
             const created = (await createRes.json()) as Record<string, unknown>;
             expect(created.status).toBe("PENDING");
-            expect(created.pauseBetweenPhases).toBe(false);
             const id = created.id as string;
 
             // It settles at MANIFEST_FILE_READY without any build instruction.
-            const built = await pollUntil(
-               id,
-               (s) => TERMINAL_STATUSES.includes(s),
-               90_000,
-            );
+            const built = await pollUntilTerminal(id);
             expect(built.status).toBe("MANIFEST_FILE_READY");
 
             // The manifest carries the self-assigned physical table name (from
@@ -213,59 +194,37 @@ describe("Materialization REST API: auto-run + two-round (E2E)", () => {
          },
          { timeout: 120_000 },
       );
+   });
 
-      it("rejects action=build on an auto-run materialization (409)", async () => {
-         // Force a pause so we can observe a BUILD_PLAN_READY record, but mark it
-         // auto-run via metadata by creating a real auto-run and racing build is
-         // flaky; instead assert the guard on a freshly created auto-run that we
-         // immediately try to build. Auto-run never needs Round 2.
-         const createRes = await createMaterialization({
-            pauseBetweenPhases: false,
-         });
-         expect(createRes.status).toBe(201);
-         const { id } = (await createRes.json()) as { id: string };
+   // ── Group B: Orchestrated single-call build ──────────────────────
 
-         // Drive to terminal so there is no in-flight round, then assert build
-         // is rejected (auto-run records never accept action=build).
-         await pollUntil(id, (s) => TERMINAL_STATUSES.includes(s), 90_000);
+   describe("orchestrated build (buildInstructions)", () => {
+      it(
+         "builds directly into caller-assigned names from Package.buildPlan",
+         async () => {
+            // Read the plan off the package, derive one caller-assigned
+            // instruction, and create the materialization already building it.
+            const source = await firstPlanSource();
+            expect(source.name).toBe("order_summary");
+            expect(typeof source.buildId).toBe("string");
 
-         const buildRes = await fetch(
-            url(`/materializations/${id}?action=build`),
-            {
-               method: "POST",
-               headers: { "Content-Type": "application/json" },
-               body: JSON.stringify({
+            const physicalTableName = "order_summary_built";
+            const createRes = await createMaterialization({
+               buildInstructions: {
                   sources: [
                      {
-                        buildId: "x",
-                        materializedTableId: "mt",
-                        physicalTableName: "t",
+                        buildId: source.buildId,
+                        sourceID: source.sourceID,
+                        materializedTableId: "mt-order-summary",
+                        physicalTableName,
                         realization: "COPY",
                      },
                   ],
-               }),
-            },
-         );
-         expect(buildRes.status).toBe(409);
-
-         await fetch(url(`/materializations/${id}?dropTables=true`), {
-            method: "DELETE",
-         });
-      });
-   });
-
-   // ── Group A: Full two-round lifecycle (happy path) ────────────────
-
-   describe("full two-round lifecycle", () => {
-      it(
-         "plans (round 1), builds on control-plane instruction (round 2), then deletes",
-         async () => {
-            // Round 1: create kicks off compile + plan in the background.
-            const createRes = await createMaterialization();
+               },
+            });
             expect(createRes.status).toBe(201);
             const created = (await createRes.json()) as Record<string, unknown>;
             expect(created.status).toBe("PENDING");
-            expect(created.id).toBeDefined();
             const id = created.id as string;
 
             // List should include the new run.
@@ -274,49 +233,10 @@ describe("Materialization REST API: auto-run + two-round (E2E)", () => {
             const list = (await listRes.json()) as Record<string, unknown>[];
             expect(list.some((m) => m.id === id)).toBe(true);
 
-            // Round 1 completes at BUILD_PLAN_READY with a plan for our source.
-            const planned = await pollUntil(
-               id,
-               (s) => s === "BUILD_PLAN_READY" || TERMINAL_STATUSES.includes(s),
-            );
-            expect(planned.status).toBe("BUILD_PLAN_READY");
-            const source = firstPlannedSource(planned);
-            expect(source.name).toBe("order_summary");
-            expect(typeof source.buildId).toBe("string");
-
-            // Round 2: control plane instructs a COPY build into a physical name.
-            const physicalTableName = "order_summary_built";
-            const buildRes = await fetch(
-               url(`/materializations/${id}?action=build`),
-               {
-                  method: "POST",
-                  headers: { "Content-Type": "application/json" },
-                  body: JSON.stringify({
-                     sources: [
-                        {
-                           buildId: source.buildId,
-                           sourceID: source.sourceID,
-                           materializedTableId: "mt-order-summary",
-                           physicalTableName,
-                           realization: "COPY",
-                        },
-                     ],
-                  }),
-               },
-            );
-            expect(buildRes.status).toBe(202);
-
-            // Round 2 completes at MANIFEST_FILE_READY with an inline manifest.
-            const built = await pollUntil(
-               id,
-               (s) =>
-                  s === "MANIFEST_FILE_READY" ||
-                  s === "FAILED" ||
-                  s === "CANCELLED",
-            );
+            // Settles at MANIFEST_FILE_READY with the caller-assigned name.
+            const built = await pollUntilTerminal(id);
             expect(built.status).toBe("MANIFEST_FILE_READY");
             const manifest = built.manifest as Record<string, unknown>;
-            expect(manifest).toBeDefined();
             const entries = manifest.entries as Record<
                string,
                Record<string, unknown>
@@ -327,7 +247,7 @@ describe("Materialization REST API: auto-run + two-round (E2E)", () => {
             expect(entry.sourceName).toBe("order_summary");
 
             // A terminal materialization can be deleted; dropTables=true also
-            // drops the physical table this run produced in Round 2.
+            // drops the physical table this run produced.
             const deleteRes = await fetch(
                url(`/materializations/${id}?dropTables=true`),
                { method: "DELETE" },
@@ -340,9 +260,25 @@ describe("Materialization REST API: auto-run + two-round (E2E)", () => {
          },
          { timeout: 90_000 },
       );
+
+      it("rejects buildInstructions with an unknown buildId at create (400)", async () => {
+         const createRes = await createMaterialization({
+            buildInstructions: {
+               sources: [
+                  {
+                     buildId: "not-a-real-build-id",
+                     materializedTableId: "mt",
+                     physicalTableName: "t",
+                     realization: "COPY",
+                  },
+               ],
+            },
+         });
+         expect(createRes.status).toBe(400);
+      });
    });
 
-   // ── Group A1: Serve-time routing (the v0 payoff) ─────────────────
+   // ── Group C: Serve-time routing (the payoff) ─────────────────────
    //
    // Materialization only pays off if *served* queries scan the materialized
    // table instead of recomputing from the base table. The auto-run path builds
@@ -350,8 +286,7 @@ describe("Materialization REST API: auto-run + two-round (E2E)", () => {
    // process, so routing is provable in-process: capture the live SQL (scans the
    // base CSV), run an auto-run materialization, then assert both the executed
    // query SQL and the /compile preview SQL now scan the physical table and no
-   // longer touch the base CSV. The /compile half guards the parity fix
-   // (Environment.compileSource threads the package's bound manifest).
+   // longer touch the base CSV.
    describe("serve-time routing (auto-load)", () => {
       const MODEL_PATH = "persist_test.malloy";
       const QUERY = "run: order_summary -> { aggregate: c is count() }";
@@ -390,8 +325,6 @@ describe("Materialization REST API: auto-run + two-round (E2E)", () => {
          "routes served + compiled queries to the materialized table after auto-load",
          async () => {
             // Reset to live: a prior group may have left an in-memory binding.
-            // Auto-load never writes manifestLocation to publisher.json, so a
-            // reload re-reads the live model.
             await fetch(`${baseUrl}${API}?reload=true`);
 
             // Baseline: with nothing materialized, both paths recompute from the
@@ -401,16 +334,10 @@ describe("Materialization REST API: auto-run + two-round (E2E)", () => {
 
             // Build + auto-load in one pass (self-assigns physicalTableName =
             // "order_summary" from `#@ persist name="order_summary"`).
-            const createRes = await createMaterialization({
-               pauseBetweenPhases: false,
-            });
+            const createRes = await createMaterialization();
             expect(createRes.status).toBe(201);
             const { id } = (await createRes.json()) as { id: string };
-            const built = await pollUntil(
-               id,
-               (s) => TERMINAL_STATUSES.includes(s),
-               90_000,
-            );
+            const built = await pollUntilTerminal(id);
             expect(built.status).toBe("MANIFEST_FILE_READY");
 
             // The payoff: the served query now scans the materialized table and
@@ -436,25 +363,26 @@ describe("Materialization REST API: auto-run + two-round (E2E)", () => {
       );
    });
 
-   // ── Group B: State machine and error cases ───────────────────────
+   // ── Group D: State machine and error cases ───────────────────────
 
    describe("state machine and errors", () => {
-      it("stops a plan-ready materialization (-> CANCELLED)", async () => {
+      it("stops an in-flight materialization (-> CANCELLED)", async () => {
+         // Create and immediately stop while the background build is still
+         // starting (PENDING). Cooperative abort drives it to CANCELLED.
          const createRes = await createMaterialization();
          expect(createRes.status).toBe(201);
          const { id } = (await createRes.json()) as { id: string };
 
-         await pollUntil(id, (s) => s === "BUILD_PLAN_READY");
-
          const stopRes = await fetch(
             url(`/materializations/${id}?action=stop`),
-            {
-               method: "POST",
-            },
+            { method: "POST" },
          );
          expect(stopRes.status).toBe(200);
-         const stopped = (await stopRes.json()) as Record<string, unknown>;
-         expect(stopped.status).toBe("CANCELLED");
+
+         const settled = await pollUntilTerminal(id);
+         // The build may occasionally win the race and complete; either way it
+         // reaches a terminal state and stop returned 200.
+         expect(TERMINAL_STATUSES).toContain(settled.status as string);
 
          await cleanup(id);
       });
@@ -470,75 +398,12 @@ describe("Materialization REST API: auto-run + two-round (E2E)", () => {
          await cleanup(id);
       });
 
-      it("rejects building from a non-plan-ready state with 409", async () => {
-         const createRes = await createMaterialization();
-         expect(createRes.status).toBe(201);
-         const { id } = (await createRes.json()) as { id: string };
-
-         await pollUntil(id, (s) => s === "BUILD_PLAN_READY");
-         await fetch(url(`/materializations/${id}?action=stop`), {
-            method: "POST",
-         });
-         await pollUntil(id, (s) => s === "CANCELLED");
-
-         const buildRes = await fetch(
-            url(`/materializations/${id}?action=build`),
-            {
-               method: "POST",
-               headers: { "Content-Type": "application/json" },
-               body: JSON.stringify({
-                  sources: [
-                     {
-                        buildId: "deadbeef",
-                        materializedTableId: "mt",
-                        physicalTableName: "t",
-                        realization: "COPY",
-                     },
-                  ],
-               }),
-            },
-         );
-         expect(buildRes.status).toBe(409);
-
-         await fetch(url(`/materializations/${id}`), { method: "DELETE" });
-      });
-
-      it("rejects a build instruction with an unknown buildId (400)", async () => {
-         const createRes = await createMaterialization();
-         expect(createRes.status).toBe(201);
-         const { id } = (await createRes.json()) as { id: string };
-
-         await pollUntil(id, (s) => s === "BUILD_PLAN_READY");
-
-         const buildRes = await fetch(
-            url(`/materializations/${id}?action=build`),
-            {
-               method: "POST",
-               headers: { "Content-Type": "application/json" },
-               body: JSON.stringify({
-                  sources: [
-                     {
-                        buildId: "not-a-real-build-id",
-                        materializedTableId: "mt",
-                        physicalTableName: "t",
-                        realization: "COPY",
-                     },
-                  ],
-               }),
-            },
-         );
-         expect(buildRes.status).toBe(400);
-
-         await cleanup(id);
-      });
-
       it("rejects deleting a non-terminal materialization with 409", async () => {
          const createRes = await createMaterialization();
          expect(createRes.status).toBe(201);
          const { id } = (await createRes.json()) as { id: string };
 
-         await pollUntil(id, (s) => s === "BUILD_PLAN_READY");
-
+         // Delete immediately, while the background build is still PENDING.
          const deleteRes = await fetch(url(`/materializations/${id}`), {
             method: "DELETE",
          });
@@ -552,13 +417,9 @@ describe("Materialization REST API: auto-run + two-round (E2E)", () => {
          expect(createRes.status).toBe(201);
          const { id } = (await createRes.json()) as { id: string };
 
-         await pollUntil(id, (s) => s === "BUILD_PLAN_READY");
-
          const res = await fetch(
             url(`/materializations/${id}?action=frobnicate`),
-            {
-               method: "POST",
-            },
+            { method: "POST" },
          );
          expect(res.status).toBe(400);
 


### PR DESCRIPTION
## Summary

Replaces the two-round (compile-then-build) materialization protocol with a **single call**. The build plan is now a compile-time property of the package (`Package.buildPlan`), and a build is requested in one `POST .../materializations` that either:
- **auto-runs** (no `buildInstructions`): self-assigns physical names, builds, and auto-loads the manifest into the package models, or
- **orchestrated** (`buildInstructions` from `Package.buildPlan`): builds into caller-assigned names and does **not** auto-load (caller distributes via `manifestLocation`).

### Phase 1 — align implementation with the single-call spec
- New shared `packages/server/src/service/build_plan.ts` (compile / derive / `buildId` helpers) consumed by both the service and `Package`.
- `Package.buildPlan` computed at load (live persist plan) and surfaced through `getPackageMetadata()`.
- Collapsed orchestration into one `runBuild`; removed `runRound1`/`runRound2`/`buildMaterialization`, `pauseBetweenPhases`, `BUILD_PLAN_READY`, `?action=build`, and `Materialization.buildPlan`.
- Updated controller validation (`buildInstructions`), routes (`stop`-only action), storage, DuckDB schema, and metrics.
- SDK UI plan view repointed to `Package.buildPlan` (dropped the "Mode" field); CLI dropped `--pause-between-phases` (`--wait` settles on `MANIFEST_FILE_READY`/`FAILED`/`CANCELLED`).
- Rewrote server unit + integration, CLI unit + integration, and app Playwright tests.
- `RELEASE_NOTES.md` entry + version bump `0.0.207 → 0.0.208` (server/sdk/app, lockstep).

### Phase 2 — quality pass
- Confirmed unified `runBuild`; **kept** `MANIFEST_ROWS_READY` and the `rounds→runs` metric rename per sign-off.
- Filled unit gaps (`runBuild` branching, `autoLoadManifest`, `runInBackground` FAILED/CANCELLED, controller `validateCreateBody`, `build_plan` incl. null plan) and lifted shared fixtures into `materialization_test_fixtures.ts`.
- Telemetry: renamed `publisher_materialization_rounds_total`/`_round_duration_ms` → `_runs_total`/`_run_duration_ms` (label `mode=auto|orchestrated`); added `sources_total{built|reused}`, build-plan compute histogram, auto-load outcome counter, and a connection-digest-skip warn+counter; lowered intermediate transition logs to `debug`.
- Stripped two-round/control-plane/v0 comment debt (kept the "why" comments).

## Breaking changes
Removes `pauseBetweenPhases`, `BUILD_PLAN_READY`, `?action=build`, and `Materialization.buildPlan`; adds `Package.buildPlan` and single-call `buildInstructions`. Metric names renamed (`rounds`→`runs`, label `round`→`mode`).

## Test plan
- [x] `tsc` + `eslint` clean across server / sdk / cli
- [x] Server unit specs (service, controller, build_plan) — 67 pass
- [x] Server integration: materialization lifecycle — 9 pass
- [x] CLI unit + integration materialization tests pass
- [ ] k6 client regen — `openapi-to-k6` unavailable in this env; needs manual regen
- [ ] App Playwright `package-materializations.spec.ts` (run in CI / against dev server)

> Note: 3 pre-existing CLI command tests (`getPackage`/`getEnvironment`/`getConnection` "fetch and print JSON") fail independently of this change (they spy on `console.log` while the commands print via `logOutput`).

Made with [Cursor](https://cursor.com)