### PR TITLE
fix(server): always surface materialization on a loaded package and preserve it across a metadata PATCH

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -2443,7 +2443,12 @@ components:
           description: |
             Package-level Malloy Persistence policy declared in
             malloy-publisher.json. The control plane reads it to drive scheduled
-            re-materialization. Null/absent = no package-level policy.
+            re-materialization. The object is present whenever the package has
+            loaded — with `schedule: null` when the manifest declares no
+            schedule — so the caller can treat object-present as the
+            authoritative manifest policy. Null/absent only when package
+            metadata is unavailable for this request (not loaded), which the
+            caller must treat as "unknown", not as a removal.
         manifestBindingStatus:
           type: string
           readOnly: true
@@ -2499,14 +2504,17 @@ components:
         Package-level Malloy Persistence policy from malloy-publisher.json's
         `materialization` block. Surfaced verbatim so the control plane can drive
         scheduled version-level re-materialization without re-reading the package
-        files.
+        files. The object is emitted whenever the package is loaded, even when no
+        policy is declared (all fields null), so its presence is an authoritative
+        "the manifest says this" signal rather than "policy missing".
       properties:
         schedule:
           type: ["string", "null"]
           description: >-
             5-field UNIX cron controlling how often the control plane
-            re-materializes this package's published versions. Null/absent = no
-            scheduled re-materialization (publish / on-demand only).
+            re-materializes this package's published versions. Null = no
+            scheduled re-materialization declared in the manifest (publish /
+            on-demand only).
 
     Model:
       type: object

--- a/packages/server/src/service/environment.ts
+++ b/packages/server/src/service/environment.ts
@@ -1340,6 +1340,13 @@ export class Environment {
             explores,
             queryableSources,
             manifestLocation,
+            // Carry the manifest-derived materialization policy through the
+            // PATCH. `setPackageMetadata` replaces the whole object, so omitting
+            // this wipes the in-memory `materialization` until the next reload —
+            // which makes a later getPackage report no schedule and lets the
+            // control plane misread the gap as a schedule removal. It is not a
+            // PATCH-editable field, so always preserve the existing value.
+            materialization: existing.materialization,
          });
 
          // Strict-reject, symmetric with the publish path

--- a/packages/server/src/service/materialization_schedule_surface.spec.ts
+++ b/packages/server/src/service/materialization_schedule_surface.spec.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+
+import { Environment } from "./environment";
+
+/**
+ * The publisher must surface a non-null `materialization` object on a loaded
+ * package's metadata so the control plane can treat object-present as the
+ * authoritative manifest policy ("this is what the manifest says") and
+ * object-absent as "metadata not loaded this request" — never as a schedule
+ * removal. A metadata PATCH must not drop that policy from the in-memory
+ * metadata. Regression coverage for the re-materialization schedule self-wipe
+ * (docs/bugs/materialization-schedule-self-wipe.md).
+ *
+ * Runs against a real `Environment` + real `Package.create` over temp dirs.
+ */
+describe("materialization schedule surfacing", () => {
+   const MODEL = `source: ones is duckdb.sql("SELECT 1 as x")\n`;
+   let rootDir: string;
+   let envPath: string;
+
+   async function writePackageDir(
+      manifest: Record<string, unknown>,
+   ): Promise<void> {
+      const dir = path.join(envPath, "pkg");
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(
+         path.join(dir, "publisher.json"),
+         JSON.stringify({ name: "pkg", description: "fixture", ...manifest }),
+      );
+      await fs.writeFile(path.join(dir, "model.malloy"), MODEL);
+   }
+
+   beforeEach(async () => {
+      rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "publisher-mat-"));
+      envPath = path.join(rootDir, "env");
+      await fs.mkdir(envPath, { recursive: true });
+   });
+
+   afterEach(async () => {
+      await fs.rm(rootDir, { recursive: true, force: true }).catch(() => {});
+   });
+
+   it(
+      "surfaces the manifest's materialization.schedule on load",
+      async () => {
+         const env = await Environment.create("testEnv", envPath, []);
+         await writePackageDir({ materialization: { schedule: "0 6 * * *" } });
+         await env.addPackage("pkg");
+
+         const pkg = await env.getPackage("pkg", false);
+         expect(pkg.getPackageMetadata().materialization).toEqual({
+            schedule: "0 6 * * *",
+         });
+      },
+      { timeout: 20000 },
+   );
+
+   it(
+      "surfaces a non-null materialization object even when the manifest declares none",
+      async () => {
+         const env = await Environment.create("testEnv", envPath, []);
+         await writePackageDir({});
+         await env.addPackage("pkg");
+
+         // Object present with a null schedule — NOT a null object — so the
+         // control plane reads it as an authoritative "no schedule declared",
+         // not as "metadata unavailable".
+         const pkg = await env.getPackage("pkg", false);
+         expect(pkg.getPackageMetadata().materialization).toEqual({
+            schedule: null,
+         });
+      },
+      { timeout: 20000 },
+   );
+
+   it(
+      "preserves the materialization policy across a metadata PATCH",
+      async () => {
+         const env = await Environment.create("testEnv", envPath, []);
+         await writePackageDir({ materialization: { schedule: "0 6 * * *" } });
+         await env.addPackage("pkg");
+
+         // A description-only PATCH must not wipe the schedule from the
+         // in-memory metadata. The bug: setPackageMetadata replaces the whole
+         // object, so a later getPackage reported no schedule and the control
+         // plane misread the gap as a removal and cleared the cadence.
+         const updated = await env.updatePackage("pkg", {
+            name: "pkg",
+            description: "updated",
+         });
+         expect(updated.materialization).toEqual({ schedule: "0 6 * * *" });
+
+         const pkg = await env.getPackage("pkg", false);
+         expect(pkg.getPackageMetadata().materialization).toEqual({
+            schedule: "0 6 * * *",
+         });
+      },
+      { timeout: 20000 },
+   );
+});

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -331,7 +331,16 @@ export class Package {
          explores: outcome.packageMetadata.explores,
          queryableSources: outcome.packageMetadata.queryableSources,
          manifestLocation: outcome.packageMetadata.manifestLocation ?? null,
-         materialization: outcome.packageMetadata.materialization ?? null,
+         // Always surface a non-null `materialization` object once the package
+         // has loaded (schedule null when the manifest declares no policy). The
+         // control plane treats object-present as the authoritative "this is
+         // what the manifest says" signal and object-absent as "metadata not
+         // available this request" — so it must never be dropped to null on a
+         // successfully loaded package, or the CP can misread a transient
+         // absence as a schedule removal. See `parsePackageMaterialization`.
+         materialization: outcome.packageMetadata.materialization ?? {
+            schedule: null,
+         },
       };
 
       // Build live `Model`s from worker output. Any per-model compile


### PR DESCRIPTION
## Summary

`getPackage` returned `materialization: null` both when the manifest declared no policy **and** when a loaded package's in-memory metadata had simply lost the field, so a consumer could not distinguish "no schedule" from "not surfaced this request". The control plane reads this field to drive scheduled re-materialization and was misreading a transient absence as a schedule *removal*, wiping a live cadence (re-materialization fired once, then never again).

This PR makes the field's presence authoritative:

- **Always emit a non-null `materialization` object once the package has loaded** ([`package.ts`](packages/server/src/service/package.ts), `?? { schedule: null }`), so `schedule` is null when the manifest declares none, but the object itself is present. Object-present = "this is what the manifest says"; object-absent = "metadata not available this request" (not loaded).
- **Preserve `materialization` across a metadata PATCH** ([`environment.ts`](packages/server/src/service/environment.ts) `updatePackage`): the PATCH rebuilt metadata via `setPackageMetadata({...})` without carrying the field, wiping the in-memory schedule on any name/description/explores/manifestLocation update — the likely real cause of the intermittent disappearance. (The on-disk manifest already preserved it via `writePackageManifest`'s spread.)
- Updates `api-doc.yaml` to document the object-present-when-loaded contract. The generated `api.ts` is unchanged (description-only).

This is the publisher half of a two-repo fix; the control plane will additionally persist a version's schedule write-once and stop clearing it on the build path.

## Test plan

- [x] New `materialization_schedule_surface.spec.ts` (real `Environment`): schedule surfaced on load; non-null object (`{ schedule: null }`) when no policy is declared; policy preserved across a metadata PATCH (regression).
- [x] `bun test` on the new spec + `package_manifest.spec.ts` + `package_rollback.spec.ts` — 13 pass / 0 fail.
- [x] ESLint clean on touched files.
- [ ] CI green.

Signed-off-by: Kyle Nesbit <kjnesbit@ms2.co>

Made with [Cursor](https://cursor.com)