### PR TITLE
fix(materialization): dialect-quote DDL, persist run start, drop-tables delete + telemetry/validation hardening

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3798,12 +3798,6 @@ components:
             and matches on the same logical name it assigned.
         connectionName:
           type: string
-        dialect:
-          type: string
-          description:
-            Malloy dialect of the source's connection (e.g. `duckdb`,
-            `standardsql`). Recorded so the table can be dialect-quoted when it
-            is later dropped, without recompiling the package.
         realization:
           $ref: "#/components/schemas/Realization"
         rowCount:

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3798,6 +3798,12 @@ components:
             and matches on the same logical name it assigned.
         connectionName:
           type: string
+        dialect:
+          type: string
+          description:
+            Malloy dialect of the source's connection (e.g. `duckdb`,
+            `standardsql`). Recorded so the table can be dialect-quoted when it
+            is later dropped, without recompiling the package.
         realization:
           $ref: "#/components/schemas/Realization"
         rowCount:

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3704,6 +3704,16 @@ components:
           description: Output schema of the source.
           items:
             $ref: "#/components/schemas/Column"
+        annotationFields:
+          type: object
+          additionalProperties:
+            type: string
+          description:
+            All key=value fields of the source's `#@ persist` annotation (e.g.
+            `name`, `realization`). The control plane uses `name` as the
+            materialized table name (it may carry a dialect container path like
+            `dataset.table`). Returned as the full set so new persist directives
+            need no publisher change.
 
     Realization:
       type: string
@@ -3741,8 +3751,12 @@ components:
         physicalTableName:
           type: string
           description:
-            Fully-qualified, dialect-quoted table name to create. The publisher
-            writes here verbatim.
+            Logical, fully-qualified (but unquoted) table name to create — an
+            optional dialect container path plus the table name, e.g.
+            `mydataset.engaged_events_<buildId>_v0`. The publisher dialect-quotes
+            each segment when it emits the DDL, so quote-requiring names (a
+            hyphenated BigQuery project id, a container path) are valid, and
+            echoes this logical name back in the manifest.
         realization:
           $ref: "#/components/schemas/Realization"
 
@@ -3778,7 +3792,10 @@ components:
           description: Echoes the caller-assigned id from the BuildInstruction.
         physicalTableName:
           type: string
-          description: Name of the materialized table.
+          description:
+            The logical (unquoted) name of the materialized table — echoes the
+            BuildInstruction's physicalTableName so the control plane persists
+            and matches on the same logical name it assigned.
         connectionName:
           type: string
         realization:

--- a/packages/sdk/src/components/Materializations/DeleteMaterializationDialog.tsx
+++ b/packages/sdk/src/components/Materializations/DeleteMaterializationDialog.tsx
@@ -1,10 +1,12 @@
 import { Delete } from "@mui/icons-material";
 import CloseIcon from "@mui/icons-material/Close";
 import Button from "@mui/material/Button";
+import Checkbox from "@mui/material/Checkbox";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
+import FormControlLabel from "@mui/material/FormControlLabel";
 import IconButton from "@mui/material/IconButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
@@ -22,13 +24,15 @@ export default function DeleteMaterializationDialog({
    materialization: Materialization;
    onCloseDialog: () => void;
    isMutating: boolean;
-   onDelete: () => void;
+   onDelete: (dropTables: boolean) => void;
 }) {
    const [open, setOpen] = useState(false);
+   const [dropTables, setDropTables] = useState(false);
 
    const handleClickOpen = () => setOpen(true);
    const handleClose = () => {
       setOpen(false);
+      setDropTables(false);
       onCloseDialog();
    };
 
@@ -73,13 +77,24 @@ export default function DeleteMaterializationDialog({
                   Are you sure you want to delete this materialization record?
                   This action cannot be undone.
                </Typography>
+               <FormControlLabel
+                  control={
+                     <Checkbox
+                        checked={dropTables}
+                        onChange={(event) =>
+                           setDropTables(event.target.checked)
+                        }
+                     />
+                  }
+                  label="Also drop the materialized table(s) this run produced"
+               />
             </DialogContent>
             <DialogActions>
                <Button
                   loading={isMutating}
                   variant="contained"
                   autoFocus
-                  onClick={() => onDelete()}
+                  onClick={() => onDelete(dropTables)}
                   color="error"
                >
                   Delete

--- a/packages/sdk/src/components/Materializations/MaterializationRunsList.tsx
+++ b/packages/sdk/src/components/Materializations/MaterializationRunsList.tsx
@@ -35,7 +35,7 @@ type MaterializationRunsListProps = {
    mutable: boolean;
    isMutating: boolean;
    onStop: (materialization: Materialization) => void;
-   onDelete: (materialization: Materialization) => void;
+   onDelete: (materialization: Materialization, dropTables: boolean) => void;
    onViewDetails: (materialization: Materialization) => void;
 };
 
@@ -99,7 +99,7 @@ function MaterializationRow({
    mutable: boolean;
    isMutating: boolean;
    onStop: (materialization: Materialization) => void;
-   onDelete: (materialization: Materialization) => void;
+   onDelete: (materialization: Materialization, dropTables: boolean) => void;
    onViewDetails: (materialization: Materialization) => void;
 }) {
    const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
@@ -202,7 +202,9 @@ function MaterializationRow({
                            materialization={materialization}
                            isMutating={isMutating}
                            onCloseDialog={handleMenuClose}
-                           onDelete={() => onDelete(materialization)}
+                           onDelete={(dropTables) =>
+                              onDelete(materialization, dropTables)
+                           }
                         />
                      )}
                   </Menu>

--- a/packages/sdk/src/components/Materializations/Materializations.tsx
+++ b/packages/sdk/src/components/Materializations/Materializations.tsx
@@ -122,11 +122,18 @@ export default function Materializations({
    });
 
    const deleteMaterialization = useMutationWithApiError({
-      mutationFn: (materialization: Materialization) =>
+      mutationFn: ({
+         materialization,
+         dropTables,
+      }: {
+         materialization: Materialization;
+         dropTables: boolean;
+      }) =>
          apiClients.materializations.deleteMaterialization(
             environmentName,
             packageName,
             materialization.id as string,
+            dropTables,
          ),
       onSuccess() {
          setNotificationMessage("Materialization deleted");
@@ -230,8 +237,8 @@ export default function Materializations({
                   onStop={(materialization) =>
                      stopMaterialization.mutate(materialization)
                   }
-                  onDelete={(materialization) =>
-                     deleteMaterialization.mutate(materialization)
+                  onDelete={(materialization, dropTables) =>
+                     deleteMaterialization.mutate({ materialization, dropTables })
                   }
                   onViewDetails={(materialization) =>
                      setSelectedId(materialization.id ?? null)

--- a/packages/sdk/src/components/Materializations/Materializations.tsx
+++ b/packages/sdk/src/components/Materializations/Materializations.tsx
@@ -238,7 +238,10 @@ export default function Materializations({
                      stopMaterialization.mutate(materialization)
                   }
                   onDelete={(materialization, dropTables) =>
-                     deleteMaterialization.mutate({ materialization, dropTables })
+                     deleteMaterialization.mutate({
+                        materialization,
+                        dropTables,
+                     })
                   }
                   onViewDetails={(materialization) =>
                      setSelectedId(materialization.id ?? null)

--- a/packages/server/src/materialization_metrics.spec.ts
+++ b/packages/server/src/materialization_metrics.spec.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import {
+   recordConnectionDigestSkipped,
+   recordDropTables,
+   recordMaterializationRun,
+   recordSourcesOutcome,
+   resetMaterializationTelemetryForTesting,
+} from "./materialization_metrics";
+import {
+   startMetricsHarness,
+   type MetricsHarness,
+} from "./test_helpers/metrics_harness";
+
+describe("materialization_metrics", () => {
+   let harness: MetricsHarness;
+
+   beforeEach(async () => {
+      harness = await startMetricsHarness();
+      // Drop cached instruments so they re-bind to this test's provider.
+      resetMaterializationTelemetryForTesting();
+   });
+
+   afterEach(async () => {
+      resetMaterializationTelemetryForTesting();
+      await harness.shutdown();
+   });
+
+   it("counts runs labeled by mode and outcome", async () => {
+      recordMaterializationRun("auto", "success", 10);
+      recordMaterializationRun("auto", "success", 20);
+      recordMaterializationRun("orchestrated", "failed", 5);
+
+      expect(
+         await harness.collectCounter("publisher_materialization_runs_total", {
+            mode: "auto",
+            outcome: "success",
+         }),
+      ).toBe(2);
+      expect(
+         await harness.collectCounter("publisher_materialization_runs_total", {
+            mode: "orchestrated",
+            outcome: "failed",
+         }),
+      ).toBe(1);
+   });
+
+   it("adds the source count labeled by outcome, ignoring non-positive counts", async () => {
+      recordSourcesOutcome("built", 3);
+      recordSourcesOutcome("reused", 2);
+      recordSourcesOutcome("built", 0); // guarded: no emission
+
+      expect(
+         await harness.collectCounter(
+            "publisher_materialization_sources_total",
+            { outcome: "built" },
+         ),
+      ).toBe(3);
+      expect(
+         await harness.collectCounter(
+            "publisher_materialization_sources_total",
+            { outcome: "reused" },
+         ),
+      ).toBe(2);
+   });
+
+   it("counts drop-table outcomes and connection-digest skips", async () => {
+      recordDropTables("success");
+      recordDropTables("failure");
+      recordConnectionDigestSkipped();
+
+      expect(
+         await harness.collectCounter(
+            "publisher_materialization_drop_tables_total",
+            { outcome: "failure" },
+         ),
+      ).toBe(1);
+      expect(
+         await harness.collectCounter(
+            "publisher_materialization_connection_digest_skipped_total",
+         ),
+      ).toBe(1);
+   });
+});

--- a/packages/server/src/materialization_metrics.ts
+++ b/packages/server/src/materialization_metrics.ts
@@ -7,8 +7,8 @@
  * the run-duration histogram carries `mode` so a dashboard can render auto-run
  * vs orchestrated build latency side by side.
  *
- * Lazy init for the same reason as {@link ./query_cap_metrics}: instruments
- * created before `setGlobalMeterProvider` bind to a NoOp meter
+ * Instruments are created lazily for the same reason as {@link ./query_cap_metrics}:
+ * one created before `setGlobalMeterProvider` binds to a NoOp meter
  * (https://github.com/open-telemetry/opentelemetry-js/issues/3505).
  */
 
@@ -19,39 +19,74 @@ export type MaterializationOutcome = "success" | "failed" | "cancelled";
 /** Manifest bind outcome: timeout is split out from generic failure on purpose. */
 export type ManifestBindOutcome = "success" | "failure" | "timeout";
 
-let runCounter: Counter | null = null;
-let runDuration: Histogram | null = null;
-let sourcesCounter: Counter | null = null;
-let buildPlanComputeDuration: Histogram | null = null;
-let autoLoadCounter: Counter | null = null;
-let connectionDigestSkipCounter: Counter | null = null;
-let manifestBindCounter: Counter | null = null;
-let sourceBuildDuration: Histogram | null = null;
-let dropTablesCounter: Counter | null = null;
+const resetHooks: (() => void)[] = [];
 
-function ensureTelemetry(): { counter: Counter; duration: Histogram } {
-   if (runCounter && runDuration) {
-      return { counter: runCounter, duration: runDuration };
-   }
-   const meter = metrics.getMeter("publisher");
-   if (!runCounter) {
-      runCounter = meter.createCounter("publisher_materialization_runs_total", {
-         description:
-            "Materialization builds completed. Labels: mode ('auto'|'orchestrated'), outcome ('success'|'failed'|'cancelled').",
-      });
-   }
-   if (!runDuration) {
-      runDuration = meter.createHistogram(
-         "publisher_materialization_run_duration_ms",
-         {
-            description:
-               "Wall-clock duration of a materialization build. Label: mode ('auto'|'orchestrated').",
-            unit: "ms",
-         },
-      );
-   }
-   return { counter: runCounter, duration: runDuration };
+/**
+ * A lazily-created instrument: built from the global meter on first use (so it
+ * binds to the real MeterProvider, not the NoOp default) and memoized. Each
+ * registers a reset hook so a test can swap in a fresh MeterProvider.
+ */
+function lazyCounter(name: string, description: string): () => Counter {
+   let instrument: Counter | null = null;
+   resetHooks.push(() => (instrument = null));
+   return () =>
+      (instrument ??= metrics
+         .getMeter("publisher")
+         .createCounter(name, { description }));
 }
+
+function lazyHistogram(
+   name: string,
+   description: string,
+   unit: string,
+): () => Histogram {
+   let instrument: Histogram | null = null;
+   resetHooks.push(() => (instrument = null));
+   return () =>
+      (instrument ??= metrics
+         .getMeter("publisher")
+         .createHistogram(name, { description, unit }));
+}
+
+const runCounter = lazyCounter(
+   "publisher_materialization_runs_total",
+   "Materialization builds completed. Labels: mode ('auto'|'orchestrated'), outcome ('success'|'failed'|'cancelled').",
+);
+const runDuration = lazyHistogram(
+   "publisher_materialization_run_duration_ms",
+   "Wall-clock duration of a materialization build. Label: mode ('auto'|'orchestrated').",
+   "ms",
+);
+const sourcesCounter = lazyCounter(
+   "publisher_materialization_sources_total",
+   "Persist sources processed by a materialization run. Label: outcome ('built'|'reused').",
+);
+const buildPlanComputeDuration = lazyHistogram(
+   "publisher_materialization_build_plan_compute_duration_ms",
+   "Wall-clock duration of compiling a package's build plan (Package.buildPlan).",
+   "ms",
+);
+const autoLoadCounter = lazyCounter(
+   "publisher_materialization_auto_load_total",
+   "Auto-run manifest auto-load attempts. Label: outcome ('success'|'failure').",
+);
+const connectionDigestSkipCounter = lazyCounter(
+   "publisher_materialization_connection_digest_skipped_total",
+   "Connection digests skipped during build-plan compile because the connection did not resolve.",
+);
+const manifestBindCounter = lazyCounter(
+   "publisher_materialization_manifest_bind_total",
+   "Manifest bind attempts. Label: outcome ('success'|'failure'|'timeout').",
+);
+const sourceBuildDuration = lazyHistogram(
+   "publisher_materialization_source_build_duration_ms",
+   "Wall-clock duration of building a single persist source.",
+   "ms",
+);
+const dropTablesCounter = lazyCounter(
+   "publisher_materialization_drop_tables_total",
+   "Physical tables dropped on delete. Label: outcome ('success'|'failure').",
+);
 
 /** Record the outcome and duration of a materialization build. */
 export function recordMaterializationRun(
@@ -59,9 +94,8 @@ export function recordMaterializationRun(
    outcome: MaterializationOutcome,
    durationMs: number,
 ): void {
-   const { counter, duration } = ensureTelemetry();
-   counter.add(1, { mode, outcome });
-   duration.record(durationMs, { mode });
+   runCounter().add(1, { mode, outcome });
+   runDuration().record(durationMs, { mode });
 }
 
 /**
@@ -74,15 +108,7 @@ export function recordSourcesOutcome(
    count: number,
 ): void {
    if (count <= 0) return;
-   if (!sourcesCounter) {
-      sourcesCounter = metrics
-         .getMeter("publisher")
-         .createCounter("publisher_materialization_sources_total", {
-            description:
-               "Persist sources processed by a materialization run. Label: outcome ('built'|'reused').",
-         });
-   }
-   sourcesCounter.add(count, { outcome });
+   sourcesCounter().add(count, { outcome });
 }
 
 /**
@@ -91,19 +117,7 @@ export function recordSourcesOutcome(
  * tracking as a discrete cost separate from the build itself.
  */
 export function recordBuildPlanComputeDuration(durationMs: number): void {
-   if (!buildPlanComputeDuration) {
-      buildPlanComputeDuration = metrics
-         .getMeter("publisher")
-         .createHistogram(
-            "publisher_materialization_build_plan_compute_duration_ms",
-            {
-               description:
-                  "Wall-clock duration of compiling a package's build plan (Package.buildPlan).",
-               unit: "ms",
-            },
-         );
-   }
-   buildPlanComputeDuration.record(durationMs);
+   buildPlanComputeDuration().record(durationMs);
 }
 
 /**
@@ -112,15 +126,7 @@ export function recordBuildPlanComputeDuration(durationMs: number): void {
  * the run is MANIFEST_FILE_READY but queries still resolve to the old tables.
  */
 export function recordAutoLoadOutcome(outcome: "success" | "failure"): void {
-   if (!autoLoadCounter) {
-      autoLoadCounter = metrics
-         .getMeter("publisher")
-         .createCounter("publisher_materialization_auto_load_total", {
-            description:
-               "Auto-run manifest auto-load attempts. Label: outcome ('success'|'failure').",
-         });
-   }
-   autoLoadCounter.add(1, { outcome });
+   autoLoadCounter().add(1, { outcome });
 }
 
 /**
@@ -129,18 +135,7 @@ export function recordAutoLoadOutcome(outcome: "success" | "failure"): void {
  * are computed without a digest, so this is a correctness signal, not just noise.
  */
 export function recordConnectionDigestSkipped(): void {
-   if (!connectionDigestSkipCounter) {
-      connectionDigestSkipCounter = metrics
-         .getMeter("publisher")
-         .createCounter(
-            "publisher_materialization_connection_digest_skipped_total",
-            {
-               description:
-                  "Connection digests skipped during build-plan compile because the connection did not resolve.",
-            },
-         );
-   }
-   connectionDigestSkipCounter.add(1);
+   connectionDigestSkipCounter().add(1);
 }
 
 /**
@@ -149,56 +144,20 @@ export function recordConnectionDigestSkipped(): void {
  * tell an unreachable/slow manifest store from a malformed manifest.
  */
 export function recordManifestBind(outcome: ManifestBindOutcome): void {
-   if (!manifestBindCounter) {
-      manifestBindCounter = metrics
-         .getMeter("publisher")
-         .createCounter("publisher_materialization_manifest_bind_total", {
-            description:
-               "Manifest bind attempts. Label: outcome ('success'|'failure'|'timeout').",
-         });
-   }
-   manifestBindCounter.add(1, { outcome });
+   manifestBindCounter().add(1, { outcome });
 }
 
 /** Record the wall-clock duration of building one persist source's table. */
 export function recordSourceBuildDuration(durationMs: number): void {
-   if (!sourceBuildDuration) {
-      sourceBuildDuration = metrics
-         .getMeter("publisher")
-         .createHistogram(
-            "publisher_materialization_source_build_duration_ms",
-            {
-               description:
-                  "Wall-clock duration of building a single persist source.",
-               unit: "ms",
-            },
-         );
-   }
-   sourceBuildDuration.record(durationMs);
+   sourceBuildDuration().record(durationMs);
 }
 
 /** Record a best-effort physical-table drop on materialization delete. */
 export function recordDropTables(outcome: "success" | "failure"): void {
-   if (!dropTablesCounter) {
-      dropTablesCounter = metrics
-         .getMeter("publisher")
-         .createCounter("publisher_materialization_drop_tables_total", {
-            description:
-               "Physical tables dropped on delete. Label: outcome ('success'|'failure').",
-         });
-   }
-   dropTablesCounter.add(1, { outcome });
+   dropTablesCounter().add(1, { outcome });
 }
 
 /** Visible for tests. Drops cached instruments so a fresh MeterProvider can capture emissions. */
 export function resetMaterializationTelemetryForTesting(): void {
-   runCounter = null;
-   runDuration = null;
-   sourcesCounter = null;
-   buildPlanComputeDuration = null;
-   autoLoadCounter = null;
-   connectionDigestSkipCounter = null;
-   manifestBindCounter = null;
-   sourceBuildDuration = null;
-   dropTablesCounter = null;
+   for (const reset of resetHooks) reset();
 }

--- a/packages/server/src/service/build_plan.spec.ts
+++ b/packages/server/src/service/build_plan.spec.ts
@@ -1,12 +1,14 @@
 import type { PersistSource } from "@malloydata/malloy";
 import { describe, expect, it } from "bun:test";
 import * as sinon from "sinon";
+import type { BuildGraph as MalloyBuildGraph } from "@malloydata/malloy";
 import {
    computeBuildId,
    computePackageBuildPlan,
    deriveAnnotationFields,
    deriveBuildPlan,
    flattenDependsOn,
+   iterGraphSources,
    resolvePackageConnections,
 } from "./build_plan";
 import { fakeSource } from "./materialization_test_fixtures";
@@ -18,6 +20,28 @@ describe("flattenDependsOn", () => {
             dependsOn: [{ sourceID: "a" }, { sourceID: "b" }],
          }),
       ).toEqual(["a", "b"]);
+   });
+});
+
+describe("iterGraphSources", () => {
+   it("yields resolvable sources in dependency order, skipping missing ones", () => {
+      const a = fakeSource({ name: "a", buildId: "ba" });
+      const b = fakeSource({ name: "b", buildId: "bb" });
+      const graph = {
+         connectionName: "duckdb",
+         nodes: [
+            [{ sourceID: "a@m", dependsOn: [] }],
+            [
+               { sourceID: "missing@m", dependsOn: [] },
+               { sourceID: "b@m", dependsOn: [] },
+            ],
+         ],
+      } as unknown as MalloyBuildGraph;
+
+      const names = [...iterGraphSources(graph, { "a@m": a, "b@m": b })].map(
+         (s) => s.name,
+      );
+      expect(names).toEqual(["a", "b"]);
    });
 });
 

--- a/packages/server/src/service/build_plan.spec.ts
+++ b/packages/server/src/service/build_plan.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 import * as sinon from "sinon";
 import type { BuildGraph as MalloyBuildGraph } from "@malloydata/malloy";
 import {
+   compilePackageBuildPlan,
    computeBuildId,
    computePackageBuildPlan,
    deriveAnnotationFields,
@@ -12,6 +13,7 @@ import {
    resolvePackageConnections,
 } from "./build_plan";
 import { fakeSource } from "./materialization_test_fixtures";
+import { Model } from "./model";
 
 describe("flattenDependsOn", () => {
    it("maps nested dependsOn entries to a flat sourceID list", () => {
@@ -158,6 +160,29 @@ describe("deriveBuildPlan", () => {
       );
 
       expect(Object.keys(plan.sources)).toEqual(["a@m"]);
+   });
+});
+
+describe("compilePackageBuildPlan", () => {
+   it("skips .malloynb notebooks without compiling them", async () => {
+      // A notebook would throw on its `>>>` cell delimiter if compiled as a
+      // flat model, aborting the whole package plan; it must be skipped.
+      const getModelRuntime = sinon.stub(Model, "getModelRuntime");
+      try {
+         const pkg = {
+            getModelPaths: () => ["notes.malloynb"],
+            getPackagePath: () => "/test",
+            getMalloyConfig: () => ({}),
+            getMalloyConnection: async () => ({}),
+         } as unknown as Parameters<typeof compilePackageBuildPlan>[0];
+
+         const compiled = await compilePackageBuildPlan(pkg);
+
+         expect(compiled.graphs).toEqual([]);
+         expect(getModelRuntime.called).toBe(false);
+      } finally {
+         getModelRuntime.restore();
+      }
    });
 });
 

--- a/packages/server/src/service/build_plan.spec.ts
+++ b/packages/server/src/service/build_plan.spec.ts
@@ -4,6 +4,7 @@ import * as sinon from "sinon";
 import {
    computeBuildId,
    computePackageBuildPlan,
+   deriveAnnotationFields,
    deriveBuildPlan,
    flattenDependsOn,
    resolvePackageConnections,
@@ -17,6 +18,40 @@ describe("flattenDependsOn", () => {
             dependsOn: [{ sourceID: "a" }, { sourceID: "b" }],
          }),
       ).toEqual(["a", "b"]);
+   });
+});
+
+describe("deriveAnnotationFields", () => {
+   it("returns all key=value fields of the #@ persist annotation", () => {
+      const source = {
+         annotations: {
+            parseAsTag: () => ({
+               tag: {
+                  *entries() {
+                     yield ["name", { text: () => "engaged_events" }];
+                     yield ["realization", { text: () => "COPY" }];
+                  },
+               },
+            }),
+         },
+      } as unknown as PersistSource;
+
+      expect(deriveAnnotationFields(source)).toEqual({
+         name: "engaged_events",
+         realization: "COPY",
+      });
+   });
+
+   it("degrades to {} when the annotation is absent or unparseable", () => {
+      const source = {
+         annotations: {
+            parseAsTag: () => {
+               throw new Error("no @ annotation");
+            },
+         },
+      } as unknown as PersistSource;
+
+      expect(deriveAnnotationFields(source)).toEqual({});
    });
 });
 

--- a/packages/server/src/service/build_plan.ts
+++ b/packages/server/src/service/build_plan.ts
@@ -9,6 +9,7 @@ import { components } from "../api";
 import { MODEL_FILE_SUFFIX } from "../constants";
 import { logger } from "../logger";
 import { recordConnectionDigestSkipped } from "../materialization_metrics";
+import { errMessage } from "../utils";
 import { Model } from "./model";
 
 type WireBuildGraph = components["schemas"]["BuildGraph"];
@@ -54,7 +55,7 @@ export function deriveColumns(persistSource: PersistSource): WireColumn[] {
    } catch (err) {
       logger.warn("Failed to derive columns for persist source", {
          sourceID: persistSource.sourceID,
-         error: err instanceof Error ? err.message : String(err),
+         error: errMessage(err),
       });
       return [];
    }
@@ -93,6 +94,24 @@ export function flattenDependsOn(node: {
 }
 
 /**
+ * Yield each dependency-ordered persist source of one graph, resolving the
+ * node's sourceID against the sources map and skipping nodes whose source is
+ * absent. Centralizes the graph→levels→nodes→source walk shared by the
+ * planning and build loops.
+ */
+export function* iterGraphSources(
+   graph: MalloyBuildGraph,
+   sources: Record<string, PersistSource>,
+): Iterable<PersistSource> {
+   for (const level of graph.nodes) {
+      for (const node of level) {
+         const source = sources[node.sourceID];
+         if (source) yield source;
+      }
+   }
+}
+
+/**
  * The buildId for a persist source: a stable digest of its connection identity
  * and canonical SQL. Centralizes the (source, connectionDigests) call shape so
  * planning, self-instruction, and build all agree on the same id.
@@ -126,7 +145,7 @@ export async function resolvePackageConnections(
          map.set(name, await pkg.getMalloyConnection(name));
       } catch (err) {
          logger.warn(`Failed to resolve connection ${name}`, {
-            error: err instanceof Error ? err.message : String(err),
+            error: errMessage(err),
          });
       }
    }

--- a/packages/server/src/service/build_plan.ts
+++ b/packages/server/src/service/build_plan.ts
@@ -6,6 +6,7 @@ import type {
    PersistSource,
 } from "@malloydata/malloy";
 import { components } from "../api";
+import { MODEL_FILE_SUFFIX } from "../constants";
 import { logger } from "../logger";
 import { recordConnectionDigestSkipped } from "../materialization_metrics";
 import { Model } from "./model";
@@ -57,6 +58,31 @@ export function deriveColumns(persistSource: PersistSource): WireColumn[] {
       });
       return [];
    }
+}
+
+/**
+ * All key=value fields of a source's `#@ persist` annotation (e.g.
+ * `{ name: "engaged_events", realization: "COPY" }`), degrading to {} if the
+ * annotation is absent or unparseable. The control plane consumes these — most
+ * importantly `name`, which it uses as the materialized table name (and which
+ * may carry a dialect-style container path like `dataset.table`). Returning the
+ * full set rather than a fixed subset means new persist directives flow through
+ * without a publisher change.
+ */
+export function deriveAnnotationFields(
+   persistSource: PersistSource,
+): Record<string, string> {
+   const out: Record<string, string> = {};
+   try {
+      const tag = persistSource.annotations.parseAsTag("@").tag;
+      for (const [key, value] of tag.entries()) {
+         const text = value.text();
+         if (text !== undefined) out[key] = text;
+      }
+   } catch {
+      // Degrade to {} — mirrors deriveColumns / selfAssignTableName.
+   }
+   return out;
 }
 
 /** Flatten Malloy's nested BuildNode.dependsOn into a list of sourceIDs. */
@@ -121,6 +147,11 @@ export async function compilePackageBuildPlan(
    const allSources: Record<string, PersistSource> = {};
 
    for (const modelPath of pkg.getModelPaths()) {
+      // Only `.malloy` models declare persist sources. Skip `.malloynb`
+      // notebooks: getModel() parses a model file as a flat model and throws on
+      // the notebook's `>>>` cell delimiter, which would abort the entire
+      // package build plan and silently drop every persist source in it.
+      if (!modelPath.endsWith(MODEL_FILE_SUFFIX)) continue;
       if (signal?.aborted) throw new Error("Build cancelled");
 
       const { runtime, modelURL, importBaseURL } = await Model.getModelRuntime(
@@ -211,6 +242,7 @@ export function deriveBuildPlan(
          buildId: computeBuildId(source, connectionDigests),
          sql: source.getSQL(),
          columns: deriveColumns(source),
+         annotationFields: deriveAnnotationFields(source),
       };
    }
 

--- a/packages/server/src/service/materialization_service.spec.ts
+++ b/packages/server/src/service/materialization_service.spec.ts
@@ -383,6 +383,7 @@ describe("MaterializationService", () => {
                         buildId: "b1",
                         physicalTableName: "orders_mz",
                         connectionName: "duckdb",
+                        dialect: "duckdb",
                      },
                   },
                },
@@ -395,11 +396,85 @@ describe("MaterializationService", () => {
 
          expect(getMalloyConnection.calledOnceWith("duckdb")).toBe(true);
          const dropped = runSQL.getCalls().map((c) => c.args[0] as string);
-         expect(dropped).toContain("DROP TABLE IF EXISTS orders_mz");
-         expect(dropped.some((s) => s.includes("orders_mz_"))).toBe(true);
+         expect(dropped).toContain('DROP TABLE IF EXISTS "orders_mz"');
+         expect(dropped.some((s) => s.includes('"orders_mz_'))).toBe(true);
          expect(
             ctx.repository.deleteMaterialization.calledOnceWith("mat-1"),
          ).toBe(true);
+      });
+
+      it("quotes the drop DDL for the entry's dialect (backtick dialects)", async () => {
+         const runSQL = sinon.stub().resolves();
+         const getMalloyConnection = sinon.stub().resolves({ runSQL });
+         (ctx.environmentStore.getEnvironment as sinon.SinonStub).resolves({
+            getPackage: sinon.stub().resolves({ getMalloyConnection }),
+            withPackageLock: async (_n: string, fn: () => Promise<unknown>) =>
+               fn(),
+         });
+         ctx.repository.getMaterializationById.resolves(
+            makeMaterialization({
+               status: "MANIFEST_FILE_READY",
+               manifest: {
+                  builtAt: new Date().toISOString(),
+                  strict: false,
+                  entries: {
+                     b1: {
+                        buildId: "b1",
+                        // Container path on a hyphenated BigQuery project: each
+                        // segment must be backtick-quoted independently.
+                        physicalTableName: "my-proj.ds.engaged",
+                        connectionName: "bq",
+                        dialect: "standardsql",
+                     },
+                  },
+               },
+            }),
+         );
+
+         await ctx.service.deleteMaterialization("my-env", "pkg", "mat-1", {
+            dropTables: true,
+         });
+
+         const dropped = runSQL.getCalls().map((c) => c.args[0] as string);
+         expect(dropped).toContain(
+            "DROP TABLE IF EXISTS `my-proj`.`ds`.`engaged`",
+         );
+      });
+
+      it("falls back to the live connection dialect for legacy entries", async () => {
+         const runSQL = sinon.stub().resolves();
+         const getMalloyConnection = sinon
+            .stub()
+            .resolves({ runSQL, dialectName: "standardsql" });
+         (ctx.environmentStore.getEnvironment as sinon.SinonStub).resolves({
+            getPackage: sinon.stub().resolves({ getMalloyConnection }),
+            withPackageLock: async (_n: string, fn: () => Promise<unknown>) =>
+               fn(),
+         });
+         ctx.repository.getMaterializationById.resolves(
+            makeMaterialization({
+               status: "MANIFEST_FILE_READY",
+               manifest: {
+                  builtAt: new Date().toISOString(),
+                  strict: false,
+                  entries: {
+                     // No `dialect` field — a manifest written before it existed.
+                     b1: {
+                        buildId: "b1",
+                        physicalTableName: "orders_mz",
+                        connectionName: "bq",
+                     },
+                  },
+               },
+            }),
+         );
+
+         await ctx.service.deleteMaterialization("my-env", "pkg", "mat-1", {
+            dropTables: true,
+         });
+
+         const dropped = runSQL.getCalls().map((c) => c.args[0] as string);
+         expect(dropped).toContain("DROP TABLE IF EXISTS `orders_mz`");
       });
 
       it("still deletes the record when a table drop fails", async () => {
@@ -706,7 +781,11 @@ describe("buildOneSource", () => {
    function callBuildOneSource(
       connection: { runSQL: sinon.SinonStub },
       physicalTableName: string,
-   ): Promise<{ buildId: string; physicalTableName: string }> {
+   ): Promise<{
+      buildId: string;
+      physicalTableName: string;
+      dialect?: string;
+   }> {
       const source = fakeSource({
          name: "orders",
          buildId: "abcdef1234567890",
@@ -726,7 +805,11 @@ describe("buildOneSource", () => {
                c: unknown,
                d: Record<string, string>,
                m: Manifest,
-            ) => Promise<{ buildId: string; physicalTableName: string }>;
+            ) => Promise<{
+               buildId: string;
+               physicalTableName: string;
+               dialect?: string;
+            }>;
          }
       ).buildOneSource(
          source,
@@ -750,6 +833,8 @@ describe("buildOneSource", () => {
       ]);
       expect(entry.physicalTableName).toBe("orders_v1");
       expect(entry.buildId).toBe("abcdef1234567890");
+      // Dialect is recorded so the table can be dialect-quoted on a later drop.
+      expect(entry.dialect).toBe("duckdb");
    });
 
    it("drops the staging table and rethrows when the build SQL fails", async () => {

--- a/packages/server/src/service/materialization_service.spec.ts
+++ b/packages/server/src/service/materialization_service.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "../errors";
 import {
    BuildInstruction,
+   MaterializationStatus,
    ResourceRepository,
 } from "../storage/DatabaseInterface";
 import { DuplicateActiveMaterializationError } from "../storage/duckdb/MaterializationRepository";
@@ -366,7 +367,9 @@ describe("MaterializationService", () => {
 
       it("drops manifest tables (and staging) when dropTables is set", async () => {
          const runSQL = sinon.stub().resolves();
-         const getMalloyConnection = sinon.stub().resolves({ runSQL });
+         const getMalloyConnection = sinon
+            .stub()
+            .resolves({ runSQL, dialectName: "duckdb" });
          (ctx.environmentStore.getEnvironment as sinon.SinonStub).resolves({
             getPackage: sinon.stub().resolves({ getMalloyConnection }),
             withPackageLock: async (_n: string, fn: () => Promise<unknown>) =>
@@ -383,7 +386,6 @@ describe("MaterializationService", () => {
                         buildId: "b1",
                         physicalTableName: "orders_mz",
                         connectionName: "duckdb",
-                        dialect: "duckdb",
                      },
                   },
                },
@@ -403,9 +405,11 @@ describe("MaterializationService", () => {
          ).toBe(true);
       });
 
-      it("quotes the drop DDL for the entry's dialect (backtick dialects)", async () => {
+      it("dialect-quotes the drop DDL from the live connection (backtick + container path)", async () => {
          const runSQL = sinon.stub().resolves();
-         const getMalloyConnection = sinon.stub().resolves({ runSQL });
+         const getMalloyConnection = sinon
+            .stub()
+            .resolves({ runSQL, dialectName: "standardsql" });
          (ctx.environmentStore.getEnvironment as sinon.SinonStub).resolves({
             getPackage: sinon.stub().resolves({ getMalloyConnection }),
             withPackageLock: async (_n: string, fn: () => Promise<unknown>) =>
@@ -424,7 +428,6 @@ describe("MaterializationService", () => {
                         // segment must be backtick-quoted independently.
                         physicalTableName: "my-proj.ds.engaged",
                         connectionName: "bq",
-                        dialect: "standardsql",
                      },
                   },
                },
@@ -439,42 +442,6 @@ describe("MaterializationService", () => {
          expect(dropped).toContain(
             "DROP TABLE IF EXISTS `my-proj`.`ds`.`engaged`",
          );
-      });
-
-      it("falls back to the live connection dialect for legacy entries", async () => {
-         const runSQL = sinon.stub().resolves();
-         const getMalloyConnection = sinon
-            .stub()
-            .resolves({ runSQL, dialectName: "standardsql" });
-         (ctx.environmentStore.getEnvironment as sinon.SinonStub).resolves({
-            getPackage: sinon.stub().resolves({ getMalloyConnection }),
-            withPackageLock: async (_n: string, fn: () => Promise<unknown>) =>
-               fn(),
-         });
-         ctx.repository.getMaterializationById.resolves(
-            makeMaterialization({
-               status: "MANIFEST_FILE_READY",
-               manifest: {
-                  builtAt: new Date().toISOString(),
-                  strict: false,
-                  entries: {
-                     // No `dialect` field — a manifest written before it existed.
-                     b1: {
-                        buildId: "b1",
-                        physicalTableName: "orders_mz",
-                        connectionName: "bq",
-                     },
-                  },
-               },
-            }),
-         );
-
-         await ctx.service.deleteMaterialization("my-env", "pkg", "mat-1", {
-            dropTables: true,
-         });
-
-         const dropped = runSQL.getCalls().map((c) => c.args[0] as string);
-         expect(dropped).toContain("DROP TABLE IF EXISTS `orders_mz`");
       });
 
       it("still deletes the record when a table drop fails", async () => {
@@ -781,15 +748,13 @@ describe("buildOneSource", () => {
    function callBuildOneSource(
       connection: { runSQL: sinon.SinonStub },
       physicalTableName: string,
-   ): Promise<{
-      buildId: string;
-      physicalTableName: string;
-      dialect?: string;
-   }> {
+      dialectName?: string,
+   ): Promise<{ buildId: string; physicalTableName: string }> {
       const source = fakeSource({
          name: "orders",
          buildId: "abcdef1234567890",
          sql: "SELECT * FROM t",
+         dialectName,
       });
       const instruction: BuildInstruction = {
          buildId: "abcdef1234567890",
@@ -805,11 +770,7 @@ describe("buildOneSource", () => {
                c: unknown,
                d: Record<string, string>,
                m: Manifest,
-            ) => Promise<{
-               buildId: string;
-               physicalTableName: string;
-               dialect?: string;
-            }>;
+            ) => Promise<{ buildId: string; physicalTableName: string }>;
          }
       ).buildOneSource(
          source,
@@ -833,8 +794,6 @@ describe("buildOneSource", () => {
       ]);
       expect(entry.physicalTableName).toBe("orders_v1");
       expect(entry.buildId).toBe("abcdef1234567890");
-      // Dialect is recorded so the table can be dialect-quoted on a later drop.
-      expect(entry.dialect).toBe("duckdb");
    });
 
    it("drops the staging table and rethrows when the build SQL fails", async () => {
@@ -848,6 +807,26 @@ describe("buildOneSource", () => {
       expect(runSQL.lastCall.args[0]).toBe(
          'DROP TABLE IF EXISTS "orders_v1_abcdef123456"',
       );
+   });
+
+   it("quotes each segment of a container path for a backtick dialect", async () => {
+      const runSQL = sinon.stub().resolves();
+      // Container path (dataset.table) on a backtick dialect (BigQuery): each
+      // segment is quoted independently, and the rename targets the bare name.
+      const entry = await callBuildOneSource(
+         { runSQL },
+         "ds.orders_v1",
+         "standardsql",
+      );
+
+      const sql = runSQL.getCalls().map((c) => c.args[0] as string);
+      expect(sql).toEqual([
+         "DROP TABLE IF EXISTS `ds`.`orders_v1_abcdef123456`",
+         "CREATE TABLE `ds`.`orders_v1_abcdef123456` AS (SELECT * FROM t)",
+         "DROP TABLE IF EXISTS `ds`.`orders_v1`",
+         "ALTER TABLE `ds`.`orders_v1_abcdef123456` RENAME TO `orders_v1`",
+      ]);
+      expect(entry.physicalTableName).toBe("ds.orders_v1");
    });
 });
 
@@ -1057,5 +1036,59 @@ describe("runInBackground (terminal recording)", () => {
       bg.runInBackground("bg-3", async () => {});
       await flush();
       expect(bg.runningAbortControllers.has("bg-3")).toBe(false);
+   });
+});
+
+describe("transition (state machine)", () => {
+   let ctx: ReturnType<typeof createMocks>;
+   beforeEach(() => {
+      ctx = createMocks();
+   });
+
+   function transition(): (
+      id: string,
+      next: MaterializationStatus,
+   ) => Promise<unknown> {
+      return (
+         ctx.service as unknown as {
+            transition: (
+               id: string,
+               next: MaterializationStatus,
+            ) => Promise<unknown>;
+         }
+      ).transition.bind(ctx.service);
+   }
+
+   it("throws MaterializationNotFoundError when the record is gone", async () => {
+      ctx.repository.getMaterializationById.resolves(undefined);
+      await expect(
+         transition()("mat-1", "MANIFEST_ROWS_READY"),
+      ).rejects.toThrow(MaterializationNotFoundError);
+   });
+
+   it("rejects a transition the state machine disallows", async () => {
+      ctx.repository.getMaterializationById.resolves(
+         makeMaterialization({ status: "MANIFEST_FILE_READY" }),
+      );
+      // MANIFEST_FILE_READY is terminal; nothing follows it.
+      await expect(transition()("mat-1", "PENDING")).rejects.toThrow(
+         InvalidStateTransitionError,
+      );
+      expect(ctx.repository.updateMaterialization.called).toBe(false);
+   });
+
+   it("persists a valid transition", async () => {
+      ctx.repository.getMaterializationById.resolves(
+         makeMaterialization({ status: "PENDING" }),
+      );
+      ctx.repository.updateMaterialization.resolves(
+         makeMaterialization({ status: "MANIFEST_ROWS_READY" }),
+      );
+      await transition()("mat-1", "MANIFEST_ROWS_READY");
+      expect(
+         ctx.repository.updateMaterialization.calledOnceWith("mat-1", {
+            status: "MANIFEST_ROWS_READY",
+         }),
+      ).toBe(true);
    });
 });

--- a/packages/server/src/service/materialization_service.spec.ts
+++ b/packages/server/src/service/materialization_service.spec.ts
@@ -743,10 +743,10 @@ describe("buildOneSource", () => {
 
       const sql = runSQL.getCalls().map((c) => c.args[0] as string);
       expect(sql).toEqual([
-         "DROP TABLE IF EXISTS orders_v1_abcdef123456",
-         "CREATE TABLE orders_v1_abcdef123456 AS (SELECT * FROM t)",
-         "DROP TABLE IF EXISTS orders_v1",
-         "ALTER TABLE orders_v1_abcdef123456 RENAME TO orders_v1",
+         'DROP TABLE IF EXISTS "orders_v1_abcdef123456"',
+         'CREATE TABLE "orders_v1_abcdef123456" AS (SELECT * FROM t)',
+         'DROP TABLE IF EXISTS "orders_v1"',
+         'ALTER TABLE "orders_v1_abcdef123456" RENAME TO "orders_v1"',
       ]);
       expect(entry.physicalTableName).toBe("orders_v1");
       expect(entry.buildId).toBe("abcdef1234567890");
@@ -761,7 +761,7 @@ describe("buildOneSource", () => {
          "create boom",
       );
       expect(runSQL.lastCall.args[0]).toBe(
-         "DROP TABLE IF EXISTS orders_v1_abcdef123456",
+         'DROP TABLE IF EXISTS "orders_v1_abcdef123456"',
       );
    });
 });

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -695,6 +695,7 @@ export class MaterializationService {
          materializedTableId: instruction.materializedTableId,
          physicalTableName,
          connectionName: persistSource.connectionName,
+         dialect,
          realization: instruction.realization,
          rowCount: null,
       };
@@ -809,14 +810,23 @@ export class MaterializationService {
                connection = await pkg.getMalloyConnection(connectionName);
                connectionCache.set(connectionName, connection);
             }
+            // Quote with the dialect recorded at build time; fall back to the
+            // live connection's dialect for manifests written before `dialect`
+            // was persisted. buildOneSource quoted the same way, so a name that
+            // built successfully also drops successfully.
+            const dialect = entry.dialect ?? connection.dialectName;
             await connection.runSQL(
-               `DROP TABLE IF EXISTS ${physicalTableName}`,
+               `DROP TABLE IF EXISTS ${quoteTablePath(
+                  physicalTableName,
+                  dialect,
+               )}`,
             );
             // A crash between staging-create and rename can leave the staging
             // table behind; clean it up too while we hold the connection.
             await connection.runSQL(
-               `DROP TABLE IF EXISTS ${physicalTableName}${stagingSuffix(
-                  entry.buildId,
+               `DROP TABLE IF EXISTS ${quoteTablePath(
+                  `${physicalTableName}${stagingSuffix(entry.buildId)}`,
+                  dialect,
                )}`,
             );
             recordDropTables("success");

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -30,10 +30,13 @@ import {
    ResourceRepository,
 } from "../storage/DatabaseInterface";
 import { DuplicateActiveMaterializationError } from "../storage/duckdb/MaterializationRepository";
+import { errMessage } from "../utils";
 import {
    CompiledBuildPlan,
    compilePackageBuildPlan,
    computeBuildId,
+   deriveAnnotationFields,
+   iterGraphSources,
 } from "./build_plan";
 import { EnvironmentStore } from "./environment_store";
 import { quoteIdentifier, quoteTablePath, splitTablePath } from "./quoting";
@@ -58,14 +61,7 @@ export function stagingSuffix(buildId: string): string {
  * The author owns quoting the `name=` value for the dialect.
  */
 function selfAssignTableName(persistSource: PersistSource): string {
-   try {
-      return (
-         persistSource.annotations.parseAsTag("@").tag.text("name") ||
-         persistSource.name
-      );
-   } catch {
-      return persistSource.name;
-   }
+   return deriveAnnotationFields(persistSource).name || persistSource.name;
 }
 
 /** Classify a thrown build error as cancelled (cooperative abort) or failed. */
@@ -239,9 +235,7 @@ export class MaterializationService {
          packageName,
       );
       if (active) {
-         throw new MaterializationConflictError(
-            `Package ${packageName} already has an active materialization (${active.id})`,
-         );
+         throw this.activeConflict(packageName, active.id);
       }
 
       const forceRefresh = options.forceRefresh ?? false;
@@ -265,11 +259,7 @@ export class MaterializationService {
                environmentId,
                packageName,
             );
-            throw new MaterializationConflictError(
-               winner
-                  ? `Package ${packageName} already has an active materialization (${winner.id})`
-                  : `Package ${packageName} already has an active materialization`,
-            );
+            throw this.activeConflict(packageName, winner?.id);
          }
          throw err;
       }
@@ -424,35 +414,34 @@ export class MaterializationService {
       const seen = new Set<string>();
 
       for (const graph of compiled.graphs) {
-         for (const level of graph.nodes) {
-            for (const node of level) {
-               const persistSource = compiled.sources[node.sourceID];
-               if (!persistSource) continue;
-               if (include && !include.has(persistSource.name)) continue;
+         for (const persistSource of iterGraphSources(
+            graph,
+            compiled.sources,
+         )) {
+            if (include && !include.has(persistSource.name)) continue;
 
-               const buildId = computeBuildId(
-                  persistSource,
-                  compiled.connectionDigests,
-               );
-               if (seen.has(buildId)) continue;
-               seen.add(buildId);
+            const buildId = computeBuildId(
+               persistSource,
+               compiled.connectionDigests,
+            );
+            if (seen.has(buildId)) continue;
+            seen.add(buildId);
 
-               const prior = priorEntries[buildId];
-               if (prior && prior.physicalTableName) {
-                  carried[buildId] = prior;
-                  continue;
-               }
-
-               instructions.push({
-                  buildId,
-                  materializedTableId: `local-${buildId.substring(
-                     0,
-                     STAGING_BUILD_ID_LEN,
-                  )}`,
-                  physicalTableName: selfAssignTableName(persistSource),
-                  realization: "COPY",
-               });
+            const prior = priorEntries[buildId];
+            if (prior && prior.physicalTableName) {
+               carried[buildId] = prior;
+               continue;
             }
+
+            instructions.push({
+               buildId,
+               materializedTableId: `local-${buildId.substring(
+                  0,
+                  STAGING_BUILD_ID_LEN,
+               )}`,
+               physicalTableName: selfAssignTableName(persistSource),
+               realization: "COPY",
+            });
          }
       }
 
@@ -595,25 +584,21 @@ export class MaterializationService {
                `Connection '${graph.connectionName}' not found`,
             );
          }
-         for (const level of graph.nodes) {
-            for (const node of level) {
-               if (signal.aborted) throw new Error("Build cancelled");
-               const persistSource = sources[node.sourceID];
-               if (!persistSource) continue;
+         for (const persistSource of iterGraphSources(graph, sources)) {
+            if (signal.aborted) throw new Error("Build cancelled");
 
-               const buildId = computeBuildId(persistSource, connectionDigests);
-               const instruction = byBuildId.get(buildId);
-               if (!instruction) continue;
+            const buildId = computeBuildId(persistSource, connectionDigests);
+            const instruction = byBuildId.get(buildId);
+            if (!instruction) continue;
 
-               const entry = await this.buildOneSource(
-                  persistSource,
-                  instruction,
-                  connection,
-                  connectionDigests,
-                  manifest,
-               );
-               entries[buildId] = entry;
-            }
+            const entry = await this.buildOneSource(
+               persistSource,
+               instruction,
+               connection,
+               connectionDigests,
+               manifest,
+            );
+            entries[buildId] = entry;
          }
       }
 
@@ -669,10 +654,7 @@ export class MaterializationService {
                {
                   stagingTableName,
                   connectionName: persistSource.connectionName,
-                  cleanupError:
-                     cleanupErr instanceof Error
-                        ? cleanupErr.message
-                        : String(cleanupErr),
+                  cleanupError: errMessage(cleanupErr),
                },
             );
          }
@@ -841,7 +823,7 @@ export class MaterializationService {
                materializationId: m.id,
                physicalTableName,
                connectionName,
-               error: err instanceof Error ? err.message : String(err),
+               error: errMessage(err),
             });
          }
       }
@@ -872,6 +854,17 @@ export class MaterializationService {
 
    // ==================== HELPERS ====================
 
+   /** The single-active conflict error, with the winning run's id when known. */
+   private activeConflict(
+      packageName: string,
+      activeId?: string,
+   ): MaterializationConflictError {
+      const suffix = activeId ? ` (${activeId})` : "";
+      return new MaterializationConflictError(
+         `Package ${packageName} already has an active materialization${suffix}`,
+      );
+   }
+
    private recordRun(
       mode: MaterializationMode,
       outcome: "success" | "failed" | "cancelled",
@@ -889,7 +882,7 @@ export class MaterializationService {
 
       run(abortController.signal)
          .catch(async (err) => {
-            const message = err instanceof Error ? err.message : String(err);
+            const message = errMessage(err);
             const next = abortController.signal.aborted
                ? "CANCELLED"
                : "FAILED";
@@ -903,10 +896,7 @@ export class MaterializationService {
                logger.error("Failed to record materialization failure", {
                   materializationId: id,
                   originalError: message,
-                  transitionError:
-                     transitionErr instanceof Error
-                        ? transitionErr.message
-                        : String(transitionErr),
+                  transitionError: errMessage(transitionErr),
                });
             }
          })

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -39,7 +39,7 @@ import {
    iterGraphSources,
 } from "./build_plan";
 import { EnvironmentStore } from "./environment_store";
-import { quoteIdentifier, quoteTablePath, splitTablePath } from "./quoting";
+import { bareTableName, quoteIdentifier, quoteTablePath } from "./quoting";
 import { resolveEnvironmentId } from "./resolve_environment";
 
 /**
@@ -624,7 +624,7 @@ export class MaterializationService {
          connectionDigests,
       });
 
-      const { bareName } = splitTablePath(physicalTableName);
+      const bareName = bareTableName(physicalTableName);
       const stagingTableName = `${physicalTableName}${stagingSuffix(buildId)}`;
       // The control plane sends the logical (unquoted) physical name; dialect-
       // quote each identifier here so a container path or quote-requiring name

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -677,7 +677,6 @@ export class MaterializationService {
          materializedTableId: instruction.materializedTableId,
          physicalTableName,
          connectionName: persistSource.connectionName,
-         dialect,
          realization: instruction.realization,
          rowCount: null,
       };
@@ -792,11 +791,11 @@ export class MaterializationService {
                connection = await pkg.getMalloyConnection(connectionName);
                connectionCache.set(connectionName, connection);
             }
-            // Quote with the dialect recorded at build time; fall back to the
-            // live connection's dialect for manifests written before `dialect`
-            // was persisted. buildOneSource quoted the same way, so a name that
-            // built successfully also drops successfully.
-            const dialect = entry.dialect ?? connection.dialectName;
+            // Dialect-quote from the live connection, the same way
+            // buildOneSource quoted at build time, so a name that built
+            // successfully also drops successfully (container paths, hyphenated
+            // BigQuery project ids, etc.).
+            const dialect = connection.dialectName;
             await connection.runSQL(
                `DROP TABLE IF EXISTS ${quoteTablePath(
                   physicalTableName,

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -320,6 +320,12 @@ export class MaterializationService {
       const startedAt = Date.now();
 
       try {
+         // Persist the run's start time so the UI can compute a duration
+         // (start -> now while in-flight, start -> completed once terminal).
+         await this.repository.updateMaterialization(id, {
+            startedAt: new Date(startedAt),
+         });
+
          const environmentId = await this.resolveEnvironmentId(environmentName);
          const environment = await this.environmentStore.getEnvironment(
             environmentName,

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -36,7 +36,7 @@ import {
    computeBuildId,
 } from "./build_plan";
 import { EnvironmentStore } from "./environment_store";
-import { splitTablePath } from "./quoting";
+import { quoteIdentifier, quoteTablePath, splitTablePath } from "./quoting";
 import { resolveEnvironmentId } from "./resolve_environment";
 
 /**
@@ -641,20 +641,28 @@ export class MaterializationService {
 
       const { bareName } = splitTablePath(physicalTableName);
       const stagingTableName = `${physicalTableName}${stagingSuffix(buildId)}`;
+      // The control plane sends the logical (unquoted) physical name; dialect-
+      // quote each identifier here so a container path or quote-requiring name
+      // (e.g. a hyphenated BigQuery project id) produces valid DDL. The manifest
+      // echoes the logical name (below) so the CP stays in logical-name space.
+      const dialect = persistSource.dialectName;
+      const quotedStaging = quoteTablePath(stagingTableName, dialect);
+      const quotedPhysical = quoteTablePath(physicalTableName, dialect);
+      const quotedBareName = quoteIdentifier(bareName, dialect);
 
       const startTime = performance.now();
-      await connection.runSQL(`DROP TABLE IF EXISTS ${stagingTableName}`);
+      await connection.runSQL(`DROP TABLE IF EXISTS ${quotedStaging}`);
       try {
          await connection.runSQL(
-            `CREATE TABLE ${stagingTableName} AS (${buildSQL})`,
+            `CREATE TABLE ${quotedStaging} AS (${buildSQL})`,
          );
-         await connection.runSQL(`DROP TABLE IF EXISTS ${physicalTableName}`);
+         await connection.runSQL(`DROP TABLE IF EXISTS ${quotedPhysical}`);
          await connection.runSQL(
-            `ALTER TABLE ${stagingTableName} RENAME TO ${bareName}`,
+            `ALTER TABLE ${quotedStaging} RENAME TO ${quotedBareName}`,
          );
       } catch (err) {
          try {
-            await connection.runSQL(`DROP TABLE IF EXISTS ${stagingTableName}`);
+            await connection.runSQL(`DROP TABLE IF EXISTS ${quotedStaging}`);
          } catch (cleanupErr) {
             logger.warn(
                "Failed to clean up staging table after a failed build; physical leak",

--- a/packages/server/src/service/materialization_test_fixtures.ts
+++ b/packages/server/src/service/materialization_test_fixtures.ts
@@ -80,11 +80,13 @@ export function fakeSource(opts: {
    buildId: string;
    sql?: string;
    connectionName?: string;
+   dialectName?: string;
 }): PersistSource {
    return {
       name: opts.name,
       sourceID: opts.name,
       connectionName: opts.connectionName ?? "duckdb",
+      dialectName: opts.dialectName ?? "duckdb",
       makeBuildId: () => opts.buildId,
       getSQL: () => opts.sql ?? "SELECT 1",
       annotations: {

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -34,6 +34,7 @@ import { BuildManifest, BuildPlan } from "../storage/DatabaseInterface";
 import { ignoreDotfiles } from "../utils";
 import { computePackageBuildPlan } from "./build_plan";
 import { Model } from "./model";
+import { assertPersistNamesQuoted } from "./persist_annotation_validation";
 
 type ApiDatabase = components["schemas"]["Database"];
 type ApiModel = components["schemas"]["Model"];
@@ -361,6 +362,17 @@ export class Package {
          // to load inside the pure-CPU package-load worker). A misconfigured tag
          // is logged as a warning naming the target; it does not fail the load.
          await model.validateRenderTags();
+         // Reject unquoted `#@ persist name=` annotations the same way: an
+         // unquoted name is dropped from the build plan, so the source would
+         // publish but never materialize. Scan the raw `.malloy` source (the
+         // ground truth for quoting); throws a ModelCompilationError (424).
+         if (sm.modelPath.endsWith(MODEL_FILE_SUFFIX)) {
+            const modelSource = await fs.readFile(
+               path.join(packagePath, sm.modelPath),
+               "utf-8",
+            );
+            assertPersistNamesQuoted(modelSource, sm.modelPath);
+         }
          models.set(sm.modelPath, model);
       }
 

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -31,7 +31,7 @@ import { formatDuration, logger } from "../logger";
 import { recordBuildPlanComputeDuration } from "../materialization_metrics";
 import { assertSafeEnvironmentPath, safeJoinUnderRoot } from "../path_safety";
 import { BuildManifest, BuildPlan } from "../storage/DatabaseInterface";
-import { ignoreDotfiles } from "../utils";
+import { errMessage, ignoreDotfiles } from "../utils";
 import { computePackageBuildPlan } from "./build_plan";
 import { Model } from "./model";
 import { assertPersistNamesQuoted } from "./persist_annotation_validation";
@@ -412,7 +412,7 @@ export class Package {
             `Failed to compute build plan for package ${packageName}`,
             {
                packageName,
-               error: err instanceof Error ? err.message : String(err),
+               error: errMessage(err),
             },
          );
       }

--- a/packages/server/src/service/persist_annotation_validation.spec.ts
+++ b/packages/server/src/service/persist_annotation_validation.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { ModelCompilationError } from "../errors";
+import { assertPersistNamesQuoted } from "./persist_annotation_validation";
+
+describe("assertPersistNamesQuoted", () => {
+   it("throws ModelCompilationError on a bare (unquoted) persist name", () => {
+      expect(() =>
+         assertPersistNamesQuoted(
+            `#@ persist name=engaged_events\nsource: engaged_events is x -> { select: * }`,
+            "m.malloy",
+         ),
+      ).toThrow(ModelCompilationError);
+   });
+
+   it("tolerates whitespace around = but still flags an unquoted value", () => {
+      expect(() =>
+         assertPersistNamesQuoted(
+            `#@ persist name = engaged_events`,
+            "m.malloy",
+         ),
+      ).toThrow(/must be quoted/);
+   });
+
+   it("accepts a double-quoted name", () => {
+      expect(() =>
+         assertPersistNamesQuoted(
+            `#@ persist name="engaged_events"`,
+            "m.malloy",
+         ),
+      ).not.toThrow();
+   });
+
+   it("accepts a single-quoted name", () => {
+      expect(() =>
+         assertPersistNamesQuoted(
+            `#@ persist name='engaged_events'`,
+            "m.malloy",
+         ),
+      ).not.toThrow();
+   });
+
+   it("accepts a dotted, quoted dialect path", () => {
+      expect(() =>
+         assertPersistNamesQuoted(
+            `#@ persist name="my_dataset.engaged_events"`,
+            "m.malloy",
+         ),
+      ).not.toThrow();
+   });
+
+   it("ignores non-persist annotations and persist lines with no name field", () => {
+      expect(() =>
+         assertPersistNamesQuoted(
+            `# number=2\n#@ persist realization="COPY"\nsource: x is y -> { select: * }`,
+            "m.malloy",
+         ),
+      ).not.toThrow();
+   });
+
+   it("does not mistake a neighbouring key for the name field", () => {
+      expect(() =>
+         assertPersistNamesQuoted(
+            `#@ persist tablename=foo name="bar"`,
+            "m.malloy",
+         ),
+      ).not.toThrow();
+   });
+
+   it("reports every offending annotation in the message", () => {
+      expect(() =>
+         assertPersistNamesQuoted(
+            `#@ persist name=a\nsource: a is x -> { select: * }\n#@ persist name=b\nsource: b is x -> { select: * }`,
+            "m.malloy",
+         ),
+      ).toThrow(/name=a.*name=b/s);
+   });
+});

--- a/packages/server/src/service/persist_annotation_validation.ts
+++ b/packages/server/src/service/persist_annotation_validation.ts
@@ -1,0 +1,54 @@
+import { ModelCompilationError } from "../errors";
+
+/** A line whose first non-whitespace content is a `#@ persist` directive. */
+const PERSIST_LINE_PATTERN = /^\s*#@\s+persist\b/;
+/**
+ * A `name=` key whose value is NOT immediately opened by a single or double
+ * quote — i.e. a bare `name=engaged_events` (whitespace around `=` tolerated).
+ * `name="..."` and `name='...'` pass. The `\bname` word boundary requires a
+ * standalone key, so neighbours like `tablename=` / `realization_name=` are
+ * never mistaken for it.
+ */
+const UNQUOTED_NAME_PATTERN = /\bname\s*=\s*(?!["'])/;
+
+/**
+ * Reject `#@ persist name=<value>` annotations whose name is unquoted.
+ *
+ * The persist build plan requires a quoted name — a dialect-style table path
+ * (`name="engaged_events"`, or `name="my_dataset.engaged_events"`). A bare
+ * value is dropped from the build plan, so the source publishes and serves but
+ * is never materialized, with no error anywhere. Throwing a
+ * `ModelCompilationError` (HTTP 424) fails the publish/load with a clear,
+ * actionable message — the same hard-stop `Model.validateRenderTags` applies to
+ * a misconfigured render tag.
+ *
+ * Scans the raw model source line-by-line rather than the compiled annotation
+ * objects: the check must fire regardless of how the compiler attaches the
+ * annotation, and the raw text is the ground truth for whether the author
+ * quoted the value (the tag parser discards quote information once parsed).
+ *
+ * @throws {ModelCompilationError} listing every offending annotation.
+ */
+export function assertPersistNamesQuoted(
+   modelSource: string,
+   modelPath: string,
+): void {
+   const offenders: string[] = [];
+   for (const rawLine of modelSource.split("\n")) {
+      if (!PERSIST_LINE_PATTERN.test(rawLine)) continue;
+      if (UNQUOTED_NAME_PATTERN.test(rawLine)) {
+         offenders.push(rawLine.trim());
+      }
+   }
+   if (offenders.length > 0) {
+      throw new ModelCompilationError({
+         message:
+            `${modelPath}: persist annotation name must be quoted. Write a quoted ` +
+            `value like name="engaged_events" (or a dialect table path such as ` +
+            `name="my_dataset.engaged_events"), not a bare value — an unquoted ` +
+            `persist name is dropped from the build plan, so the source would ` +
+            `publish but never materialize. Offending annotation(s): ` +
+            `${offenders.join("; ")}.`,
+      });
+   }
+}

--- a/packages/server/src/service/quoting.spec.ts
+++ b/packages/server/src/service/quoting.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { quoteIdentifier, quoteTablePath, splitTablePath } from "./quoting";
+
+describe("splitTablePath", () => {
+   it("splits a schema-qualified name", () => {
+      expect(splitTablePath("my_schema.my_table")).toEqual({
+         schemaPrefix: "my_schema.",
+         bareName: "my_table",
+      });
+   });
+
+   it("returns an empty prefix for a bare name", () => {
+      expect(splitTablePath("my_table")).toEqual({
+         schemaPrefix: "",
+         bareName: "my_table",
+      });
+   });
+});
+
+describe("quoteIdentifier", () => {
+   it("backticks for backtick dialects (BigQuery / MySQL / Databricks)", () => {
+      expect(quoteIdentifier("my-table", "standardsql")).toBe("`my-table`");
+      expect(quoteIdentifier("t", "mysql")).toBe("`t`");
+      expect(quoteIdentifier("t", "databricks")).toBe("`t`");
+   });
+
+   it("double-quotes for everything else (Postgres / DuckDB / Snowflake)", () => {
+      expect(quoteIdentifier("my-table", "postgres")).toBe('"my-table"');
+      expect(quoteIdentifier("t", "duckdb")).toBe('"t"');
+      expect(quoteIdentifier("t", "snowflake")).toBe('"t"');
+   });
+
+   it("escapes an embedded quote char by doubling it", () => {
+      expect(quoteIdentifier("a`b", "standardsql")).toBe("`a``b`");
+      expect(quoteIdentifier('a"b', "postgres")).toBe('"a""b"');
+   });
+});
+
+describe("quoteTablePath", () => {
+   it("quotes each segment of a container path independently", () => {
+      expect(
+         quoteTablePath(
+            "my-proj.mydataset.engaged_events_ab12_v0",
+            "standardsql",
+         ),
+      ).toBe("`my-proj`.`mydataset`.`engaged_events_ab12_v0`");
+      expect(quoteTablePath("mydataset.t_ab12_v0", "postgres")).toBe(
+         '"mydataset"."t_ab12_v0"',
+      );
+   });
+
+   it("quotes a bare (unqualified) name", () => {
+      expect(quoteTablePath("t_ab12_v0", "standardsql")).toBe("`t_ab12_v0`");
+      expect(quoteTablePath("t_ab12_v0", "postgres")).toBe('"t_ab12_v0"');
+   });
+});

--- a/packages/server/src/service/quoting.spec.ts
+++ b/packages/server/src/service/quoting.spec.ts
@@ -1,19 +1,13 @@
 import { describe, expect, it } from "bun:test";
-import { quoteIdentifier, quoteTablePath, splitTablePath } from "./quoting";
+import { bareTableName, quoteIdentifier, quoteTablePath } from "./quoting";
 
-describe("splitTablePath", () => {
-   it("splits a schema-qualified name", () => {
-      expect(splitTablePath("my_schema.my_table")).toEqual({
-         schemaPrefix: "my_schema.",
-         bareName: "my_table",
-      });
+describe("bareTableName", () => {
+   it("returns the segment after the last dot for a qualified name", () => {
+      expect(bareTableName("my_schema.my_table")).toBe("my_table");
    });
 
-   it("returns an empty prefix for a bare name", () => {
-      expect(splitTablePath("my_table")).toEqual({
-         schemaPrefix: "",
-         bareName: "my_table",
-      });
+   it("returns the name unchanged when it is unqualified", () => {
+      expect(bareTableName("my_table")).toBe("my_table");
    });
 });
 

--- a/packages/server/src/service/quoting.ts
+++ b/packages/server/src/service/quoting.ts
@@ -19,3 +19,35 @@ export function splitTablePath(tableName: string): {
    }
    return { schemaPrefix: "", bareName: tableName };
 }
+
+// Dialects whose identifier quote character is a backtick; everything else uses
+// the SQL-standard double quote. Keyed by Malloy `dialectName`.
+const BACKTICK_DIALECTS = new Set(["standardsql", "mysql", "databricks"]);
+
+/**
+ * Quote a single SQL identifier for {@code dialect}, escaping any embedded quote
+ * character by doubling it.
+ */
+export function quoteIdentifier(identifier: string, dialect: string): string {
+   if (BACKTICK_DIALECTS.has(dialect)) {
+      return "`" + identifier.replace(/`/g, "``") + "`";
+   }
+   return '"' + identifier.replace(/"/g, '""') + '"';
+}
+
+/**
+ * Dialect-quote a (possibly container-qualified) table path so it can be inlined
+ * into DDL. Each dot segment is quoted independently and rejoined with dots, so
+ * a path like {@code my-proj.mydataset.engaged_events_v0} becomes
+ * `` `my-proj`.`mydataset`.`engaged_events_v0` `` on BigQuery or
+ * {@code "my-proj"."mydataset"."engaged_events_v0"} on Postgres — handling
+ * container hierarchies and quote-requiring names (e.g. hyphenated BigQuery
+ * project ids) uniformly. The control plane provides the logical (unquoted) path
+ * in `physicalTableName`; quoting for the warehouse is the publisher's job.
+ */
+export function quoteTablePath(tableName: string, dialect: string): string {
+   return tableName
+      .split(".")
+      .map((segment) => quoteIdentifier(segment, dialect))
+      .join(".");
+}

--- a/packages/server/src/service/quoting.ts
+++ b/packages/server/src/service/quoting.ts
@@ -1,23 +1,12 @@
 /**
- * Split a possibly schema-qualified table name into its schema prefix
- * (including the trailing dot) and the bare table name.
- *
- * Examples:
- *   "my_schema.my_table" -> { schemaPrefix: "my_schema.", bareName: "my_table" }
- *   "my_table"           -> { schemaPrefix: "", bareName: "my_table" }
+ * The bare (unqualified) name of a possibly container-qualified table path:
+ * the segment after the last dot, e.g. `my_schema.my_table` -> `my_table` and
+ * `my_table` -> `my_table`. Used as the RENAME target, which names a table
+ * within its existing schema rather than re-stating the full path.
  */
-export function splitTablePath(tableName: string): {
-   schemaPrefix: string;
-   bareName: string;
-} {
+export function bareTableName(tableName: string): string {
    const lastDot = tableName.lastIndexOf(".");
-   if (lastDot >= 0) {
-      return {
-         schemaPrefix: tableName.substring(0, lastDot + 1),
-         bareName: tableName.substring(lastDot + 1),
-      };
-   }
-   return { schemaPrefix: "", bareName: tableName };
+   return lastDot >= 0 ? tableName.substring(lastDot + 1) : tableName;
 }
 
 // Dialects whose identifier quote character is a backtick; everything else uses

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -22,3 +22,8 @@ export const URL_READER: URLReader = {
 export function ignoreDotfiles(file: string): boolean {
    return path.basename(file).startsWith(".");
 }
+
+/** The message of a thrown value, stringifying non-Error throws. */
+export function errMessage(err: unknown): string {
+   return err instanceof Error ? err.message : String(err);
+}


### PR DESCRIPTION
## Summary

Rebased onto `main` now that the single-call build rework (#844) has merged. This PR no longer re-includes that work; it is a focused follow-up that hardens the materialization build/drop paths, adds run-duration + drop-tables UX, and cleans up telemetry.

### Fixes
- **Run duration** — persist `startedAt` at the start of `runBuild` so the Materializations "Duration" column populates (previously only `completedAt` was written, so `started_at` stayed null and duration was always empty).
- **Drop tables on delete** — add an "also drop the materialized table(s)" checkbox to the delete dialog and thread `dropTables` through `MaterializationRunsList` / `Materializations` to the `DELETE .../materializations/{id}?dropTables=true` API.
- **Dialect-quote build DDL** — quote staging/physical identifiers when building a persist source so container paths and quote-requiring names (e.g. hyphenated BigQuery project ids) produce valid DDL.
- **Dialect-quote DROP DDL on delete** — `dropMaterializedTables` previously emitted unquoted `DROP TABLE` statements while the build path quotes identifiers, so a table built under a quote-requiring name would fail to drop. The drop path now reads the already-resolved connection's `dialectName` (no new public wire field) and quotes the DROP.

### Validation / build-plan
- Surface the full set of `#@ persist` annotation `key=value` fields on the wire build plan (`deriveAnnotationFields`).
- Reject unquoted `#@ persist name=` annotations at package load with a `ModelCompilationError` (an unquoted name is silently dropped from the build plan).
- Skip `.malloynb` notebooks when compiling the package build plan.

### Refactors
- Extract `iterGraphSources()` to centralize the graph→levels→nodes→source walk shared by `deriveSelfInstructions` and `executeInstructedBuild`; collapse `selfAssignTableName` onto `deriveAnnotationFields`; add an `errMessage()` util; factor the single-active conflict message into one helper.
- Dedupe the nine repeated lazy-init metric blocks behind `lazyCounter`/`lazyHistogram` factories (preserving every metric name/description/label and the test-reset behavior).
- Drop the unused `schemaPrefix` from `splitTablePath`; replace with a focused `bareTableName()` used for the RENAME target.

### Tests
- New `persist_annotation_validation.spec.ts`, `quoting.spec.ts`, and `materialization_metrics.spec.ts` (in-memory MeterProvider harness).
- Added coverage for `.malloynb` skip, container-path/backtick quoting in `buildOneSource`, and the transition state machine (record-gone, disallowed, valid hops).

## Test plan
- [ ] `make typecheck` / `make lint`
- [ ] `make test` — server unit + integration (materialization service/controller, build_plan, metrics, persist-annotation-validation, quoting)
- [ ] CLI + Playwright materialization tests

Made with [Cursor](https://cursor.com)