### PR TITLE
feat(server): manifest-driven freshness gating for persisted sources

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -2507,6 +2507,41 @@ components:
             5-field UNIX cron controlling how often the control plane
             re-materializes this package's published versions. Null/absent = no
             scheduled re-materialization (publish / on-demand only).
+        freshness:
+          oneOf:
+            - $ref: "#/components/schemas/MaterializationFreshnessConfig"
+            - type: "null"
+          description: |
+            Staleness policy. The control plane threads it (resolved to seconds)
+            plus each serving table's build time into the build manifest; the
+            publisher evaluates it when it binds the manifest (package load /
+            reload), re-evaluating on the next rebind rather than per query.
+            Null/absent = no freshness gate (serve the materialized table
+            whenever one exists).
+
+    MaterializationFreshnessConfig:
+      type: object
+      description: >-
+        Freshness gate for a package's persisted sources, applied when the
+        publisher binds the build manifest. A source's materialized table backs
+        queries only while it was younger than `window` at bind time; once
+        older, `fallback` decides what the binding does.
+      properties:
+        window:
+          type: ["string", "null"]
+          description: >-
+            Maximum age a materialized table may have at manifest bind time to
+            stay bound, as a duration with a unit suffix (`s`/`m`/`h`/`d`, e.g.
+            `24h`, `7d`, `30m`). Null/absent = no window (never considered
+            stale).
+        fallback:
+          type: ["string", "null"]
+          description: >-
+            What the binding does when the materialized table is older than
+            `window` at bind time: `live` (default) drops the binding so queries
+            run live against the base tables; `stale_ok` keeps the stale table
+            bound; `fail` is treated like `live` today (the bound model has no
+            per-query error hook). Null/absent defaults to `live`.
 
     Model:
       type: object
@@ -3825,6 +3860,34 @@ components:
           $ref: "#/components/schemas/Realization"
         rowCount:
           type: ["integer", "null"]
+        builtAt:
+          type: ["string", "null"]
+          format: date-time
+          description: >-
+            When this table's data was built (the materialized table's create
+            time). The publisher uses it as the freshness clock when it binds the
+            manifest: the table is bound only while
+            `bindTime - builtAt <= freshnessWindowSeconds`. Null = no freshness
+            clock (treated as never stale).
+        freshnessWindowSeconds:
+          type: ["integer", "null"]
+          description: >-
+            Maximum age in seconds the table may have at manifest bind time
+            before it is considered stale (from the package's
+            materialization.freshness window). Null/absent = no freshness gate
+            (always bind).
+        freshnessFallback:
+          type: string
+          enum: [live, stale_ok, fail]
+          description: >-
+            What the binding does when this table is older than
+            `freshnessWindowSeconds` at bind time: `live` (default) drops the
+            binding so queries run live, `stale_ok` keeps the stale table bound,
+            `fail` is treated like `live` today (the bound model has no per-query
+            error hook). Absent defaults to `live`. Ignored when
+            `freshnessWindowSeconds` is null. Always one of the three values —
+            the control plane resolves the package config to a valid fallback
+            before writing the manifest.
 
   parameters:
     environmentName:

--- a/packages/server/src/materialization_metrics.spec.ts
+++ b/packages/server/src/materialization_metrics.spec.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
    recordConnectionDigestSkipped,
    recordDropTables,
+   recordManifestStaleEntry,
    recordMaterializationRun,
    recordSourcesOutcome,
    resetMaterializationTelemetryForTesting,
@@ -78,6 +79,25 @@ describe("materialization_metrics", () => {
       expect(
          await harness.collectCounter(
             "publisher_materialization_connection_digest_skipped_total",
+         ),
+      ).toBe(1);
+   });
+
+   it("counts stale manifest entries labeled by fallback", async () => {
+      recordManifestStaleEntry("live");
+      recordManifestStaleEntry("live");
+      recordManifestStaleEntry("fail");
+
+      expect(
+         await harness.collectCounter(
+            "publisher_materialization_manifest_stale_entries_total",
+            { fallback: "live" },
+         ),
+      ).toBe(2);
+      expect(
+         await harness.collectCounter(
+            "publisher_materialization_manifest_stale_entries_total",
+            { fallback: "fail" },
          ),
       ).toBe(1);
    });

--- a/packages/server/src/materialization_metrics.ts
+++ b/packages/server/src/materialization_metrics.ts
@@ -78,6 +78,10 @@ const manifestBindCounter = lazyCounter(
    "publisher_materialization_manifest_bind_total",
    "Manifest bind attempts. Label: outcome ('success'|'failure'|'timeout').",
 );
+const manifestStaleEntryCounter = lazyCounter(
+   "publisher_materialization_manifest_stale_entries_total",
+   "Materialized tables dropped from a bind because they were stale (older than the freshness window), so the source serves live. Label: fallback ('live'|'fail').",
+);
 const sourceBuildDuration = lazyHistogram(
    "publisher_materialization_source_build_duration_ms",
    "Wall-clock duration of building a single persist source.",
@@ -145,6 +149,17 @@ export function recordConnectionDigestSkipped(): void {
  */
 export function recordManifestBind(outcome: ManifestBindOutcome): void {
    manifestBindCounter().add(1, { outcome });
+}
+
+/**
+ * Record a materialized table dropped from a bind because it was stale, so the
+ * source falls back to serving live. The key operational signal that a package
+ * is serving live despite a materialized table existing; `fallback` separates
+ * the configured `live` policy from a `fail` policy that can't yet error per
+ * query and so degrades to live.
+ */
+export function recordManifestStaleEntry(fallback: "live" | "fail"): void {
+   manifestStaleEntryCounter().add(1, { fallback });
 }
 
 /** Record the wall-clock duration of building one persist source's table. */

--- a/packages/server/src/package_load/package_load_pool.spec.ts
+++ b/packages/server/src/package_load/package_load_pool.spec.ts
@@ -175,6 +175,39 @@ describe("PackageLoadPool (real worker)", () => {
       }
    });
 
+   it("carries the package materialization config (schedule + freshness) across the worker boundary", async () => {
+      fs.writeFileSync(
+         path.join(tempDir, "publisher.json"),
+         JSON.stringify({
+            name: "pkg",
+            materialization: {
+               schedule: "0 6 * * *",
+               freshness: { window: "24h", fallback: "stale_ok" },
+            },
+         }),
+      );
+      fs.writeFileSync(
+         path.join(tempDir, "trivial.malloy"),
+         `source: nums is duckdb.sql("select 1 as a")`,
+      );
+
+      const { malloyConfig, duckdb } = await buildConfig();
+      try {
+         const outcome = await pool.loadPackage({
+            packagePath: tempDir,
+            packageName: "pkg",
+            malloyConfig,
+            defaultConnectionName: "duckdb",
+         });
+         expect(outcome.packageMetadata.materialization).toEqual({
+            schedule: "0 6 * * *",
+            freshness: { window: "24h", fallback: "stale_ok" },
+         });
+      } finally {
+         await duckdb.close();
+      }
+   });
+
    it("propagates a per-model compile failure in-band (not as a rejected Promise)", async () => {
       writeManifest(tempDir);
       fs.writeFileSync(

--- a/packages/server/src/package_load/package_load_pool.ts
+++ b/packages/server/src/package_load/package_load_pool.ts
@@ -99,6 +99,7 @@ import type {
    SerializedModel,
    WorkerToMainMessage,
 } from "./protocol";
+import type { PackageMaterializationConfig } from "../service/package_manifest";
 
 // ──────────────────────────────────────────────────────────────────────
 // Configuration
@@ -233,7 +234,7 @@ export interface LoadPackageOutcome {
       explores?: string[];
       queryableSources?: "declared" | "all";
       manifestLocation?: string | null;
-      materialization?: { schedule: string | null } | null;
+      materialization?: PackageMaterializationConfig | null;
    };
    models: Array<
       Omit<SerializedModel, "modelDef" | "sourceInfos"> & {

--- a/packages/server/src/package_load/package_load_worker.ts
+++ b/packages/server/src/package_load/package_load_worker.ts
@@ -83,7 +83,10 @@ import { HackyDataStylesAccumulator } from "../data_styles";
 import { ModelCompilationError } from "../errors";
 import { validateAuthorizeProbes } from "../service/authorize";
 import { type FilterDefinition } from "../service/filter";
-import { parsePackageMaterialization } from "../service/package_manifest";
+import {
+   parsePackageMaterialization,
+   type PackageMaterializationConfig,
+} from "../service/package_manifest";
 import {
    extractQueriesFromModelDef,
    extractSourcesFromModelDef,
@@ -383,7 +386,7 @@ async function readPackageMetadata(packagePath: string): Promise<{
    explores?: string[];
    queryableSources?: "declared" | "all";
    manifestLocation?: string | null;
-   materialization?: { schedule: string | null } | null;
+   materialization?: PackageMaterializationConfig | null;
 }> {
    const manifestPath = path.join(packagePath, PACKAGE_MANIFEST_NAME);
    const contents = await fs.promises.readFile(manifestPath, "utf8");
@@ -410,8 +413,8 @@ async function readPackageMetadata(packagePath: string): Promise<{
          typeof parsed.manifestLocation === "string"
             ? parsed.manifestLocation
             : null,
-      // Package-level Malloy Persistence policy; surfaced to the control plane,
-      // which owns scheduling. Only `schedule` is read today.
+      // Package-level Malloy Persistence policy (schedule + freshness),
+      // surfaced verbatim to the control plane, which owns scheduling.
       materialization: parsePackageMaterialization(parsed.materialization),
    };
 }

--- a/packages/server/src/package_load/protocol.ts
+++ b/packages/server/src/package_load/protocol.ts
@@ -65,6 +65,7 @@
  */
 
 import type { SQLSourceDef, TableSourceDef } from "@malloydata/malloy";
+import type { PackageMaterializationConfig } from "../service/package_manifest";
 
 // ──────────────────────────────────────────────────────────────────────
 // Direction: main ──▶ worker (load-package job)
@@ -179,7 +180,7 @@ export interface LoadPackageResult {
       explores?: string[];
       queryableSources?: "declared" | "all";
       manifestLocation?: string | null;
-      materialization?: { schedule: string | null } | null;
+      materialization?: PackageMaterializationConfig | null;
    };
    models: SerializedModel[];
    /** Wall-clock ms inside the worker for the full package load. */

--- a/packages/server/src/service/manifest_loader.spec.ts
+++ b/packages/server/src/service/manifest_loader.spec.ts
@@ -5,7 +5,10 @@ import * as fs from "fs/promises";
 import os from "os";
 import path from "path";
 import { pathToFileURL } from "url";
-import { fetchManifestEntries } from "./manifest_loader";
+import {
+   evaluateManifestFreshness,
+   fetchManifestEntries,
+} from "./manifest_loader";
 
 describe("fetchManifestEntries", () => {
    let dir: string;
@@ -95,5 +98,172 @@ describe("fetchManifestEntries", () => {
       await expect(fetchManifestEntries("gs://bucket-only")).rejects.toThrow(
          /Malformed manifest URI/,
       );
+   });
+
+   const hoursAgo = (h: number): string =>
+      new Date(Date.now() - h * 3_600_000).toISOString();
+
+   it("binds a fresh table within its freshness window", async () => {
+      const file = await writeManifest({
+         entries: {
+            b1: {
+               buildId: "b1",
+               physicalTableName: "t_fresh",
+               builtAt: hoursAgo(1),
+               freshnessWindowSeconds: 24 * 3600,
+               freshnessFallback: "live",
+            },
+         },
+      });
+
+      expect(await fetchManifestEntries(file)).toEqual({
+         b1: { tableName: "t_fresh" },
+      });
+   });
+
+   it("drops a stale table when the fallback is live (serve live)", async () => {
+      const file = await writeManifest({
+         entries: {
+            b1: {
+               buildId: "b1",
+               physicalTableName: "t_stale",
+               builtAt: hoursAgo(48),
+               freshnessWindowSeconds: 24 * 3600,
+               freshnessFallback: "live",
+            },
+         },
+      });
+
+      expect(await fetchManifestEntries(file)).toEqual({});
+   });
+
+   it("keeps a stale table when the fallback is stale_ok", async () => {
+      const file = await writeManifest({
+         entries: {
+            b1: {
+               buildId: "b1",
+               physicalTableName: "t_stale_ok",
+               builtAt: hoursAgo(48),
+               freshnessWindowSeconds: 24 * 3600,
+               freshnessFallback: "stale_ok",
+            },
+         },
+      });
+
+      expect(await fetchManifestEntries(file)).toEqual({
+         b1: { tableName: "t_stale_ok" },
+      });
+   });
+
+   it("drops a stale table when the fallback is fail", async () => {
+      const file = await writeManifest({
+         entries: {
+            b1: {
+               buildId: "b1",
+               physicalTableName: "t_fail",
+               builtAt: hoursAgo(48),
+               freshnessWindowSeconds: 24 * 3600,
+               freshnessFallback: "fail",
+            },
+         },
+      });
+
+      // A stale `fail` source drops its binding (serves live) rather than
+      // serving stale data; per-query erroring needs Malloy-runtime support.
+      expect(await fetchManifestEntries(file)).toEqual({});
+   });
+
+   it("binds when no freshness window is configured (today's behavior)", async () => {
+      const file = await writeManifest({
+         entries: {
+            b1: {
+               buildId: "b1",
+               physicalTableName: "t_ungated",
+               builtAt: hoursAgo(1000),
+            },
+         },
+      });
+
+      expect(await fetchManifestEntries(file)).toEqual({
+         b1: { tableName: "t_ungated" },
+      });
+   });
+});
+
+describe("evaluateManifestFreshness", () => {
+   const now = new Date("2026-06-27T12:00:00Z");
+   const builtAt = (secondsAgo: number): string =>
+      new Date(now.getTime() - secondsAgo * 1000).toISOString();
+
+   it("serves the table when no window is set", () => {
+      expect(evaluateManifestFreshness({ builtAt: builtAt(10_000) }, now)).toBe(
+         "serve_table",
+      );
+   });
+
+   it("serves the table when within the window", () => {
+      expect(
+         evaluateManifestFreshness(
+            { builtAt: builtAt(100), freshnessWindowSeconds: 3600 },
+            now,
+         ),
+      ).toBe("serve_table");
+   });
+
+   it("serves live when stale and fallback is live (default)", () => {
+      expect(
+         evaluateManifestFreshness(
+            { builtAt: builtAt(7200), freshnessWindowSeconds: 3600 },
+            now,
+         ),
+      ).toBe("serve_live");
+      expect(
+         evaluateManifestFreshness(
+            {
+               builtAt: builtAt(7200),
+               freshnessWindowSeconds: 3600,
+               freshnessFallback: "live",
+            },
+            now,
+         ),
+      ).toBe("serve_live");
+   });
+
+   it("serves the table when stale and fallback is stale_ok", () => {
+      expect(
+         evaluateManifestFreshness(
+            {
+               builtAt: builtAt(7200),
+               freshnessWindowSeconds: 3600,
+               freshnessFallback: "stale_ok",
+            },
+            now,
+         ),
+      ).toBe("serve_table");
+   });
+
+   it("fails when stale and fallback is fail", () => {
+      expect(
+         evaluateManifestFreshness(
+            {
+               builtAt: builtAt(7200),
+               freshnessWindowSeconds: 3600,
+               freshnessFallback: "fail",
+            },
+            now,
+         ),
+      ).toBe("fail");
+   });
+
+   it("fails open (serve_table) for a missing or unparseable builtAt", () => {
+      expect(
+         evaluateManifestFreshness({ freshnessWindowSeconds: 3600 }, now),
+      ).toBe("serve_table");
+      expect(
+         evaluateManifestFreshness(
+            { builtAt: "not-a-date", freshnessWindowSeconds: 3600 },
+            now,
+         ),
+      ).toBe("serve_table");
    });
 });

--- a/packages/server/src/service/manifest_loader.ts
+++ b/packages/server/src/service/manifest_loader.ts
@@ -7,6 +7,65 @@ import { logger } from "../logger";
 import { BuildManifest } from "../storage/DatabaseInterface";
 
 type WireBuildManifest = components["schemas"]["BuildManifest"];
+type WireManifestEntry = components["schemas"]["ManifestEntry"];
+
+/**
+ * What the manifest binding should do with a persist source's materialized
+ * table. Decided when the publisher (re)binds the manifest (package load /
+ * reload), not per query — the table substitution is compiled into the model at
+ * bind time, so the decision stands until the next rebind. The gate comes from
+ * `materialization.freshness`, threaded by the control plane onto each entry as
+ * `builtAt` + `freshnessWindowSeconds` + `freshnessFallback`:
+ *   - `serve_table`: the table is fresh (or un-gated) — bind it.
+ *   - `serve_live`: the table is stale and the policy is `live` — drop the
+ *     binding so the source serves live.
+ *   - `fail`: the table is stale and the policy is `fail`. The bound model has
+ *     no per-query error hook, so the binding is still dropped (serve live);
+ *     the value is kept distinct only for logging and for if/when the Malloy
+ *     runtime gains a query-time error hook.
+ */
+export type FreshnessDecision = "serve_table" | "serve_live" | "fail";
+
+/**
+ * Evaluate an entry's freshness against `now` (the bind timestamp). Best-effort
+ * and fail-open: a missing window, missing/unparseable `builtAt`, or unknown
+ * fallback resolves to `serve_table` so a malformed gate never blocks serving.
+ * A stale table applies its fallback (default `live`).
+ */
+export function evaluateManifestFreshness(
+   entry: Pick<
+      WireManifestEntry,
+      "builtAt" | "freshnessWindowSeconds" | "freshnessFallback"
+   >,
+   now: Date,
+): FreshnessDecision {
+   const windowSeconds = entry.freshnessWindowSeconds;
+   // No gate configured -> always serve the table (today's behavior).
+   if (windowSeconds == null || windowSeconds <= 0) {
+      return "serve_table";
+   }
+   if (!entry.builtAt) {
+      return "serve_table";
+   }
+   const builtAtMs = Date.parse(entry.builtAt);
+   if (Number.isNaN(builtAtMs)) {
+      return "serve_table";
+   }
+   const ageSeconds = (now.getTime() - builtAtMs) / 1000;
+   if (ageSeconds <= windowSeconds) {
+      return "serve_table";
+   }
+   // Stale: apply the fallback (default live).
+   switch ((entry.freshnessFallback ?? "live").toLowerCase()) {
+      case "stale_ok":
+         return "serve_table";
+      case "fail":
+         return "fail";
+      case "live":
+      default:
+         return "serve_live";
+   }
+}
 
 // Lazily-created clients reused across fetches. Both use the ambient credential
 // chain (ADC for GCS; the default provider chain for S3) — the same auth the
@@ -79,6 +138,7 @@ export async function fetchManifestEntries(
       );
    }
 
+   const now = new Date();
    const entries: BuildManifest["entries"] = {};
    for (const [buildId, entry] of Object.entries(parsed.entries ?? {})) {
       const physicalTableName = entry?.physicalTableName;
@@ -89,7 +149,29 @@ export async function fetchManifestEntries(
          });
          continue;
       }
-      entries[buildId] = { tableName: physicalTableName };
+      // Freshness gate, evaluated at (re)bind time: a stale table is dropped
+      // from the binding so the source serves live (Malloy serves live for any
+      // buildId absent from the manifest, since we bind with strict:false).
+      // `stale_ok` keeps the binding. A fresh or un-gated entry binds as before.
+      // The gate is not re-checked per query — only on the next rebind.
+      const decision = evaluateManifestFreshness(entry, now);
+      if (decision === "serve_table") {
+         entries[buildId] = { tableName: physicalTableName };
+         continue;
+      }
+      // `fail` has no per-query enforcement point (the table substitution is
+      // compiled into the model at bind time), so a stale `fail` source drops
+      // its binding and serves live rather than serving stale data; per-query
+      // erroring would need Malloy-runtime support. `live` and `fail` therefore
+      // both drop the binding, differing only in the log.
+      logger.info("Manifest entry is stale; dropping binding (serving live)", {
+         uri,
+         buildId,
+         physicalTableName,
+         freshnessFallback: entry.freshnessFallback ?? "live",
+         builtAt: entry.builtAt ?? null,
+         freshnessWindowSeconds: entry.freshnessWindowSeconds ?? null,
+      });
    }
    return entries;
 }

--- a/packages/server/src/service/manifest_loader.ts
+++ b/packages/server/src/service/manifest_loader.ts
@@ -4,6 +4,7 @@ import * as fs from "fs/promises";
 import { fileURLToPath } from "url";
 import { components } from "../api";
 import { logger } from "../logger";
+import { recordManifestStaleEntry } from "../materialization_metrics";
 import { BuildManifest } from "../storage/DatabaseInterface";
 
 type WireBuildManifest = components["schemas"]["BuildManifest"];
@@ -163,12 +164,16 @@ export async function fetchManifestEntries(
       // compiled into the model at bind time), so a stale `fail` source drops
       // its binding and serves live rather than serving stale data; per-query
       // erroring would need Malloy-runtime support. `live` and `fail` therefore
-      // both drop the binding, differing only in the log.
-      logger.info("Manifest entry is stale; dropping binding (serving live)", {
+      // both drop the binding, differing only in the metric label.
+      const fallback = decision === "fail" ? "fail" : "live";
+      recordManifestStaleEntry(fallback);
+      // Per-entry detail at debug to keep a large stale manifest from flooding
+      // info logs on every bind; the counter is the operational signal.
+      logger.debug("Manifest entry is stale; dropping binding (serving live)", {
          uri,
          buildId,
          physicalTableName,
-         freshnessFallback: entry.freshnessFallback ?? "live",
+         freshnessFallback: fallback,
          builtAt: entry.builtAt ?? null,
          freshnessWindowSeconds: entry.freshnessWindowSeconds ?? null,
       });

--- a/packages/server/src/service/package_manifest.spec.ts
+++ b/packages/server/src/service/package_manifest.spec.ts
@@ -5,7 +5,7 @@ describe("service/package_manifest", () => {
    describe("parsePackageMaterialization", () => {
       it("extracts a string schedule", () => {
          expect(parsePackageMaterialization({ schedule: "0 6 * * *" })).toEqual(
-            { schedule: "0 6 * * *" },
+            { schedule: "0 6 * * *", freshness: null },
          );
       });
 
@@ -14,20 +14,45 @@ describe("service/package_manifest", () => {
          expect(parsePackageMaterialization(null)).toBeNull();
       });
 
+      it("extracts the freshness window and fallback", () => {
+         expect(
+            parsePackageMaterialization({
+               schedule: "*/15 * * * *",
+               freshness: { window: "24h", fallback: "stale_ok" },
+            }),
+         ).toEqual({
+            schedule: "*/15 * * * *",
+            freshness: { window: "24h", fallback: "stale_ok" },
+         });
+      });
+
+      it("defaults the freshness fallback to null when absent", () => {
+         expect(
+            parsePackageMaterialization({ freshness: { window: "7d" } }),
+         ).toEqual({ schedule: null, freshness: { window: "7d", fallback: null } });
+      });
+
       it("ignores extra/unknown fields", () => {
          expect(
             parsePackageMaterialization({
                schedule: "*/15 * * * *",
-               freshness: { window: "24h" },
+               somethingElse: true,
             }),
-         ).toEqual({ schedule: "*/15 * * * *" });
+         ).toEqual({ schedule: "*/15 * * * *", freshness: null });
       });
 
-      it("degrades a non-string schedule to null", () => {
+      it("degrades non-string leaf values to null", () => {
          expect(parsePackageMaterialization({ schedule: 42 })).toEqual({
             schedule: null,
+            freshness: null,
          });
-         expect(parsePackageMaterialization({})).toEqual({ schedule: null });
+         expect(parsePackageMaterialization({})).toEqual({
+            schedule: null,
+            freshness: null,
+         });
+         expect(
+            parsePackageMaterialization({ freshness: { window: 1, fallback: 2 } }),
+         ).toEqual({ schedule: null, freshness: { window: null, fallback: null } });
       });
 
       it("returns null for non-object input", () => {

--- a/packages/server/src/service/package_manifest.spec.ts
+++ b/packages/server/src/service/package_manifest.spec.ts
@@ -29,7 +29,10 @@ describe("service/package_manifest", () => {
       it("defaults the freshness fallback to null when absent", () => {
          expect(
             parsePackageMaterialization({ freshness: { window: "7d" } }),
-         ).toEqual({ schedule: null, freshness: { window: "7d", fallback: null } });
+         ).toEqual({
+            schedule: null,
+            freshness: { window: "7d", fallback: null },
+         });
       });
 
       it("ignores extra/unknown fields", () => {
@@ -51,8 +54,13 @@ describe("service/package_manifest", () => {
             freshness: null,
          });
          expect(
-            parsePackageMaterialization({ freshness: { window: 1, fallback: 2 } }),
-         ).toEqual({ schedule: null, freshness: { window: null, fallback: null } });
+            parsePackageMaterialization({
+               freshness: { window: 1, fallback: 2 },
+            }),
+         ).toEqual({
+            schedule: null,
+            freshness: { window: null, fallback: null },
+         });
       });
 
       it("returns null for non-object input", () => {

--- a/packages/server/src/service/package_manifest.ts
+++ b/packages/server/src/service/package_manifest.ts
@@ -4,18 +4,37 @@
  * testable in isolation from the package-load worker that consumes it.
  */
 
+/**
+ * Freshness policy the control plane resolves onto each build-manifest entry and
+ * the publisher applies when it binds the manifest. Each field degrades to null
+ * when absent or not a string; the control plane validates the window duration
+ * and fallback value.
+ */
+export interface MaterializationFreshnessConfig {
+   /** Duration with a unit suffix (`s`/`m`/`h`/`d`), e.g. `24h`. */
+   window: string | null;
+   /** `live` (default) | `stale_ok` | `fail`. */
+   fallback: string | null;
+}
+
 export interface PackageMaterializationConfig {
    /**
     * 5-field UNIX cron the control plane uses to schedule version-level
     * re-materialization. Null when absent or not a string.
     */
    schedule: string | null;
+   /**
+    * Staleness policy applied at manifest bind time. Null when absent so the API
+    * field is null rather than an empty object.
+    */
+   freshness: MaterializationFreshnessConfig | null;
 }
 
 /**
  * Read the manifest's `materialization` object, keeping only recognized fields.
  * Returns null when the block is absent so the API field is null rather than an
- * empty object; a non-string schedule degrades to null.
+ * empty object; non-string leaf values degrade to null. The control plane (not
+ * the publisher) validates the cron, the freshness window, and the fallback.
  */
 export function parsePackageMaterialization(
    raw: unknown,
@@ -24,5 +43,20 @@ export function parsePackageMaterialization(
       return null;
    }
    const schedule = (raw as { schedule?: unknown }).schedule;
-   return { schedule: typeof schedule === "string" ? schedule : null };
+   return {
+      schedule: typeof schedule === "string" ? schedule : null,
+      freshness: parseFreshness((raw as { freshness?: unknown }).freshness),
+   };
+}
+
+function parseFreshness(raw: unknown): MaterializationFreshnessConfig | null {
+   if (!raw || typeof raw !== "object") {
+      return null;
+   }
+   const window = (raw as { window?: unknown }).window;
+   const fallback = (raw as { fallback?: unknown }).fallback;
+   return {
+      window: typeof window === "string" ? window : null,
+      fallback: typeof fallback === "string" ? fallback : null,
+   };
 }

--- a/packages/server/src/telemetry.ts
+++ b/packages/server/src/telemetry.ts
@@ -6,7 +6,7 @@ import { metrics, type Meter } from "@opentelemetry/api";
  * silently split a metric onto a second meter and drop it from the
  * Prometheus scrape.
  */
-export const METER_NAME = "publisher";
+const METER_NAME = "publisher";
 
 /**
  * The shared publisher meter. Resolves lazily through the OTel global

--- a/packages/server/tests/integration/materialization/manifest_binding.integration.spec.ts
+++ b/packages/server/tests/integration/materialization/manifest_binding.integration.spec.ts
@@ -123,6 +123,32 @@ describe("Manifest binding via Package.manifestLocation (E2E)", () => {
       return file;
    }
 
+   async function writeManifestWithFreshness(opts: {
+      builtAt: string;
+      freshnessWindowSeconds: number;
+      freshnessFallback?: "live" | "stale_ok" | "fail";
+   }): Promise<string> {
+      const file = path.join(tmpDir, `manifest-fresh-${Date.now()}.json`);
+      await fsp.writeFile(
+         file,
+         JSON.stringify({
+            builtAt: new Date().toISOString(),
+            strict: false,
+            entries: {
+               build123: {
+                  buildId: "build123",
+                  sourceName: "order_summary",
+                  physicalTableName: "main.order_summary_mz",
+                  connectionName: "duckdb",
+                  ...opts,
+               },
+            },
+         }),
+         "utf8",
+      );
+      return file;
+   }
+
    it("starts with no manifestLocation and serves live", async () => {
       expect((await getPackage()).manifestLocation ?? null).toBeNull();
       expect(await queryOrderSummaryStatus()).toBe(200);
@@ -167,6 +193,43 @@ describe("Manifest binding via Package.manifestLocation (E2E)", () => {
          expect(cleared.boundManifestUri ?? null).toBeNull();
          expect((await getPackage(true)).manifestLocation ?? null).toBeNull();
          expect(await queryOrderSummaryStatus()).toBe(200);
+      },
+      { timeout: 60_000 },
+   );
+
+   it(
+      "binds a fresh entry but drops a stale one (serving live)",
+      async () => {
+         const hoursAgo = (h: number): string =>
+            new Date(Date.now() - h * 3_600_000).toISOString();
+
+         // Within the freshness window -> the table is bound.
+         const freshFile = await writeManifestWithFreshness({
+            builtAt: hoursAgo(1),
+            freshnessWindowSeconds: 24 * 3600,
+         });
+         const fresh = await (
+            await patchPackage({ manifestLocation: freshFile })
+         ).json();
+         expect(fresh.manifestBindingStatus).toBe("bound");
+         expect(fresh.manifestEntryCount).toBe(1);
+         expect(await queryOrderSummaryStatus()).toBe(200);
+
+         // Past the window with the default `live` fallback -> dropped from the
+         // binding so the source serves live (unbound, zero entries), and the
+         // package keeps serving.
+         const staleFile = await writeManifestWithFreshness({
+            builtAt: hoursAgo(48),
+            freshnessWindowSeconds: 24 * 3600,
+         });
+         const stale = await (
+            await patchPackage({ manifestLocation: staleFile })
+         ).json();
+         expect(stale.manifestBindingStatus).toBe("unbound");
+         expect(stale.manifestEntryCount).toBe(0);
+         expect(await queryOrderSummaryStatus()).toBe(200);
+
+         await patchPackage({ manifestLocation: null });
       },
       { timeout: 60_000 },
    );


### PR DESCRIPTION
## Summary

Adds the publisher-side half of the **Phase A freshness gate**: a persist source's materialized table backs a query only while it is younger than the package's configured freshness window; once stale, a per-package `fallback` (`live` | `stale_ok` | `fail`) decides what happens. The control-plane side (threading `builtAt` + `freshnessWindowSeconds` + `freshnessFallback` onto each manifest entry) is a sibling PR in `ms2data/service`.

What's here:

- **`materialization.freshness` parsing** (`package_manifest.ts`): reads `{ window, fallback }` from `malloy-publisher.json`'s `materialization` block (alongside `schedule`), threaded through the package-load protocol.
- **Freshness evaluation** (`manifest_loader.ts`): `evaluateManifestFreshness(entry, now)` → `serve_table` | `serve_live` | `fail`. Fail-open on a missing/unparseable gate.
- **Gating at manifest bind**: stale `live`/`fail` entries are dropped from the Malloy binding (the source serves live via `strict:false`); `stale_ok` keeps the binding; fresh/un-gated bind as before.
- **Telemetry**: a `stale manifest entry` counter (by fallback) and de-noised stale logging.
- **Tests**: unit coverage for parsing + evaluation + the worker boundary, plus a manifest-binding integration spec.

## Known limitation — enforcement is at bind time, not per query

The freshness decision is made when the package's manifest is **(re)bound** (package load / `reloadAllModels`), then frozen into the Malloy `Runtime`. Malloy substitutes per query but only on **presence** in the frozen map, so a table that crosses its window while a package stays loaded keeps serving until the next rebind. In particular, `fail` currently degrades to live (Malloy's `strict` is per-manifest, not per-entry).

The full analysis and the design for genuine per-query enforcement (per-query manifest for `live`/`stale_ok`; a small Malloy hook for `fail`) is captured in the persistence-doc appendix (ms2data/service#5297).

## Test plan

- [x] `bun test` freshness specs (parsing, evaluation, worker boundary) — green
- [x] `tsc --noEmit` — clean
- [ ] CI

Made with [Cursor](https://cursor.com)