### PR TITLE
fix(server): list project-qualified BigQuery datasets so the orphan sweep can reclaim them

### DIFF
--- a/packages/server/src/service/db_utils.spec.ts
+++ b/packages/server/src/service/db_utils.spec.ts
@@ -7,8 +7,16 @@ mock.module("@azure/identity", () => ({
 mock.module("@azure/storage-blob", () => ({
    ContainerClient: class {},
 }));
+// Records bigquery.dataset() calls so tests can assert how a (possibly
+// project-qualified) schema name is split into datasetId + projectId.
+const bqDatasetCalls: Array<{ id: string; options?: unknown }> = [];
 mock.module("@google-cloud/bigquery", () => ({
-   BigQuery: class {},
+   BigQuery: class {
+      dataset(id: string, options?: unknown) {
+         bqDatasetCalls.push({ id, options });
+         return { getTables: async () => [[]] };
+      }
+   },
 }));
 
 import { Connection } from "@malloydata/malloy";
@@ -1029,5 +1037,49 @@ describe("publisher proxy introspection", () => {
       await expect(getSchemasForConnection(conn, noConn)).rejects.toThrow(
          'failed for connection "analytics": ECONNREFUSED',
       );
+   });
+});
+
+// ---------------------------------------------------------------------------
+// listTablesForSchema — bigquery (project-qualified dataset)
+// ---------------------------------------------------------------------------
+describe("listTablesForSchema bigquery", () => {
+   const bqConnection = {
+      name: "bq",
+      type: "bigquery",
+      bigqueryConnection: {
+         defaultProjectId: "default-proj",
+         serviceAccountKeyJson: JSON.stringify({ project_id: "default-proj" }),
+      },
+   } as unknown as ApiConnection;
+   const malloyConn = {} as unknown as Connection;
+
+   it("splits a project-qualified schema into a bare dataset id + projectId", async () => {
+      bqDatasetCalls.length = 0;
+      await listTablesForSchema(bqConnection, "myproj.myds", malloyConn);
+      expect(bqDatasetCalls).toHaveLength(1);
+      expect(bqDatasetCalls[0]?.id).toBe("myds");
+      expect(bqDatasetCalls[0]?.options).toEqual({ projectId: "myproj" });
+   });
+
+   it("splits on the last dot so domain-scoped project ids survive", async () => {
+      bqDatasetCalls.length = 0;
+      await listTablesForSchema(
+         bqConnection,
+         "domain.com:proj.myds",
+         malloyConn,
+      );
+      expect(bqDatasetCalls[0]?.id).toBe("myds");
+      expect(bqDatasetCalls[0]?.options).toEqual({
+         projectId: "domain.com:proj",
+      });
+   });
+
+   it("passes a bare dataset name through unqualified", async () => {
+      bqDatasetCalls.length = 0;
+      await listTablesForSchema(bqConnection, "myds", malloyConn);
+      expect(bqDatasetCalls).toHaveLength(1);
+      expect(bqDatasetCalls[0]?.id).toBe("myds");
+      expect(bqDatasetCalls[0]?.options).toBeUndefined();
    });
 });

--- a/packages/server/src/service/db_utils.ts
+++ b/packages/server/src/service/db_utils.ts
@@ -1077,7 +1077,20 @@ async function listTablesForBigQuery(
 ): Promise<ApiTable[]> {
    try {
       const bigquery = createBigQueryClient(connection);
-      const dataset = bigquery.dataset(schemaName);
+      // A 3-segment table reference ("project.dataset.table") reaches here with a
+      // project-qualified schema ("project.dataset"). bigquery.dataset() takes a
+      // BARE dataset id plus an optional projectId, so passing "project.dataset" as
+      // the id resolves to a non-existent dataset in the client's default project —
+      // the dataset's tables never list, so the orphan sweep can't see (and reclaim)
+      // those tables. Split the project off the last dot. (Domain-scoped project ids
+      // like "domain.com:project" keep their dots/colon since we split on the last.)
+      const lastDot = schemaName.lastIndexOf(".");
+      const dataset =
+         lastDot === -1
+            ? bigquery.dataset(schemaName)
+            : bigquery.dataset(schemaName.slice(lastDot + 1), {
+                 projectId: schemaName.slice(0, lastDot),
+              });
       const [tables] = await dataset.getTables();
 
       let names = tables


### PR DESCRIPTION
## Problem
`listTablesForBigQuery` passed a project-qualified schema (`project.dataset`, from a 3-segment table reference) straight to `bigquery.dataset()`, which takes a **bare** dataset id plus an optional `projectId`. The whole string resolved to a non-existent dataset in the client's default project, so the dataset's tables never listed — and the control plane's orphan sweep could not see (or reclaim) materialized tables living there.

## Fix
Split the project off the **last** dot and pass it via `{ projectId }` (domain-scoped ids like `domain.com:project` survive since we split on the last dot). Bare dataset names are unchanged.

## Tests
Adds bigquery cases to the `db_utils` unit tests (project-qualified split, domain-scoped project id, bare passthrough). `bun test src/service/db_utils.spec.ts` → 61 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)