### PR TITLE
Fix/connection introspection diagnostics

### DIFF
--- a/packages/server/src/package_load/connection_error.spec.ts
+++ b/packages/server/src/package_load/connection_error.spec.ts
@@ -101,6 +101,22 @@ describe("buildConnectionDiagnostic", () => {
       expect(msg).toContain("could not be reached");
       expect(msg).not.toContain("undefined");
    });
+
+   it("uses connection-level phrasing when no target is in hand (resolution failure)", () => {
+      // The path real publisher connections take: the token is validated at
+      // `lookupConnection` time, before any specific table/SQL is known.
+      const msg = buildConnectionDiagnostic({
+         kind: "auth",
+         status: 401,
+         connection: "prod_warehouse",
+         rawMessage: "Request failed with status code 401",
+      });
+      expect(msg).toContain("establishing the connection");
+      // No specific target → must not emit a quoted-empty / "undefined" target.
+      expect(msg).not.toContain("undefined");
+      expect(msg).not.toContain('introspecting ""');
+      expect(msg).toContain("401 Unauthorized");
+   });
 });
 
 describe("connectionFailureToError", () => {

--- a/packages/server/src/package_load/connection_error.spec.ts
+++ b/packages/server/src/package_load/connection_error.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for schema-fetch failure classification + diagnostics.
+ *
+ * These are pure-function tests — no worker, no connection. They pin the
+ * behaviour the pool relies on to decide which failures get short-circuited
+ * into a single connection diagnostic vs. left as normal compile errors.
+ */
+import { describe, expect, it } from "bun:test";
+import { ConnectionAuthError, ConnectionError } from "../errors";
+import {
+   buildConnectionDiagnostic,
+   classifySchemaFetchError,
+   connectionFailureToError,
+   isInfrastructureFailure,
+} from "./connection_error";
+
+describe("classifySchemaFetchError", () => {
+   it("classifies 401 / 403 (status-first) as auth", () => {
+      // The exact shape Axios produces and db-publisher passes through.
+      expect(
+         classifySchemaFetchError("Request failed with status code 401"),
+      ).toEqual({ kind: "auth", status: 401 });
+      expect(
+         classifySchemaFetchError("Request failed with status code 403"),
+      ).toEqual({ kind: "auth", status: 403 });
+   });
+
+   it("classifies 404 as not_found (NOT short-circuited)", () => {
+      const c = classifySchemaFetchError("Request failed with status code 404");
+      expect(c).toEqual({ kind: "not_found", status: 404 });
+      expect(isInfrastructureFailure(c.kind)).toBe(false);
+   });
+
+   it("classifies 5xx and 408 as transport", () => {
+      for (const code of [500, 502, 503, 504, 408]) {
+         expect(
+            classifySchemaFetchError(`Request failed with status code ${code}`),
+         ).toEqual({ kind: "transport", status: code });
+      }
+   });
+
+   it("classifies raw network/timeout errors (no HTTP status) as transport", () => {
+      for (const msg of [
+         "connect ECONNREFUSED 127.0.0.1:443",
+         "getaddrinfo ENOTFOUND warehouse.example.com",
+         "socket hang up",
+         "timeout of 600000ms exceeded",
+         "read ECONNRESET",
+      ]) {
+         expect(classifySchemaFetchError(msg).kind).toBe("transport");
+      }
+   });
+
+   it("falls back to auth keywords when no HTTP status is present", () => {
+      expect(classifySchemaFetchError("Unauthorized").kind).toBe("auth");
+      expect(classifySchemaFetchError("the token is expired").kind).toBe(
+         "auth",
+      );
+      expect(classifySchemaFetchError("invalid credentials").kind).toBe("auth");
+   });
+
+   it("treats genuine table-not-found text as not_found", () => {
+      expect(classifySchemaFetchError("Table foo does not exist").kind).toBe(
+         "not_found",
+      );
+      expect(classifySchemaFetchError("no such table: bar").kind).toBe(
+         "not_found",
+      );
+   });
+
+   it("leaves anything unrecognized as 'other' (not short-circuited)", () => {
+      const c = classifySchemaFetchError("something unexpected happened");
+      expect(c.kind).toBe("other");
+      expect(isInfrastructureFailure(c.kind)).toBe(false);
+   });
+});
+
+describe("buildConnectionDiagnostic", () => {
+   it("names connection, table, status, and disclaims a model error (auth)", () => {
+      const msg = buildConnectionDiagnostic({
+         kind: "auth",
+         status: 401,
+         connection: "prod_warehouse",
+         target: "analytics.orders",
+         rawMessage: "Request failed with status code 401",
+      });
+      expect(msg).toContain("prod_warehouse");
+      expect(msg).toContain("analytics.orders");
+      expect(msg).toContain("401 Unauthorized");
+      expect(msg.toLowerCase()).toContain("token");
+      expect(msg).toContain("not an error in your Malloy model");
+   });
+
+   it("phrases unreachable transport failures without a bogus status", () => {
+      const msg = buildConnectionDiagnostic({
+         kind: "transport",
+         connection: "warehouse",
+         target: "schema.tbl",
+         rawMessage: "connect ECONNREFUSED 10.0.0.1:443",
+      });
+      expect(msg).toContain("could not be reached");
+      expect(msg).not.toContain("undefined");
+   });
+});
+
+describe("connectionFailureToError", () => {
+   it("maps auth → ConnectionAuthError (422) and transport → ConnectionError (502)", () => {
+      const auth = connectionFailureToError({
+         kind: "auth",
+         status: 401,
+         connection: "c",
+         target: "t",
+         rawMessage: "Request failed with status code 401",
+      });
+      const transport = connectionFailureToError({
+         kind: "transport",
+         status: 503,
+         connection: "c",
+         target: "t",
+         rawMessage: "Request failed with status code 503",
+      });
+      expect(auth).toBeInstanceOf(ConnectionAuthError);
+      expect(transport).toBeInstanceOf(ConnectionError);
+   });
+});

--- a/packages/server/src/package_load/connection_error.ts
+++ b/packages/server/src/package_load/connection_error.ts
@@ -47,8 +47,13 @@ export interface SchemaFetchFailure {
    status?: number;
    /** Connection name the model referenced (e.g. `prod_warehouse`). */
    connection: string;
-   /** What we were introspecting — a table path or an inline SQL source. */
-   target: string;
+   /**
+    * What we were introspecting — a table path or an inline SQL source.
+    * Omitted when the failure happened while *resolving* the connection
+    * itself (e.g. db-publisher validates the token at `create()` time, so
+    * the 401 surfaces before any specific table/SQL is in hand).
+    */
+   target?: string;
    /** The raw (flattened) error string from the connection layer. */
    rawMessage: string;
 }
@@ -144,8 +149,14 @@ export function buildConnectionDiagnostic(failure: SchemaFetchFailure): string {
          ? "The access token is likely expired or invalid; refresh the connection and reload."
          : "The data plane may be down, unreachable, or timing out; check the connection and retry.";
 
+   // With a specific table/SQL in hand we name it; a connection-resolution
+   // failure (no target) reads as "while establishing the connection".
+   const locus = target
+      ? `while introspecting "${target}"`
+      : "while establishing the connection";
+
    return (
-      `Connection "${connection}" ${statusPhrase} while introspecting "${target}". ` +
+      `Connection "${connection}" ${statusPhrase} ${locus}. ` +
       `${cause} ` +
       `This is a connection problem, not an error in your Malloy model ` +
       `(underlying error: ${rawMessage}).`

--- a/packages/server/src/package_load/connection_error.ts
+++ b/packages/server/src/package_load/connection_error.ts
@@ -1,0 +1,165 @@
+/**
+ * Classification + diagnostics for connection schema-introspection failures.
+ *
+ * Why this exists
+ * ---------------
+ * When a connection can't introspect a table/SQL schema for an
+ * **infrastructure** reason — an expired token (HTTP 401), a forbidden
+ * scope (403), or the data plane being down/unreachable/timing out
+ * (5xx / network / timeout) — the failure travels a long, lossy path
+ * before a developer ever sees it:
+ *
+ *   1. `PublisherConnection.extractAndThrowError` (in @malloydata/db-publisher)
+ *      flattens the AxiosError to a bare `Error(error.response?.data?.message
+ *      || error.message)`. For a 401 with no body that's just
+ *      `"Request failed with status code 401"` — no status field, no
+ *      connection name, no table path, no auth-vs-not-found signal.
+ *   2. Malloy's `BaseConnection.fetchSchemaForTables` **catches** that throw
+ *      per-table and returns it as a **string** in `result.errors[table]`.
+ *   3. The Malloy compiler then can't resolve `conn.table('...')`, so the
+ *      source and *every field that references it* emit their own
+ *      "X is not defined" error — a cascade that reads like a broken
+ *      Malloy model when the real cause is the connection.
+ *
+ * We cannot fix step 1 here (db-publisher is an installed dependency, not
+ * in this repo's workspace), but the flattened message still *contains*
+ * the HTTP status text, so we can classify it server-side and short-circuit
+ * the cascade with one clear connection diagnostic. See
+ * {@link PackageLoadPool.handleSchemaForTables}.
+ *
+ * Only **auth** and **transport** failures are treated as infrastructure
+ * failures and short-circuited. A genuine **not_found** (404 / "table does
+ * not exist") and anything we can't confidently classify ("other") are left
+ * alone so they keep producing normal Malloy compile diagnostics — a real
+ * modeling mistake must still surface as a modeling error.
+ */
+import { ConnectionAuthError, ConnectionError } from "../errors";
+
+export type SchemaFetchFailureKind =
+   | "auth"
+   | "transport"
+   | "not_found"
+   | "other";
+
+export interface SchemaFetchFailure {
+   kind: SchemaFetchFailureKind;
+   /** HTTP status, when one could be parsed from the error text. */
+   status?: number;
+   /** Connection name the model referenced (e.g. `prod_warehouse`). */
+   connection: string;
+   /** What we were introspecting — a table path or an inline SQL source. */
+   target: string;
+   /** The raw (flattened) error string from the connection layer. */
+   rawMessage: string;
+}
+
+const HTTP_STATUS_TEXT: Record<number, string> = {
+   400: "Bad Request",
+   401: "Unauthorized",
+   403: "Forbidden",
+   404: "Not Found",
+   408: "Request Timeout",
+   429: "Too Many Requests",
+   500: "Internal Server Error",
+   502: "Bad Gateway",
+   503: "Service Unavailable",
+   504: "Gateway Timeout",
+};
+
+/**
+ * Classify a schema-fetch failure from the (already-flattened) error string
+ * the connection layer produced.
+ *
+ * Status-first, because the HTTP status is the most reliable signal and the
+ * common case (`"Request failed with status code 401"`) carries it. Falls
+ * back to keyword heuristics for failures that carry no HTTP status (raw
+ * socket/DNS/timeout errors) or whose body text replaced the status line.
+ */
+export function classifySchemaFetchError(message: string): {
+   kind: SchemaFetchFailureKind;
+   status?: number;
+} {
+   const match =
+      /status code (\d{3})/i.exec(message) ??
+      /\bHTTP\s+(\d{3})\b/i.exec(message);
+   const status = match ? Number(match[1]) : undefined;
+
+   if (status === 401 || status === 403) return { kind: "auth", status };
+   if (status === 404) return { kind: "not_found", status };
+   if (status === 408 || (status !== undefined && status >= 500)) {
+      return { kind: "transport", status };
+   }
+
+   // No decisive HTTP status — fall back to keyword heuristics.
+   if (
+      /\b(unauthori[sz]ed|forbidden|access denied|authentication failed|not authenticated|(token|credentials?)[^.]*\b(expired|invalid|missing)|(expired|invalid|missing)[^.]*\b(token|credentials?))\b/i.test(
+         message,
+      )
+   ) {
+      return { kind: "auth", status };
+   }
+   if (
+      /(ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|EPIPE|EHOSTUNREACH|ENETUNREACH|socket hang up|network error|timeout of \d+\s*ms exceeded|getaddrinfo)/i.test(
+         message,
+      )
+   ) {
+      return { kind: "transport", status };
+   }
+   if (
+      /(not found|does ?n'?o?t exist|no such table|unknown table)/i.test(
+         message,
+      )
+   ) {
+      return { kind: "not_found", status };
+   }
+   return { kind: "other", status };
+}
+
+/**
+ * True for failures caused by the connection/credentials/transport rather
+ * than the Malloy model. Only these are short-circuited; everything else
+ * keeps producing normal compile diagnostics.
+ */
+export function isInfrastructureFailure(kind: SchemaFetchFailureKind): boolean {
+   return kind === "auth" || kind === "transport";
+}
+
+/**
+ * Build a single, developer-facing diagnostic that names the connection, the
+ * table/SQL being introspected, the HTTP status, and the likely cause —
+ * explicitly telling the reader this is *not* a Malloy model error, so they
+ * don't go chasing the "X is not defined" cascade.
+ */
+export function buildConnectionDiagnostic(failure: SchemaFetchFailure): string {
+   const { kind, status, connection, target, rawMessage } = failure;
+   const statusText =
+      status !== undefined ? HTTP_STATUS_TEXT[status] : undefined;
+   const statusPhrase =
+      status !== undefined
+         ? `returned ${status}${statusText ? ` ${statusText}` : ""}`
+         : "could not be reached";
+
+   const cause =
+      kind === "auth"
+         ? "The access token is likely expired or invalid; refresh the connection and reload."
+         : "The data plane may be down, unreachable, or timing out; check the connection and retry.";
+
+   return (
+      `Connection "${connection}" ${statusPhrase} while introspecting "${target}". ` +
+      `${cause} ` +
+      `This is a connection problem, not an error in your Malloy model ` +
+      `(underlying error: ${rawMessage}).`
+   );
+}
+
+/**
+ * The typed Error to fail the package load with, so the HTTP layer maps it
+ * correctly: `ConnectionAuthError` → 422, `ConnectionError` → 502 (see
+ * `internalErrorToHttpError`). Only called for infrastructure failures.
+ */
+export function connectionFailureToError(failure: SchemaFetchFailure): Error {
+   const message = buildConnectionDiagnostic(failure);
+   return failure.kind === "auth"
+      ? new ConnectionAuthError(message)
+      : new ConnectionError(message);
+}

--- a/packages/server/src/package_load/package_load_pool.spec.ts
+++ b/packages/server/src/package_load/package_load_pool.spec.ts
@@ -31,16 +31,19 @@ import {
    __setPackageLoadPoolForTests,
    getPackageLoadWorkerCount,
 } from "./package_load_pool";
-import type { Connection } from "@malloydata/malloy";
+import type { Connection, LookupConnection } from "@malloydata/malloy";
 import { BaseConnection } from "@malloydata/malloy/connection";
 import { ConnectionAuthError, ConnectionError } from "../errors";
 
 /**
- * A non-duckdb connection whose schema introspection always fails the same
- * way `PublisherConnection` does for an expired token: it THROWS, and Malloy's
- * `BaseConnection` catches that into `result.errors[table]` as a string. This
- * lets the real-worker tests drive the pool's failure classification (and the
- * compile cascade it short-circuits) without a live remote data plane.
+ * A non-duckdb connection that RESOLVES fine but THROWS when introspecting a
+ * table schema — exercising the `fetchSchemaForTables` failure path (Malloy's
+ * `BaseConnection` catches the throw into `result.errors[table]` as a string).
+ *
+ * NOTE: this is NOT how an expired *publisher* token fails. `PublisherConnection`
+ * validates the token at `create()`/resolution time, so it fails earlier, at the
+ * connection-metadata RPC — see `buildConfigWithUnresolvableFlaky` below, which
+ * covers that path. This double covers schema-fetch; that one covers resolution.
  */
 class FlakyConnection extends BaseConnection {
    constructor(private readonly failure: Error) {
@@ -375,6 +378,99 @@ run: sales -> { group_by: item, venue; aggregate: total }`;
       } finally {
          await duckdb.close();
       }
+   });
+
+   // ───────────────────────────────────────────────────────────────
+   // Connection-RESOLUTION failures (the path real publisher connections
+   // actually take). `@malloydata/db-publisher`'s
+   // `PublisherConnection.create()` validates the token against the data
+   // plane (`getConnection` + `test`) at resolution time, so an expired
+   // token throws out of `lookupConnection` — i.e. the worker's
+   // `connection-metadata` RPC — BEFORE any `fetchSchemaForTables`.
+   // `FlakyConnection` above can't model this: it constructs synchronously
+   // and only fails at schema-fetch. These tests fail at resolution, which
+   // is where the live bug reproduces.
+   // ───────────────────────────────────────────────────────────────
+
+   /**
+    * A config whose `flaky` connection throws on RESOLUTION (not schema
+    * fetch), mirroring `PublisherConnection.create()` rejecting on a 401/5xx.
+    */
+   async function buildConfigWithUnresolvableFlaky(failure: Error): Promise<{
+      malloyConfig: import("@malloydata/malloy").MalloyConfig;
+      duckdb: { close: () => Promise<void> };
+   }> {
+      const { MalloyConfig, FixedConnectionMap } = await import(
+         "@malloydata/malloy"
+      );
+      const { DuckDBConnection } = await import("@malloydata/db-duckdb");
+      const duckdb = new DuckDBConnection("duckdb", ":memory:");
+      const base = new FixedConnectionMap(
+         new Map<string, Connection>([
+            ["duckdb", duckdb as unknown as Connection],
+         ]),
+         "duckdb",
+      );
+      const connections: LookupConnection<Connection> = {
+         lookupConnection: async (name?: string): Promise<Connection> => {
+            if (name === "flaky") throw failure;
+            return base.lookupConnection(name);
+         },
+      };
+      const malloyConfig = new MalloyConfig({ connections: {} });
+      malloyConfig.wrapConnections(() => connections);
+      return { malloyConfig, duckdb };
+   }
+
+   async function loadUnresolvablePackageExpectingRejection(
+      failure: Error,
+   ): Promise<Error> {
+      writeManifest(tempDir);
+      fs.writeFileSync(path.join(tempDir, "sales.malloy"), FLAKY_MODEL);
+      const { malloyConfig, duckdb } =
+         await buildConfigWithUnresolvableFlaky(failure);
+      try {
+         let caught: unknown;
+         try {
+            await pool.loadPackage({
+               packagePath: tempDir,
+               packageName: "pkg",
+               malloyConfig,
+               defaultConnectionName: "duckdb",
+            });
+         } catch (e) {
+            caught = e;
+         }
+         if (!(caught instanceof Error)) {
+            throw new Error("expected loadPackage to reject, but it resolved");
+         }
+         return caught;
+      } finally {
+         await duckdb.close();
+      }
+   }
+
+   it("auth failure at connection RESOLUTION (401) surfaces ONE ConnectionAuthError, not the cascade", async () => {
+      const err = await loadUnresolvablePackageExpectingRejection(
+         new Error("Request failed with status code 401"),
+      );
+      expect(err).toBeInstanceOf(ConnectionAuthError);
+      expect(err.message).toContain("flaky");
+      expect(err.message).toContain("401");
+      // Connection-level phrasing: no specific table is in hand at resolution.
+      expect(err.message).toContain("establishing the connection");
+      // The derivative cascade must NOT leak into the surfaced diagnostic.
+      expect(err.message).not.toContain("is not defined");
+      expect(err.message).not.toContain("import reference failure");
+   });
+
+   it("transport failure at connection RESOLUTION (503) surfaces ONE ConnectionError", async () => {
+      const err = await loadUnresolvablePackageExpectingRejection(
+         new Error("Request failed with status code 503"),
+      );
+      expect(err).toBeInstanceOf(ConnectionError);
+      expect(err.message).toContain("503");
+      expect(err.message).not.toContain("is not defined");
    });
 });
 

--- a/packages/server/src/package_load/package_load_pool.spec.ts
+++ b/packages/server/src/package_load/package_load_pool.spec.ts
@@ -31,6 +31,42 @@ import {
    __setPackageLoadPoolForTests,
    getPackageLoadWorkerCount,
 } from "./package_load_pool";
+import type { Connection } from "@malloydata/malloy";
+import { BaseConnection } from "@malloydata/malloy/connection";
+import { ConnectionAuthError, ConnectionError } from "../errors";
+
+/**
+ * A non-duckdb connection whose schema introspection always fails the same
+ * way `PublisherConnection` does for an expired token: it THROWS, and Malloy's
+ * `BaseConnection` catches that into `result.errors[table]` as a string. This
+ * lets the real-worker tests drive the pool's failure classification (and the
+ * compile cascade it short-circuits) without a live remote data plane.
+ */
+class FlakyConnection extends BaseConnection {
+   constructor(private readonly failure: Error) {
+      super();
+   }
+   get name(): string {
+      return "flaky";
+   }
+   get dialectName(): string {
+      // Borrow duckdb's dialect so table paths validate and the compiler can
+      // reach the schema-fetch step (where introspection then fails).
+      return "duckdb";
+   }
+   getDigest(): string {
+      return "flaky-digest";
+   }
+   async fetchTableSchema(): Promise<never> {
+      throw this.failure;
+   }
+   async fetchSelectSchema(): Promise<never> {
+      throw this.failure;
+   }
+   async runSQL(): Promise<never> {
+      throw new Error("FlakyConnection.runSQL is not used by compile tests");
+   }
+}
 
 // ──────────────────────────────────────────────────────────────────────
 // getPackageLoadWorkerCount — env var parsing
@@ -224,6 +260,118 @@ describe("PackageLoadPool (real worker)", () => {
          });
          expect(outcome.models).toHaveLength(1);
          expect(outcome.models[0].compilationError).toBeUndefined();
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   // ───────────────────────────────────────────────────────────────
+   // Connection introspection failures (the DX bug this fixes)
+   //
+   // A model that references a flaky non-duckdb connection. When schema
+   // introspection fails, the source can't resolve, so every field
+   // referencing it would normally emit its own "X is not defined" — the
+   // misleading cascade. These tests assert auth/transport failures are
+   // short-circuited into one connection error, while a genuine
+   // table-not-found is left to compile as a normal model error.
+   // ───────────────────────────────────────────────────────────────
+
+   const FLAKY_MODEL = `source: sales is flaky.table('analytics.orders') extend {
+  dimension: item is customer_id
+  dimension: venue is order_status
+  measure: total is order_total.sum()
+}
+run: sales -> { group_by: item, venue; aggregate: total }`;
+
+   async function buildConfigWithFlaky(failure: Error): Promise<{
+      malloyConfig: import("@malloydata/malloy").MalloyConfig;
+      duckdb: { close: () => Promise<void> };
+   }> {
+      const { MalloyConfig, FixedConnectionMap } = await import(
+         "@malloydata/malloy"
+      );
+      const { DuckDBConnection } = await import("@malloydata/db-duckdb");
+      const duckdb = new DuckDBConnection("duckdb", ":memory:");
+      const flaky = new FlakyConnection(failure);
+      const connections = new FixedConnectionMap(
+         new Map<string, Connection>([
+            ["duckdb", duckdb as unknown as Connection],
+            ["flaky", flaky as unknown as Connection],
+         ]),
+         "duckdb",
+      );
+      const malloyConfig = new MalloyConfig({ connections: {} });
+      malloyConfig.wrapConnections(() => connections);
+      return { malloyConfig, duckdb };
+   }
+
+   /** Load the flaky-model package and return the error it rejects with. */
+   async function loadFlakyPackageExpectingRejection(
+      failure: Error,
+   ): Promise<Error> {
+      writeManifest(tempDir);
+      fs.writeFileSync(path.join(tempDir, "sales.malloy"), FLAKY_MODEL);
+      const { malloyConfig, duckdb } = await buildConfigWithFlaky(failure);
+      try {
+         let caught: unknown;
+         try {
+            await pool.loadPackage({
+               packagePath: tempDir,
+               packageName: "pkg",
+               malloyConfig,
+               defaultConnectionName: "duckdb",
+            });
+         } catch (e) {
+            caught = e;
+         }
+         if (!(caught instanceof Error)) {
+            throw new Error("expected loadPackage to reject, but it resolved");
+         }
+         return caught;
+      } finally {
+         await duckdb.close();
+      }
+   }
+
+   it("auth failure (401) surfaces ONE ConnectionAuthError, not the cascade", async () => {
+      const err = await loadFlakyPackageExpectingRejection(
+         new Error("Request failed with status code 401"),
+      );
+      expect(err).toBeInstanceOf(ConnectionAuthError);
+      expect(err.message).toContain("flaky");
+      expect(err.message).toContain("analytics.orders");
+      expect(err.message).toContain("401");
+      // The derivative cascade must NOT leak into the surfaced diagnostic.
+      expect(err.message).not.toContain("is not defined");
+      expect(err.message).not.toContain("import reference failure");
+   });
+
+   it("transport failure (503) surfaces ONE ConnectionError", async () => {
+      const err = await loadFlakyPackageExpectingRejection(
+         new Error("Request failed with status code 503"),
+      );
+      expect(err).toBeInstanceOf(ConnectionError);
+      expect(err.message).toContain("503");
+      expect(err.message).not.toContain("is not defined");
+   });
+
+   it("not-found (404) is NOT short-circuited — normal model error preserved", async () => {
+      writeManifest(tempDir);
+      fs.writeFileSync(path.join(tempDir, "sales.malloy"), FLAKY_MODEL);
+      const { malloyConfig, duckdb } = await buildConfigWithFlaky(
+         new Error("Request failed with status code 404"),
+      );
+      try {
+         // Resolves (does NOT reject): the failure stays an in-band per-model
+         // compilation error, exactly as a genuine modeling mistake would.
+         const outcome = await pool.loadPackage({
+            packagePath: tempDir,
+            packageName: "pkg",
+            malloyConfig,
+            defaultConnectionName: "duckdb",
+         });
+         expect(outcome.models).toHaveLength(1);
+         expect(outcome.models[0].compilationError).toBeDefined();
       } finally {
          await duckdb.close();
       }

--- a/packages/server/src/package_load/package_load_pool.ts
+++ b/packages/server/src/package_load/package_load_pool.ts
@@ -681,11 +681,15 @@ export class PackageLoadPool {
       }
    }
 
-   /** Same as above for a single error string (SQL schema / thrown error). */
+   /**
+    * Same as above for a single error string (SQL schema, thrown schema
+    * fetch, or a connection-resolution failure). `target` is omitted for
+    * connection-resolution failures, where no specific table/SQL is in hand.
+    */
    private noteInfraFailureFromMessage(
       ctx: JobContext,
       connectionName: string,
-      target: string,
+      target: string | undefined,
       message: string,
    ): void {
       if (ctx.connectionFailure) return;
@@ -747,6 +751,22 @@ export class PackageLoadPool {
             },
          });
       } catch (error) {
+         // The connection can fail to RESOLVE for the same infra reasons a
+         // schema fetch can — and for some connections it fails here FIRST.
+         // `@malloydata/db-publisher`'s `PublisherConnection.create()` eagerly
+         // calls `getConnection()` + `test()` against the data plane, so an
+         // expired token (401) / unreachable plane (5xx) throws out of
+         // `lookupConnection` BEFORE any `fetchSchemaForTables`. Classify it
+         // here too, else the worker compiles on with an unresolved connection
+         // and the load resolves with the misleading "X is not defined"
+         // cascade instead of one clear connection diagnostic. No specific
+         // table is in hand yet, so the diagnostic is connection-level.
+         this.noteInfraFailureFromMessage(
+            ctx,
+            msg.connectionName,
+            undefined,
+            error instanceof Error ? error.message : String(error),
+         );
          reply({
             type: "rpc-error",
             requestId: msg.requestId,

--- a/packages/server/src/package_load/package_load_pool.ts
+++ b/packages/server/src/package_load/package_load_pool.ts
@@ -81,6 +81,12 @@ import { dirname, join } from "path";
 import { fileURLToPath, pathToFileURL } from "url";
 
 import { ModelCompilationError } from "../errors";
+import {
+   classifySchemaFetchError,
+   connectionFailureToError,
+   isInfrastructureFailure,
+   type SchemaFetchFailure,
+} from "./connection_error";
 import { logger } from "../logger";
 import type {
    ConnectionMetadataRequest,
@@ -167,6 +173,14 @@ interface JobContext {
    resolve: (result: LoadPackageResult) => void;
    reject: (err: Error) => void;
    timeout: ReturnType<typeof setTimeout>;
+   /**
+    * Set when a schema-fetch RPC for this job hit an infrastructure
+    * failure (expired token, unreachable data plane). The worker keeps
+    * compiling and returns a cascade of derivative "X is not defined"
+    * errors; `completeJob`/`errorJob` discard that and fail the load with
+    * this single connection diagnostic instead. First failure wins.
+    */
+   connectionFailure?: SchemaFetchFailure;
 }
 
 interface QueuedJob {
@@ -610,7 +624,16 @@ export class PackageLoadPool {
       if (!ctx) return;
       this.jobs.delete(msg.requestId);
       pw.inFlight.delete(msg.requestId);
-      ctx.resolve(msg);
+      if (ctx.connectionFailure) {
+         // A connection failed to introspect a schema for an infra reason
+         // (expired token, unreachable data plane). The worker compiled on
+         // anyway and the result is a cascade of derivative "X is not
+         // defined" errors that bury the real cause — discard it and fail
+         // the whole load with one clear connection diagnostic instead.
+         ctx.reject(connectionFailureToError(ctx.connectionFailure));
+      } else {
+         ctx.resolve(msg);
+      }
       // Worker is idle now — give it the next queued job (if any).
       this.tryDispatch();
    }
@@ -620,8 +643,62 @@ export class PackageLoadPool {
       if (!ctx) return;
       this.jobs.delete(msg.requestId);
       pw.inFlight.delete(msg.requestId);
-      ctx.reject(deserializeError(msg.error));
+      // Prefer a recorded connection failure: it's the root cause, whereas a
+      // whole-package error raised after a failed schema fetch is downstream.
+      ctx.reject(
+         ctx.connectionFailure
+            ? connectionFailureToError(ctx.connectionFailure)
+            : deserializeError(msg.error),
+      );
       this.tryDispatch();
+   }
+
+   /**
+    * Scan a schema-fetch `errors` map (keyed by table key) for the first
+    * infrastructure failure and record it on the job. No-op once one is
+    * recorded (first failure wins) or if every error is a genuine model
+    * problem (not_found / unrecognized), which is left to compile normally.
+    */
+   private noteInfraFailureFromErrors(
+      ctx: JobContext,
+      connectionName: string,
+      errors: Record<string, string> | undefined,
+      tables: Record<string, string>,
+   ): void {
+      if (ctx.connectionFailure || !errors) return;
+      for (const [tableKey, message] of Object.entries(errors)) {
+         const { kind, status } = classifySchemaFetchError(message);
+         if (isInfrastructureFailure(kind)) {
+            ctx.connectionFailure = {
+               kind,
+               status,
+               connection: connectionName,
+               target: tables[tableKey] ?? tableKey,
+               rawMessage: message,
+            };
+            return;
+         }
+      }
+   }
+
+   /** Same as above for a single error string (SQL schema / thrown error). */
+   private noteInfraFailureFromMessage(
+      ctx: JobContext,
+      connectionName: string,
+      target: string,
+      message: string,
+   ): void {
+      if (ctx.connectionFailure) return;
+      const { kind, status } = classifySchemaFetchError(message);
+      if (isInfrastructureFailure(kind)) {
+         ctx.connectionFailure = {
+            kind,
+            status,
+            connection: connectionName,
+            target,
+            rawMessage: message,
+         };
+      }
    }
 
    /** Fail a job out-of-band (timeout, worker exit). */
@@ -706,6 +783,16 @@ export class PackageLoadPool {
             msg.tables,
             buildFetchOptions(msg.options),
          );
+         // An expired token / unreachable data plane comes back here as a
+         // per-table error STRING (Malloy's BaseConnection catches the
+         // connection's throw into result.errors). Record it so the load
+         // fails with one clear diagnostic instead of the compile cascade.
+         this.noteInfraFailureFromErrors(
+            ctx,
+            msg.connectionName,
+            result.errors,
+            msg.tables,
+         );
          reply({
             type: "schema-for-tables-response",
             requestId: msg.requestId,
@@ -714,6 +801,14 @@ export class PackageLoadPool {
             errors: result.errors,
          });
       } catch (error) {
+         // Some connections throw straight out of fetchSchemaForTables;
+         // classify that too before forwarding the rpc-error.
+         this.noteInfraFailureFromMessage(
+            ctx,
+            msg.connectionName,
+            Object.values(msg.tables)[0] ?? "table schema",
+            error instanceof Error ? error.message : String(error),
+         );
          reply({
             type: "rpc-error",
             requestId: msg.requestId,
@@ -753,6 +848,14 @@ export class PackageLoadPool {
             buildFetchOptions(msg.options),
          );
          if (result.error !== undefined) {
+            // SQL-source introspection (`conn.sql(...)`) fails the same lossy
+            // way as table introspection — classify before it cascades.
+            this.noteInfraFailureFromMessage(
+               ctx,
+               msg.connectionName,
+               sqlTargetLabel(msg.sentence),
+               result.error,
+            );
             reply({
                type: "schema-for-sql-response",
                requestId: msg.requestId,
@@ -768,6 +871,12 @@ export class PackageLoadPool {
             });
          }
       } catch (error) {
+         this.noteInfraFailureFromMessage(
+            ctx,
+            msg.connectionName,
+            sqlTargetLabel(msg.sentence),
+            error instanceof Error ? error.message : String(error),
+         );
          reply({
             type: "rpc-error",
             requestId: msg.requestId,
@@ -812,6 +921,21 @@ export class PackageLoadPool {
          });
       }
    }
+}
+
+/**
+ * A short, human-readable label for an inline SQL source, used in the
+ * connection diagnostic. The full SELECT can be huge; collapse whitespace
+ * and truncate so the message stays a single readable line.
+ */
+function sqlTargetLabel(sentence: unknown): string {
+   const selectStr = (sentence as { selectStr?: unknown } | null | undefined)
+      ?.selectStr;
+   if (typeof selectStr === "string" && selectStr.trim().length > 0) {
+      const oneLine = selectStr.replace(/\s+/g, " ").trim();
+      return `SQL query (${oneLine.length > 60 ? `${oneLine.slice(0, 57)}...` : oneLine})`;
+   }
+   return "an inline SQL query";
 }
 
 function buildFetchOptions(options: {

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -23,6 +23,8 @@ import {
    PACKAGE_MANIFEST_NAME,
 } from "../constants";
 import {
+   ConnectionAuthError,
+   ConnectionError,
    ModelCompilationError,
    PackageNotFoundError,
    ServiceUnavailableError,
@@ -287,9 +289,11 @@ export class Package {
             // (shutting down, worker spawn failed, worker crashed,
             // RPC timeout) and the client should retry. Real Malloy
             // compile errors deserialised by the pool still carry
-            // their MalloyError / ModelCompilationError identity —
-            // let those bubble untouched so they keep their 4xx
-            // mapping in `errors.ts`.
+            // their MalloyError / ModelCompilationError identity, and a
+            // schema-introspection auth/transport failure surfaces as a
+            // ConnectionAuthError / ConnectionError — let all of those
+            // bubble untouched so they keep their 4xx/5xx mapping in
+            // `errors.ts` (424 / 422 / 502), not a misleading 503.
             const realError =
                err instanceof Error
                   ? err
@@ -298,7 +302,9 @@ export class Package {
                     );
             if (
                realError instanceof MalloyError ||
-               realError instanceof ModelCompilationError
+               realError instanceof ModelCompilationError ||
+               realError instanceof ConnectionAuthError ||
+               realError instanceof ConnectionError
             ) {
                throw realError;
             }
@@ -684,7 +690,9 @@ export class Package {
                : new Error(`Package-load worker pool failure: ${String(err)}`);
          if (
             realError instanceof MalloyError ||
-            realError instanceof ModelCompilationError
+            realError instanceof ModelCompilationError ||
+            realError instanceof ConnectionAuthError ||
+            realError instanceof ConnectionError
          ) {
             throw realError;
          }


### PR DESCRIPTION

## Summary

When a connection fails to introspect a schema for an **infrastructure** reason —
an expired/invalid token (HTTP 401/403) or an unreachable/timing-out data plane
(5xx / network / timeout) — Publisher surfaced it as a **cascade of Malloy
compile errors** (`import reference failure` + dozens of `'X' is not defined`).
That sends developers (or their agents) to debug their `.malloy` model when the real cause is the
connection. This PR classifies such failures during package load and fails with a
**single, accurate connection diagnostic** instead — while leaving genuine model
errors (and real "table not found") untouched.

## Before

A package whose source references a connection with an expired token fails to load with:

HTTP 424
Error(s) compiling model:
line 4: import reference failure
line 5: 'customer_id' is not defined
line 6: 'order_total' is not defined
line 7: Reference to undefined value revenue
... (one per field referencing the unresolved source)



Nothing here names the connection, the status, or the fact that a token expired.

## Root cause

Two-stage information loss:

1. **The connection layer flattens the error.** `@malloydata/db-publisher`'s
   `PublisherConnection` collapses an `AxiosError` to a bare
   `Error("Request failed with status code 401")` — no status, connection, table,
   or auth-vs-not-found signal.
2. **Malloy turns that into a cascade.** A failed table/SQL introspection leaves
   `conn.table(...)` unresolved, so the source and every field referencing it emit
   their own `"X is not defined"`.

Two findings that shaped the fix (both verified empirically):

- **Throwing from the connection does not abort the compile** — Malloy catches it
  internally and still produces the full cascade. The failure must be
  short-circuited on the main thread, before the worker's result is consumed.
- **A real expired token fails at connection *resolution*, not schema-fetch.**
  `PublisherConnection.create()` validates the token eagerly (`getConnection()` +
  `test()`), so the 401 throws out of `lookupConnection` — the worker's
  `connection-metadata` RPC — *before* any `fetchSchemaForTables`.

## The fix

- **New classifier** (`connection_error.ts`): maps a flattened error string to
  `auth` / `transport` / `not_found` / `other` (HTTP-status-first, with
  network/timeout keyword fallback) and builds a developer-facing diagnostic.
- **Short-circuit in the package-load pool**: records the first `auth`/`transport`
  failure across all three introspection RPC handlers — `handleSchemaForTables`,
  `handleSchemaForSql`, **and** `handleConnectionMetadata` (the resolution path) —
  covering both the per-table `errors` map and thrown-error paths. The load then
  fails with one typed error instead of resolving the cascade.
- **Typed errors, existing HTTP mapping**: `auth → ConnectionAuthError` (422),
  `transport → ConnectionError` (502). `Package.loadViaWorker` / `reloadAllModels`
  let these bubble through with their 4xx/5xx mapping instead of rewrapping as 503.
- **Genuine model errors preserved**: `not_found` (404 / "table does not exist")
  and anything unclassified are **not** short-circuited — they still compile to
  normal Malloy diagnostics.

## After

HTTP 422
Connection "prod_warehouse" returned 401 Unauthorized while establishing the
connection. The access token is likely expired or invalid; refresh the connection
and reload. This is a connection problem, not an error in your Malloy model
(underlying error: Request failed with status code 401).



## Testing

- Unit tests for the classifier (401/403/404/5xx/408, raw network/timeout,
  keyword fallbacks, connection-level vs table-level phrasing).
- Real-worker integration tests covering both the schema-fetch path and the
  connection-resolution path, for `auth` (→ one `ConnectionAuthError`, no cascade)
  and `transport` (→ one `ConnectionError`); `not_found` (404) asserted to remain
  a normal in-band per-model compile error. The resolution-path tests were
  confirmed **non-vacuous** (they fail without the fix).
- Verified end-to-end against a live publisher-type proxy connection with an
  invalid token: branch-before returned the 424 cascade; branch-after returns the
  single 422 diagnostic above.
- Full server unit suite green; lint and production build clean.

## Follow-ups (next steps)

This PR makes the failure **legible**; it does not reduce how often it happens.
The most common trigger — a token that aged out — is best removed by the next two
changes, which this PR is a prerequisite for (they previously presented *as* a
model cascade and so were hard to even identify as connection problems):

1. **Evict the stale connection/token cache.** Publisher persists the built
   connection — token and all — under `publisher_data/` and reuses it across
   restarts, so injecting a fresh token and reloading can keep using the expired
   one until `publisher_data/` is cleared. This makes the "refresh the connection
   and reload" remediation in the new diagnostic only partially effective today.
   Next PR: reconcile/evict the persisted connection on reload so a config token
   change actually takes effect.
2. **Token auto-refresh.** Tokens are short-lived and don't refresh on their own
   (a window reload/re-login doesn't refresh the connection's token either). The
   connection/credential layer that owns the token should refresh it proactively
   so the expired-token case largely stops occurring. Separate layer/repo from
   this server-side fix.

## Out of scope (this PR)

- The ideal upstream fix — a typed error from `@malloydata/db-publisher` carrying
  `{ status, kind }` — lives in a separate repo; this PR classifies server-side
  from the (status-bearing) error string.
- Grouping derivative `"not defined"` errors under the root cause for
  *unclassified* connection failures (defense-in-depth).

## Compatibility / risk

No behavior change for other connection types (BigQuery, DuckDB, Postgres, …) on
success, and genuine model/compile errors are unchanged — only infrastructure
auth/transport failures are short-circuited.