### PR TITLE
refactor(model): update render tag validation to log warnings instead of throwing errors

### DIFF
--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -25,11 +25,6 @@ import * as fs from "fs/promises";
 import { createRequire } from "module";
 import * as path from "path";
 import { components } from "../api";
-import { deserializeError } from "../package_load/package_load_pool";
-import type {
-   SerializedModel,
-   SerializedNotebookCell,
-} from "../package_load/protocol";
 import {
    getDefaultQueryRowLimit,
    getMaxQueryRows,
@@ -46,8 +41,19 @@ import {
    PayloadTooLargeError,
 } from "../errors";
 import { logger } from "../logger";
+import { deserializeError } from "../package_load/package_load_pool";
+import type {
+   SerializedModel,
+   SerializedNotebookCell,
+} from "../package_load/protocol";
 import { BuildManifest } from "../storage/DatabaseInterface";
 import { URL_READER } from "../utils";
+import { modelAnnotations } from "./annotations";
+import {
+   collectAuthorizeExprs,
+   evaluateAuthorize,
+   validateAuthorizeProbes,
+} from "./authorize";
 import {
    buildFilterClause,
    FilterValidationError,
@@ -55,21 +61,15 @@ import {
    type FilterDefinition,
    type FilterParams,
 } from "./filter";
-import {
-   collectAuthorizeExprs,
-   evaluateAuthorize,
-   validateAuthorizeProbes,
-} from "./authorize";
-import { modelAnnotations } from "./annotations";
 import { malloyGivenToApi, type MalloyGiven } from "./given";
-import {
-   extractQueriesFromModelDef,
-   extractSourcesFromModelDef,
-} from "./source_extraction";
 import {
    assertWithinModelResponseLimits,
    resolveModelQueryRowLimit,
 } from "./model_limits";
+import {
+   extractQueriesFromModelDef,
+   extractSourcesFromModelDef,
+} from "./source_extraction";
 
 type ApiCompiledModel = components["schemas"]["CompiledModel"];
 type ApiNotebookCell = components["schemas"]["NotebookCell"];
@@ -980,13 +980,13 @@ export class Model {
     * annotated source view (`run: <source> -> <view>`) compile-only -- no
     * execution -- to get a stable result schema, then runs the renderer's
     * headless `validateRenderTags`. Targets with no annotations carry no render
-    * tags, so they are skipped without compiling. Any
-    * error-severity finding throws a `ModelCompilationError` (HTTP 424) so a
-    * misconfigured tag (e.g. a child-only `# big_value { sparkline=... }` placed
-    * on a view with no activating big_value) fails the package load with a clear
-    * message instead of rendering as "[object Object]" at query time. Warnings
-    * (e.g. unread tags) are left for the query-time `renderLogs` surface so a
-    * benign render lint never blocks a load.
+    * tags, so they are skipped without compiling. Any error-severity finding
+    * (e.g. a child-only `# big_value { sparkline=... }` placed on a view with no
+    * activating big_value) is logged as a warning naming the offending target;
+    * it does not fail the package load. Such a tag still renders as
+    * "[object Object]" at query time, so the warning is the operator-facing
+    * signal. Lower-severity findings are left for the query-time `renderLogs`
+    * surface.
     */
    public async validateRenderTags(): Promise<void> {
       const mm = this.modelMaterializer;
@@ -1053,11 +1053,11 @@ export class Model {
             (log) => log.severity === "error",
          );
          if (errors.length > 0) {
-            throw new ModelCompilationError({
-               message: `Invalid renderer configuration on '${target.label}': ${errors
+            logger.warn(
+               `Invalid renderer configuration on '${target.label}': ${errors
                   .map((e) => e.message)
                   .join("; ")}`,
-            });
+            );
          }
       }
    }

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -359,8 +359,7 @@ export class Package {
          );
          // Validate renderer tags on the main thread (the renderer is too heavy
          // to load inside the pure-CPU package-load worker). A misconfigured tag
-         // throws a ModelCompilationError (424), aborting the whole load like any
-         // other per-model compile error above.
+         // is logged as a warning naming the target; it does not fail the load.
          await model.validateRenderTags();
          models.set(sm.modelPath, model);
       }
@@ -709,9 +708,10 @@ export class Package {
                { buildManifest },
             );
             // Validate renderer tags here too (loadViaWorker does it for the
-            // create path). Reload keeps per-model placeholders rather than
-            // aborting the whole package, so a render-tag error is recorded as
-            // this model's compilationError instead of thrown.
+            // create path). Render-tag findings are logged as warnings inside
+            // validateRenderTags and never throw. The catch is defensive: an
+            // unexpected internal failure is recorded as this model's
+            // compilationError rather than aborting the whole reload.
             try {
                await model.validateRenderTags();
                nextModels.set(sm.modelPath, model);

--- a/packages/server/src/service/package_worker_path.spec.ts
+++ b/packages/server/src/service/package_worker_path.spec.ts
@@ -28,10 +28,12 @@ import {
    describe,
    expect,
    it,
+   spyOn,
 } from "bun:test";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import { logger } from "../logger";
 import {
    PackageLoadPool,
    __setPackageLoadPoolForTests,
@@ -280,14 +282,13 @@ source: gated is duckdb.sql("select 1 as id")`,
       }
    });
 
-   it("rejects a package whose view carries an invalid renderer tag", async () => {
+   it("logs a warning for a package whose view carries an invalid renderer tag", async () => {
       writeManifest();
       // `# big_value { sparkline=... }` is a child-only renderer config placed on
       // the view itself, with no activating big_value. The renderer declines to
-      // match it; without compile-time validation it renders as "[object Object]"
-      // at query time. Render-tag validation runs on the main thread after the
-      // worker hydrates the model, so the load must reject with a 424
-      // ModelCompilationError naming the offending view.
+      // match it. Render-tag validation runs on the main thread after the worker
+      // hydrates the model. The misconfiguration is logged as a warning naming
+      // the offending view; it does not fail the package load.
       fs.writeFileSync(
          path.join(tempDir, "bad_render.malloy"),
          `source: nums is duckdb.sql("select 1 as a, 2 as b") extend {
@@ -302,21 +303,21 @@ source: gated is duckdb.sql("select 1 as id")`,
 }`,
       );
 
-      const { ModelCompilationError } = await import("../errors");
+      const warnSpy = spyOn(logger, "warn");
       const { malloyConfig, duckdb } = await makeMalloyConfig();
       try {
-         let caught: unknown;
-         try {
-            await Package.create("env", "pkg", tempDir, malloyConfig);
-         } catch (err) {
-            caught = err;
-         }
-         expect(caught).toBeInstanceOf(ModelCompilationError);
-         expect((caught as Error).message).toContain(
-            "Invalid renderer configuration",
-         );
-         expect((caught as Error).message).toContain("nums -> card");
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         expect(pkg.getModelPaths()).toEqual(["bad_render.malloy"]);
+         const warnings = warnSpy.mock.calls.map((c) => String(c[0]));
+         expect(
+            warnings.some(
+               (m) =>
+                  m.includes("Invalid renderer configuration") &&
+                  m.includes("nums -> card"),
+            ),
+         ).toBe(true);
       } finally {
+         warnSpy.mockRestore();
          await duckdb.close();
       }
    });
@@ -341,7 +342,7 @@ source: gated is duckdb.sql("select 1 as id")`,
       }
    });
 
-   it("rejects a package whose backtick-quoted (hyphenated) source has a bad view render tag", async () => {
+   it("logs a warning for a backtick-quoted (hyphenated) source with a bad view render tag", async () => {
       writeManifest();
       // A source whose name needs Malloy backtick-quoting (here, a hyphen). The
       // validation target must quote the identifier; otherwise `run: bad-source
@@ -363,26 +364,26 @@ source: gated is duckdb.sql("select 1 as id")`,
 }`,
       );
 
-      const { ModelCompilationError } = await import("../errors");
+      const warnSpy = spyOn(logger, "warn");
       const { malloyConfig, duckdb } = await makeMalloyConfig();
       try {
-         let caught: unknown;
-         try {
-            await Package.create("env", "pkg", tempDir, malloyConfig);
-         } catch (err) {
-            caught = err;
-         }
-         expect(caught).toBeInstanceOf(ModelCompilationError);
-         expect((caught as Error).message).toContain(
-            "Invalid renderer configuration",
-         );
-         expect((caught as Error).message).toContain("bad-source -> card");
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         expect(pkg.getModelPaths()).toEqual(["hyphen_render.malloy"]);
+         const warnings = warnSpy.mock.calls.map((c) => String(c[0]));
+         expect(
+            warnings.some(
+               (m) =>
+                  m.includes("Invalid renderer configuration") &&
+                  m.includes("bad-source -> card"),
+            ),
+         ).toBe(true);
       } finally {
+         warnSpy.mockRestore();
          await duckdb.close();
       }
    });
 
-   it("rejects a package whose source name contains an escaped backtick with a bad view render tag", async () => {
+   it("logs a warning for a source name containing an escaped backtick with a bad view render tag", async () => {
       writeManifest();
       // Source name with a literal backtick (written escaped in Malloy as
       // `wei\`rd`). The validation target must re-escape it; a bare wrap would
@@ -403,26 +404,26 @@ source: gated is duckdb.sql("select 1 as id")`,
 }`,
       );
 
-      const { ModelCompilationError } = await import("../errors");
+      const warnSpy = spyOn(logger, "warn");
       const { malloyConfig, duckdb } = await makeMalloyConfig();
       try {
-         let caught: unknown;
-         try {
-            await Package.create("env", "pkg", tempDir, malloyConfig);
-         } catch (err) {
-            caught = err;
-         }
-         expect(caught).toBeInstanceOf(ModelCompilationError);
-         expect((caught as Error).message).toContain(
-            "Invalid renderer configuration",
-         );
-         expect((caught as Error).message).toContain("card");
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         expect(pkg.getModelPaths()).toEqual(["backtick_render.malloy"]);
+         const warnings = warnSpy.mock.calls.map((c) => String(c[0]));
+         expect(
+            warnings.some(
+               (m) =>
+                  m.includes("Invalid renderer configuration") &&
+                  m.includes("card"),
+            ),
+         ).toBe(true);
       } finally {
+         warnSpy.mockRestore();
          await duckdb.close();
       }
    });
 
-   it("rejects a .malloynb notebook whose source view carries an invalid renderer tag", async () => {
+   it("logs a warning for a .malloynb notebook whose source view carries an invalid renderer tag", async () => {
       writeManifest();
       fs.writeFileSync(
          path.join(tempDir, "bad_render.malloynb"),
@@ -439,18 +440,22 @@ source: nums is duckdb.sql("select 1 as a, 2 as b") extend {
 }`,
       );
 
-      const { ModelCompilationError } = await import("../errors");
+      const warnSpy = spyOn(logger, "warn");
       const { malloyConfig, duckdb } = await makeMalloyConfig();
       try {
-         await expect(
-            Package.create("env", "pkg", tempDir, malloyConfig),
-         ).rejects.toBeInstanceOf(ModelCompilationError);
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         expect(pkg.getModelPaths()).toEqual(["bad_render.malloynb"]);
+         const warnings = warnSpy.mock.calls.map((c) => String(c[0]));
+         expect(
+            warnings.some((m) => m.includes("Invalid renderer configuration")),
+         ).toBe(true);
       } finally {
+         warnSpy.mockRestore();
          await duckdb.close();
       }
    });
 
-   it("re-validates renderer tags on reload, recording a model that develops a bad tag as a per-model error", async () => {
+   it("re-validates renderer tags on reload, logging a warning for a model that develops a bad tag", async () => {
       writeManifest();
       // Start valid so Package.create succeeds.
       fs.writeFileSync(
@@ -463,13 +468,15 @@ source: nums is duckdb.sql("select 1 as a, 2 as b") extend {
       );
 
       const { malloyConfig, duckdb } = await makeMalloyConfig();
+      const warnSpy = spyOn(logger, "warn");
       try {
          const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
          expect(pkg.getModel("m.malloy")).toBeDefined();
+         warnSpy.mockClear();
 
-         // The model now develops a misconfigured render tag. Reload must catch
-         // it (not just Package.create) and surface it as the model's error,
-         // without aborting the whole reload.
+         // The model now develops a misconfigured render tag. Reload re-validates
+         // (not just Package.create) and logs a warning for it, without aborting
+         // the reload or failing the model.
          fs.writeFileSync(
             path.join(tempDir, "m.malloy"),
             `source: nums is duckdb.sql("select 1 as a, 2 as b") extend {
@@ -487,10 +494,13 @@ source: nums is duckdb.sql("select 1 as a, 2 as b") extend {
 
          const reloaded = pkg.getModel("m.malloy");
          expect(reloaded).toBeDefined();
-         await expect(reloaded!.getModel()).rejects.toThrow(
-            "Invalid renderer configuration",
-         );
+         await expect(reloaded!.getModel()).resolves.toBeDefined();
+         const warnings = warnSpy.mock.calls.map((c) => String(c[0]));
+         expect(
+            warnings.some((m) => m.includes("Invalid renderer configuration")),
+         ).toBe(true);
       } finally {
+         warnSpy.mockRestore();
          await duckdb.close();
       }
    });


### PR DESCRIPTION
- Adjusted the `validateRenderTags` method to log warnings for misconfigured renderer tags instead of throwing a `ModelCompilationError`, allowing package loads to proceed without failure.
- Updated related tests to verify that warnings are logged correctly for invalid renderer configurations in various scenarios, including packages and sources with bad render tags.
- Cleaned up imports in `model.ts` for better organization and clarity.

This change enhances the user experience by providing more informative logging while maintaining the integrity of the package loading process.