### PR TITLE
feat(server): expose per-source package-relative modelPath in the build plan

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3755,6 +3755,14 @@ components:
             materialized table name (it may carry a dialect container path like
             `dataset.table`). Returned as the full set so new persist directives
             need no publisher change.
+        modelPath:
+          type: string
+          description:
+            Package-relative path of the `.malloy` model that declares this
+            source (e.g. `order_rollup.malloy`). The source's sourceID embeds an
+            absolute `file://` modelURL with no package boundary, so this is the
+            only place the relative path is exposed; callers use it to deep-link
+            the source back to its model.
 
     Realization:
       type: string

--- a/packages/server/src/service/build_plan.spec.ts
+++ b/packages/server/src/service/build_plan.spec.ts
@@ -229,6 +229,27 @@ describe("deriveBuildPlan", () => {
 
       expect(Object.keys(plan.sources)).toEqual(["a@m"]);
    });
+
+   it("carries the per-source package-relative modelPath", () => {
+      const a = fakeSource({ name: "a", buildId: "bid-a" });
+      const b = fakeSource({ name: "b", buildId: "bid-b" });
+      const plan = deriveBuildPlan(
+         [
+            {
+               connectionName: "duckdb",
+               nodes: [[{ sourceID: "a@m", dependsOn: [] }]],
+            },
+         ] as unknown as Parameters<typeof deriveBuildPlan>[0],
+         { "a@m": a, "b@m": b },
+         { duckdb: "dig" },
+         undefined,
+         { "a@m": "rollup.malloy" },
+      );
+
+      // Mapped source gets its model path; an unmapped source stays undefined.
+      expect(plan.sources["a@m"].modelPath).toBe("rollup.malloy");
+      expect(plan.sources["b@m"].modelPath).toBeUndefined();
+   });
 });
 
 describe("compilePackageBuildPlan", () => {

--- a/packages/server/src/service/build_plan.ts
+++ b/packages/server/src/service/build_plan.ts
@@ -42,6 +42,13 @@ export interface CompiledBuildPlan {
    sources: Record<string, PersistSource>;
    connectionDigests: Record<string, string>;
    connections: Map<string, MalloyConnection>;
+   /**
+    * sourceID -> the package-relative path of the `.malloy` model that declares
+    * the source (the only place that mapping is known, since a sourceID's
+    * embedded modelURL is an absolute `file://` path with no package boundary).
+    * Optional so existing fixtures/callers that don't track it still typecheck.
+    */
+   sourceModelPaths?: Record<string, string>;
 }
 
 /** Output columns of a persist source, degrading to [] if unavailable. */
@@ -192,6 +199,7 @@ export async function compilePackageBuildPlan(
 ): Promise<CompiledBuildPlan> {
    const allGraphs: MalloyBuildGraph[] = [];
    const allSources: Record<string, PersistSource> = {};
+   const sourceModelPaths: Record<string, string> = {};
 
    for (const modelPath of pkg.getModelPaths()) {
       // Only `.malloy` models declare persist sources. Skip `.malloynb`
@@ -225,6 +233,7 @@ export async function compilePackageBuildPlan(
       allGraphs.push(...buildPlan.graphs);
       for (const [sourceID, source] of Object.entries(buildPlan.sources)) {
          allSources[sourceID] = source;
+         sourceModelPaths[sourceID] = modelPath;
       }
    }
 
@@ -256,6 +265,7 @@ export async function compilePackageBuildPlan(
       sources: allSources,
       connectionDigests,
       connections,
+      sourceModelPaths,
    };
 }
 
@@ -265,6 +275,7 @@ export function deriveBuildPlan(
    sources: Record<string, PersistSource>,
    connectionDigests: Record<string, string>,
    sourceNames?: string[],
+   sourceModelPaths?: Record<string, string>,
 ): BuildPlan {
    const include = sourceNames ? new Set(sourceNames) : null;
 
@@ -290,6 +301,7 @@ export function deriveBuildPlan(
          sql: source.getSQL(),
          columns: deriveColumns(source),
          annotationFields: deriveAnnotationFields(source),
+         modelPath: sourceModelPaths?.[sourceID],
       };
    }
 
@@ -313,5 +325,7 @@ export async function computePackageBuildPlan(
       compiled.graphs,
       compiled.sources,
       compiled.connectionDigests,
+      undefined,
+      compiled.sourceModelPaths,
    );
 }


### PR DESCRIPTION
## Summary
- Track which `.malloy` model declares each persist source while compiling a package build plan, threading a `sourceID -> package-relative modelPath` map through `compilePackageBuildPlan` and `deriveBuildPlan`.
- Surface that path as `modelPath` on each build-plan source. A source's sourceID embeds an absolute `file://` modelURL with no package boundary, so this is the only place the package-relative path is exposed; callers use it to deep-link a source back to its model.
- Document the new `modelPath` field in `api-doc.yaml`.

The new map is optional on `CompiledBuildPlan` / `deriveBuildPlan` so existing fixtures and callers that don't track it still typecheck.

## Test plan
- [ ] `deriveBuildPlan` carries the per-source package-relative `modelPath` (mapped source gets its path, unmapped source stays `undefined`) — covered by the added spec.
- [ ] Existing server build-plan tests still pass.

Made with [Cursor](https://cursor.com)