### PR TITLE
feat(proxy): per-connection sslmode + optional multi-key host-key pinning

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3189,10 +3189,11 @@ components:
             hostname can't be checked; `verify-ca` validates the server cert
             chain against the trusted CA bundle (e.g. the baked Amazon RDS roots)
             without the hostname, `no-verify` encrypts without verifying, and
-            `disable` uses no TLS. Defaults to `no-verify` when a proxy is set (so
-            a force-SSL target isn't rejected for plaintext). Only valid on a
-            proxied connection — a direct connection uses the deployment PGSSLMODE
-            and rejects this field.
+            `disable` uses no TLS. The server defaults it to `no-verify` when a
+            proxy is set (so a force-SSL target isn't rejected for plaintext) — a
+            server-applied default, not a schema default. Only valid on a proxied
+            connection — a direct connection uses the deployment PGSSLMODE and
+            rejects this field.
 
     MysqlConnection:
       type: object

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3130,12 +3130,14 @@ components:
         hostKey:
           type: string
           description: |
-            Pinned bastion host public key, as an OpenSSH known_hosts line or its
-            base64 blob (e.g. from `ssh-keyscan <bastion>`), verified on every
-            connect. Plain and hashed (`|1|…`) known_hosts lines both work — only
-            the key blob is compared, never the hostname. A missing or mismatched
-            host key fails the connection closed, unless
-            PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY=true is set.
+            Optional pinned bastion host public key(s), as one or more OpenSSH
+            known_hosts lines (or bare base64 blobs), verified on every connect.
+            List multiple lines to pin a load-balanced/HA bastion that presents a
+            different key per backend — any listed key is accepted; a mismatch
+            fails the connection closed. Plain and hashed (`|1|…`) lines both work
+            — only the key blob is compared, never the hostname. When omitted, the
+            tunnel connects without host-key verification (the self-service
+            default); the SSH transport is still encrypted.
 
     ConnectionAttributes:
       type: object
@@ -3178,6 +3180,18 @@ components:
           description:
             Complete PostgreSQL connection string (alternative to individual
             parameters)
+        sslmode:
+          type: string
+          enum: [disable, no-verify, verify-ca]
+          description:
+            TLS mode for a connection reached through a `proxy` (SSH bastion).
+            Because the driver connects to a local tunnel endpoint, the cert
+            hostname can't be checked; `verify-ca` validates the server cert
+            chain against the trusted CA bundle (e.g. the baked Amazon RDS roots)
+            without the hostname, `no-verify` encrypts without verifying, and
+            `disable` uses no TLS. Defaults to `no-verify` when a proxy is set (so
+            a force-SSL target isn't rejected for plaintext); ignored on the
+            non-proxied path, which uses the server's PGSSLMODE.
 
     MysqlConnection:
       type: object

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3190,8 +3190,9 @@ components:
             chain against the trusted CA bundle (e.g. the baked Amazon RDS roots)
             without the hostname, `no-verify` encrypts without verifying, and
             `disable` uses no TLS. Defaults to `no-verify` when a proxy is set (so
-            a force-SSL target isn't rejected for plaintext); ignored on the
-            non-proxied path, which uses the server's PGSSLMODE.
+            a force-SSL target isn't rejected for plaintext). Only valid on a
+            proxied connection — a direct connection uses the deployment PGSSLMODE
+            and rejects this field.
 
     MysqlConnection:
       type: object

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -97,8 +97,8 @@ VPC; it is not an IP-restriction mechanism (restrict the database directly for t
 > tenant-configured bastion, so it is authorized by whoever configures the connection. It
 > is **not** behind an env-flag gate, and is deliberately kept separate from the
 > `publisher` type's `PUBLISHER_ALLOW_PROXY_CONNECTIONS` (that flag is about
-> publisher-to-publisher HTTP proxying, a different decision). The trust control is
-> **host-key pinning** (below), which is fail-closed.
+> publisher-to-publisher HTTP proxying, a different decision). Optional **host-key
+> pinning** (below) adds a fail-closed trust control on the tunnel.
 
 ```json
 {
@@ -131,26 +131,36 @@ VPC; it is not an IP-restriction mechanism (restrict the database directly for t
 - `proxy.ssh.privateKey` (+ optional `privateKeyPass`) — the customer generates the
   keypair, authorizes their own public key on the bastion, and provides the private key
   here. Public-key auth only.
-- `proxy.ssh.hostKey` — the bastion's host public key, pinned and verified on every
-  connect (fail-closed). Get it with `ssh-keyscan <bastion>` and paste a line of the
-  output (or just the base64 blob). Both plain and hashed (`|1|…`, from `ssh-keyscan -H`)
-  lines work — only the key blob is compared, never the hostname. If `hostKey` is
-  omitted the tunnel is refused unless `PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY=true` (intended
-  for local dev only).
+- `proxy.ssh.hostKey` — **optional** pinned bastion host public key(s), verified on every
+  connect (fail-closed on mismatch). Provide one or more OpenSSH `known_hosts` lines (or
+  bare base64 blobs), one per line; a load-balanced/HA bastion presents a different key per
+  backend, so list every backend's key and any listed key is accepted. Both plain and
+  hashed (`|1|…`, from `ssh-keyscan -H`) lines work — only the key blob is compared, never
+  the hostname. **When omitted, the tunnel connects without host-key verification** (the
+  self-service default, matching mainstream BI tools); the SSH transport is still
+  encrypted, but an unpinned publisher→bastion hop is exposed to MITM — mitigated by the
+  customer allowlisting our egress on the bastion's inbound SSH.
 
 A proxy makes the server open an outbound SSH tunnel to a tenant-configured host, so
-connection configuration is the authorization boundary, and host-key pinning is the trust
-control on the tunnel itself.
+connection configuration is the authorization boundary; host-key pinning is an optional,
+additional trust control on the tunnel itself.
 
 ### TLS to the database through the tunnel
 
-The `pg` driver honors `PGSSLMODE` on a proxied connection just as on a direct one (it reads
-it from the environment). One limitation: the driver connects to the local forward endpoint
-(`127.0.0.1`), not the real database host, so full verification (`sslmode=verify-full`)
-fails the certificate **hostname** check even when the CA is trusted. Use
-`sslmode=no-verify` through a tunnel — the SSH transport is already encrypted and the
-bastion→DB leg is inside the private network — until per-connection `servername` support
-lands (see malloydata/malloy#2960).
+A proxied connection sets its TLS mode per-connection via `postgresConnection.sslmode`
+(the non-proxied path keeps using the environment's `PGSSLMODE`). The driver connects to the
+local forward endpoint (`127.0.0.1`), not the real database host, so the certificate
+**hostname** can't be checked. The supported modes:
+
+- `no-verify` (**default** when a proxy is set) — encrypt without verifying. Chosen as the
+  default so a force-SSL target (the common RDS case) isn't rejected for plaintext.
+- `verify-ca` — validate the server cert **chain** against the trusted CA bundle
+  (`NODE_EXTRA_CA_CERTS`, e.g. the baked Amazon RDS roots) while skipping the hostname
+  check. Fails if no CA bundle is available.
+- `disable` — no TLS.
+
+Full verification (`verify-full`) can't work through the tunnel until per-connection
+`servername` override lands (see malloydata/malloy#2960).
 
 ## Example: mixed connections
 

--- a/packages/server/src/service/connection.spec.ts
+++ b/packages/server/src/service/connection.spec.ts
@@ -1,10 +1,12 @@
 import { DuckDBConnection } from "@malloydata/db-duckdb";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import fs from "fs/promises";
+import os from "os";
 import path from "path";
 import sinon from "sinon";
 import { components } from "../api";
 import {
+   buildProxiedSslQuery,
    createEnvironmentConnections,
    testConnectionConfig,
 } from "./connection";
@@ -1844,5 +1846,73 @@ describe("connection integration tests", () => {
          },
          { timeout: 30000 },
       );
+   });
+});
+
+describe("buildProxiedSslQuery", () => {
+   const ORIG_CA = process.env.NODE_EXTRA_CA_CERTS;
+   afterEach(() => {
+      if (ORIG_CA === undefined) delete process.env.NODE_EXTRA_CA_CERTS;
+      else process.env.NODE_EXTRA_CA_CERTS = ORIG_CA;
+   });
+
+   it("defaults to no-verify when sslmode is unset (force-SSL target isn't rejected for plaintext)", () => {
+      expect(buildProxiedSslQuery("conn")).toBe("?sslmode=no-verify");
+   });
+
+   it("returns no-verify for explicit no-verify", () => {
+      expect(buildProxiedSslQuery("conn", "no-verify")).toBe(
+         "?sslmode=no-verify",
+      );
+   });
+
+   it("emits an explicit sslmode=disable, never an empty query", () => {
+      // Regression: an empty query lets pg fall back to the deployment's PGSSLMODE
+      // env, which would verify and fail the 127.0.0.1 hostname check.
+      expect(buildProxiedSslQuery("conn", "disable")).toBe("?sslmode=disable");
+   });
+
+   it("builds a chain-verifying, hostname-skipped query for verify-ca", () => {
+      process.env.NODE_EXTRA_CA_CERTS = "/etc/ssl/certs/rds bundle.pem";
+      const q = buildProxiedSslQuery("conn", "verify-ca");
+      expect(q).toContain("uselibpqcompat=true");
+      expect(q).toContain("sslmode=verify-ca");
+      expect(q).toContain(
+         `sslrootcert=${encodeURIComponent("/etc/ssl/certs/rds bundle.pem")}`,
+      );
+   });
+
+   it("throws for verify-ca when no CA bundle is available", () => {
+      delete process.env.NODE_EXTRA_CA_CERTS;
+      expect(() => buildProxiedSslQuery("conn", "verify-ca")).toThrow(
+         /no trusted CA bundle/i,
+      );
+   });
+
+   it("throws for an unsupported sslmode", () => {
+      expect(() => buildProxiedSslQuery("conn", "require")).toThrow(
+         /unsupported sslmode/i,
+      );
+   });
+
+   it("verify-ca connectionString parses to an ssl config (pg-connection-string version guard)", async () => {
+      // uselibpqcompat=true (pg-connection-string >= 2.7) is what turns verify-ca
+      // into "verify chain, skip hostname". If pg is ever downgraded below that
+      // floor, sslmode would be ignored — this guard fails loudly instead.
+      const caPath = path.join(os.tmpdir(), `proxy-ca-${process.pid}.pem`);
+      await fs.writeFile(
+         caPath,
+         "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n",
+      );
+      process.env.NODE_EXTRA_CA_CERTS = caPath;
+      try {
+         const q = buildProxiedSslQuery("conn", "verify-ca");
+         const { parse } = await import("pg-connection-string");
+         const parsed = parse(`postgresql://127.0.0.1:5432/db${q}`);
+         expect(parsed.ssl).toBeTruthy();
+         expect(typeof parsed.ssl).toBe("object");
+      } finally {
+         await fs.rm(caPath, { force: true });
+      }
    });
 });

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -925,6 +925,42 @@ function buildSnowflakePrivateKeyConnection(
    });
 }
 
+// TLS mode for a proxied postgres connection, as `pg` connectionString query
+// params. @malloydata/db-postgres exposes no ssl config, but it forwards a
+// connectionString straight to pg — which parses sslmode. The tunnel terminates
+// at 127.0.0.1, so pg's hostname check can't apply: `verify-ca` validates the
+// cert chain against the trusted CA bundle (NODE_EXTRA_CA_CERTS, e.g. the baked
+// Amazon RDS roots) WITHOUT the hostname; `no-verify` encrypts without checking;
+// `disable` uses no TLS. Full verify-full through a tunnel needs a servername
+// override (a raw ssl object) — awaits an upstream passthrough (malloydata/malloy#2960).
+export function buildProxiedSslQuery(name: string, sslmode?: string): string {
+   const caBundle = process.env.NODE_EXTRA_CA_CERTS;
+   // Default: encrypt (no-verify) so a force-SSL target (the common RDS case)
+   // isn't rejected for plaintext. Operators opt up to verify-ca when the
+   // target's CA is in the trust bundle, or down to disable for non-TLS DBs.
+   const mode = sslmode ?? "no-verify";
+   switch (mode) {
+      case "disable":
+         // Explicit: with no sslmode in the connectionString, pg falls back to
+         // the PGSSLMODE env (set on the non-proxied path), which would verify
+         // and fail the 127.0.0.1 hostname check. Force plaintext explicitly.
+         return "?sslmode=disable";
+      case "no-verify":
+         return "?sslmode=no-verify";
+      case "verify-ca":
+         if (!caBundle) {
+            throw new Error(
+               `Connection proxy on '${name}' uses sslmode 'verify-ca' but no trusted CA bundle is available (NODE_EXTRA_CA_CERTS is unset). Add the CA bundle to the image or use sslmode 'no-verify'.`,
+            );
+         }
+         return `?uselibpqcompat=true&sslmode=verify-ca&sslrootcert=${encodeURIComponent(caBundle)}`;
+      default:
+         throw new Error(
+            `Connection proxy on '${name}' has unsupported sslmode '${mode}' (expected disable | no-verify | verify-ca).`,
+         );
+   }
+}
+
 function buildProxiedPostgresConnection(
    metadata: EnvironmentConnectionMetadata,
    endpoint: ProxyEndpoint,
@@ -936,13 +972,20 @@ function buildProxiedPostgresConnection(
          `Proxied connection '${name}' has type 'postgres' but no postgresConnection config.`,
       );
    }
+   // Build a connectionString to the LOCAL tunnel endpoint carrying the TLS mode.
+   // This is NOT the tenant's connectionString (rejected in validateConnectionShape
+   // because it can't be tunneled) — we construct it ourselves and it targets
+   // 127.0.0.1:<localport>, so there's no ambiguity about where it connects.
+   const enc = encodeURIComponent;
+   const auth = pg.userName
+      ? `${enc(pg.userName)}${pg.password ? `:${enc(pg.password)}` : ""}@`
+      : "";
+   const db = pg.databaseName ? `/${enc(pg.databaseName)}` : "";
+   const ssl = buildProxiedSslQuery(name, pg.sslmode);
+   const connectionString = `postgresql://${auth}${endpoint.host}:${endpoint.port}${db}${ssl}`;
    return new PooledPostgresConnection({
       name,
-      host: endpoint.host,
-      port: endpoint.port,
-      username: pg.userName,
-      password: pg.password,
-      databaseName: pg.databaseName,
+      connectionString,
       // Pool sizing mirrors buildSnowflakePrivateKeyConnection.
       poolMin: 1,
       poolMax: 20,

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -948,6 +948,8 @@ export function buildProxiedSslQuery(name: string, sslmode?: string): string {
       case "no-verify":
          return "?sslmode=no-verify";
       case "verify-ca":
+         // Env-set backstop; validateConnectionShape does the readable-file check
+         // at config load (so a bad bundle fails fast instead of at connect time).
          if (!caBundle) {
             throw new Error(
                `Connection proxy on '${name}' uses sslmode 'verify-ca' but no trusted CA bundle is available (NODE_EXTRA_CA_CERTS is unset). Add the CA bundle to the image or use sslmode 'no-verify'.`,

--- a/packages/server/src/service/connection_config.spec.ts
+++ b/packages/server/src/service/connection_config.spec.ts
@@ -582,7 +582,7 @@ describe("SSH proxy validation", () => {
          ...validSshProxy,
          postgresConnection: {
             ...validSshProxy.postgresConnection!,
-            databaseName: "reporting@prod",
+            databaseName: "sales@prod",
          },
       };
       expect(() => assembleEnvironmentConnections([conn])).toThrow(

--- a/packages/server/src/service/connection_config.spec.ts
+++ b/packages/server/src/service/connection_config.spec.ts
@@ -540,6 +540,19 @@ describe("SSH proxy validation", () => {
       );
    });
 
+   it("rejects an empty-string sslmode at config load (not deferred to connect)", () => {
+      const conn = {
+         ...validSshProxy,
+         postgresConnection: {
+            ...validSshProxy.postgresConnection!,
+            sslmode: "",
+         },
+      } as unknown as ApiConnection;
+      expect(() => assembleEnvironmentConnections([conn])).toThrow(
+         "unsupported sslmode",
+      );
+   });
+
    it("rejects sslmode=verify-ca when no CA bundle is available", () => {
       const prior = process.env.NODE_EXTRA_CA_CERTS;
       delete process.env.NODE_EXTRA_CA_CERTS;

--- a/packages/server/src/service/connection_config.spec.ts
+++ b/packages/server/src/service/connection_config.spec.ts
@@ -464,4 +464,102 @@ describe("SSH proxy validation", () => {
          "requires explicit host and port",
       );
    });
+
+   it("accepts a multi-line hostKey and sslmode=no-verify", () => {
+      const conn: ApiConnection = {
+         ...validSshProxy,
+         postgresConnection: {
+            ...validSshProxy.postgresConnection!,
+            sslmode: "no-verify",
+         },
+         proxy: {
+            type: "ssh",
+            ssh: {
+               ...validSshProxy.proxy!.ssh!,
+               hostKey:
+                  "bastion ssh-ed25519 AAAAdecoy\nbastion ssh-rsa AAAAreal",
+            },
+         },
+      };
+      expect(() => assembleEnvironmentConnections([conn])).not.toThrow();
+   });
+
+   it("rejects a hostKey that parses to zero keys (comment/blank only) — fail-closed at config load", () => {
+      const conn: ApiConnection = {
+         ...validSshProxy,
+         proxy: {
+            type: "ssh",
+            ssh: {
+               ...validSshProxy.proxy!.ssh!,
+               hostKey: "# ssh-keyscan bastion timed out\n   \n",
+            },
+         },
+      };
+      expect(() => assembleEnvironmentConnections([conn])).toThrow(
+         "no usable host-key line",
+      );
+   });
+
+   it("rejects an unsupported sslmode", () => {
+      const conn = {
+         ...validSshProxy,
+         postgresConnection: {
+            ...validSshProxy.postgresConnection!,
+            sslmode: "require",
+         },
+      } as unknown as ApiConnection;
+      expect(() => assembleEnvironmentConnections([conn])).toThrow(
+         "unsupported sslmode 'require'",
+      );
+   });
+
+   it("rejects sslmode=verify-ca when no CA bundle is available", () => {
+      const prior = process.env.NODE_EXTRA_CA_CERTS;
+      delete process.env.NODE_EXTRA_CA_CERTS;
+      try {
+         const conn: ApiConnection = {
+            ...validSshProxy,
+            postgresConnection: {
+               ...validSshProxy.postgresConnection!,
+               sslmode: "verify-ca",
+            },
+         };
+         expect(() => assembleEnvironmentConnections([conn])).toThrow(
+            "verify-ca",
+         );
+      } finally {
+         if (prior !== undefined) process.env.NODE_EXTRA_CA_CERTS = prior;
+      }
+   });
+
+   it("rejects sslmode set on a non-proxied connection (silent-ignore footgun)", () => {
+      const conn: ApiConnection = {
+         name: "pg-direct",
+         type: "postgres",
+         postgresConnection: {
+            host: "db.example.com",
+            port: 5432,
+            databaseName: "mydb",
+            userName: "user",
+            password: "pass",
+            sslmode: "verify-ca",
+         },
+      };
+      expect(() => assembleEnvironmentConnections([conn])).toThrow(
+         "only supported for proxied connections",
+      );
+   });
+
+   it("rejects a proxied database name with URI-reserved characters", () => {
+      const conn: ApiConnection = {
+         ...validSshProxy,
+         postgresConnection: {
+            ...validSshProxy.postgresConnection!,
+            databaseName: "reporting@prod",
+         },
+      };
+      expect(() => assembleEnvironmentConnections([conn])).toThrow(
+         "URI-reserved characters",
+      );
+   });
 });

--- a/packages/server/src/service/connection_config.spec.ts
+++ b/packages/server/src/service/connection_config.spec.ts
@@ -500,6 +500,33 @@ describe("SSH proxy validation", () => {
       );
    });
 
+   it("rejects a whitespace-only hostKey (must not silently connect unpinned)", () => {
+      const conn: ApiConnection = {
+         ...validSshProxy,
+         proxy: {
+            type: "ssh",
+            ssh: {
+               ...validSshProxy.proxy!.ssh!,
+               hostKey: "   ",
+            },
+         },
+      };
+      expect(() => assembleEnvironmentConnections([conn])).toThrow(
+         "no usable host-key line",
+      );
+   });
+
+   it("treats an empty-string hostKey as unpinned (omission-equivalent)", () => {
+      const conn: ApiConnection = {
+         ...validSshProxy,
+         proxy: {
+            type: "ssh",
+            ssh: { ...validSshProxy.proxy!.ssh!, hostKey: "" },
+         },
+      };
+      expect(() => assembleEnvironmentConnections([conn])).not.toThrow();
+   });
+
    it("rejects an unsupported sslmode", () => {
       const conn = {
          ...validSshProxy,

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -335,8 +335,11 @@ function validateConnectionShape(connection: ApiConnection): void {
       // first lookup and a failed build is retried on every subsequent query, so
       // a permanent sslmode misconfig left to throw at connect time would re-dial
       // the tenant's bastion indefinitely. Fail at config load instead.
+      // `!= null` (not truthiness) so a present-but-empty sslmode ("") is caught
+      // here as unsupported rather than slipping through to fail at tunnel-build;
+      // null/undefined mean unset (server applies the default).
       const sslmode = connection.postgresConnection?.sslmode;
-      if (sslmode) {
+      if (sslmode != null) {
          if (!(PROXIED_SSLMODES as readonly string[]).includes(sslmode)) {
             throw new Error(
                `Connection proxy on '${connection.name}' has unsupported sslmode '${sslmode}' ` +

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -1,9 +1,17 @@
 import { createPrivateKey } from "crypto";
+import { existsSync } from "fs";
 import path from "path";
 import { components } from "../api";
+import { parseHostKeys } from "./proxy";
 
 type ApiConnection = components["schemas"]["Connection"];
 type AttachedDatabase = components["schemas"]["AttachedDatabase"];
+
+// TLS modes accepted on a proxied postgres connection. Canonical here (rather
+// than in connection.ts, which imports this module) so both the config-load
+// validator and the connect-time builder derive from one list. Mirrors the
+// `sslmode` enum in api-doc.yaml.
+export const PROXIED_SSLMODES = ["disable", "no-verify", "verify-ca"] as const;
 
 export type CoreConnectionEntry = {
    is: string;
@@ -265,8 +273,11 @@ function validateConnectionShape(connection: ApiConnection): void {
       // authorized by whoever configures the connection — deliberately NOT gated
       // by an env flag, and kept separate from the `publisher` HTTP multi-hop
       // type's PUBLISHER_ALLOW_PROXY_CONNECTIONS gate below (that flag is about
-      // publisher-to-publisher proxying, a distinct operator decision). Host-key
-      // pinning is fail-closed at connect time (see openProxy).
+      // publisher-to-publisher proxying, a distinct operator decision). Optional
+      // host-key pinning is fail-closed at connect time when configured (see
+      // openProxy); the proxy-specific fields are validated up front below so a
+      // permanent misconfig fails at config load, not by repeatedly dialing the
+      // tenant's bastion at query time.
       if (connection.proxy.type !== "ssh") {
          throw new Error(
             `Connection '${connection.name}' has an unsupported proxy type '${connection.proxy.type}'. Only 'ssh' is supported.`,
@@ -303,6 +314,69 @@ function validateConnectionShape(connection: ApiConnection): void {
                `postgres connection; the connectionString form is not supported with a proxy.`,
          );
       }
+
+      // hostKey is optional (absent => connect unpinned), but a hostKey that is
+      // PRESENT yet parses to zero keys — only blank lines or `#` comments, e.g.
+      // a paste that grabbed just ssh-keyscan's `# host:port ...` header — is a
+      // misconfigured pin, not a licence to connect unverified. Reject it here so
+      // the operator gets a config error instead of a silently unpinned tunnel.
+      const hostKey = connection.proxy.ssh?.hostKey;
+      if (hostKey?.trim() && parseHostKeys(hostKey).size === 0) {
+         throw new Error(
+            `Connection proxy on '${connection.name}' has a hostKey with no usable host-key line ` +
+               `(only blanks/comments). Provide an OpenSSH known_hosts line or base64 blob, or omit ` +
+               `hostKey to connect unpinned.`,
+         );
+      }
+
+      // Validate the proxied TLS mode up front. The tunnel is dialed lazily on
+      // first lookup and a failed build is retried on every subsequent query, so
+      // a permanent sslmode misconfig left to throw at connect time would re-dial
+      // the tenant's bastion indefinitely. Fail at config load instead.
+      const sslmode = connection.postgresConnection?.sslmode;
+      if (sslmode) {
+         if (!(PROXIED_SSLMODES as readonly string[]).includes(sslmode)) {
+            throw new Error(
+               `Connection proxy on '${connection.name}' has unsupported sslmode '${sslmode}' ` +
+                  `(expected ${PROXIED_SSLMODES.join(" | ")}).`,
+            );
+         }
+         if (sslmode === "verify-ca") {
+            const caBundle = process.env.NODE_EXTRA_CA_CERTS;
+            if (!caBundle || !existsSync(caBundle)) {
+               throw new Error(
+                  `Connection proxy on '${connection.name}' uses sslmode 'verify-ca' but no readable ` +
+                     `CA bundle is available (NODE_EXTRA_CA_CERTS is unset or points at a missing file). ` +
+                     `Add the CA bundle to the image or use sslmode 'no-verify'.`,
+               );
+            }
+         }
+      }
+
+      // The proxied path builds a connectionString to the local tunnel endpoint;
+      // pg decodes the database path with decodeURI, which leaves URI-reserved
+      // characters percent-encoded — so a db name containing them would resolve
+      // to the wrong database. Reject it clearly rather than failing later with a
+      // confusing "database does not exist". (user/password use decodeURIComponent
+      // on parse and round-trip fine.)
+      const dbName = connection.postgresConnection?.databaseName;
+      if (dbName && decodeURI(encodeURIComponent(dbName)) !== dbName) {
+         throw new Error(
+            `Connection proxy on '${connection.name}' has a database name with characters that can't ` +
+               `be carried over a proxied connection (${JSON.stringify(dbName)}). Use a database name ` +
+               `without URI-reserved characters (; , / ? : @ & = + $ #).`,
+         );
+      }
+   }
+
+   // sslmode is only honored on the proxied path (the direct path builds TLS from
+   // the deployment PGSSLMODE). Reject it on a non-proxied connection so a tenant
+   // who sets it doesn't silently get a different TLS posture than they asked for.
+   if (!connection.proxy && connection.postgresConnection?.sslmode) {
+      throw new Error(
+         `Connection '${connection.name}' sets postgresConnection.sslmode but has no proxy; sslmode is ` +
+            `only supported for proxied connections (direct connections use the deployment PGSSLMODE).`,
+      );
    }
 
    switch (connection.type) {

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -315,13 +315,15 @@ function validateConnectionShape(connection: ApiConnection): void {
          );
       }
 
-      // hostKey is optional (absent => connect unpinned), but a hostKey that is
-      // PRESENT yet parses to zero keys — only blank lines or `#` comments, e.g.
-      // a paste that grabbed just ssh-keyscan's `# host:port ...` header — is a
-      // misconfigured pin, not a licence to connect unverified. Reject it here so
-      // the operator gets a config error instead of a silently unpinned tunnel.
+      // hostKey is optional (omitted or empty string => connect unpinned), but a
+      // non-empty hostKey that parses to zero keys — only blank lines, whitespace,
+      // or `#` comments, e.g. a paste that grabbed just ssh-keyscan's
+      // `# host:port ...` header — is a misconfigured pin, not a licence to
+      // connect unverified. Reject it here so the operator gets a config error
+      // instead of a silently unpinned tunnel. (Truthiness, not trim(): "" is the
+      // unpinned signal; "   " is a non-empty value that must yield a key.)
       const hostKey = connection.proxy.ssh?.hostKey;
-      if (hostKey?.trim() && parseHostKeys(hostKey).size === 0) {
+      if (hostKey && parseHostKeys(hostKey).size === 0) {
          throw new Error(
             `Connection proxy on '${connection.name}' has a hostKey with no usable host-key line ` +
                `(only blanks/comments). Provide an OpenSSH known_hosts line or base64 blob, or omit ` +

--- a/packages/server/src/service/proxy.spec.ts
+++ b/packages/server/src/service/proxy.spec.ts
@@ -303,36 +303,67 @@ describe("openProxy — SSH tunnel", () => {
       ).rejects.toThrow(/host-key mismatch/i);
    });
 
-   it("rejects when hostKey is absent and opt-out env is not set", async () => {
-      const orig = process.env.PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY;
-      delete process.env.PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY;
-
+   it("connects when hostKey is absent — unpinned self-service default", async () => {
+      // No hostKey → connect without host-key verification (the SSH transport is
+      // still encrypted). Matches mainstream BI tools' SSH-tunnel default.
+      const ep = await openProxy(
+         {
+            type: "ssh",
+            ssh: {
+               host: "127.0.0.1",
+               port: sshServer.port,
+               username: "testuser",
+               privateKey: clientPrivatePem,
+            },
+         },
+         { host: "127.0.0.1", port: echoServer.port },
+      );
       try {
-         await expect(
-            openProxy(
-               {
-                  type: "ssh",
-                  ssh: {
-                     host: "127.0.0.1",
-                     port: sshServer.port,
-                     username: "testuser",
-                     privateKey: clientPrivatePem,
-                  },
-               },
-               { host: "127.0.0.1", port: echoServer.port },
-            ),
-         ).rejects.toThrow(/no hostKey provided/i);
+         const reply = await connectAndSend(ep.port, "unpinned");
+         expect(reply).toContain("unpinned");
       } finally {
-         if (orig !== undefined) {
-            process.env.PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY = orig;
-         }
+         await closeQuietly(() => ep.close());
       }
    });
 
-   it("connects when hostKey is absent and opt-out env is set", async () => {
-      process.env.PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY = "true";
+   it("accepts a multi-line hostKey listing several keys — matches any (LB bastion)", async () => {
+      // A load-balanced bastion presents a different host key per backend, so the
+      // pin lists every backend's key and any match is accepted.
+      const decoy = Buffer.alloc(32, 0xff).toString("base64");
+      const multiKey = [
+         `bastion.example.com ssh-ed25519 ${decoy}`,
+         `bastion.example.com ssh-rsa ${sshServer.hostKeyBase64}`,
+      ].join("\n");
+      const ep = await openProxy(
+         {
+            type: "ssh",
+            ssh: {
+               host: "127.0.0.1",
+               port: sshServer.port,
+               username: "testuser",
+               privateKey: clientPrivatePem,
+               hostKey: multiKey,
+            },
+         },
+         { host: "127.0.0.1", port: echoServer.port },
+      );
       try {
-         const ep = await openProxy(
+         const reply = await connectAndSend(ep.port, "multi-key");
+         expect(reply).toContain("multi-key");
+      } finally {
+         await closeQuietly(() => ep.close());
+      }
+   });
+
+   it("rejects a multi-line hostKey when none of the listed keys match", async () => {
+      const decoy1 = Buffer.alloc(32, 0xff).toString("base64");
+      const decoy2 = Buffer.alloc(32, 0xaa).toString("base64");
+      const multiKey = [
+         `bastion.example.com ssh-ed25519 ${decoy1}`,
+         `bastion.example.com ssh-rsa ${decoy2}`,
+      ].join("\n");
+      await expect(
+         openProxy(
             {
                type: "ssh",
                ssh: {
@@ -340,19 +371,12 @@ describe("openProxy — SSH tunnel", () => {
                   port: sshServer.port,
                   username: "testuser",
                   privateKey: clientPrivatePem,
+                  hostKey: multiKey,
                },
             },
             { host: "127.0.0.1", port: echoServer.port },
-         );
-         try {
-            const reply = await connectAndSend(ep.port, "allow-unknown");
-            expect(reply).toContain("allow-unknown");
-         } finally {
-            await closeQuietly(() => ep.close());
-         }
-      } finally {
-         delete process.env.PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY;
-      }
+         ),
+      ).rejects.toThrow(/host-key mismatch/i);
    });
 
    it("rejects for unsupported proxy type", async () => {

--- a/packages/server/src/service/proxy.spec.ts
+++ b/packages/server/src/service/proxy.spec.ts
@@ -300,7 +300,7 @@ describe("openProxy — SSH tunnel", () => {
             },
             { host: "127.0.0.1", port: echoServer.port },
          ),
-      ).rejects.toThrow(/host-key mismatch/i);
+      ).rejects.toThrow(/host-key verification failed/i);
    });
 
    it("connects when hostKey is absent — unpinned self-service default", async () => {
@@ -355,6 +355,29 @@ describe("openProxy — SSH tunnel", () => {
       }
    });
 
+   it("fails closed when hostKey is set but parses to zero keys (comment/blank only)", async () => {
+      // A set-but-degenerate pin must NOT fall through to the unpinned branch —
+      // the security boundary is gated on hostKey being configured, not on it
+      // parsing to >=1 key. (Config load rejects this earlier; this guards the
+      // boundary itself.)
+      const commentOnly = "# ssh-keyscan bastion.example.com timed out\n   \n";
+      await expect(
+         openProxy(
+            {
+               type: "ssh",
+               ssh: {
+                  host: "127.0.0.1",
+                  port: sshServer.port,
+                  username: "testuser",
+                  privateKey: clientPrivatePem,
+                  hostKey: commentOnly,
+               },
+            },
+            { host: "127.0.0.1", port: echoServer.port },
+         ),
+      ).rejects.toThrow(/host-key verification failed/i);
+   });
+
    it("rejects a multi-line hostKey when none of the listed keys match", async () => {
       const decoy1 = Buffer.alloc(32, 0xff).toString("base64");
       const decoy2 = Buffer.alloc(32, 0xaa).toString("base64");
@@ -376,7 +399,7 @@ describe("openProxy — SSH tunnel", () => {
             },
             { host: "127.0.0.1", port: echoServer.port },
          ),
-      ).rejects.toThrow(/host-key mismatch/i);
+      ).rejects.toThrow(/host-key verification failed/i);
    });
 
    it("rejects for unsupported proxy type", async () => {

--- a/packages/server/src/service/proxy.ts
+++ b/packages/server/src/service/proxy.ts
@@ -8,24 +8,26 @@
  * A connection proxy is a normal connection capability (authorized by whoever
  * configures the connection); it is intentionally NOT behind an env-flag gate,
  * and is kept separate from the `publisher` HTTP multi-hop type's
- * PUBLISHER_ALLOW_PROXY_CONNECTIONS gate. The trust boundary is host-key pinning
- * (below), which is fail-closed.
+ * PUBLISHER_ALLOW_PROXY_CONNECTIONS gate. When host-key pinning is configured it
+ * is fail-closed (below).
  *
  * # Host-key policy
  *
- * Publisher is fail-closed by default: if `ssh.hostKey` is absent the tunnel
- * is refused at connect time to prevent MITM.  Set the environment variable
- *
- *   PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY=true
- *
- * to disable this check for development/testing.  Never set this in
- * production.
+ * `ssh.hostKey` is optional. When set, it pins the bastion's host key(s) and the
+ * tunnel is fail-closed on mismatch; it may list multiple known_hosts lines (a
+ * load-balanced/HA bastion presents a different key per backend), and any listed
+ * key is accepted. When absent, the tunnel connects without host-key
+ * verification — the self-service default, matching mainstream BI tools' SSH
+ * tunnels. The SSH transport is still encrypted; unpinned, a MITM on the
+ * publisher→bastion hop is possible, mitigated by the customer allowlisting our
+ * egress on the bastion.
  */
 
 import net from "net";
 import { Client as SshClient } from "ssh2";
 import type { ConnectConfig, SyncHostVerifier } from "ssh2";
 import { components } from "../api";
+import { logger } from "../logger";
 
 type ConnectionProxy = components["schemas"]["ConnectionProxy"];
 
@@ -39,17 +41,27 @@ const SSH_CONNECT_TIMEOUT_MS = 15_000;
 const SSH_KEEPALIVE_INTERVAL_MS = 15_000;
 
 /**
- * Extract the base64 wire-format key from a stored hostKey, accepting any of:
- * a full known_hosts line (`[markers] host keytype AAAA…`), a `keytype AAAA…`
- * pair, or the bare base64 blob. SSH public-key blobs always base64-encode to a
- * string starting with "AAAA" (the 4-byte length prefix of the key-type name),
- * so we pick that token; otherwise fall back to the last whitespace-delimited
- * token. This matches what ssh2's hostVerifier hands us (`key.toString("base64")`).
+ * Parse a stored hostKey into the set of base64 wire-format key blobs to accept.
+ * The value may hold one or more OpenSSH known_hosts entries (one per line) — a
+ * load-balanced bastion presents a different host key per backend, so pinning
+ * such a bastion means listing every backend's key. Blank lines and `#` comments
+ * are skipped. Each entry may be a full known_hosts line (`[markers] host keytype
+ * AAAA…`), a `keytype AAAA…` pair, or a bare base64 blob; SSH key blobs
+ * base64-encode to a string starting with "AAAA" (the length prefix of the
+ * key-type name), so we pick that token, else the last whitespace-delimited
+ * token. Compared against what ssh2 hands us (`key.toString("base64")`).
  */
-function extractHostKeyBase64(raw: string): string {
-   const tokens = raw.trim().split(/\s+/);
-   const blob = tokens.find((t) => /^AAAA[A-Za-z0-9+/]+={0,2}$/.test(t));
-   return blob ?? tokens[tokens.length - 1] ?? "";
+export function parseHostKeys(raw: string): Set<string> {
+   const keys = new Set<string>();
+   for (const line of raw.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const tokens = trimmed.split(/\s+/);
+      const blob = tokens.find((t) => /^AAAA[A-Za-z0-9+/]+={0,2}$/.test(t));
+      const key = blob ?? tokens[tokens.length - 1];
+      if (key) keys.add(key);
+   }
+   return keys;
 }
 
 /**
@@ -112,31 +124,29 @@ function openSshProxy(
          hostVerifier: ((key: Buffer): boolean => {
             // `key` is the raw Buffer of the host's public key.
             const presented = key.toString("base64");
-            if (ssh.hostKey) {
-               const expected = extractHostKeyBase64(ssh.hostKey);
-               if (presented !== expected) {
-                  fail(
-                     new Error(
-                        `SSH host-key mismatch for ${ssh.host}: expected ${expected.slice(0, 24)}… but got ${presented.slice(0, 24)}….`,
-                     ),
-                  );
-                  return false;
+            const pinned = ssh.hostKey
+               ? parseHostKeys(ssh.hostKey)
+               : new Set<string>();
+            if (pinned.size > 0) {
+               // Pinned: fail-closed, accepting any listed key (an LB/HA bastion
+               // presents a different key per backend).
+               if (pinned.has(presented)) {
+                  return true;
                }
-               return true;
+               fail(
+                  new Error(
+                     `SSH host-key mismatch for ${ssh.host}: the presented key is ` +
+                        `not among the ${pinned.size} pinned host key(s).`,
+                  ),
+               );
+               return false;
             }
-            // No hostKey provided.
-            if (process.env.PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY === "true") {
-               return true;
-            }
-            fail(
-               new Error(
-                  `SSH connection to ${ssh.host} refused: no hostKey provided and ` +
-                     `PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY is not 'true'.  ` +
-                     `Set hostKey to the bastion's host public key (an OpenSSH ` +
-                     `known_hosts line or its base64 blob, e.g. from ssh-keyscan).`,
-               ),
+            // Unpinned (no hostKey): connect without host-key verification — the
+            // self-service default (see file header).
+            logger.warn(
+               `Connecting to SSH bastion ${ssh.host} without host-key verification (no hostKey pinned).`,
             );
-            return false;
+            return true;
          }) as SyncHostVerifier,
       };
 

--- a/packages/server/src/service/proxy.ts
+++ b/packages/server/src/service/proxy.ts
@@ -124,19 +124,23 @@ function openSshProxy(
          hostVerifier: ((key: Buffer): boolean => {
             // `key` is the raw Buffer of the host's public key.
             const presented = key.toString("base64");
-            const pinned = ssh.hostKey
-               ? parseHostKeys(ssh.hostKey)
-               : new Set<string>();
-            if (pinned.size > 0) {
-               // Pinned: fail-closed, accepting any listed key (an LB/HA bastion
-               // presents a different key per backend).
+            // "Pinned" is gated on hostKey being CONFIGURED, not on it parsing to
+            // ≥1 key: a set-but-degenerate hostKey (only blanks/comments) must
+            // fail closed, never fall through to the unpinned branch. Config load
+            // (validateConnectionShape) already rejects that case; this is the
+            // security-boundary backstop for any path that reaches here directly.
+            if (ssh.hostKey?.trim()) {
+               // Fail-closed, accepting any listed key — an LB/HA bastion presents
+               // a different host key per backend.
+               const pinned = parseHostKeys(ssh.hostKey);
                if (pinned.has(presented)) {
                   return true;
                }
                fail(
                   new Error(
-                     `SSH host-key mismatch for ${ssh.host}: the presented key is ` +
-                        `not among the ${pinned.size} pinned host key(s).`,
+                     `SSH host-key verification failed for ${ssh.host}: the presented key ` +
+                        `(${presented.slice(0, 24)}…) is not among the ${pinned.size} pinned ` +
+                        `host key(s).`,
                   ),
                );
                return false;

--- a/packages/server/src/service/proxy.ts
+++ b/packages/server/src/service/proxy.ts
@@ -124,12 +124,13 @@ function openSshProxy(
          hostVerifier: ((key: Buffer): boolean => {
             // `key` is the raw Buffer of the host's public key.
             const presented = key.toString("base64");
-            // "Pinned" is gated on hostKey being CONFIGURED, not on it parsing to
-            // ≥1 key: a set-but-degenerate hostKey (only blanks/comments) must
-            // fail closed, never fall through to the unpinned branch. Config load
-            // (validateConnectionShape) already rejects that case; this is the
-            // security-boundary backstop for any path that reaches here directly.
-            if (ssh.hostKey?.trim()) {
+            // "Pinned" is gated on hostKey being a non-empty value, not on it
+            // parsing to ≥1 key: a set-but-degenerate hostKey (only whitespace,
+            // blanks, or comments) must fail closed, never fall through to the
+            // unpinned branch. Config load (validateConnectionShape) already
+            // rejects that case; this is the security-boundary backstop for any
+            // path that reaches here directly. ("" is the unpinned signal.)
+            if (ssh.hostKey) {
                // Fail-closed, accepting any listed key — an LB/HA bastion presents
                // a different host key per backend.
                const pinned = parseHostKeys(ssh.hostKey);


### PR DESCRIPTION
Follow-up to #858 (SSH-bastion connection proxy). Makes proxied Postgres connections robust for real-world bastions and databases — specifically load-balanced/HA bastions and force-SSL RDS — by adding a per-connection TLS mode, relaxing host-key pinning from required-single-key to optional-multi-key, and validating all proxy config up front.

## Why

Three things #858's design got wrong for real targets, found testing against a customer's AWS setup:

1. **Required single-key host-key pinning breaks load-balanced bastions.** Their bastion is an ELB fronting ≥2 backends, each with a *different* SSH host key (confirmed: 8 scans → 2 distinct keys). A single required pin fails ~50% of connects. Mainstream self-service tools (Metabase, Looker, Redash, Hex, Retool, Superset) don't pin bastion host keys at all — encrypted SSH transport is the baseline, pinning is opt-in.
2. **No per-connection TLS mode.** Proxied connections inherited the deployment `PGSSLMODE`. Through the tunnel the driver connects to `127.0.0.1`, so any hostname-verifying mode fails the cert ALTNAME check even with the CA trusted — a force-SSL RDS target couldn't connect.
3. **Static config errors surfaced at connect time**, after dialing the tenant's bastion — which fails *open* for a degenerate hostKey and re-dials the bastion indefinitely for a bad sslmode.

## What

**Per-connection `postgresConnection.sslmode`** `{disable, no-verify, verify-ca}`, applied only on the proxied path (self-built connectionString to the local endpoint; the non-proxied path keeps using env `PGSSLMODE`).
- **`no-verify` (default when a proxy is set)** — encrypt without verifying, so a force-SSL target isn't rejected for plaintext.
- **`verify-ca`** — chain-verify against `NODE_EXTRA_CA_CERTS` (the baked RDS roots from #860) via `uselibpqcompat`, skipping the hostname the tunnel can't satisfy.
- **`disable`** — emits an explicit `?sslmode=disable` so pg can't silently fall back to the deployment `PGSSLMODE` and verify.

**`hostKey` is now optional and multi-key.** Absent → connect unpinned (still encrypted; a warning is logged). Present → fail-closed, **match-any** over one-or-more `known_hosts` lines, so an LB/HA bastion can pin every backend's key. Removes the `PUBLISHER_SSH_ALLOW_UNKNOWN_HOSTKEY` env flag (its meaning inverts under the new default).

**Fail-fast validation + fail-closed boundary** (from a 5-reviewer pass — the general fix for #3). `validateConnectionShape` now rejects, at config load *before any bastion is dialed*:
- a hostKey that is set but parses to zero keys (blanks/`#` comments only) — was a silent fail-*open* downgrade to an unpinned tunnel;
- an unsupported `sslmode`, or `verify-ca` when the CA bundle is unset/missing — was thrown only inside the lazily-dialed builder, so a permanent typo re-dialed the bastion on every query;
- `sslmode` set on a non-proxied connection — was silently ignored;
- a proxied database name with URI-reserved chars (pg decodes the path with `decodeURI`) — was a silent wrong-database.

And `hostVerifier` gates "pinned" on hostKey being *configured*, not on it parsing to ≥1 key — so a set-but-degenerate pin fails closed at the security boundary regardless of how config reached it (defense-in-depth), and the mismatch error carries the presented-key fingerprint (needed to know which LB backend's key to add).

Docs (`docs/connections.md`) and the `SshProxyConfig.hostKey` / `PostgresConnection.sslmode` schema descriptions updated.

## Robustness matrix

| Config | Behavior |
|---|---|
| Direct postgres, no sslmode | Unchanged — deployment PGSSLMODE |
| Direct postgres + sslmode set | Rejected at load (no silent-ignore) |
| Proxy, no hostKey | Connect unpinned (encrypted), warn |
| Proxy + single / multi-key hostKey | Fail-closed match-any (LB/HA bastion) |
| Proxy + hostKey comment/blank only | Rejected at load; fails closed at boundary |
| Proxy + no-verify (default) | Encrypt, skip verify (force-SSL RDS) |
| Proxy + verify-ca (+CA present) | Chain-verify, hostname skipped |
| Proxy + verify-ca, CA missing | Rejected at load (no bastion re-dial churn) |
| Proxy + disable / invalid sslmode | Explicit plaintext / rejected at load |
| Proxy + reserved-char db name | Rejected at load with guidance |

## Security note

Unpinned + `no-verify` means the publisher→bastion→DB path is unauthenticated end-to-end — a network MITM could capture DB credentials. This matches the default posture of the tools above; the compensating control is the customer allowlisting our published egress IPs on the bastion's inbound SSH. Stronger-than-default customers should prefer **`verify-ca`** (authenticates the actual database endpoint) and/or pin host keys. `verify-full` through a tunnel awaits per-connection `servername` passthrough (malloydata/malloy#2960).

## Tests

- `buildProxiedSslQuery`: default→no-verify, explicit `disable`→`?sslmode=disable` (regression: never empty), `verify-ca` query shape, throws without a CA bundle, throws on unknown mode, and a `pg-connection-string` version guard (verify-ca must still parse to an ssl config if pg is ever downgraded).
- `connection_config` proxy validation: multi-line hostKey + no-verify accepted; comment-only hostKey, unsupported sslmode, verify-ca-without-CA, sslmode-without-proxy, and reserved-char db name all rejected at load.
- `proxy.spec`: unpinned-connect (default), multi-line match-any accept, all-mismatch reject, set-but-degenerate hostKey fails closed; existing single-key / known_hosts-line / hashed-line / mismatch cases retained.

`tsc` clean; proxy 9/9, connection_config 37/37, buildProxiedSslQuery 7/7.