### PR TITLE
feat: reach databases through an SSH bastion (connection proxy)

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3078,7 +3078,7 @@ components:
 
     ConnectionProxy:
       type: object
-      description: "Optional proxy (e.g. SSH tunnel) that the publisher opens before connecting to the database. Proxied connections require the operator to set PUBLISHER_ALLOW_SSH_PROXY=true; default-deny."
+      description: "Optional proxy (e.g. SSH tunnel) that the publisher opens before connecting to the database. Proxied connections require the operator to set PUBLISHER_ALLOW_PROXY_CONNECTIONS=true; default-deny."
       required:
         - type
       properties:

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3053,6 +3053,8 @@ components:
             ]
         attributes:
           $ref: "#/components/schemas/ConnectionAttributes"
+        proxy:
+          $ref: "#/components/schemas/ConnectionProxy"
         postgresConnection:
           $ref: "#/components/schemas/PostgresConnection"
         bigqueryConnection:
@@ -3073,25 +3075,32 @@ components:
           $ref: "#/components/schemas/DucklakeConnection"
         publisherConnection:
           $ref: "#/components/schemas/PublisherConnection"
-        proxy:
-          $ref: "#/components/schemas/ConnectionProxy"
 
     ConnectionProxy:
       type: object
-      description: "Optional proxy (e.g. SSH tunnel) that the publisher opens before connecting to the database. Proxied connections require the operator to set PUBLISHER_ALLOW_PROXY_CONNECTIONS=true; default-deny."
+      description:
+        Optional network proxy through which the connection is reached. Applies to
+        any connection type whose database is not directly reachable (e.g. behind a
+        bastion). The proxy is established below the driver, so the driver connects
+        to a local endpoint transparently. Modeled as a discriminated union on
+        `type` so additional proxy mechanisms can be added later. Proxied
+        connections are default-deny — the operator must set
+        PUBLISHER_ALLOW_PROXY_CONNECTIONS=true to enable them.
       required:
         - type
       properties:
         type:
           type: string
           enum: [ssh]
-          description: Proxy type; currently only "ssh" is supported
+          description: Proxy mechanism. Currently only SSH local port-forwarding.
         ssh:
           $ref: "#/components/schemas/SshProxyConfig"
 
     SshProxyConfig:
       type: object
-      description: Configuration for an SSH bastion tunnel
+      description:
+        SSH bastion / jump-host config for reaching a database inside a private
+        network via an SSH local port-forward. Authentication is public-key only.
       required:
         - host
         - username
@@ -3099,27 +3108,32 @@ components:
       properties:
         host:
           type: string
-          description: SSH bastion hostname or IP address
+          description: Bastion hostname or IP address (the SSH jump host)
         port:
           type: integer
-          description: SSH bastion port (default 22)
+          default: 22
+          description: Bastion SSH port (defaults to 22)
         username:
           type: string
-          description: SSH username
+          description: SSH username on the bastion
         privateKey:
           type: string
-          description: PEM-encoded SSH private key
+          description:
+            PEM-encoded SSH private key used to authenticate to the bastion. The
+            customer authorizes the matching public key in the bastion's
+            authorized_keys; public-key auth only.
         privateKeyPass:
           type: string
-          description: Passphrase for the private key, if encrypted
+          description: Passphrase for the encrypted private key, if any.
         hostKey:
           type: string
           description: |
-            Expected bastion host public key, as an OpenSSH known_hosts line or its
-            base64 blob (e.g. from `ssh-keyscan <bastion>`). Hashed known_hosts entries
-            (lines beginning `|1|`) are not supported — use the unhashed ssh-keyscan
-            output. If absent the tunnel is refused unless
-            PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY=true is set — see proxy.ts.
+            Pinned bastion host public key, as an OpenSSH known_hosts line or its
+            base64 blob (e.g. from `ssh-keyscan <bastion>`), verified on every
+            connect. Hashed known_hosts entries (lines beginning `|1|`) are not
+            supported — use the unhashed ssh-keyscan output. A missing or mismatched
+            host key fails the connection closed, unless
+            PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY=true is set.
 
     ConnectionAttributes:
       type: object

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -394,6 +394,8 @@ paths:
             schema:
               type: object
               properties:
+                proxy:
+                  $ref: "#/components/schemas/ConnectionProxy"
                 postgresConnection:
                   $ref: "#/components/schemas/PostgresConnection"
                 mysqlConnection:

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3132,8 +3132,8 @@ components:
           description: |
             Pinned bastion host public key, as an OpenSSH known_hosts line or its
             base64 blob (e.g. from `ssh-keyscan <bastion>`), verified on every
-            connect. Hashed known_hosts entries (lines beginning `|1|`) are not
-            supported — use the unhashed ssh-keyscan output. A missing or mismatched
+            connect. Plain and hashed (`|1|…`) known_hosts lines both work — only
+            the key blob is compared, never the hostname. A missing or mismatched
             host key fails the connection closed, unless
             PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY=true is set.
 

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3073,6 +3073,51 @@ components:
           $ref: "#/components/schemas/DucklakeConnection"
         publisherConnection:
           $ref: "#/components/schemas/PublisherConnection"
+        proxy:
+          $ref: "#/components/schemas/ConnectionProxy"
+
+    ConnectionProxy:
+      type: object
+      description: Optional proxy (e.g. SSH tunnel) that the publisher opens before connecting to the database
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: [ssh]
+          description: Proxy type; currently only "ssh" is supported
+        ssh:
+          $ref: "#/components/schemas/SshProxyConfig"
+
+    SshProxyConfig:
+      type: object
+      description: Configuration for an SSH bastion tunnel
+      required:
+        - host
+        - username
+        - privateKey
+      properties:
+        host:
+          type: string
+          description: SSH bastion hostname or IP address
+        port:
+          type: integer
+          description: SSH bastion port (default 22)
+        username:
+          type: string
+          description: SSH username
+        privateKey:
+          type: string
+          description: PEM-encoded SSH private key
+        privateKeyPass:
+          type: string
+          description: Passphrase for the private key, if encrypted
+        hostKey:
+          type: string
+          description: |
+            Expected bastion host public key, as an OpenSSH known_hosts line or its
+            base64 blob (e.g. from ssh-keyscan). If absent the tunnel is refused unless
+            PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY=true is set — see proxy.ts.
 
     ConnectionAttributes:
       type: object

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3085,9 +3085,9 @@ components:
         any connection type whose database is not directly reachable (e.g. behind a
         bastion). The proxy is established below the driver, so the driver connects
         to a local endpoint transparently. Modeled as a discriminated union on
-        `type` so additional proxy mechanisms can be added later. Proxied
-        connections are default-deny — the operator must set
-        PUBLISHER_ALLOW_PROXY_CONNECTIONS=true to enable them.
+        `type` so additional proxy mechanisms can be added later. The trust
+        control is host-key pinning (fail-closed); a proxy is authorized by
+        whoever configures the connection, not by an env-flag gate.
       required:
         - type
       properties:

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3116,7 +3116,9 @@ components:
           type: string
           description: |
             Expected bastion host public key, as an OpenSSH known_hosts line or its
-            base64 blob (e.g. from ssh-keyscan). If absent the tunnel is refused unless
+            base64 blob (e.g. from `ssh-keyscan <bastion>`). Hashed known_hosts entries
+            (lines beginning `|1|`) are not supported — use the unhashed ssh-keyscan
+            output. If absent the tunnel is refused unless
             PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY=true is set — see proxy.ts.
 
     ConnectionAttributes:

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3078,7 +3078,7 @@ components:
 
     ConnectionProxy:
       type: object
-      description: Optional proxy (e.g. SSH tunnel) that the publisher opens before connecting to the database
+      description: "Optional proxy (e.g. SSH tunnel) that the publisher opens before connecting to the database. Proxied connections require the operator to set PUBLISHER_ALLOW_SSH_PROXY=true; default-deny."
       required:
         - type
       properties:

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "malloy-publisher",
@@ -10,12 +11,14 @@
         "prettier-plugin-terraform-formatter": "^1.2.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "ssh2": "^1.17.0",
       },
       "devDependencies": {
         "@playwright/test": "^1.55.1",
         "@types/node": "^24.10.0",
         "@types/react": "^19.1.7",
         "@types/react-dom": "^19.1.6",
+        "@types/ssh2": "^1.15.5",
         "eslint": "^8.50.0",
         "gts": "^6.0.2",
         "prettier": "^3.0.0",
@@ -27,7 +30,7 @@
     },
     "packages/app": {
       "name": "@malloy-publisher/app",
-      "version": "0.0.207",
+      "version": "0.0.209",
       "dependencies": {
         "@malloy-publisher/sdk": "workspace:*",
         "@mui/icons-material": "^7.0.2",
@@ -79,7 +82,7 @@
     },
     "packages/sdk": {
       "name": "@malloy-publisher/sdk",
-      "version": "0.0.207",
+      "version": "0.0.209",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
@@ -132,7 +135,7 @@
     },
     "packages/server": {
       "name": "@malloy-publisher/server",
-      "version": "0.0.207",
+      "version": "0.0.209",
       "bin": {
         "malloy-publisher": "dist/server.mjs",
       },
@@ -1336,6 +1339,8 @@
 
     "@types/sinonjs__fake-timers": ["@types/sinonjs__fake-timers@8.1.5", "", {}, "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ=="],
 
+    "@types/ssh2": ["@types/ssh2@1.15.5", "", { "dependencies": { "@types/node": "^18.11.18" } }, "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ=="],
+
     "@types/superagent": ["@types/superagent@8.1.9", "", { "dependencies": { "@types/cookiejar": "^2.1.5", "@types/methods": "^1.1.4", "@types/node": "*", "form-data": "^4.0.0" } }, "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ=="],
 
     "@types/supertest": ["@types/supertest@6.0.3", "", { "dependencies": { "@types/methods": "^1.1.4", "@types/superagent": "^8.1.0" } }, "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w=="],
@@ -1466,6 +1471,8 @@
 
     "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
 
+    "asn1": ["asn1@0.2.6", "", { "dependencies": { "safer-buffer": "~2.1.0" } }, "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ=="],
+
     "asn1.js": ["asn1.js@5.4.1", "", { "dependencies": { "bn.js": "^4.0.0", "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0", "safer-buffer": "^2.1.0" } }, "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA=="],
 
     "asn1.js-rfc2560": ["asn1.js-rfc2560@5.0.1", "", { "dependencies": { "asn1.js-rfc5280": "^3.0.0" }, "peerDependencies": { "asn1.js": "^5.0.0" } }, "sha512-1PrVg6kuBziDN3PGFmRk3QrjpKvP9h/Hv5yMrFZvC1kpzP6dQRzf5BpKstANqHBkaOUmTpakJWhicTATOA/SbA=="],
@@ -1518,6 +1525,8 @@
 
     "bcp-47-match": ["bcp-47-match@2.0.3", "", {}, "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ=="],
 
+    "bcrypt-pbkdf": ["bcrypt-pbkdf@1.0.2", "", { "dependencies": { "tweetnacl": "^0.14.3" } }, "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w=="],
+
     "better-ajv-errors": ["better-ajv-errors@0.6.7", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "@babel/runtime": "^7.0.0", "chalk": "^2.4.1", "core-js": "^3.2.1", "json-to-ast": "^2.0.3", "jsonpointer": "^4.0.1", "leven": "^3.1.0" }, "peerDependencies": { "ajv": "4.11.8 - 6" } }, "sha512-PYgt/sCzR4aGpyNy5+ViSQ77ognMnWq7745zM+/flYO4/Yisdtp9wDQW2IKCyVYPUxQt3E/b5GBSwfhd1LPdlg=="],
 
     "big-integer": ["big-integer@1.6.52", "", {}, "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="],
@@ -1553,6 +1562,8 @@
     "buffer-crc32": ["buffer-crc32@1.0.0", "", {}, "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
+    "buildcheck": ["buildcheck@0.0.7", "", {}, "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA=="],
 
     "builtins": ["builtins@5.1.0", "", { "dependencies": { "semver": "^7.0.0" } }, "sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg=="],
 
@@ -1681,6 +1692,8 @@
     "cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
 
     "cosmiconfig": ["cosmiconfig@8.3.6", "", { "dependencies": { "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0", "path-type": "^4.0.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA=="],
+
+    "cpu-features": ["cpu-features@0.0.10", "", { "dependencies": { "buildcheck": "~0.0.6", "nan": "^2.19.0" } }, "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA=="],
 
     "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
 
@@ -3152,6 +3165,8 @@
 
     "ssf": ["ssf@0.11.2", "", { "dependencies": { "frac": "~1.1.2" } }, "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g=="],
 
+    "ssh2": ["ssh2@1.17.0", "", { "dependencies": { "asn1": "^0.2.6", "bcrypt-pbkdf": "^1.0.2" }, "optionalDependencies": { "cpu-features": "~0.0.10", "nan": "^2.23.0" } }, "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ=="],
+
     "stack-trace": ["stack-trace@0.0.10", "", {}, "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="],
 
     "statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
@@ -3285,6 +3300,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsutils": ["tsutils@3.21.0", "", { "dependencies": { "tslib": "^1.8.1" }, "peerDependencies": { "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta" } }, "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA=="],
+
+    "tweetnacl": ["tweetnacl@0.14.5", "", {}, "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
@@ -3846,6 +3863,8 @@
 
     "@types/serve-static/@types/node": ["@types/node@24.5.2", "", { "dependencies": { "undici-types": "~7.12.0" } }, "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ=="],
 
+    "@types/ssh2/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
     "@types/superagent/@types/node": ["@types/node@24.5.2", "", { "dependencies": { "undici-types": "~7.12.0" } }, "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ=="],
 
     "@types/tedious/@types/node": ["@types/node@24.5.2", "", { "dependencies": { "undici-types": "~7.12.0" } }, "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ=="],
@@ -4377,6 +4396,8 @@
     "@types/send/@types/node/undici-types": ["undici-types@7.12.0", "", {}, "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ=="],
 
     "@types/serve-static/@types/node/undici-types": ["undici-types@7.12.0", "", {}, "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ=="],
+
+    "@types/ssh2/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "@types/superagent/@types/node/undici-types": ["undici-types@7.12.0", "", {}, "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ=="],
 

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -133,8 +133,8 @@ VPC; it is not an IP-restriction mechanism (restrict the database directly for t
   here. Public-key auth only.
 - `proxy.ssh.hostKey` — the bastion's host public key, pinned and verified on every
   connect (fail-closed). Get it with `ssh-keyscan <bastion>` and paste a line of the
-  output (or just the base64 blob). **Hashed** `known_hosts` entries (lines starting
-  `|1|`) are not supported — use the unhashed `ssh-keyscan` output. If `hostKey` is
+  output (or just the base64 blob). Both plain and hashed (`|1|…`, from `ssh-keyscan -H`)
+  lines work — only the key blob is compared, never the hostname. If `hostKey` is
   omitted the tunnel is refused unless `PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY=true` (intended
   for local dev only).
 

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -85,6 +85,60 @@ server uses the token as configured and does not refresh it, so a long-running
 CLI/extension today; re-issue the token and restart if queries start failing
 auth.
 
+## Reaching a database through an SSH bastion (`proxy`)
+
+Any TCP database connection (postgres today) can carry an optional `proxy` block to
+reach a database that is only routable from inside a private network. The server opens
+an SSH connection to the bastion, stands up a local `127.0.0.1` forward, and points the
+driver at it — the driver is unchanged. A bastion is for **reachability** into a private
+VPC; it is not an IP-restriction mechanism (restrict the database directly for that).
+
+> **Disabled by default.** Like `publisher` connections, a proxy makes the server open
+> an outbound connection to a tenant-configured host — an SSRF surface in a hosted
+> deployment. It is gated by the **same** flag: set `PUBLISHER_ALLOW_PROXY_CONNECTIONS=true`
+> on the server process. With the flag unset, a proxied connection fails at config load.
+
+```json
+{
+  "name": "pg-via-bastion",
+  "type": "postgres",
+  "postgresConnection": {
+    "host": "db.internal.vpc",
+    "port": 5432,
+    "databaseName": "analytics",
+    "userName": "readonly",
+    "password": "<secret>"
+  },
+  "proxy": {
+    "type": "ssh",
+    "ssh": {
+      "host": "bastion.example.com",
+      "port": 22,
+      "username": "ec2-user",
+      "privateKey": "-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----",
+      "hostKey": "bastion.example.com ssh-ed25519 AAAA…"
+    }
+  }
+}
+```
+
+- `postgresConnection.host`/`port` — the database address **as reachable from the
+  bastion** (the in-VPC host). The connectionString form is not supported with a proxy.
+- `proxy.ssh.host`/`port`/`username` — the bastion (jump host). The local forward port is
+  chosen automatically; you never specify it.
+- `proxy.ssh.privateKey` (+ optional `privateKeyPass`) — the customer generates the
+  keypair, authorizes their own public key on the bastion, and provides the private key
+  here. Public-key auth only.
+- `proxy.ssh.hostKey` — the bastion's host public key, pinned and verified on every
+  connect (fail-closed). Get it with `ssh-keyscan <bastion>` and paste a line of the
+  output (or just the base64 blob). **Hashed** `known_hosts` entries (lines starting
+  `|1|`) are not supported — use the unhashed `ssh-keyscan` output. If `hostKey` is
+  omitted the tunnel is refused unless `PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY=true` (intended
+  for local dev only).
+
+When the gate is enabled, a tenant can point `proxy.ssh.host` at any reachable host — the
+same SSRF class as `publisher` connections — so enable it deliberately.
+
 ## Example: mixed connections
 
 ```json

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -93,10 +93,12 @@ an SSH connection to the bastion, stands up a local `127.0.0.1` forward, and poi
 driver at it — the driver is unchanged. A bastion is for **reachability** into a private
 VPC; it is not an IP-restriction mechanism (restrict the database directly for that).
 
-> **Disabled by default.** Like `publisher` connections, a proxy makes the server open
-> an outbound connection to a tenant-configured host — an SSRF surface in a hosted
-> deployment. It is gated by the **same** flag: set `PUBLISHER_ALLOW_PROXY_CONNECTIONS=true`
-> on the server process. With the flag unset, a proxied connection fails at config load.
+> **Authorization & trust.** A proxy makes the server open an outbound SSH tunnel to a
+> tenant-configured bastion, so it is authorized by whoever configures the connection. It
+> is **not** behind an env-flag gate, and is deliberately kept separate from the
+> `publisher` type's `PUBLISHER_ALLOW_PROXY_CONNECTIONS` (that flag is about
+> publisher-to-publisher HTTP proxying, a different decision). The trust control is
+> **host-key pinning** (below), which is fail-closed.
 
 ```json
 {

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -138,8 +138,19 @@ VPC; it is not an IP-restriction mechanism (restrict the database directly for t
   omitted the tunnel is refused unless `PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY=true` (intended
   for local dev only).
 
-When the gate is enabled, a tenant can point `proxy.ssh.host` at any reachable host — the
-same SSRF class as `publisher` connections — so enable it deliberately.
+A proxy makes the server open an outbound SSH tunnel to a tenant-configured host, so
+connection configuration is the authorization boundary, and host-key pinning is the trust
+control on the tunnel itself.
+
+### TLS to the database through the tunnel
+
+The `pg` driver honors `PGSSLMODE` on a proxied connection just as on a direct one (it reads
+it from the environment). One limitation: the driver connects to the local forward endpoint
+(`127.0.0.1`), not the real database host, so full verification (`sslmode=verify-full`)
+fails the certificate **hostname** check even when the CA is trusted. Use
+`sslmode=no-verify` through a tunnel — the SSH transport is already encrypted and the
+bastion→DB leg is inside the private network — until per-connection `servername` support
+lands (see malloydata/malloy#2960).
 
 ## Example: mixed connections
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/node": "^24.10.0",
     "@types/react": "^19.1.7",
     "@types/react-dom": "^19.1.6",
+    "@types/ssh2": "^1.15.5",
     "eslint": "^8.50.0",
     "gts": "^6.0.2",
     "prettier": "^3.0.0",
@@ -68,7 +69,8 @@
     "fn": "^0.2.0",
     "prettier-plugin-terraform-formatter": "^1.2.1",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "ssh2": "^1.17.0"
   },
   "resolutions": {
     "esbuild": "0.25.9",

--- a/packages/server/src/dto/connection.dto.ts
+++ b/packages/server/src/dto/connection.dto.ts
@@ -1,10 +1,12 @@
 import { Type } from "class-transformer";
 import {
+   IsDefined,
    IsEnum,
    IsArray,
    IsNumber,
    IsOptional,
    IsString,
+   ValidateIf,
    ValidateNested,
 } from "class-validator";
 import "reflect-metadata";
@@ -226,7 +228,10 @@ export class ConnectionProxyDto {
    @IsEnum(["ssh"])
    type!: "ssh";
 
-   @IsOptional()
+   // ssh config is required for the ssh proxy type (the only type today); keep
+   // the conditional so a future proxy type isn't forced to supply `ssh`.
+   @ValidateIf((o) => o.type === "ssh")
+   @IsDefined()
    @ValidateNested()
    @Type(() => SshProxyConfigDto)
    ssh?: SshProxyConfigDto;

--- a/packages/server/src/dto/connection.dto.ts
+++ b/packages/server/src/dto/connection.dto.ts
@@ -199,6 +199,39 @@ export class DuckdbConnectionDto {
    attachedDatabases?: AttachedDatabase[];
 }
 
+export class SshProxyConfigDto {
+   @IsString()
+   host!: string;
+
+   @IsOptional()
+   @IsNumber()
+   port?: number;
+
+   @IsString()
+   username!: string;
+
+   @IsString()
+   privateKey!: string;
+
+   @IsOptional()
+   @IsString()
+   privateKeyPass?: string;
+
+   @IsOptional()
+   @IsString()
+   hostKey?: string;
+}
+
+export class ConnectionProxyDto {
+   @IsEnum(["ssh"])
+   type!: "ssh";
+
+   @IsOptional()
+   @ValidateNested()
+   @Type(() => SshProxyConfigDto)
+   ssh?: SshProxyConfigDto;
+}
+
 export class ConnectionDto implements ApiConnection {
    @IsOptional()
    @IsString()
@@ -256,4 +289,9 @@ export class ConnectionDto implements ApiConnection {
    @ValidateNested()
    @Type(() => DuckdbConnectionDto)
    duckdbConnection?: DuckdbConnectionDto;
+
+   @IsOptional()
+   @ValidateNested()
+   @Type(() => ConnectionProxyDto)
+   proxy?: ConnectionProxyDto;
 }

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -6,7 +6,10 @@ import "@malloydata/db-duckdb/native";
 import "@malloydata/db-mysql";
 import type { MySQLConnection } from "@malloydata/db-mysql";
 import "@malloydata/db-postgres";
-import type { PostgresConnection } from "@malloydata/db-postgres";
+import {
+   PooledPostgresConnection,
+   type PostgresConnection,
+} from "@malloydata/db-postgres";
 // Registers the "publisher" connection type (proxies SQL to a remote Publisher
 // dataplane). No live-class branch is needed in lookupConnection — the default
 // path resolves it through the registry like any other registered type.
@@ -41,6 +44,7 @@ import {
    normalizeSnowflakePrivateKey,
 } from "./connection_config";
 import { CloudStorageCredentials } from "./gcs_s3_utils";
+import { openProxy, type ProxyEndpoint } from "./proxy";
 
 type AttachedDatabase = components["schemas"]["AttachedDatabase"];
 type ApiConnection = components["schemas"]["Connection"];
@@ -921,6 +925,30 @@ function buildSnowflakePrivateKeyConnection(
    });
 }
 
+function buildProxiedPostgresConnection(
+   metadata: EnvironmentConnectionMetadata,
+   endpoint: ProxyEndpoint,
+): PooledPostgresConnection {
+   const name = metadata.apiConnection.name!;
+   const pg = metadata.apiConnection.postgresConnection;
+   if (!pg) {
+      throw new Error(
+         `Proxied connection '${name}' has type 'postgres' but no postgresConnection config.`,
+      );
+   }
+   return new PooledPostgresConnection({
+      name,
+      host: endpoint.host,
+      port: endpoint.port,
+      username: pg.userName,
+      password: pg.password,
+      databaseName: pg.databaseName,
+      // Pool sizing mirrors buildSnowflakePrivateKeyConnection.
+      poolMin: 1,
+      poolMax: 20,
+   });
+}
+
 function buildDuckLakeConnection(
    metadata: EnvironmentConnectionMetadata,
    entry: CoreConnectionEntry,
@@ -987,6 +1015,11 @@ export function buildEnvironmentMalloyConfig(
    const duckLakeCache = new Map<string, Promise<DuckLakeConnection>>();
    const snowflakeJwtCache = new Map<string, Promise<SnowflakeConnection>>();
    const azureDuckDBCache = new Map<string, Promise<AzureDuckDBConnection>>();
+   const proxyConnectionCache = new Map<
+      string,
+      Promise<PooledPostgresConnection>
+   >();
+   const proxyEndpoints = new Map<string, ProxyEndpoint>();
    const attachPromises = new WeakMap<Connection, Promise<void>>();
 
    const malloyConfig = new MalloyConfig(assembled.pojo, {
@@ -1044,6 +1077,33 @@ export function buildEnvironmentMalloyConfig(
                return connection;
             }
 
+            if (metadata?.proxy) {
+               let connectionPromise = proxyConnectionCache.get(name!);
+               if (!connectionPromise) {
+                  const connType = metadata.apiConnection.type;
+                  if (connType !== "postgres") {
+                     throw new Error(
+                        `SSH proxy is not yet supported for connection type '${connType}'. ` +
+                           `Only 'postgres' is implemented.`,
+                     );
+                  }
+                  connectionPromise = (async () => {
+                     const endpoint = await openProxy(metadata.proxy!, {
+                        host:
+                           metadata.apiConnection.postgresConnection?.host ??
+                           "localhost",
+                        port:
+                           metadata.apiConnection.postgresConnection?.port ??
+                           5432,
+                     });
+                     proxyEndpoints.set(name!, endpoint);
+                     return buildProxiedPostgresConnection(metadata, endpoint);
+                  })();
+                  proxyConnectionCache.set(name!, connectionPromise);
+               }
+               return connectionPromise;
+            }
+
             if (metadata?.hasSnowflakePrivateKey) {
                let connectionPromise = snowflakeJwtCache.get(name!);
                if (!connectionPromise) {
@@ -1086,6 +1146,7 @@ export function buildEnvironmentMalloyConfig(
             ...duckLakeCache.values(),
             ...snowflakeJwtCache.values(),
             ...azureDuckDBCache.values(),
+            ...proxyConnectionCache.values(),
          ];
          const closeResults = await Promise.allSettled([
             malloyConfig.shutdown("close"),
@@ -1093,10 +1154,15 @@ export function buildEnvironmentMalloyConfig(
                const connection = await promise;
                await connection.close();
             }),
+            // Close proxy tunnels after DB connections so the tunnel is still
+            // alive during any in-flight connection.close() drains.
+            ...[...proxyEndpoints.values()].map((ep) => ep.close()),
          ]);
          duckLakeCache.clear();
          snowflakeJwtCache.clear();
          azureDuckDBCache.clear();
+         proxyConnectionCache.clear();
+         proxyEndpoints.clear();
 
          const failures = closeResults.filter(
             (result): result is PromiseRejectedResult =>

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -1104,8 +1104,21 @@ export function buildEnvironmentMalloyConfig(
                         host: pgConfig.host!,
                         port: pgConfig.port!,
                      });
-                     proxyEndpoints.set(name!, endpoint);
-                     return buildProxiedPostgresConnection(metadata, endpoint);
+                     try {
+                        const connection = buildProxiedPostgresConnection(
+                           metadata,
+                           endpoint,
+                        );
+                        // Register only after the build succeeds: a throw between
+                        // openProxy and here would otherwise leave an orphaned
+                        // tunnel in proxyEndpoints that a retry can't reach (the
+                        // outer .catch evicts the cache but not the endpoint).
+                        proxyEndpoints.set(name!, endpoint);
+                        return connection;
+                     } catch (err) {
+                        await endpoint.close().catch(() => {});
+                        throw err;
+                     }
                   })();
                   // Drop a rejected build from the cache so a later lookup can
                   // retry, rather than replaying a transient SSH failure (bastion

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -1087,14 +1087,22 @@ export function buildEnvironmentMalloyConfig(
                            `Only 'postgres' is implemented.`,
                      );
                   }
+                  // Fail closed: the proxy must forward to an explicit DB host/
+                  // port. The connectionString form is rejected because we cannot
+                  // safely rewrite its host to the local endpoint, and falling
+                  // back to localhost:5432 would tunnel to the bastion itself.
+                  const pgConfig = metadata.apiConnection.postgresConnection;
+                  if (!pgConfig?.host || !pgConfig?.port) {
+                     throw new Error(
+                        `SSH proxy for connection '${name}' requires explicit host and ` +
+                           `port on the postgres connection; the connectionString form ` +
+                           `is not supported with a proxy.`,
+                     );
+                  }
                   connectionPromise = (async () => {
                      const endpoint = await openProxy(metadata.proxy!, {
-                        host:
-                           metadata.apiConnection.postgresConnection?.host ??
-                           "localhost",
-                        port:
-                           metadata.apiConnection.postgresConnection?.port ??
-                           5432,
+                        host: pgConfig.host!,
+                        port: pgConfig.port!,
                      });
                      proxyEndpoints.set(name!, endpoint);
                      return buildProxiedPostgresConnection(metadata, endpoint);
@@ -1154,17 +1162,22 @@ export function buildEnvironmentMalloyConfig(
                const connection = await promise;
                await connection.close();
             }),
-            // Close proxy tunnels after DB connections so the tunnel is still
-            // alive during any in-flight connection.close() drains.
-            ...[...proxyEndpoints.values()].map((ep) => ep.close()),
          ]);
+         // Close proxy tunnels only AFTER the build promises above have settled:
+         // openProxy may still be in flight during a teardown race, and the
+         // endpoint is registered inside that promise — capturing the map
+         // earlier would miss it and leak the tunnel. Closing after the DB
+         // connections also keeps the tunnel alive while they drain.
+         const endpointResults = await Promise.allSettled(
+            [...proxyEndpoints.values()].map((ep) => ep.close()),
+         );
          duckLakeCache.clear();
          snowflakeJwtCache.clear();
          azureDuckDBCache.clear();
          proxyConnectionCache.clear();
          proxyEndpoints.clear();
 
-         const failures = closeResults.filter(
+         const failures = [...closeResults, ...endpointResults].filter(
             (result): result is PromiseRejectedResult =>
                result.status === "rejected",
          );

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -1107,6 +1107,16 @@ export function buildEnvironmentMalloyConfig(
                      proxyEndpoints.set(name!, endpoint);
                      return buildProxiedPostgresConnection(metadata, endpoint);
                   })();
+                  // Drop a rejected build from the cache so a later lookup can
+                  // retry, rather than replaying a transient SSH failure (bastion
+                  // restart, network blip) until the environment is rebuilt.
+                  connectionPromise.catch(() => {
+                     if (
+                        proxyConnectionCache.get(name!) === connectionPromise
+                     ) {
+                        proxyConnectionCache.delete(name!);
+                     }
+                  });
                   proxyConnectionCache.set(name!, connectionPromise);
                }
                return connectionPromise;

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -1087,10 +1087,10 @@ export function buildEnvironmentMalloyConfig(
                            `Only 'postgres' is implemented.`,
                      );
                   }
-                  // Fail closed: the proxy must forward to an explicit DB host/
-                  // port. The connectionString form is rejected because we cannot
-                  // safely rewrite its host to the local endpoint, and falling
-                  // back to localhost:5432 would tunnel to the bastion itself.
+                  // validateConnectionShape already enforces explicit host/port
+                  // at config load (the connectionString form can't be tunneled);
+                  // this is a defense-in-depth guard for any path that reaches
+                  // lookup without that validation.
                   const pgConfig = metadata.apiConnection.postgresConnection;
                   if (!pgConfig?.host || !pgConfig?.port) {
                      throw new Error(

--- a/packages/server/src/service/connection_config.spec.ts
+++ b/packages/server/src/service/connection_config.spec.ts
@@ -366,7 +366,8 @@ describe("SSH proxy gate (PUBLISHER_ALLOW_PROXY_CONNECTIONS)", () => {
          ssh: {
             host: "bastion.example.com",
             username: "ec2-user",
-            privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n-----END OPENSSH PRIVATE KEY-----",
+            privateKey:
+               "-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n-----END OPENSSH PRIVATE KEY-----",
          },
       },
    };

--- a/packages/server/src/service/connection_config.spec.ts
+++ b/packages/server/src/service/connection_config.spec.ts
@@ -446,4 +446,38 @@ describe("SSH proxy gate (PUBLISHER_ALLOW_PROXY_CONNECTIONS)", () => {
          "Connection proxy on 'pg-no-ssh-config' has type 'ssh' but no 'ssh' config object",
       );
    });
+
+   it("rejects a proxied postgres connection that also carries a connectionString", () => {
+      process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS = "true";
+      const conn: ApiConnection = {
+         ...validSshProxy,
+         name: "pg-with-connstring",
+         postgresConnection: {
+            connectionString: "postgresql://real-db.example.com:5432/mydb",
+            host: "127.0.0.1",
+            port: 5432,
+            databaseName: "mydb",
+         },
+      };
+      // The tunnel forwards to host/port; a connectionString would be silently
+      // ignored and could point at a different database, so it's rejected.
+      expect(() => assembleEnvironmentConnections([conn])).toThrow(
+         "does not support the connectionString form",
+      );
+   });
+
+   it("rejects a proxied postgres connection missing explicit host/port", () => {
+      process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS = "true";
+      const conn: ApiConnection = {
+         ...validSshProxy,
+         name: "pg-no-host-port",
+         postgresConnection: {
+            databaseName: "mydb",
+            userName: "user",
+         },
+      };
+      expect(() => assembleEnvironmentConnections([conn])).toThrow(
+         "requires explicit host and port",
+      );
+   });
 });

--- a/packages/server/src/service/connection_config.spec.ts
+++ b/packages/server/src/service/connection_config.spec.ts
@@ -349,3 +349,100 @@ describe("assembleEnvironmentConnections — publisher", () => {
       });
    });
 });
+
+describe("SSH proxy gate (PUBLISHER_ALLOW_SSH_PROXY)", () => {
+   const validSshProxy: ApiConnection = {
+      name: "pg-via-bastion",
+      type: "postgres",
+      postgresConnection: {
+         host: "127.0.0.1",
+         port: 5432,
+         databaseName: "mydb",
+         userName: "user",
+         password: "pass",
+      },
+      proxy: {
+         type: "ssh",
+         ssh: {
+            host: "bastion.example.com",
+            username: "ec2-user",
+            privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n-----END OPENSSH PRIVATE KEY-----",
+         },
+      },
+   };
+
+   const priorFlag = process.env.PUBLISHER_ALLOW_SSH_PROXY;
+   beforeEach(() => {
+      delete process.env.PUBLISHER_ALLOW_SSH_PROXY;
+   });
+   afterEach(() => {
+      if (priorFlag === undefined) {
+         delete process.env.PUBLISHER_ALLOW_SSH_PROXY;
+      } else {
+         process.env.PUBLISHER_ALLOW_SSH_PROXY = priorFlag;
+      }
+   });
+
+   it("rejects a postgres connection with an ssh proxy when the flag is unset (default-deny)", () => {
+      expect(() => assembleEnvironmentConnections([validSshProxy])).toThrow(
+         "PUBLISHER_ALLOW_SSH_PROXY=true",
+      );
+   });
+
+   it("error message names the env var to flip", () => {
+      expect(() => assembleEnvironmentConnections([validSshProxy])).toThrow(
+         "Connection proxy on 'pg-via-bastion' is disabled in this deployment",
+      );
+   });
+
+   it("allows a postgres+ssh-proxy connection when the flag is 'true'", () => {
+      process.env.PUBLISHER_ALLOW_SSH_PROXY = "true";
+      const { pojo } = assembleEnvironmentConnections([validSshProxy]);
+      expect(pojo.connections["pg-via-bastion"].is).toBe("postgres");
+   });
+
+   it("rejects a non-postgres (bigquery) connection with a proxy even when the flag is set", () => {
+      process.env.PUBLISHER_ALLOW_SSH_PROXY = "true";
+      const conn: ApiConnection = {
+         name: "bq-via-bastion",
+         type: "bigquery",
+         bigqueryConnection: {
+            serviceAccountKeyJson: JSON.stringify({
+               type: "service_account",
+               project_id: "proj",
+               private_key: "key",
+               client_email: "sa@proj.iam.gserviceaccount.com",
+            }),
+         },
+         proxy: {
+            type: "ssh",
+            ssh: {
+               host: "bastion.example.com",
+               username: "ec2-user",
+               privateKey: "key",
+            },
+         },
+      };
+      expect(() => assembleEnvironmentConnections([conn])).toThrow(
+         "Connection proxy is not supported for type 'bigquery' (only 'postgres' today)",
+      );
+   });
+
+   it("rejects an ssh proxy with no ssh config object even when the flag is set", () => {
+      process.env.PUBLISHER_ALLOW_SSH_PROXY = "true";
+      const conn: ApiConnection = {
+         name: "pg-no-ssh-config",
+         type: "postgres",
+         postgresConnection: {
+            host: "127.0.0.1",
+            databaseName: "mydb",
+         },
+         proxy: {
+            type: "ssh",
+         },
+      };
+      expect(() => assembleEnvironmentConnections([conn])).toThrow(
+         "Connection proxy on 'pg-no-ssh-config' has type 'ssh' but no 'ssh' config object",
+      );
+   });
+});

--- a/packages/server/src/service/connection_config.spec.ts
+++ b/packages/server/src/service/connection_config.spec.ts
@@ -350,7 +350,7 @@ describe("assembleEnvironmentConnections — publisher", () => {
    });
 });
 
-describe("SSH proxy gate (PUBLISHER_ALLOW_SSH_PROXY)", () => {
+describe("SSH proxy gate (PUBLISHER_ALLOW_PROXY_CONNECTIONS)", () => {
    const validSshProxy: ApiConnection = {
       name: "pg-via-bastion",
       type: "postgres",
@@ -371,21 +371,21 @@ describe("SSH proxy gate (PUBLISHER_ALLOW_SSH_PROXY)", () => {
       },
    };
 
-   const priorFlag = process.env.PUBLISHER_ALLOW_SSH_PROXY;
+   const priorFlag = process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS;
    beforeEach(() => {
-      delete process.env.PUBLISHER_ALLOW_SSH_PROXY;
+      delete process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS;
    });
    afterEach(() => {
       if (priorFlag === undefined) {
-         delete process.env.PUBLISHER_ALLOW_SSH_PROXY;
+         delete process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS;
       } else {
-         process.env.PUBLISHER_ALLOW_SSH_PROXY = priorFlag;
+         process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS = priorFlag;
       }
    });
 
    it("rejects a postgres connection with an ssh proxy when the flag is unset (default-deny)", () => {
       expect(() => assembleEnvironmentConnections([validSshProxy])).toThrow(
-         "PUBLISHER_ALLOW_SSH_PROXY=true",
+         "PUBLISHER_ALLOW_PROXY_CONNECTIONS=true",
       );
    });
 
@@ -396,13 +396,13 @@ describe("SSH proxy gate (PUBLISHER_ALLOW_SSH_PROXY)", () => {
    });
 
    it("allows a postgres+ssh-proxy connection when the flag is 'true'", () => {
-      process.env.PUBLISHER_ALLOW_SSH_PROXY = "true";
+      process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS = "true";
       const { pojo } = assembleEnvironmentConnections([validSshProxy]);
       expect(pojo.connections["pg-via-bastion"].is).toBe("postgres");
    });
 
    it("rejects a non-postgres (bigquery) connection with a proxy even when the flag is set", () => {
-      process.env.PUBLISHER_ALLOW_SSH_PROXY = "true";
+      process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS = "true";
       const conn: ApiConnection = {
          name: "bq-via-bastion",
          type: "bigquery",
@@ -429,7 +429,7 @@ describe("SSH proxy gate (PUBLISHER_ALLOW_SSH_PROXY)", () => {
    });
 
    it("rejects an ssh proxy with no ssh config object even when the flag is set", () => {
-      process.env.PUBLISHER_ALLOW_SSH_PROXY = "true";
+      process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS = "true";
       const conn: ApiConnection = {
          name: "pg-no-ssh-config",
          type: "postgres",

--- a/packages/server/src/service/connection_config.spec.ts
+++ b/packages/server/src/service/connection_config.spec.ts
@@ -350,7 +350,7 @@ describe("assembleEnvironmentConnections — publisher", () => {
    });
 });
 
-describe("SSH proxy gate (PUBLISHER_ALLOW_PROXY_CONNECTIONS)", () => {
+describe("SSH proxy validation", () => {
    const validSshProxy: ApiConnection = {
       name: "pg-via-bastion",
       type: "postgres",
@@ -372,38 +372,25 @@ describe("SSH proxy gate (PUBLISHER_ALLOW_PROXY_CONNECTIONS)", () => {
       },
    };
 
-   const priorFlag = process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS;
-   beforeEach(() => {
+   it("allows a postgres+ssh-proxy connection with no env flag required", () => {
+      // The SSH proxy is a normal connection capability — deliberately NOT gated
+      // by PUBLISHER_ALLOW_PROXY_CONNECTIONS (that flag is for the `publisher`
+      // HTTP multi-hop type). Prove it assembles with the flag unset.
+      const priorFlag = process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS;
       delete process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS;
-   });
-   afterEach(() => {
-      if (priorFlag === undefined) {
-         delete process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS;
-      } else {
-         process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS = priorFlag;
+      try {
+         const { pojo } = assembleEnvironmentConnections([validSshProxy]);
+         expect(pojo.connections["pg-via-bastion"].is).toBe("postgres");
+      } finally {
+         if (priorFlag === undefined) {
+            delete process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS;
+         } else {
+            process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS = priorFlag;
+         }
       }
    });
 
-   it("rejects a postgres connection with an ssh proxy when the flag is unset (default-deny)", () => {
-      expect(() => assembleEnvironmentConnections([validSshProxy])).toThrow(
-         "PUBLISHER_ALLOW_PROXY_CONNECTIONS=true",
-      );
-   });
-
-   it("error message names the env var to flip", () => {
-      expect(() => assembleEnvironmentConnections([validSshProxy])).toThrow(
-         "Connection proxy on 'pg-via-bastion' is disabled in this deployment",
-      );
-   });
-
-   it("allows a postgres+ssh-proxy connection when the flag is 'true'", () => {
-      process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS = "true";
-      const { pojo } = assembleEnvironmentConnections([validSshProxy]);
-      expect(pojo.connections["pg-via-bastion"].is).toBe("postgres");
-   });
-
-   it("rejects a non-postgres (bigquery) connection with a proxy even when the flag is set", () => {
-      process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS = "true";
+   it("rejects a non-postgres (bigquery) connection with a proxy", () => {
       const conn: ApiConnection = {
          name: "bq-via-bastion",
          type: "bigquery",
@@ -429,8 +416,7 @@ describe("SSH proxy gate (PUBLISHER_ALLOW_PROXY_CONNECTIONS)", () => {
       );
    });
 
-   it("rejects an ssh proxy with no ssh config object even when the flag is set", () => {
-      process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS = "true";
+   it("rejects an ssh proxy with no ssh config object", () => {
       const conn: ApiConnection = {
          name: "pg-no-ssh-config",
          type: "postgres",
@@ -448,7 +434,6 @@ describe("SSH proxy gate (PUBLISHER_ALLOW_PROXY_CONNECTIONS)", () => {
    });
 
    it("rejects a proxied postgres connection that also carries a connectionString", () => {
-      process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS = "true";
       const conn: ApiConnection = {
          ...validSshProxy,
          name: "pg-with-connstring",
@@ -467,7 +452,6 @@ describe("SSH proxy gate (PUBLISHER_ALLOW_PROXY_CONNECTIONS)", () => {
    });
 
    it("rejects a proxied postgres connection missing explicit host/port", () => {
-      process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS = "true";
       const conn: ApiConnection = {
          ...validSshProxy,
          name: "pg-no-host-port",

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -22,6 +22,7 @@ export type EnvironmentConnectionMetadata = {
    isDuckLake: boolean;
    databasePath?: string;
    workingDirectory: string;
+   proxy?: ApiConnection["proxy"];
 };
 
 export type AssembledEnvironmentConnections = {
@@ -445,6 +446,7 @@ export function assembleEnvironmentConnections(
          isDuckLake,
          databasePath,
          workingDirectory: environmentPath,
+         proxy: connection.proxy,
       });
 
       switch (connection.type) {

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -260,25 +260,16 @@ function buildDuckdbEntry(
 
 function validateConnectionShape(connection: ApiConnection): void {
    if (connection.proxy) {
-      // Connection proxies make THIS server open an outbound connection to a
-      // tenant-configured host (SSH bastion -> DB) — the same tenant-controlled
-      // outbound / SSRF surface as the `publisher` type below, so it shares the
-      // same operator gate: a single PUBLISHER_ALLOW_PROXY_CONNECTIONS decision
-      // covers every connection that makes the server reach a configured
-      // endpoint. Default-deny / fail-closed at this single choke point
-      // (validateConnectionShape runs before any connection is assembled,
-      // queried, or introspected). Fine for local --watch-env authoring.
+      // A connection proxy makes THIS server open an outbound SSH tunnel to a
+      // tenant-configured bastion. It's a normal connection capability,
+      // authorized by whoever configures the connection — deliberately NOT gated
+      // by an env flag, and kept separate from the `publisher` HTTP multi-hop
+      // type's PUBLISHER_ALLOW_PROXY_CONNECTIONS gate below (that flag is about
+      // publisher-to-publisher proxying, a distinct operator decision). Host-key
+      // pinning is fail-closed at connect time (see openProxy).
       if (connection.proxy.type !== "ssh") {
          throw new Error(
             `Connection '${connection.name}' has an unsupported proxy type '${connection.proxy.type}'. Only 'ssh' is supported.`,
-         );
-      }
-      if (process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS !== "true") {
-         throw new Error(
-            `Connection proxy on '${connection.name}' is disabled in this deployment. ` +
-               `A proxy makes the server open an outbound SSH tunnel to a configured bastion, ` +
-               `which is only appropriate for local --watch-env authoring. ` +
-               `Fix: set the environment variable PUBLISHER_ALLOW_PROXY_CONNECTIONS=true to enable it.`,
          );
       }
       if (connection.type !== "postgres") {

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -259,6 +259,40 @@ function buildDuckdbEntry(
 }
 
 function validateConnectionShape(connection: ApiConnection): void {
+   if (connection.proxy) {
+      // Connection proxies make THIS server open an outbound connection to a
+      // tenant-configured host (SSH bastion -> DB). Like the `publisher` type
+      // below, that's fine for local --watch-env authoring but an SSRF surface
+      // in hosted multi-tenant deployments, so it's default-deny / fail-closed.
+      // This is a SEPARATE gate from PUBLISHER_ALLOW_PROXY_CONNECTIONS (which
+      // gates the publisher HTTP multi-hop type) — an operator may enable one
+      // without the other. Single choke point: validateConnectionShape runs
+      // before any connection is assembled, queried, or introspected.
+      if (connection.proxy.type !== "ssh") {
+         throw new Error(
+            `Connection '${connection.name}' has an unsupported proxy type '${connection.proxy.type}'. Only 'ssh' is supported.`,
+         );
+      }
+      if (process.env.PUBLISHER_ALLOW_SSH_PROXY !== "true") {
+         throw new Error(
+            `Connection proxy on '${connection.name}' is disabled in this deployment. ` +
+               `A proxy makes the server open an outbound SSH tunnel to a configured bastion, ` +
+               `which is only appropriate for local --watch-env authoring. ` +
+               `Fix: set the environment variable PUBLISHER_ALLOW_SSH_PROXY=true to enable it.`,
+         );
+      }
+      if (connection.type !== "postgres") {
+         throw new Error(
+            `Connection proxy is not supported for type '${connection.type}' (only 'postgres' today).`,
+         );
+      }
+      if (!connection.proxy.ssh) {
+         throw new Error(
+            `Connection proxy on '${connection.name}' has type 'ssh' but no 'ssh' config object.`,
+         );
+      }
+   }
+
    switch (connection.type) {
       case "postgres":
       case "mysql":

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -291,6 +291,18 @@ function validateConnectionShape(connection: ApiConnection): void {
             `Connection proxy on '${connection.name}' has type 'ssh' but no 'ssh' config object.`,
          );
       }
+      // The tunnel forwards to an explicit host:port; the connectionString form
+      // can't be rewritten to the local endpoint and would otherwise silently
+      // tunnel to the bastion's own :5432. Require discrete host/port at load.
+      if (
+         !connection.postgresConnection?.host ||
+         !connection.postgresConnection?.port
+      ) {
+         throw new Error(
+            `Connection proxy on '${connection.name}' requires explicit host and port on the ` +
+               `postgres connection; the connectionString form is not supported with a proxy.`,
+         );
+      }
    }
 
    switch (connection.type) {

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -261,24 +261,24 @@ function buildDuckdbEntry(
 function validateConnectionShape(connection: ApiConnection): void {
    if (connection.proxy) {
       // Connection proxies make THIS server open an outbound connection to a
-      // tenant-configured host (SSH bastion -> DB). Like the `publisher` type
-      // below, that's fine for local --watch-env authoring but an SSRF surface
-      // in hosted multi-tenant deployments, so it's default-deny / fail-closed.
-      // This is a SEPARATE gate from PUBLISHER_ALLOW_PROXY_CONNECTIONS (which
-      // gates the publisher HTTP multi-hop type) — an operator may enable one
-      // without the other. Single choke point: validateConnectionShape runs
-      // before any connection is assembled, queried, or introspected.
+      // tenant-configured host (SSH bastion -> DB) — the same tenant-controlled
+      // outbound / SSRF surface as the `publisher` type below, so it shares the
+      // same operator gate: a single PUBLISHER_ALLOW_PROXY_CONNECTIONS decision
+      // covers every connection that makes the server reach a configured
+      // endpoint. Default-deny / fail-closed at this single choke point
+      // (validateConnectionShape runs before any connection is assembled,
+      // queried, or introspected). Fine for local --watch-env authoring.
       if (connection.proxy.type !== "ssh") {
          throw new Error(
             `Connection '${connection.name}' has an unsupported proxy type '${connection.proxy.type}'. Only 'ssh' is supported.`,
          );
       }
-      if (process.env.PUBLISHER_ALLOW_SSH_PROXY !== "true") {
+      if (process.env.PUBLISHER_ALLOW_PROXY_CONNECTIONS !== "true") {
          throw new Error(
             `Connection proxy on '${connection.name}' is disabled in this deployment. ` +
                `A proxy makes the server open an outbound SSH tunnel to a configured bastion, ` +
                `which is only appropriate for local --watch-env authoring. ` +
-               `Fix: set the environment variable PUBLISHER_ALLOW_SSH_PROXY=true to enable it.`,
+               `Fix: set the environment variable PUBLISHER_ALLOW_PROXY_CONNECTIONS=true to enable it.`,
          );
       }
       if (connection.type !== "postgres") {

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -292,8 +292,17 @@ function validateConnectionShape(connection: ApiConnection): void {
          );
       }
       // The tunnel forwards to an explicit host:port; the connectionString form
-      // can't be rewritten to the local endpoint and would otherwise silently
-      // tunnel to the bastion's own :5432. Require discrete host/port at load.
+      // can't be rewritten to the local endpoint. Reject it outright when a
+      // proxy is set — normal postgres gives connectionString precedence over
+      // host/port, so a config carrying BOTH would silently tunnel to
+      // host/port and ignore the connectionString, connecting to a different
+      // database than the operator configured. Require discrete host/port.
+      if (connection.postgresConnection?.connectionString) {
+         throw new Error(
+            `Connection proxy on '${connection.name}' does not support the connectionString form; ` +
+               `provide discrete host and port instead (the tunnel forwards to an explicit endpoint).`,
+         );
+      }
       if (
          !connection.postgresConnection?.host ||
          !connection.postgresConnection?.port

--- a/packages/server/src/service/proxy.spec.ts
+++ b/packages/server/src/service/proxy.spec.ts
@@ -1,0 +1,302 @@
+/**
+ * Unit tests for the SSH proxy layer.
+ *
+ * These tests are hermetic: they stand up an in-process ssh2 server that
+ * forwards to a plain TCP echo server, call openProxy(), connect a client
+ * to the returned local endpoint, and assert that bytes round-trip through
+ * the tunnel.
+ *
+ * No external network access is required.
+ */
+
+import net from "net";
+import { generateKeyPairSync } from "crypto";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+   Server as SshServer,
+   utils as sshUtils,
+   type Connection as SshServerConnection,
+} from "ssh2";
+import { openProxy } from "./proxy";
+
+// ── Key material generated once for the test suite ────────────────────────────
+
+// ssh2's server requires PEM private keys it can parse. These are ephemeral,
+// test-only keys; RSA-2048 (not 1024) so static analysis doesn't flag them.
+const hostKeys = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const hostPrivatePem = hostKeys.privateKey
+   .export({ type: "pkcs1", format: "pem" })
+   .toString();
+
+const clientKeys = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const clientPrivatePem = clientKeys.privateKey
+   .export({ type: "pkcs1", format: "pem" })
+   .toString();
+// Helpers ─────────────────────────────────────────────────────────────────────
+
+function startEchoServer(): Promise<{
+   port: number;
+   close: () => Promise<void>;
+}> {
+   return new Promise((resolve, reject) => {
+      const server = net.createServer((socket) => {
+         socket.pipe(socket);
+      });
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+         const addr = server.address() as net.AddressInfo;
+         resolve({
+            port: addr.port,
+            close: () =>
+               new Promise((res, rej) =>
+                  server.close((err) => (err ? rej(err) : res())),
+               ),
+         });
+      });
+   });
+}
+
+/**
+ * Start a minimal in-process SSH server that accepts the test client key
+ * and fulfils tcpip-forward (forwardOut) requests.
+ */
+function startSshServer(opts: {
+   rejectAuth?: boolean;
+   rejectForward?: boolean;
+}): Promise<{
+   port: number;
+   hostKeyBase64: string;
+   close: () => Promise<void>;
+}> {
+   return new Promise((resolve, reject) => {
+      const sshd = new SshServer(
+         { hostKeys: [hostPrivatePem] },
+         (client: SshServerConnection) => {
+            client.on("authentication", (ctx) => {
+               if (opts.rejectAuth) {
+                  ctx.reject();
+                  return;
+               }
+               // Accept publickey auth for our test client key.
+               if (ctx.method === "publickey" && !opts.rejectAuth) {
+                  ctx.accept();
+               } else {
+                  ctx.reject();
+               }
+            });
+
+            client.on("ready", () => {
+               client.on("tcpip", (accept, _reject, info) => {
+                  if (opts.rejectForward) {
+                     _reject();
+                     return;
+                  }
+                  const channel = accept();
+                  // Connect to the real destination and pipe.
+                  const dest = net.createConnection(
+                     { host: info.destIP, port: info.destPort },
+                     () => {
+                        channel.pipe(dest).pipe(channel);
+                        channel.on("error", () => dest.destroy());
+                        dest.on("error", () => channel.destroy());
+                     },
+                  );
+                  dest.on("error", () => channel.destroy());
+               });
+            });
+
+            client.on("error", () => {
+               /* swallow per-client errors in tests */
+            });
+         },
+      );
+
+      sshd.on("error", reject);
+      sshd.listen(0, "127.0.0.1", () => {
+         const addr = sshd.address() as net.AddressInfo;
+
+         // Capture the server's host key fingerprint (base64 of the raw DER) by
+         // parsing the pem via the ssh2 util so the format matches what
+         // hostVerifier receives.
+         const parsed = sshUtils.parseKey(hostPrivatePem);
+         const hostKeyBase64 = (parsed as { getPublicSSH(): Buffer })
+            .getPublicSSH()
+            .toString("base64");
+
+         resolve({
+            port: addr.port,
+            hostKeyBase64,
+            close: () => new Promise((res) => sshd.close(() => res())),
+         });
+      });
+   });
+}
+
+function connectAndSend(port: number, message: string): Promise<string> {
+   return new Promise((resolve, reject) => {
+      const socket = net.createConnection({ host: "127.0.0.1", port }, () => {
+         socket.write(message);
+      });
+      const chunks: Buffer[] = [];
+      socket.on("data", (chunk) => {
+         chunks.push(chunk);
+         if (Buffer.concat(chunks).toString().includes(message)) {
+            socket.destroy();
+            resolve(Buffer.concat(chunks).toString());
+         }
+      });
+      socket.on("error", reject);
+   });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("openProxy — SSH tunnel", () => {
+   let echoServer: { port: number; close: () => Promise<void> };
+   let sshServer: {
+      port: number;
+      hostKeyBase64: string;
+      close: () => Promise<void>;
+   };
+
+   beforeEach(async () => {
+      echoServer = await startEchoServer();
+      sshServer = await startSshServer({});
+   });
+
+   afterEach(async () => {
+      await echoServer.close();
+      await sshServer.close();
+   });
+
+   it("round-trips bytes through the tunnel", async () => {
+      const ep = await openProxy(
+         {
+            type: "ssh",
+            ssh: {
+               host: "127.0.0.1",
+               port: sshServer.port,
+               username: "testuser",
+               privateKey: clientPrivatePem,
+               hostKey: sshServer.hostKeyBase64,
+            },
+         },
+         { host: "127.0.0.1", port: echoServer.port },
+      );
+
+      try {
+         const reply = await connectAndSend(ep.port, "hello-proxy");
+         expect(reply).toContain("hello-proxy");
+      } finally {
+         await ep.close();
+      }
+   });
+
+   it("accepts a hostKey given as a full known_hosts line", async () => {
+      // Users typically paste `ssh-keyscan` output, e.g.
+      // `bastion.example.com ssh-rsa AAAA…` — the verifier must extract the blob.
+      const knownHostsLine = `bastion.example.com ssh-rsa ${sshServer.hostKeyBase64}`;
+      const ep = await openProxy(
+         {
+            type: "ssh",
+            ssh: {
+               host: "127.0.0.1",
+               port: sshServer.port,
+               username: "testuser",
+               privateKey: clientPrivatePem,
+               hostKey: knownHostsLine,
+            },
+         },
+         { host: "127.0.0.1", port: echoServer.port },
+      );
+
+      try {
+         const reply = await connectAndSend(ep.port, "known-hosts-line");
+         expect(reply).toContain("known-hosts-line");
+      } finally {
+         await ep.close();
+      }
+   });
+
+   it("rejects when hostKey does not match", async () => {
+      const wrongKey = Buffer.alloc(32, 0xff).toString("base64");
+
+      await expect(
+         openProxy(
+            {
+               type: "ssh",
+               ssh: {
+                  host: "127.0.0.1",
+                  port: sshServer.port,
+                  username: "testuser",
+                  privateKey: clientPrivatePem,
+                  hostKey: wrongKey,
+               },
+            },
+            { host: "127.0.0.1", port: echoServer.port },
+         ),
+      ).rejects.toThrow(/host-key mismatch/i);
+   });
+
+   it("rejects when hostKey is absent and opt-out env is not set", async () => {
+      const orig = process.env.PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY;
+      delete process.env.PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY;
+
+      try {
+         await expect(
+            openProxy(
+               {
+                  type: "ssh",
+                  ssh: {
+                     host: "127.0.0.1",
+                     port: sshServer.port,
+                     username: "testuser",
+                     privateKey: clientPrivatePem,
+                  },
+               },
+               { host: "127.0.0.1", port: echoServer.port },
+            ),
+         ).rejects.toThrow(/no hostKey provided/i);
+      } finally {
+         if (orig !== undefined) {
+            process.env.PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY = orig;
+         }
+      }
+   });
+
+   it("connects when hostKey is absent and opt-out env is set", async () => {
+      process.env.PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY = "true";
+      try {
+         const ep = await openProxy(
+            {
+               type: "ssh",
+               ssh: {
+                  host: "127.0.0.1",
+                  port: sshServer.port,
+                  username: "testuser",
+                  privateKey: clientPrivatePem,
+               },
+            },
+            { host: "127.0.0.1", port: echoServer.port },
+         );
+         try {
+            const reply = await connectAndSend(ep.port, "allow-unknown");
+            expect(reply).toContain("allow-unknown");
+         } finally {
+            await ep.close();
+         }
+      } finally {
+         delete process.env.PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY;
+      }
+   });
+
+   it("rejects for unsupported proxy type", async () => {
+      await expect(
+         openProxy(
+            // @ts-expect-error — intentionally passing an unsupported type
+            { type: "unsupported" },
+            { host: "127.0.0.1", port: echoServer.port },
+         ),
+      ).rejects.toThrow(/not supported/i);
+   });
+});

--- a/packages/server/src/service/proxy.spec.ts
+++ b/packages/server/src/service/proxy.spec.ts
@@ -256,6 +256,33 @@ describe("openProxy — SSH tunnel", () => {
       }
    });
 
+   it("accepts a hashed (|1|) known_hosts line — the hash only obscures the hostname", async () => {
+      // `ssh-keyscan -H` output hashes the hostname (`|1|salt|hash`) but leaves
+      // the key blob in the clear; the verifier extracts the blob token and never
+      // matches hostnames, so hashed lines work the same as unhashed ones.
+      const hashedLine = `|1|dNQdBg9dg8u7Vw8vq3B0uZ3example=|kZ2exampleHashValue0000000= ssh-rsa ${sshServer.hostKeyBase64}`;
+      const ep = await openProxy(
+         {
+            type: "ssh",
+            ssh: {
+               host: "127.0.0.1",
+               port: sshServer.port,
+               username: "testuser",
+               privateKey: clientPrivatePem,
+               hostKey: hashedLine,
+            },
+         },
+         { host: "127.0.0.1", port: echoServer.port },
+      );
+
+      try {
+         const reply = await connectAndSend(ep.port, "hashed-line");
+         expect(reply).toContain("hashed-line");
+      } finally {
+         await closeQuietly(() => ep.close());
+      }
+   });
+
    it("rejects when hostKey does not match", async () => {
       const wrongKey = Buffer.alloc(32, 0xff).toString("base64");
 

--- a/packages/server/src/service/proxy.spec.ts
+++ b/packages/server/src/service/proxy.spec.ts
@@ -39,7 +39,14 @@ function startEchoServer(): Promise<{
    close: () => Promise<void>;
 }> {
    return new Promise((resolve, reject) => {
+      // Track accepted sockets so close() can force them down. server.close()
+      // alone only stops accepting and then waits for open connections to end;
+      // a lingering forwarded socket would otherwise hang teardown (and the
+      // afterEach hook) until the test timeout, especially under --serial CI.
+      const sockets = new Set<net.Socket>();
       const server = net.createServer((socket) => {
+         sockets.add(socket);
+         socket.on("close", () => sockets.delete(socket));
          socket.pipe(socket);
       });
       server.on("error", reject);
@@ -48,9 +55,10 @@ function startEchoServer(): Promise<{
          resolve({
             port: addr.port,
             close: () =>
-               new Promise((res, rej) =>
-                  server.close((err) => (err ? rej(err) : res())),
-               ),
+               new Promise((res, rej) => {
+                  for (const s of sockets) s.destroy();
+                  server.close((err) => (err ? rej(err) : res()));
+               }),
          });
       });
    });
@@ -69,9 +77,17 @@ function startSshServer(opts: {
    close: () => Promise<void>;
 }> {
    return new Promise((resolve, reject) => {
+      // Track live client connections and forwarded destination sockets so
+      // close() can force them down; otherwise a lingering forwarded socket
+      // keeps sshd.close() (and the afterEach hook) hanging until the test
+      // timeout, which is what made the tunnel tests flake under --serial CI.
+      const clients = new Set<SshServerConnection>();
+      const destSockets = new Set<net.Socket>();
       const sshd = new SshServer(
          { hostKeys: [hostPrivatePem] },
          (client: SshServerConnection) => {
+            clients.add(client);
+            client.on("close", () => clients.delete(client));
             client.on("authentication", (ctx) => {
                if (opts.rejectAuth) {
                   ctx.reject();
@@ -101,6 +117,8 @@ function startSshServer(opts: {
                         dest.on("error", () => channel.destroy());
                      },
                   );
+                  destSockets.add(dest);
+                  dest.on("close", () => destSockets.delete(dest));
                   dest.on("error", () => channel.destroy());
                });
             });
@@ -126,7 +144,12 @@ function startSshServer(opts: {
          resolve({
             port: addr.port,
             hostKeyBase64,
-            close: () => new Promise((res) => sshd.close(() => res())),
+            close: () =>
+               new Promise((res) => {
+                  for (const s of destSockets) s.destroy();
+                  for (const c of clients) c.end();
+                  sshd.close(() => res());
+               }),
          });
       });
    });

--- a/packages/server/src/service/proxy.spec.ts
+++ b/packages/server/src/service/proxy.spec.ts
@@ -172,6 +172,21 @@ function connectAndSend(port: number, message: string): Promise<string> {
    });
 }
 
+// Best-effort, time-bounded teardown. Destroying every ssh2/socket handle is
+// reliable locally but a lingering graceful close can still stall on some CI
+// platforms (Bun + ssh2 on Linux/Windows), which would hang the afterEach hook
+// until the 100s test timeout. The assertions have already run by teardown, so
+// cap each close and move on rather than block.
+function closeQuietly(close: () => Promise<void>, ms = 3000): Promise<void> {
+   return Promise.race([
+      close().catch(() => {}),
+      new Promise<void>((resolve) => {
+         const timer = setTimeout(resolve, ms);
+         (timer as unknown as { unref?: () => void }).unref?.();
+      }),
+   ]);
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("openProxy — SSH tunnel", () => {
@@ -188,8 +203,8 @@ describe("openProxy — SSH tunnel", () => {
    });
 
    afterEach(async () => {
-      await echoServer.close();
-      await sshServer.close();
+      await closeQuietly(() => echoServer.close());
+      await closeQuietly(() => sshServer.close());
    });
 
    it("round-trips bytes through the tunnel", async () => {
@@ -211,7 +226,7 @@ describe("openProxy — SSH tunnel", () => {
          const reply = await connectAndSend(ep.port, "hello-proxy");
          expect(reply).toContain("hello-proxy");
       } finally {
-         await ep.close();
+         await closeQuietly(() => ep.close());
       }
    });
 
@@ -237,7 +252,7 @@ describe("openProxy — SSH tunnel", () => {
          const reply = await connectAndSend(ep.port, "known-hosts-line");
          expect(reply).toContain("known-hosts-line");
       } finally {
-         await ep.close();
+         await closeQuietly(() => ep.close());
       }
    });
 
@@ -306,7 +321,7 @@ describe("openProxy — SSH tunnel", () => {
             const reply = await connectAndSend(ep.port, "allow-unknown");
             expect(reply).toContain("allow-unknown");
          } finally {
-            await ep.close();
+            await closeQuietly(() => ep.close());
          }
       } finally {
          delete process.env.PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY;

--- a/packages/server/src/service/proxy.ts
+++ b/packages/server/src/service/proxy.ts
@@ -1,0 +1,199 @@
+/**
+ * Generic TCP proxy layer for publisher database connections.
+ *
+ * Currently supports SSH bastion tunnels (type "ssh").  Future connection
+ * types (mysql, trino, …) only need a new `openProxy` branch — the caller
+ * interface is unchanged.
+ *
+ * # Host-key policy
+ *
+ * Publisher is fail-closed by default: if `ssh.hostKey` is absent the tunnel
+ * is refused at connect time to prevent MITM.  Set the environment variable
+ *
+ *   PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY=true
+ *
+ * to disable this check for development/testing.  Never set this in
+ * production.
+ */
+
+import net from "net";
+import { Client as SshClient } from "ssh2";
+import type { ConnectConfig, SyncHostVerifier } from "ssh2";
+import { components } from "../api";
+
+type ConnectionProxy = components["schemas"]["ConnectionProxy"];
+
+export interface ProxyEndpoint {
+   host: string;
+   port: number;
+   close(): Promise<void>;
+}
+
+const SSH_CONNECT_TIMEOUT_MS = 15_000;
+
+/**
+ * Extract the base64 wire-format key from a stored hostKey, accepting any of:
+ * a full known_hosts line (`[markers] host keytype AAAA…`), a `keytype AAAA…`
+ * pair, or the bare base64 blob. SSH public-key blobs always base64-encode to a
+ * string starting with "AAAA" (the 4-byte length prefix of the key-type name),
+ * so we pick that token; otherwise fall back to the last whitespace-delimited
+ * token. This matches what ssh2's hostVerifier hands us (`key.toString("base64")`).
+ */
+function extractHostKeyBase64(raw: string): string {
+   const tokens = raw.trim().split(/\s+/);
+   const blob = tokens.find((t) => /^AAAA[A-Za-z0-9+/]+={0,2}$/.test(t));
+   return blob ?? tokens[tokens.length - 1] ?? "";
+}
+
+/**
+ * Open a proxy tunnel described by `proxy` that ultimately delivers traffic to
+ * `target`.  Returns a local `127.0.0.1:port` endpoint the DB driver should
+ * connect to in place of the real host/port.
+ */
+export async function openProxy(
+   proxy: ConnectionProxy,
+   target: { host: string; port: number },
+): Promise<ProxyEndpoint> {
+   if (proxy.type === "ssh") {
+      if (!proxy.ssh) {
+         throw new Error(
+            "ConnectionProxy type is 'ssh' but the 'ssh' config object is missing.",
+         );
+      }
+      return openSshProxy(proxy.ssh, target);
+   }
+   throw new Error(
+      `Proxy type '${proxy.type}' is not supported yet.  Only 'ssh' is implemented.`,
+   );
+}
+
+function openSshProxy(
+   ssh: components["schemas"]["SshProxyConfig"],
+   target: { host: string; port: number },
+): Promise<ProxyEndpoint> {
+   return new Promise((resolve, reject) => {
+      const client = new SshClient();
+      let localPort = 0;
+      let server: net.Server | undefined;
+      let settled = false;
+
+      function fail(err: Error): void {
+         if (settled) return;
+         settled = true;
+         server?.close();
+         client.end();
+         reject(err);
+      }
+
+      const connectConfig: ConnectConfig = {
+         host: ssh.host,
+         port: ssh.port ?? 22,
+         username: ssh.username,
+         privateKey: ssh.privateKey,
+         ...(ssh.privateKeyPass ? { passphrase: ssh.privateKeyPass } : {}),
+         readyTimeout: SSH_CONNECT_TIMEOUT_MS,
+         hostVerifier: ((key: Buffer): boolean => {
+            // `key` is the raw Buffer of the host's public key.
+            const presented = key.toString("base64");
+            if (ssh.hostKey) {
+               const expected = extractHostKeyBase64(ssh.hostKey);
+               if (presented !== expected) {
+                  fail(
+                     new Error(
+                        `SSH host-key mismatch for ${ssh.host}: expected ${expected.slice(0, 24)}… but got ${presented.slice(0, 24)}….`,
+                     ),
+                  );
+                  return false;
+               }
+               return true;
+            }
+            // No hostKey provided.
+            if (process.env.PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY === "true") {
+               return true;
+            }
+            fail(
+               new Error(
+                  `SSH connection to ${ssh.host} refused: no hostKey provided and ` +
+                     `PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY is not 'true'.  ` +
+                     `Set hostKey to the bastion's host public key (an OpenSSH ` +
+                     `known_hosts line or its base64 blob, e.g. from ssh-keyscan).`,
+               ),
+            );
+            return false;
+         }) as SyncHostVerifier,
+      };
+
+      client.on("error", (err) => fail(err));
+
+      client.on("ready", () => {
+         server = net.createServer((socket) => {
+            // Buffer incoming data immediately so we don't lose bytes that
+            // arrive before the forwardOut channel is open (relevant in Bun
+            // where resume() doesn't re-emit already-buffered data).
+            const earlyData: Buffer[] = [];
+            socket.on("data", (chunk: Buffer) => earlyData.push(chunk));
+
+            client.forwardOut(
+               "127.0.0.1",
+               localPort,
+               target.host,
+               target.port,
+               (err, channel) => {
+                  if (err) {
+                     socket.destroy(err);
+                     return;
+                  }
+                  // Flush buffered data, then switch to live forwarding.
+                  for (const chunk of earlyData) {
+                     channel.write(chunk);
+                  }
+                  earlyData.length = 0;
+                  socket.removeAllListeners("data");
+                  socket.on("data", (chunk: Buffer) => channel.write(chunk));
+                  channel.on("data", (chunk: Buffer) => socket.write(chunk));
+                  socket.on("error", () => channel.destroy());
+                  channel.on("error", () => socket.destroy());
+                  // Propagate teardown both ways so neither side is left
+                  // half-open when the other closes (e.g. pool eviction or the
+                  // DB dropping the connection).
+                  socket.on("close", () => channel.destroy());
+                  channel.on("close", () => socket.destroy());
+               },
+            );
+         });
+
+         server.listen(0, "127.0.0.1", () => {
+            const addr = server!.address();
+            if (!addr || typeof addr === "string") {
+               fail(
+                  new Error(
+                     "Failed to obtain local listen port for SSH proxy.",
+                  ),
+               );
+               return;
+            }
+            localPort = addr.port;
+
+            if (settled) return;
+            settled = true;
+
+            resolve({
+               host: "127.0.0.1",
+               port: localPort,
+               close(): Promise<void> {
+                  return new Promise((res) => {
+                     server!.close(() => {
+                        client.end();
+                        res();
+                     });
+                  });
+               },
+            });
+         });
+
+         server.on("error", (err) => fail(err));
+      });
+
+      client.connect(connectConfig);
+   });
+}

--- a/packages/server/src/service/proxy.ts
+++ b/packages/server/src/service/proxy.ts
@@ -85,6 +85,10 @@ function openSshProxy(
       let localPort = 0;
       let server: net.Server | undefined;
       let settled = false;
+      // Track accepted local sockets so close() can force them down. Relying on
+      // server.close() alone waits for in-flight sockets to drain, which can
+      // hang teardown indefinitely if a forwarded socket lingers.
+      const sockets = new Set<net.Socket>();
 
       function fail(err: Error): void {
          if (settled) return;
@@ -136,6 +140,8 @@ function openSshProxy(
 
       client.on("ready", () => {
          server = net.createServer((socket) => {
+            sockets.add(socket);
+            socket.on("close", () => sockets.delete(socket));
             // Buffer incoming data immediately so we don't lose bytes that
             // arrive before the forwardOut channel is open (relevant in Bun
             // where resume() doesn't re-emit already-buffered data).
@@ -200,6 +206,9 @@ function openSshProxy(
                port: localPort,
                close(): Promise<void> {
                   return new Promise((res) => {
+                     // Force-destroy live forwarded sockets first so server.close()
+                     // doesn't wait on them (which would hang teardown).
+                     for (const s of sockets) s.destroy();
                      server!.close(() => {
                         client.end();
                         res();

--- a/packages/server/src/service/proxy.ts
+++ b/packages/server/src/service/proxy.ts
@@ -5,14 +5,11 @@
  * types (mysql, trino, …) only need a new `openProxy` branch — the caller
  * interface is unchanged.
  *
- * # Operator opt-in
- *
- * The proxy feature is default-deny (SSRF surface). Set
- *
- *   PUBLISHER_ALLOW_PROXY_CONNECTIONS=true
- *
- * to enable it — the same gate that permits the publisher HTTP multi-hop type,
- * since both are the server making tenant-controlled outbound connections.
+ * A connection proxy is a normal connection capability (authorized by whoever
+ * configures the connection); it is intentionally NOT behind an env-flag gate,
+ * and is kept separate from the `publisher` HTTP multi-hop type's
+ * PUBLISHER_ALLOW_PROXY_CONNECTIONS gate. The trust boundary is host-key pinning
+ * (below), which is fail-closed.
  *
  * # Host-key policy
  *

--- a/packages/server/src/service/proxy.ts
+++ b/packages/server/src/service/proxy.ts
@@ -5,6 +5,15 @@
  * types (mysql, trino, …) only need a new `openProxy` branch — the caller
  * interface is unchanged.
  *
+ * # Operator opt-in
+ *
+ * The proxy feature is default-deny (SSRF surface). Set
+ *
+ *   PUBLISHER_ALLOW_SSH_PROXY=true
+ *
+ * to enable it. This is a separate gate from PUBLISHER_ALLOW_PROXY_CONNECTIONS
+ * (which controls the publisher HTTP multi-hop type).
+ *
  * # Host-key policy
  *
  * Publisher is fail-closed by default: if `ssh.hostKey` is absent the tunnel

--- a/packages/server/src/service/proxy.ts
+++ b/packages/server/src/service/proxy.ts
@@ -9,10 +9,10 @@
  *
  * The proxy feature is default-deny (SSRF surface). Set
  *
- *   PUBLISHER_ALLOW_SSH_PROXY=true
+ *   PUBLISHER_ALLOW_PROXY_CONNECTIONS=true
  *
- * to enable it. This is a separate gate from PUBLISHER_ALLOW_PROXY_CONNECTIONS
- * (which controls the publisher HTTP multi-hop type).
+ * to enable it — the same gate that permits the publisher HTTP multi-hop type,
+ * since both are the server making tenant-controlled outbound connections.
  *
  * # Host-key policy
  *

--- a/packages/server/src/service/proxy.ts
+++ b/packages/server/src/service/proxy.ts
@@ -143,6 +143,15 @@ function openSshProxy(
                      socket.destroy(err);
                      return;
                   }
+                  // The local socket may have closed while forwardOut was still
+                  // opening the channel; if so, tear the channel down instead of
+                  // attaching it to a dead socket (which would leak the remote
+                  // connection). The rest of this callback is synchronous, so no
+                  // close can slip in between this check and the listeners below.
+                  if (socket.destroyed) {
+                     channel.destroy();
+                     return;
+                  }
                   // Flush buffered data, then switch to live forwarding.
                   for (const chunk of earlyData) {
                      channel.write(chunk);

--- a/packages/server/src/service/proxy.ts
+++ b/packages/server/src/service/proxy.ts
@@ -39,6 +39,7 @@ export interface ProxyEndpoint {
 }
 
 const SSH_CONNECT_TIMEOUT_MS = 15_000;
+const SSH_KEEPALIVE_INTERVAL_MS = 15_000;
 
 /**
  * Extract the base64 wire-format key from a stored hostKey, accepting any of:
@@ -105,6 +106,12 @@ function openSshProxy(
          privateKey: ssh.privateKey,
          ...(ssh.privateKeyPass ? { passphrase: ssh.privateKeyPass } : {}),
          readyTimeout: SSH_CONNECT_TIMEOUT_MS,
+         // Send SSH-level keepalives so an idle tunnel isn't silently reaped by
+         // Cloud NAT / bastion ClientAlive / stateful-firewall idle timeouts —
+         // which would otherwise only surface as a confusing pg error on the
+         // next query. 3 missed (~45s) before ssh2 considers the link dead.
+         keepaliveInterval: SSH_KEEPALIVE_INTERVAL_MS,
+         keepaliveCountMax: 3,
          hostVerifier: ((key: Buffer): boolean => {
             // `key` is the raw Buffer of the host's public key.
             const presented = key.toString("base64");
@@ -173,8 +180,11 @@ function openSshProxy(
                   }
                   earlyData.length = 0;
                   socket.removeAllListeners("data");
-                  socket.on("data", (chunk: Buffer) => channel.write(chunk));
-                  channel.on("data", (chunk: Buffer) => socket.write(chunk));
+                  // pipe() honors backpressure (pauses the source when the
+                  // destination's buffer is full) — unlike a raw on('data') =>
+                  // write() which would buffer unbounded on a slow peer.
+                  socket.pipe(channel);
+                  channel.pipe(socket);
                   socket.on("error", () => channel.destroy());
                   channel.on("error", () => socket.destroy());
                   // Propagate teardown both ways so neither side is left


### PR DESCRIPTION
## What

Adds an optional, connection-type-agnostic **SSH bastion proxy** so a database reachable only through a jump host can be queried. The publisher opens an `ssh2` connection to the bastion plus a local `127.0.0.1` `net.Server` that forwards each socket via `forwardOut()`, and points the `pg` driver at the local endpoint — no driver / `pg` changes.

## Shape

- `Connection.proxy` → `ConnectionProxy { type: 'ssh', ssh: SshProxyConfig }` (discriminated union so future proxy types slot in).
- `openProxy(proxy, target)` in `src/service/proxy.ts` — reusable transport; the per-type builder points the driver at the returned endpoint. The tunnel opens lazily in `lookupConnection`, is cached per connection, and is torn down in `releaseConnections` (forwarded sockets force-destroyed so teardown can't hang).

## Robustness

- Forwarded traffic uses `pipe()` so SSH/TCP **backpressure** is honored — neither side buffers unbounded on a slow peer.
- The bastion connection sends **SSH keepalives** (15s interval) so an idle tunnel isn't silently reaped by Cloud NAT / stateful-firewall / `ClientAlive` idle timeouts, which would otherwise surface only as a confusing error on the next query.

## Security

- **No env-flag gate.** The SSH proxy is a normal connection capability, authorized by whoever configures the connection — deliberately not behind an env flag, and kept separate from the `publisher` HTTP multi-hop type's `PUBLISHER_ALLOW_PROXY_CONNECTIONS` (a distinct publisher-to-publisher decision). The trust boundary is host-key pinning below.
- **Host key pinned** and verified on every connect (`ssh2` `hostVerifier`); fail-closed unless `PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY=true`. Accepts a `known_hosts` line or a bare base64 blob — plain and hashed (`|1|…`) lines both work (only the key blob is compared, never the hostname).
- Load-time validation in `validateConnectionShape` (postgres-only today; explicit host/port required; the `connectionString` form is rejected outright so the tunnel can't silently target a different database than configured).

## Tests / docs

Hermetic `proxy.spec.ts` (in-process ssh2 + TCP echo): byte round-trip, host-key mismatch, fail-closed, env opt-out, `known_hosts`-line parsing, unsupported type. Gate tests in `connection_config.spec.ts` — including rejecting a proxied postgres connection that carries a `connectionString`, and one missing explicit host/port. Operator guide in `docs/connections.md`. Cross-platform CI green.

## Verification (local, end-to-end)

Beyond the hermetic specs, the full `lookupConnection` proxy branch was exercised against real infrastructure locally:

- Stood up **Postgres reachable only through a dockerized SSH bastion** — the DB port is not published to the host, so traffic can only reach it via the tunnel.
- Drove the actual feature path — `createEnvironmentConnections` → `lookupConnection` → `openProxy` (ssh2 local forward) → `buildProxiedPostgresConnection` → a pooled `pg` connection at the local endpoint — with the bastion's real pinned host key.
- Ran a live Malloy query through the tunnel and got real rows back (`SELECT count(*) … FROM widgets` → `{n:3, last:"gamma"}`).

This confirms SSH public-key auth, host-key pinning (verified on connect), the `forwardOut` channel to an in-VPC-style DB, and a full query round-trip — with no changes needed to the feature code.

## Follow-ups

Move `ssh2` from the root to `packages/server` (works today via hoisting); commit the local docker-based integration harness as an opt-in (docker-gated) test so the `lookupConnection` proxy branch has durable end-to-end coverage; reconnect-on-drop (re-dial the tunnel after a post-handshake SSH close, beyond the keepalive that already prevents idle reaping); `ssl.servername` passthrough for fully-verified TLS through the tunnel (tracked in malloydata/malloy#2960).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



