### PR TITLE
feat(server): surface non-fatal render-tag findings as package warnings

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -2413,6 +2413,41 @@ components:
             fail-safe — the unresolved entry simply lists nothing rather than
             exposing everything — so this is the signal that a package is
             misconfigured; publishing such a package is rejected.
+        warnings:
+          type: array
+          readOnly: true
+          description: >-
+            Non-fatal render-tag findings collected when the package loaded: a
+            render annotation (e.g. `# big_value` or `# currency`) misconfigured
+            for the field it sits on, so it renders as "[object Object]" or an
+            inline error at query time but does not stop the model compiling or
+            the package loading. Server-computed and read-only: ignored on
+            create/update requests and only returned in responses. Present only
+            when there are such findings.
+          items:
+            type: object
+            properties:
+              model:
+                type: string
+                description: >-
+                  Package-relative path of the model the finding is on.
+              target:
+                type: string
+                description: >-
+                  The query or view the finding sits on, e.g. `by_carrier` or
+                  `flights -> by_carrier`.
+              message:
+                type: string
+                description: The render validator's description of the problem.
+              severity:
+                type: string
+                enum:
+                  - error
+                  - warn
+                description: >-
+                  Finding severity. Currently only `error`-severity render
+                  findings are surfaced here; lower-severity findings remain on
+                  the query-time `renderLogs` surface.
         queryableSources:
           type: string
           enum:

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -115,6 +115,18 @@ function quoteMalloyIdentifier(name: string | undefined): string {
    return "`" + (name ?? "").replace(/\\/g, "\\\\").replace(/`/g, "\\`") + "`";
 }
 
+/**
+ * A non-fatal render-tag finding from {@link Model.validateRenderTags}: an
+ * error-severity issue that affects only how a field renders, never whether the
+ * model compiles or a query runs. `target` is the query or view it sits on
+ * (e.g. `by_carrier` or `flights -> by_carrier`).
+ */
+export interface RenderTagWarning {
+   target: string;
+   message: string;
+   severity: "error" | "warn";
+}
+
 export class Model {
    private packageName: string;
    private modelPath: string;
@@ -952,12 +964,13 @@ export class Model {
     * it does not fail the package load. Such a tag still renders as
     * "[object Object]" at query time, so the warning is the operator-facing
     * signal. Lower-severity findings are left for the query-time `renderLogs`
-    * surface.
+    * surface. The findings are returned so the owning Package can surface them
+    * as non-fatal `warnings` on its response.
     */
-   public async validateRenderTags(): Promise<void> {
+   public async validateRenderTags(): Promise<RenderTagWarning[]> {
       const mm = this.modelMaterializer;
       if (!mm) {
-         return;
+         return [];
       }
       // Dynamic import (like execute_query_tool.ts): the renderer is heavy and
       // mutates DOM globals on load, so only pull it in when there's a model to
@@ -1003,6 +1016,7 @@ export class Model {
          }
       }
 
+      const findings: RenderTagWarning[] = [];
       for (const target of targets) {
          let result: Malloy.Result;
          try {
@@ -1024,8 +1038,16 @@ export class Model {
                   .map((e) => e.message)
                   .join("; ")}`,
             );
+            for (const e of errors) {
+               findings.push({
+                  target: target.label,
+                  message: e.message,
+                  severity: "error",
+               });
+            }
          }
       }
+      return findings;
    }
 
    public async getModel(): Promise<ApiCompiledModel> {

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -40,6 +40,7 @@ type ApiDatabase = components["schemas"]["Database"];
 type ApiModel = components["schemas"]["Model"];
 type ApiNotebook = components["schemas"]["Notebook"];
 export type ApiPackage = components["schemas"]["Package"];
+type ApiPackageWarning = NonNullable<ApiPackage["warnings"]>[number];
 type ApiColumn = components["schemas"]["Column"];
 type ApiTableDescription = components["schemas"]["TableDescription"];
 // A thunk lets callers pass a live reference to the *current* environment
@@ -77,6 +78,12 @@ export class Package {
    // no persist source. Surfaced read-only on getPackageMetadata() so a caller
    // can derive build instructions without a separate plan round-trip.
    private buildPlan: BuildPlan | null = null;
+   // Non-fatal render-tag findings aggregated across the package's models (each
+   // tagged with its model path), surfaced read-only on
+   // getPackageMetadata().warnings. Refreshed on load and reload. A bad render
+   // tag does not fail the load (see Model.validateRenderTags); this is the
+   // response-level signal that a tag is misconfigured.
+   private renderTagWarnings: ApiPackageWarning[] = [];
    private static meter = publisherMeter();
    private static packageLoadHistogram = this.meter.createHistogram(
       "malloy_package_load_duration",
@@ -350,6 +357,7 @@ export class Package {
       // placeholders instead; that branch goes through a different
       // hydration path.)
       const models = new Map<string, Model>();
+      const renderTagWarnings: ApiPackageWarning[] = [];
       for (const sm of outcome.models) {
          if (sm.compilationError) {
             const err = Model.deserializeCompilationError(sm.compilationError);
@@ -371,7 +379,10 @@ export class Package {
          // Validate renderer tags on the main thread (the renderer is too heavy
          // to load inside the pure-CPU package-load worker). A misconfigured tag
          // is logged as a warning naming the target; it does not fail the load.
-         await model.validateRenderTags();
+         // The findings also ride the package response as non-fatal `warnings`.
+         for (const w of await model.validateRenderTags()) {
+            renderTagWarnings.push({ model: sm.modelPath, ...w });
+         }
          // Reject unquoted `#@ persist name=` annotations the same way: an
          // unquoted name is dropped from the build plan, so the source would
          // publish but never materialize. Scan the raw `.malloy` source (the
@@ -406,6 +417,7 @@ export class Package {
          models,
          malloyConfig,
       );
+      pkg.renderTagWarnings = renderTagWarnings;
 
       // Compute the persist build plan off the live (unbound) models, before the
       // caller binds any configured manifest, so the surfaced plan reflects the
@@ -483,6 +495,9 @@ export class Package {
       const warnings = this.exploreWarnings();
       if (warnings.length > 0) {
          metadata.exploresWarnings = warnings;
+      }
+      if (this.renderTagWarnings.length > 0) {
+         metadata.warnings = [...this.renderTagWarnings];
       }
       return metadata;
    }
@@ -704,6 +719,7 @@ export class Package {
       }
 
       const nextModels = new Map<string, Model>();
+      const renderTagWarnings: ApiPackageWarning[] = [];
       for (const sm of outcome.models) {
          if (sm.compilationError) {
             const err = Model.deserializeCompilationError(sm.compilationError);
@@ -735,7 +751,9 @@ export class Package {
             // unexpected internal failure is recorded as this model's
             // compilationError rather than aborting the whole reload.
             try {
-               await model.validateRenderTags();
+               for (const w of await model.validateRenderTags()) {
+                  renderTagWarnings.push({ model: sm.modelPath, ...w });
+               }
                nextModels.set(sm.modelPath, model);
             } catch (renderErr) {
                const err =
@@ -760,6 +778,7 @@ export class Package {
          }
       }
       this.models = nextModels;
+      this.renderTagWarnings = renderTagWarnings;
       // A reload re-reads publisher.json in the worker; pick up any change to
       // the explore set and query-boundary mode so listModels()/the gate
       // reflect edited explores without a full Package.create.

--- a/packages/server/src/service/package_worker_path.spec.ts
+++ b/packages/server/src/service/package_worker_path.spec.ts
@@ -316,6 +316,17 @@ source: gated is duckdb.sql("select 1 as id")`,
                   m.includes("nums -> card"),
             ),
          ).toBe(true);
+         // The same finding rides the package response (non-fatal) so the
+         // control plane / UI can surface it without scraping logs.
+         const responseWarnings = pkg.getPackageMetadata().warnings ?? [];
+         expect(
+            responseWarnings.some(
+               (w) =>
+                  w.model === "bad_render.malloy" &&
+                  w.target === "nums -> card" &&
+                  w.severity === "error",
+            ),
+         ).toBe(true);
       } finally {
          warnSpy.mockRestore();
          await duckdb.close();
@@ -337,6 +348,8 @@ source: gated is duckdb.sql("select 1 as id")`,
       try {
          const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
          expect(pkg.getModelPaths()).toEqual(["good_render.malloy"]);
+         // A clean package omits the warnings field entirely.
+         expect(pkg.getPackageMetadata().warnings).toBeUndefined();
       } finally {
          await duckdb.close();
       }
@@ -449,6 +462,14 @@ source: nums is duckdb.sql("select 1 as a, 2 as b") extend {
          expect(
             warnings.some((m) => m.includes("Invalid renderer configuration")),
          ).toBe(true);
+         // The notebook finding also rides the package response (not just logs).
+         const responseWarnings = pkg.getPackageMetadata().warnings ?? [];
+         expect(
+            responseWarnings.some(
+               (w) =>
+                  w.model === "bad_render.malloynb" && w.severity === "error",
+            ),
+         ).toBe(true);
       } finally {
          warnSpy.mockRestore();
          await duckdb.close();
@@ -499,8 +520,90 @@ source: nums is duckdb.sql("select 1 as a, 2 as b") extend {
          expect(
             warnings.some((m) => m.includes("Invalid renderer configuration")),
          ).toBe(true);
+         // Reload refreshes the response-level warnings too.
+         const responseWarnings = pkg.getPackageMetadata().warnings ?? [];
+         expect(responseWarnings.some((w) => w.model === "m.malloy")).toBe(
+            true,
+         );
       } finally {
          warnSpy.mockRestore();
+         await duckdb.close();
+      }
+   });
+
+   it("clears render-tag warnings on reload when a bad tag is fixed (bad -> clean)", async () => {
+      writeManifest();
+      // Start BAD so the package loads with a warning.
+      fs.writeFileSync(
+         path.join(tempDir, "m.malloy"),
+         `source: nums is duckdb.sql("select 1 as a, 2 as b") extend {
+  measure: total is a.sum()
+  # big_value { sparkline=trend }
+  view: card is {
+    aggregate: total
+    nest:
+      # line_chart { size=spark }
+      trend is { group_by: a; aggregate: total }
+  }
+}`,
+      );
+
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         expect(
+            (pkg.getPackageMetadata().warnings ?? []).some(
+               (w) => w.model === "m.malloy",
+            ),
+         ).toBe(true);
+
+         // Fix the tag, then reload: renderTagWarnings is rebuilt from scratch,
+         // so the stale finding must disappear (field omitted when empty).
+         fs.writeFileSync(
+            path.join(tempDir, "m.malloy"),
+            `source: nums is duckdb.sql("select 1 as a, 2 as b") extend {
+  measure: total is a.sum()
+  # bar_chart
+  view: chart is { group_by: a; aggregate: total }
+}`,
+         );
+         await pkg.reloadAllModels({});
+
+         expect(pkg.getPackageMetadata().warnings).toBeUndefined();
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("aggregates render-tag warnings from multiple models, each tagged with its own path", async () => {
+      writeManifest();
+      const badModel = (view: string) =>
+         `source: nums is duckdb.sql("select 1 as a, 2 as b") extend {
+  measure: total is a.sum()
+  # big_value { sparkline=trend }
+  view: ${view} is {
+    aggregate: total
+    nest:
+      # line_chart { size=spark }
+      trend is { group_by: a; aggregate: total }
+  }
+}`;
+      fs.writeFileSync(path.join(tempDir, "a.malloy"), badModel("card_a"));
+      fs.writeFileSync(path.join(tempDir, "b.malloy"), badModel("card_b"));
+
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const responseWarnings = pkg.getPackageMetadata().warnings ?? [];
+         const models = new Set(responseWarnings.map((w) => w.model));
+         expect(models.has("a.malloy")).toBe(true);
+         expect(models.has("b.malloy")).toBe(true);
+         expect(models.size).toBe(2);
+         // The message field is carried through, not just model/target/severity.
+         expect(
+            responseWarnings.every((w) => (w.message ?? "").length > 0),
+         ).toBe(true);
+      } finally {
          await duckdb.close();
       }
    });


### PR DESCRIPTION
## What

Surface the non-fatal render-tag validation findings on the package load/create response as a new read-only `warnings` array, so an API or UI consumer can show which render tag is misconfigured instead of only finding it in the server logs.

## Why

#846 made render-tag validation non-fatal: a misconfigured tag (e.g. a child-only `# big_value { sparkline=... }` on a view with no activating big_value, or a numeric `# currency` on a non-numeric field) is logged as a warning and the package still loads. But the only signal was the log line. `Model.validateRenderTags()` already computed the findings; this returns them and attaches them to the package response so they are programmatically visible.

## What changed

- `Model.validateRenderTags()` now returns its error-severity findings (`{ target, message, severity }`) in addition to logging them; it no longer stashes them on the model (no unused field/getter).
- `Package` aggregates each model's findings (tagged with the model path) on both the initial load and on reload, and `getPackageMetadata()` overlays them as a read-only `warnings` array beside the existing `exploresWarnings`. A clean package omits the field.
- `api-doc.yaml`: the `Package` schema gains `warnings` (`{ model, target, message, severity }`, read-only, server-computed). The generated clients regenerate from it.

Validation stays on the main thread, where #846 put it (the render-validator is too heavy for the pure-CPU package-load worker). This builds on the worker-path prototype in `sagark/validate-render-tags-on-load`, but moves the logic onto the main-thread validator and keeps it non-fatal.

## Testing

- `package_worker_path.spec.ts` extended: a bad render tag loads (no 424) with the finding on `getPackageMetadata().warnings` (`{ model, target, severity: "error" }`) for both `.malloy` and `.malloynb`; a clean package has no `warnings`; reload refreshes them, including clearing when a bad tag is fixed; and findings aggregate across multiple models each tagged by its path. Server unit suite green (1010 tests).
- Verified live against a running server: a package with a bad render tag returns HTTP 200 with the `warnings` array, and a clean package returns none.

## Open question

The field is named `warnings` (generic) but currently carries only render-tag findings, while explore-config problems live under the separate `exploresWarnings`. If `warnings` is meant to be the package's catch-all warnings surface, a `kind` discriminator on each item would let other warning kinds coexist later; if not, `renderTagWarnings` would mirror `exploresWarnings`. Happy to go either way. `severity` currently only ever carries `error` (lower-severity findings stay on the query-time `renderLogs` surface); the `warn` enum value is kept for forward-compat and noted as such in the schema.
