### PR TITLE
fix(runtime sdk): encode model path as a single URL segment (%2F)

### DIFF
--- a/packages/server/src/runtime/publisher.js
+++ b/packages/server/src/runtime/publisher.js
@@ -79,7 +79,12 @@
          "/packages/" +
          encodeURIComponent(target.pkg) +
          "/models/" +
-         modelPath.split("/").map(encodeURIComponent).join("/") +
+         // Encode the whole model path as ONE path segment (slashes -> %2F). A model
+         // in a subfolder ("model/x.malloy") must not become two URL segments: some
+         // servers only match a single-segment {path} and would 405 a multi-segment
+         // path. This matches the typed SDK (encodeURIComponent) and the server's
+         // encoded-slash handling.
+         encodeURIComponent(modelPath) +
          "/query";
       var body = { compactJson: compactJson };
       if (malloyQuery) body.query = malloyQuery;


### PR DESCRIPTION
## Problem
The served `/sdk/publisher.js` builds the query URL as:
```js
"/models/" + modelPath.split("/").map(encodeURIComponent).join("/") + "/query"
```
This keeps **literal slashes**, so a model in a subfolder (`model/x.malloy`) becomes a **multi-segment** URL path. Servers that match only a single-segment `{path}` variable (e.g. a Spring `AntPathMatcher` route `…/models/{path}/query`) don't match the POST and fall through to a GET-only handler → **HTTP 405 "Method 'POST' is not supported."**

This hits **in-package HTML data apps** (which load this vanilla SDK). It does *not* hit the typed axios SDK, which `encodeURIComponent`s the **whole** path (slashes → `%2F`, one segment) — so app/notebook/MCP queries against the same subfolder model work fine.

## Fix
Encode the whole model path as one segment, matching the typed SDK:
```js
"/models/" + encodeURIComponent(modelPath) + "/query"
```
- Safe on the open-source publisher: the server route (`packages/server/src/server.ts`, `…/models/*?/query`) matches the `*?` wildcard and decodes the `%2F` param back to `model/x.malloy`.
- Also works against single-segment servers that accept encoded slashes.
- One-liner in `packages/server/src/runtime/publisher.js` (`rawQuery`, which backs both `query` and `queryFull`). `dist/` is build-generated.

## Test
Query a package whose model is in a subfolder from a data app (or `POST …/models/model%2Fx.malloy/query`): 200 instead of 405. Flat models are unaffected (`encodeURIComponent("x.malloy")` == `"x.malloy"`).