### PR TITLE
feat(server): match build instructions by sourceID, not a recomputed buildId

### DIFF
--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -560,8 +560,20 @@ export class MaterializationService {
    ): Promise<Record<string, ManifestEntry>> {
       const { graphs, sources, connectionDigests, connections } = compiled;
 
+      // Index instructions by sourceID (the stable per-source handle) so the
+      // build no longer recomputes the buildId to find an instruction.
+      // Recomputing it here forced a caller's buildId to equal the publisher's
+      // content hash, so a caller that derives buildIds by any other scheme
+      // would have its sources silently skipped (the recomputed buildId would
+      // not match the instruction). buildId is treated as opaque, caller-assigned
+      // identity. A buildId index is kept as a fallback for instructions without
+      // a sourceID (e.g. standalone auto-run).
+      const bySourceID = new Map<string, BuildInstruction>();
       const byBuildId = new Map<string, BuildInstruction>();
       for (const instruction of instructions) {
+         if (instruction.sourceID) {
+            bySourceID.set(instruction.sourceID, instruction);
+         }
          byBuildId.set(instruction.buildId, instruction);
       }
 
@@ -587,8 +599,15 @@ export class MaterializationService {
          for (const persistSource of iterGraphSources(graph, sources)) {
             if (signal.aborted) throw new Error("Build cancelled");
 
+            // The manifest is keyed by the content buildId — what Malloy
+            // recomputes to resolve upstream persist references during SQL
+            // generation — independent of the instruction's identity buildId.
             const buildId = computeBuildId(persistSource, connectionDigests);
-            const instruction = byBuildId.get(buildId);
+            // Prefer sourceID matching (so the caller's buildId scheme stays
+            // opaque to the build); fall back to buildId for instructions
+            // without a sourceID (auto-run).
+            const instruction =
+               bySourceID.get(persistSource.sourceID) ?? byBuildId.get(buildId);
             if (!instruction) continue;
 
             const entry = await this.buildOneSource(


### PR DESCRIPTION
## Why
`executeInstructedBuild` recomputes each source's `buildId` (`computeBuildId`) to look up its `BuildInstruction`. That forces a caller's `buildId` to equal the publisher's content hash — the publisher effectively dictates the buildId scheme. A caller that assigns buildIds by any other scheme would have the recomputed buildId fail to match the instruction, and the source would be **silently skipped** (not built).

## What
- Match instructions by **`sourceID`** — the stable per-source handle on the instruction — instead of a recomputed buildId, so `buildId` is treated as opaque, caller-assigned identity.
- Keep a `buildId` index as a **fallback** for instructions without a `sourceID` (e.g. standalone auto-run).
- The manifest stays keyed by the **content `buildId`** (`computeBuildId`) — what Malloy recomputes to resolve upstream `#@ persist` references during SQL generation; it is per-build and independent of the instruction's identity buildId.

## Compatibility
Backward-compatible: when `sourceID` selects the same instruction the recomputed `buildId` did, behavior is unchanged. The benefit is that orchestrating callers can own `buildId` identity rather than being forced to match the publisher's content-hash scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)