### PR TITLE
feat(docker): trust Amazon RDS root CAs in the image (NODE_EXTRA_CA_CERTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,6 +111,17 @@ ARG DUCKDB_VERSION=1.5.3
 ENV NODE_ENV=production
 ENV PATH="/root/.duckdb/cli/${DUCKDB_VERSION}:$PATH"
 RUN mkdir -p /etc/publisher
+
+# Trust the Amazon RDS root CAs so Postgres->RDS connections verify the server
+# certificate out of the box. Node/Bun ignore the OS trust store and use their
+# own bundled CA set, so NODE_EXTRA_CA_CERTS is the load-bearing knob (it appends
+# to that set). Fetched at build (curl is in base-deps) rather than vendored, so
+# there is no committed cert to keep fresh: a CA rotation is picked up on the next
+# image build/release, and every consumer of this image (the worker, the
+# SSH-bastion connection path) inherits the trust anchor without re-mounting a CA.
+RUN curl -fsSL https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
+    -o /etc/ssl/certs/rds-global-bundle.pem
+ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/rds-global-bundle.pem
 # Declare the runtime ports so `docker run -P` and Docker Desktop's
 # port-preview surface them. The server already listens on all three (REST on
 # 4000, core MCP on 4040, agent MCP on 4041); this just makes them discoverable.


### PR DESCRIPTION
## What

Bakes the AWS-published **Amazon RDS root CA bundle** into the image and points `NODE_EXTRA_CA_CERTS` at it, so Postgres → RDS connections verify the server certificate out of the box.

```dockerfile
RUN curl -fsSL https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
    -o /etc/ssl/certs/rds-global-bundle.pem
ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/rds-global-bundle.pem
```

## Why

Node/Bun ignore the OS trust store and ship their own CA set that doesn't include the Amazon RDS roots, so any connection to RDS Postgres fails with `self signed certificate in certificate chain` unless the operator separately trusts the CA. "Publisher speaks TLS to RDS" is intrinsic to the image, so the trust anchor belongs here — every consumer (the worker deployment, the SSH-bastion connection path) inherits it instead of re-hitting the error and re-mounting a CA in their own wiring.

`NODE_EXTRA_CA_CERTS` **appends** to the default CA set, so this only *adds* trust for RDS — no existing TLS behavior changes.

## Why fetch-at-build (not a committed PEM)

Nothing is vendored: the bundle is pulled at Docker build (curl is already in `base-deps`), so a CA rotation is picked up automatically on the next image build/release rather than requiring someone to remember to refresh a checked-in file. The `docker_smoke_test` in CI builds the image, which exercises the fetch.

Tradeoff: build-time reproducibility isn't bit-exact (two builds could differ if AWS rotates the bundle between them), and the build depends on `truststore.pki.rds.amazonaws.com` being reachable. Both are acceptable for a trust bundle — "current at build time" is the desired behavior. If bit-exact reproducibility is preferred, I can pin a `sha256` in the `RUN` (a rotation then fails the build loudly until bumped).

## Context

Replaces a service-side k8s ConfigMap approach (ms2data/service#5345, now closed) that mounted the same bundle into the worker — this puts the trust anchor where the capability lives, and dissolves the ConfigMap's refresh/rollout/duplication concerns. Per-region bundles are also served at the same host if a smaller trust surface is ever wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
