### PR TITLE
feat(pages): let full-screen data apps fill the embedded page viewer

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -2571,6 +2571,16 @@ components:
           description:
             Title extracted from the file's <title> tag, or the path if
             not present
+        fit:
+          type: string
+          enum:
+            - viewport
+          description:
+            Layout hint read from a <meta name="publisher:fit"> tag in the
+            page <head>. "viewport" tells the embedded page viewer to fill the
+            available height instead of auto-sizing to the page's content
+            height, for full-screen apps like slide decks. Omitted for ordinary
+            content pages, which keep content-height auto-sizing.
 
     RawNotebook:
       type: object

--- a/docs/html-data-apps.md
+++ b/docs/html-data-apps.md
@@ -260,6 +260,31 @@ The stream is `GET /api/v0/environments/<env>/packages/<pkg>/events`. It emits a
 connects and reports `mode: disabled`, and no reloads fire, which is the expected
 production posture.
 
+## Full-screen apps in the page viewer
+
+When you open a page from inside the Publisher app (the package's Pages list), it
+is shown in an iframe wrapped in light chrome (a title and an "open standalone"
+link). By default that iframe is sized to the page's content height: the page's
+runtime measures how tall its content actually is and the viewer matches it, so
+an ordinary dashboard never gets a nested scrollbar.
+
+A full-screen app, such as a slide deck that sizes itself to `100vh`, has no
+content height to measure, so the default sizing would clip it. Declare that the
+page should fill the viewer instead with a single meta tag in the `<head>`:
+
+```html
+<meta name="publisher:fit" content="viewport" />
+```
+
+The viewer then makes the iframe fill the available height, so the page's own
+`100vh` resolves against the real viewport and looks the same as it does opened
+standalone. Because the viewer reads this tag from the page's markup, it works
+even for a page that does not load `publisher.js`. The tag must sit near the top
+of `<head>` (within the first 4KB, the same window the title is read from). Pages
+without it keep content-height sizing, so marking one app full-screen does not
+affect any other page, and opening a page directly at
+`/environments/<env>/packages/<pkg>/<file>` is unaffected either way.
+
 ## Listing a package's pages
 
 `GET /api/v0/environments/<env>/packages/<pkg>/pages` returns the package's HTML
@@ -276,9 +301,12 @@ pages, which the Publisher app uses to show what a package offers. Each entry is
 
 `resource` is the root-relative URL to open the page (note it is not under
 `/api/v0`), `path` is the file's path within `public/`, and `title` is taken from
-the page's `<title>` tag, falling back to `path`. The listing covers `.html` and
-`.htm` files up to three directories deep and is empty for a package with no
-`public/` directory.
+the page's `<title>` tag, falling back to `path`. An entry also carries
+`fit: "viewport"` when the page opts into filling the viewer with
+`<meta name="publisher:fit" content="viewport">` (see
+[Full-screen apps in the page viewer](#full-screen-apps-in-the-page-viewer)), and
+omits the field otherwise. The listing covers `.html` and `.htm` files up to
+three directories deep and is empty for a package with no `public/` directory.
 
 ## The package manifest
 

--- a/packages/sdk/src/components/PageViewer/PageViewer.tsx
+++ b/packages/sdk/src/components/PageViewer/PageViewer.tsx
@@ -33,6 +33,12 @@ function parsePageResource(resourceUri: string) {
  * runtime postMessages `{ type: "publisher:resize", height }` as content
  * height changes; we listen and resize the iframe to match so embedded
  * dashboards don't get a nested scrollbar.
+ *
+ * Full-screen apps (e.g. slide decks) can opt out of content-height sizing
+ * with `<meta name="publisher:fit" content="viewport">`, surfaced as
+ * `Page.fit === "viewport"`. The iframe then fills the available viewport
+ * height (matching the standalone view) instead of collapsing to the page's
+ * near-zero reported content height.
  */
 export default function PageViewer({ resourceUri }: PageViewerProps) {
    const { server, apiClients } = useServer();
@@ -57,9 +63,14 @@ export default function PageViewer({ resourceUri }: PageViewerProps) {
       queryFn: () => apiClients.pages.listPages(environmentName, packageName),
       enabled: !!parsed,
    });
-   const title =
-      pagesQuery.data?.data?.find((p) => p.path === pagePath)?.title ??
-      pagePath;
+   const pageMeta = pagesQuery.data?.data?.find((p) => p.path === pagePath);
+   const title = pageMeta?.title ?? pagePath;
+   // Full-screen apps opt in via <meta name="publisher:fit" content="viewport">
+   // (surfaced as Page.fit by the /pages listing). In fill mode the iframe fills
+   // the available viewport height instead of being sized to the page's reported
+   // content height: a viewport-filling deck has ~no content height to report,
+   // so the default auto-size would clip it. Ordinary pages keep auto-sizing.
+   const fillViewport = pageMeta?.fit === "viewport";
 
    const iframeRef = useRef<HTMLIFrameElement | null>(null);
    // Start small so the iframe doesn't pre-commit space before the first
@@ -68,6 +79,10 @@ export default function PageViewer({ resourceUri }: PageViewerProps) {
    const [iframeHeight, setIframeHeight] = useState<number>(120);
 
    useEffect(() => {
+      // Fill mode pins the iframe to 100%, so content-height resize messages are
+      // irrelevant; skip subscribing (and the per-message re-renders) until the
+      // page is in content-height mode.
+      if (fillViewport) return;
       function onMessage(e: MessageEvent) {
          if (!isPublisherResizeMessage(e.data)) return;
          if (e.source !== iframeRef.current?.contentWindow) return;
@@ -77,7 +92,7 @@ export default function PageViewer({ resourceUri }: PageViewerProps) {
       }
       window.addEventListener("message", onMessage);
       return () => window.removeEventListener("message", onMessage);
-   }, []);
+   }, [fillViewport]);
 
    if (!parsed) {
       return (
@@ -99,12 +114,23 @@ export default function PageViewer({ resourceUri }: PageViewerProps) {
    }
 
    return (
-      <Box sx={{ p: 3, maxWidth: 1200, mx: "auto" }}>
+      <Box
+         sx={{
+            p: 3,
+            // Fill mode fills the available height of PageViewer's ancestor, so
+            // it must render inside a height-constrained container. The Publisher
+            // app provides one (MainPage's 100dvh flex chain); an SDK consumer
+            // embedding PageViewer should give it a bounded-height parent.
+            ...(fillViewport
+               ? { height: "100%", display: "flex", flexDirection: "column" }
+               : { maxWidth: 1200, mx: "auto" }),
+         }}
+      >
          <Stack
             direction="row"
             alignItems="baseline"
             spacing={1}
-            sx={{ mb: 1 }}
+            sx={{ mb: 1, flexShrink: 0 }}
          >
             <Typography
                variant="h6"
@@ -140,6 +166,11 @@ export default function PageViewer({ resourceUri }: PageViewerProps) {
                borderRadius: 1.5,
                overflow: "hidden",
                backgroundColor: "background.paper",
+               // Fill mode: grow to consume the remaining viewport height (the
+               // SPA gives PageViewer a 100dvh flex ancestor) so the iframe
+               // below can be 100% tall. minHeight:0 lets this flex child
+               // actually shrink/grow instead of overflowing its parent.
+               ...(fillViewport ? { flex: 1, minHeight: 0 } : {}),
             }}
          >
             <iframe
@@ -154,7 +185,10 @@ export default function PageViewer({ resourceUri }: PageViewerProps) {
                style={{
                   display: "block",
                   width: "100%",
-                  height: iframeHeight,
+                  // Fill mode pins the iframe to the available height so the
+                  // deck's own 100vh resolves against a real viewport. Otherwise
+                  // track the content height reported via publisher:resize.
+                  height: fillViewport ? "100%" : iframeHeight,
                   border: 0,
                }}
             />

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -491,7 +491,32 @@ type PageItem = {
    packageName: string;
    path: string;
    title: string;
+   fit?: "viewport";
 };
+
+// The spots in an HTML head where a "<meta ...>" literal would NOT be a live
+// tag: HTML comments (terminated or unterminated) and raw-text/RCDATA elements
+// (script/style/title/textarea). One alternation so a single .replace covers
+// them all (and so the fixpoint loop below applies one self-referential
+// replace, which is the complete-sanitization shape CodeQL recognizes).
+const NON_TAG_TEXT_PATTERN =
+   /<!--[\s\S]*?-->|<!--[\s\S]*$|<(script|style|title|textarea)\b[\s\S]*?<\/\1\s*>/gi;
+
+// Remove those matches until the string stops changing. A single pass is
+// incomplete because removing one match can splice the surrounding text into a
+// new one (CWE-116), so re-apply the same pattern to its own output until a
+// fixpoint. Each pass only deletes, so the string strictly shrinks and the loop
+// terminates, bounded by the input length (callers pass at most the first 4KB).
+function stripNonTagText(input: string): string {
+   let current = input;
+   let previous: string;
+   do {
+      previous = current;
+      current = current.replace(NON_TAG_TEXT_PATTERN, "");
+   } while (current !== previous);
+   return current;
+}
+
 async function listPackagePages(
    environmentName: string,
    packageName: string,
@@ -539,8 +564,9 @@ async function listPackagePages(
             (entry.name.endsWith(".html") || entry.name.endsWith(".htm"))
          ) {
             const rel = path.relative(publicRoot, full).replace(/\\/g, "/");
-            // Cheap title extraction: read first 4KB and grep for <title>.
+            // Cheap metadata extraction: read first 4KB and grep the <head>.
             let title = rel;
+            let fit: "viewport" | undefined;
             try {
                const fh = await fs.open(full, "r");
                try {
@@ -549,6 +575,33 @@ async function listPackagePages(
                   const head = buf.slice(0, bytesRead).toString("utf8");
                   const m = head.match(/<title[^>]*>([^<]+)<\/title>/i);
                   if (m) title = m[1].trim();
+                  // Full-screen apps (e.g. slide decks) opt into a viewport-fill
+                  // embed with <meta name="publisher:fit" content="viewport">.
+                  // FIRST strip the spots where the literal string is NOT a live
+                  // tag (comments, script/style/title/textarea), THEN look at the
+                  // <head> region only (up to </head> or <body>). Order matters:
+                  // stripping before locating the boundary keeps a literal
+                  // "<body>"/"</head>" inside a comment or <script> from
+                  // truncating the scan and hiding a real tag. What's left and
+                  // matches is a genuine <meta> the browser would honor too, so a
+                  // documented/commented example or a string in a code block
+                  // can't opt the page in. Match by name (attribute order/quoting
+                  // vary), then confirm content="viewport"; the [\s"'] before
+                  // `name` keeps `data-name="publisher:fit"` out. Like the title,
+                  // the tag must sit within the first 4KB.
+                  const cleaned = stripNonTagText(head);
+                  const headEnd = cleaned.search(/<\/head\s*>|<body[\s>]/i);
+                  const headTags =
+                     headEnd === -1 ? cleaned : cleaned.slice(0, headEnd);
+                  const fitMeta = headTags.match(
+                     /<meta\b[^>]*[\s"']name\s*=\s*["']publisher:fit["'][^>]*>/i,
+                  );
+                  if (
+                     fitMeta &&
+                     /\bcontent\s*=\s*["']\s*viewport\s*["']/i.test(fitMeta[0])
+                  ) {
+                     fit = "viewport";
+                  }
                } finally {
                   await fh.close();
                }
@@ -560,6 +613,7 @@ async function listPackagePages(
                packageName,
                path: rel,
                title,
+               fit,
             });
          }
       }

--- a/packages/server/tests/fixtures/html-pages-test/public/barehtml.html
+++ b/packages/server/tests/fixtures/html-pages-test/public/barehtml.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>Bare HTML</title>
+<!-- example only, must NOT opt in: <meta name="publisher:fit" content="viewport"> -->
+<h1>No head or body tags; the tag appears only in a comment.</h1>

--- a/packages/server/tests/fixtures/html-pages-test/public/bodymeta.html
+++ b/packages/server/tests/fixtures/html-pages-test/public/bodymeta.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+   <title>Body Meta</title>
+   <body>
+      <meta name="publisher:fit" content="viewport" />
+      <h1>A real fit meta in &lt;body&gt;; the head-only scan means no opt-in.</h1>
+   </body>
+</html>

--- a/packages/server/tests/fixtures/html-pages-test/public/fitcomment.html
+++ b/packages/server/tests/fixtures/html-pages-test/public/fitcomment.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+   <head>
+      <!-- this deck does <body> styling tricks; the literal must not truncate the scan -->
+      <meta name="publisher:fit" content="viewport" />
+      <title>Fit After Comment</title>
+   </head>
+   <body style="height: 100vh; margin: 0; overflow: hidden">
+      <section style="height: 100%">A full-screen slide</section>
+   </body>
+</html>

--- a/packages/server/tests/fixtures/html-pages-test/public/nohead.html
+++ b/packages/server/tests/fixtures/html-pages-test/public/nohead.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+   <title>No Head Close Tag</title>
+   <body>
+      <h1>Omits the optional &lt;/head&gt; end tag</h1>
+      <!-- shown in body, must NOT opt in: <meta name="publisher:fit" content="viewport"> -->
+   </body>
+</html>

--- a/packages/server/tests/fixtures/html-pages-test/public/notfit.html
+++ b/packages/server/tests/fixtures/html-pages-test/public/notfit.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+   <head>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <meta data-name="publisher:fit" content="viewport" />
+      <title>Tall Dashboard</title>
+   </head>
+   <body>
+      <h1>A normal dashboard that hugs its content</h1>
+      <!-- shown in body, must NOT opt in: <meta name="publisher:fit" content="viewport"> -->
+   </body>
+</html>

--- a/packages/server/tests/fixtures/html-pages-test/public/slides.html
+++ b/packages/server/tests/fixtures/html-pages-test/public/slides.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+   <head>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <meta name="publisher:fit" content="viewport" />
+      <title>FY27 Slide Deck</title>
+   </head>
+   <body style="height: 100vh; margin: 0; overflow: hidden">
+      <section style="height: 100%">A full-screen slide</section>
+   </body>
+</html>

--- a/packages/server/tests/fixtures/html-pages-test/public/unterminated.html
+++ b/packages/server/tests/fixtures/html-pages-test/public/unterminated.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+   <head>
+      <title>Unterminated Comment</title>
+      <!-- never closed, must NOT opt in: <meta name="publisher:fit" content="viewport">
+   </head>
+   <body>
+      <h1>An unterminated comment swallows the tag.</h1>
+   </body>
+</html>

--- a/packages/server/tests/integration/html_pages/html_pages.integration.spec.ts
+++ b/packages/server/tests/integration/html_pages/html_pages.integration.spec.ts
@@ -66,6 +66,7 @@ interface PageItem {
    packageName?: string;
    path?: string;
    title?: string;
+   fit?: "viewport";
 }
 
 // Creating a symlink that escapes the package needs privileges the Windows CI
@@ -322,7 +323,17 @@ describe("In-package HTML data apps (E2E)", () => {
       const paths = pages.map((p) => p.path).sort();
       // Only HTML files under public/ are listed; the toEqual pins the exact
       // set, so non-public files (manifest, models, data) can't appear.
-      expect(paths).toEqual(["index.html", "sub/page2.html"]);
+      expect(paths).toEqual([
+         "barehtml.html",
+         "bodymeta.html",
+         "fitcomment.html",
+         "index.html",
+         "nohead.html",
+         "notfit.html",
+         "slides.html",
+         "sub/page2.html",
+         "unterminated.html",
+      ]);
 
       const index = pages.find((p) => p.path === "index.html");
       expect(index?.title).toBe("Carrier Dashboard");
@@ -330,6 +341,57 @@ describe("In-package HTML data apps (E2E)", () => {
       expect(index?.resource).toBe(
          `/environments/${ENV_NAME}/packages/${PACKAGE_NAME}/index.html`,
       );
+   });
+
+   it("surfaces fit=viewport only for pages that opt in via <meta name=publisher:fit>", async () => {
+      const res = await fetch(apiUrl("/pages"));
+      expect(res.status).toBe(200);
+      const pages = (await res.json()) as PageItem[];
+
+      // slides.html opts in with <meta name="publisher:fit" content="viewport">
+      // (alongside a standard charset + viewport meta) → fill the embedded viewer.
+      expect(pages.find((p) => p.path === "slides.html")?.fit).toBe("viewport");
+
+      // fitcomment.html has a real <meta publisher:fit> AFTER a comment that
+      // contains the literal "<body>"; stripping comments before locating the
+      // </head>/<body> boundary must keep that literal from truncating the scan
+      // and hiding the real tag (it must still opt in).
+      expect(pages.find((p) => p.path === "fitcomment.html")?.fit).toBe(
+         "viewport",
+      );
+
+      // notfit.html carries the STANDARD <meta name="viewport"> (device-width),
+      // a decoy <meta data-name="publisher:fit"> in <head>, and the real tag as
+      // text in a <body> comment. None is a genuine <head> name=publisher:fit,
+      // so it must NOT be mistaken for an opt-in.
+      expect(pages.find((p) => p.path === "notfit.html")?.fit).toBeUndefined();
+
+      // A page with no relevant meta keeps content-height auto-sizing (the
+      // field is omitted, never `null`/`"content"`).
+      expect(pages.find((p) => p.path === "index.html")?.fit).toBeUndefined();
+
+      // nohead.html omits the optional </head> end tag and shows the tag in a
+      // <body> comment; the scan stops at <body>, so it must NOT opt in.
+      expect(pages.find((p) => p.path === "nohead.html")?.fit).toBeUndefined();
+
+      // barehtml.html omits BOTH </head> and <body> and shows the tag only in
+      // an HTML comment; comment-stripping must keep it from opting in.
+      expect(
+         pages.find((p) => p.path === "barehtml.html")?.fit,
+      ).toBeUndefined();
+
+      // bodymeta.html has a REAL (uncommented) <meta publisher:fit> but in
+      // <body> and omits </head>, so the head-only scan must stop at <body>
+      // and not opt in (locks the <body> boundary).
+      expect(
+         pages.find((p) => p.path === "bodymeta.html")?.fit,
+      ).toBeUndefined();
+
+      // unterminated.html wraps the tag in a comment with no closing -->; the
+      // unterminated-comment strip must still keep it from opting in.
+      expect(
+         pages.find((p) => p.path === "unterminated.html")?.fit,
+      ).toBeUndefined();
    });
 
    it("400s a malformed environment/package name on /pages", async () => {


### PR DESCRIPTION
## Summary

A full-screen HTML data app (a reveal-style slide deck) is height-clipped when viewed through Publisher's embedded page viewer, but renders at full height when opened standalone. This lets a full-screen app opt into filling the viewer, so the embedded view matches the standalone one. Reported by a user testing a data app against a local Publisher.

## Why it happens

The embedded page viewer (the SDK `PageViewer`) iframes the standalone page and sizes the iframe from the content height the page reports over the `publisher:resize` postMessage, starting at 120px. That auto-sizing is the right default for ordinary dashboards because it avoids a nested scrollbar, but a viewport-filling deck fills whatever height it is given and reports almost none back, so the iframe stays short and clips it. Opened standalone there is no measuring step, so the deck's own `100vh` resolves against the real viewport and fills.

## The fix

A page opts into a viewport-fill embed with one tag in its `<head>`:

```html
<meta name="publisher:fit" content="viewport">
```

The `/pages` listing reads it from the same first 4KB it already scans for `<title>` and surfaces it as `Page.fit = "viewport"`. `PageViewer` then fills the available viewport height (the app already provides a `100dvh` flex ancestor) instead of using the content-height value. Pages without the tag keep content-height auto-sizing exactly as before, so ordinary dashboards are unchanged, and because the flag is read from the page markup it works even when the page never loads `publisher.js`.

## Before / after

<img width="2640" height="3794" alt="data-app-fit-before-after" src="https://github.com/user-attachments/assets/9224eb05-df8c-4de5-8292-c0ccb9950a02" />


## What changed

- `api-doc.yaml`: add an optional `fit` enum (`viewport`) to the `Page` schema.
- `packages/server/src/server.ts`: detect the meta tag in `listPackagePages`. The scan first strips HTML comments and raw-text elements (`script`/`style`/`title`/`textarea`), then looks at the `<head>` region only, so the same string in a comment, a code sample, or the body cannot opt a page in. Only a real `<meta>` tag the browser would honor counts.
- `packages/sdk/src/components/PageViewer/PageViewer.tsx`: in fill mode the iframe fills the available height (and stops tracking content-height resize messages); the default content-height path is unchanged.
- `docs/html-data-apps.md`: document the opt-in.

## Testing

- New integration coverage in `html_pages.integration.spec.ts`: a deck that opts in fills; a standard `<meta name="viewport">`, a `data-name="publisher:fit"` decoy, a tag shown in a body comment, an unterminated comment, a real tag placed after a comment that contains `<body>`, and a real tag placed in `<body>` are each handled correctly (only the genuine head tag opts in).
- Full gate is green: typecheck, lint, prettier, and the server test suite.
- Verified by hand against a local Publisher: a full-screen page with the tag fills the viewer (matching standalone), the same page without the tag stays clipped, and a tall ordinary dashboard still auto-sizes to its content with no nested scrollbar.

## Notes

- Backward compatible: `fit` is an optional field, so pages and clients that do not set or read it are unaffected.
- The tag must sit in the page `<head>` within the first 4KB (the same window the `<title>` is read from), and uses quoted attributes as shown above.
