### PR TITLE
feat(persistence): surface sharing/refresh + freshness; gate package crons at publish

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -2749,7 +2749,42 @@ components:
             5-field UNIX cron controlling how often the control plane
             re-materializes this package's published versions. Null = no
             scheduled re-materialization declared in the manifest (publish /
-            on-demand only).
+            on-demand only). A cron is the power tier of artifact-anchored
+            scheduling: it is valid only when every persist source in the
+            package resolves to an explicit `sharing=private`; a cron on a
+            package with any shared/unset persist source is rejected at
+            publish (declare `materialization.freshness.window` instead).
+        freshness:
+          oneOf:
+            - $ref: "#/components/schemas/Freshness"
+            - type: "null"
+          description: >-
+            The manifest's `materialization.freshness` block, verbatim. Null =
+            no freshness policy declared. `window` is the control plane's
+            refresh objective for the package's materialized sources;
+            `fallback` is the declared query-time behavior when the objective
+            is missed. The publisher only surfaces the values — the control
+            plane owns the scheduling and gating logic.
+
+    Freshness:
+      type: object
+      description: >-
+        Freshness policy declared in malloy-publisher.json's
+        `materialization.freshness` block. Fields are surfaced verbatim;
+        invalid values are dropped (reported as absent), never defaulted.
+      properties:
+        window:
+          type: string
+          description: >-
+            Maximum acceptable staleness of the package's materialized
+            sources, as a duration string (e.g. "24h"). The control plane
+            schedules refreshes to meet it.
+        fallback:
+          type: string
+          enum: [live, stale_ok, fail]
+          description: >-
+            Declared query-time behavior when the freshness window is missed:
+            serve live, serve the stale table, or fail the query.
 
     Model:
       type: object
@@ -4074,6 +4109,21 @@ components:
           description:
             The source's build SQL (with the build manifest applied for upstream
             rewrites).
+        sharing:
+          type: ["string", "null"]
+          description: >-
+            The source's declared `#@ persist ... sharing=...` value
+            ("private" | "shared"), reported verbatim. Null = unset — the
+            publisher never substitutes the platform default, so the control
+            plane can distinguish unset from an explicit `shared` and apply
+            the default (unset => shared) itself. The publisher reports the
+            most-specific declaration (the source's own persist annotation).
+        refresh:
+          type: ["string", "null"]
+          description: >-
+            The source's declared `#@ persist ... refresh=...` value
+            ("full" | "incremental"), reported verbatim; null = unset.
+            Metadata pass-through — inert to the publisher today.
         columns:
           type: array
           description: Output schema of the source.

--- a/packages/server/src/controller/package.controller.spec.ts
+++ b/packages/server/src/controller/package.controller.spec.ts
@@ -18,6 +18,7 @@ describe("PackageController.addPackage explores validation", () => {
          "Invalid explores entry 'missing.malloy' in publisher.json: file not found";
       const mockPackage = {
          formatInvalidExplores: () => invalidMsg,
+         formatInvalidSchedule: () => "",
       };
       const unloadPackage = sinon.stub().resolves(undefined);
       const deletePackage = sinon.stub().resolves(undefined);
@@ -52,7 +53,10 @@ describe("PackageController.addPackage explores validation", () => {
       // controller passes a validator and does NOT call delete/unload itself.
       const invalidMsg =
          "Invalid explores entry 'missing.malloy' in publisher.json: file not found";
-      const mockPackage = { formatInvalidExplores: () => invalidMsg };
+      const mockPackage = {
+         formatInvalidExplores: () => invalidMsg,
+         formatInvalidSchedule: () => "",
+      };
       // installPackage mimics the real contract: invoke the validator and, if it
       // returns a message, throw BadRequestError (after its internal rollback).
       const installPackage = sinon
@@ -100,6 +104,7 @@ describe("PackageController.addPackage explores validation", () => {
    it("persists when explores are valid (no-location)", async () => {
       const mockPackage = {
          formatInvalidExplores: () => "",
+         formatInvalidSchedule: () => "",
       };
       const addPackage = sinon.stub().resolves(mockPackage);
       const getEnvironment = sinon.stub().resolves({ addPackage });
@@ -122,6 +127,88 @@ describe("PackageController.addPackage explores validation", () => {
    });
 });
 
+describe("PackageController.addPackage cron schedule validation", () => {
+   afterEach(() => {
+      sinon.restore();
+   });
+
+   it("rejects a publish whose cron fails the private-only gate (no-location path)", async () => {
+      // Valid explores but an invalid materialization cron: the publish must
+      // still 400 (strict-at-publish, same split as explores — load merely
+      // warns) and roll back via unloadPackage.
+      const cronMsg =
+         "materialization.schedule (cron) in publisher.json requires every " +
+         "persist source to declare '#@ persist ... sharing=private'; source " +
+         "'orders' resolves to unset.";
+      const mockPackage = {
+         formatInvalidExplores: () => "",
+         formatInvalidSchedule: () => cronMsg,
+      };
+      const unloadPackage = sinon.stub().resolves(undefined);
+      const addPackage = sinon.stub().resolves(mockPackage);
+      const environment = { addPackage, unloadPackage };
+      const getEnvironment = sinon.stub().resolves(environment);
+      const addPackageToDatabase = sinon.stub().resolves(undefined);
+      const environmentStore = {
+         publisherConfigIsFrozen: false,
+         getEnvironment,
+         addPackageToDatabase,
+      } as unknown as EnvironmentStore;
+
+      const controller = new PackageController(environmentStore);
+
+      await expect(
+         controller.addPackage("env", { name: "pkg", description: "test" }),
+      ).rejects.toThrow(cronMsg);
+
+      expect(unloadPackage.calledOnceWith("pkg")).toBe(true);
+      expect(addPackageToDatabase.called).toBe(false);
+   });
+
+   it("location path: the cron gate runs inside installPackage's rollback window", async () => {
+      const cronMsg =
+         "materialization.schedule (cron) in publisher.json requires every " +
+         "persist source to declare '#@ persist ... sharing=private'.";
+      const mockPackage = {
+         formatInvalidExplores: () => "",
+         formatInvalidSchedule: () => cronMsg,
+      };
+      const installPackage = sinon
+         .stub()
+         .callsFake(
+            async (
+               _name: string,
+               _downloader: unknown,
+               validate?: (pkg: unknown) => string | undefined,
+            ) => {
+               const msg = validate?.(mockPackage);
+               if (msg) throw new BadRequestError(msg);
+               return mockPackage;
+            },
+         );
+      const environment = { installPackage };
+      const getEnvironment = sinon.stub().resolves(environment);
+      const addPackageToDatabase = sinon.stub().resolves(undefined);
+      const environmentStore = {
+         publisherConfigIsFrozen: false,
+         getEnvironment,
+         addPackageToDatabase,
+      } as unknown as EnvironmentStore;
+
+      const controller = new PackageController(environmentStore);
+
+      await expect(
+         controller.addPackage("env", {
+            name: "pkg",
+            description: "test",
+            location: "gs://bucket/pkg.zip",
+         }),
+      ).rejects.toThrow(cronMsg);
+
+      expect(addPackageToDatabase.called).toBe(false);
+   });
+});
+
 describe("PackageController.updatePackage explores validation", () => {
    afterEach(() => {
       sinon.restore();
@@ -138,6 +225,7 @@ describe("PackageController.updatePackage explores validation", () => {
       const mockPackage = {
          formatInvalidExplores: (override?: string[]) =>
             override?.includes("nope.malloy") ? invalidMsg : "",
+         formatInvalidSchedule: () => "",
       };
       const installPackage = sinon
          .stub()

--- a/packages/server/src/controller/package.controller.ts
+++ b/packages/server/src/controller/package.controller.ts
@@ -5,6 +5,30 @@ import { EnvironmentStore } from "../service/environment_store";
 
 type ApiPackage = components["schemas"]["Package"];
 
+/**
+ * Everything that is strict-at-publish, joined into one 400 message (or
+ * undefined when the package is publishable): invalid explores entries plus
+ * the materialization cron gate (a package-level `schedule` requires every
+ * persist source to resolve to explicit `sharing=private` — see
+ * Package.scheduleWarnings). At startup/reload both are warn-only instead
+ * (fail-safe; see Package.loadViaWorker).
+ */
+function formatPublishRejections(
+   pkg: {
+      formatInvalidExplores(exploresOverride?: string[]): string;
+      formatInvalidSchedule(): string;
+   },
+   exploresOverride?: string[],
+): string | undefined {
+   const message = [
+      pkg.formatInvalidExplores(exploresOverride),
+      pkg.formatInvalidSchedule(),
+   ]
+      .filter(Boolean)
+      .join("\n");
+   return message || undefined;
+}
+
 export class PackageController {
    private environmentStore: EnvironmentStore;
 
@@ -100,7 +124,7 @@ export class PackageController {
                   bodyLocation,
                   stagingPath,
                ),
-            (pkg) => pkg.formatInvalidExplores(),
+            (pkg) => formatPublishRejections(pkg),
          );
       } else {
          result = await environment.addPackage(packageName);
@@ -114,7 +138,7 @@ export class PackageController {
       }
 
       if (!body.location) {
-         const invalidMsg = result.formatInvalidExplores();
+         const invalidMsg = formatPublishRejections(result);
          if (invalidMsg) {
             await environment.unloadPackage(packageName).catch(() => {
                /* best-effort; the package is not persisted below */
@@ -177,7 +201,8 @@ export class PackageController {
                   stagingPath,
                ),
             (pkg) =>
-               pkg.formatInvalidExplores(
+               formatPublishRejections(
+                  pkg,
                   body.explores?.map(normalizeModelPath),
                ),
          );

--- a/packages/server/src/package_load/package_load_pool.ts
+++ b/packages/server/src/package_load/package_load_pool.ts
@@ -81,6 +81,7 @@ import { fileURLToPath, pathToFileURL } from "url";
 
 import { ModelCompilationError } from "../errors";
 import { logger } from "../logger";
+import type { PackageMaterializationConfig } from "../service/package_manifest";
 import type {
    ConnectionMetadataRequest,
    ConnectionMetadataResponse,
@@ -233,7 +234,7 @@ export interface LoadPackageOutcome {
       explores?: string[];
       queryableSources?: "declared" | "all";
       manifestLocation?: string | null;
-      materialization?: { schedule: string | null } | null;
+      materialization?: PackageMaterializationConfig | null;
    };
    models: Array<
       Omit<SerializedModel, "modelDef" | "sourceInfos"> & {

--- a/packages/server/src/package_load/package_load_worker.ts
+++ b/packages/server/src/package_load/package_load_worker.ts
@@ -83,7 +83,10 @@ import { HackyDataStylesAccumulator } from "../data_styles";
 import { ModelCompilationError } from "../errors";
 import { validateAuthorizeProbes } from "../service/authorize";
 import { type FilterDefinition } from "../service/filter";
-import { parsePackageMaterialization } from "../service/package_manifest";
+import {
+   PackageMaterializationConfig,
+   parsePackageMaterialization,
+} from "../service/package_manifest";
 import {
    extractQueriesFromModelDef,
    extractSourcesFromModelDef,
@@ -383,7 +386,7 @@ async function readPackageMetadata(packagePath: string): Promise<{
    explores?: string[];
    queryableSources?: "declared" | "all";
    manifestLocation?: string | null;
-   materialization?: { schedule: string | null } | null;
+   materialization?: PackageMaterializationConfig | null;
 }> {
    const manifestPath = path.join(packagePath, PACKAGE_MANIFEST_NAME);
    const contents = await fs.promises.readFile(manifestPath, "utf8");

--- a/packages/server/src/package_load/protocol.ts
+++ b/packages/server/src/package_load/protocol.ts
@@ -65,6 +65,7 @@
  */
 
 import type { SQLSourceDef, TableSourceDef } from "@malloydata/malloy";
+import type { PackageMaterializationConfig } from "../service/package_manifest";
 
 // ──────────────────────────────────────────────────────────────────────
 // Direction: main ──▶ worker (load-package job)
@@ -179,7 +180,7 @@ export interface LoadPackageResult {
       explores?: string[];
       queryableSources?: "declared" | "all";
       manifestLocation?: string | null;
-      materialization?: { schedule: string | null } | null;
+      materialization?: PackageMaterializationConfig | null;
    };
    models: SerializedModel[];
    /** Wall-clock ms inside the worker for the full package load. */

--- a/packages/server/src/service/build_plan.spec.ts
+++ b/packages/server/src/service/build_plan.spec.ts
@@ -212,6 +212,50 @@ describe("deriveBuildPlan", () => {
       });
    });
 
+   it("reports declared sharing/refresh verbatim and null when unset", () => {
+      // The control plane distinguishes unset from an explicit `shared` (it
+      // applies the platform default itself), so the publisher must report
+      // the declared value verbatim — never substitute the default.
+      const declared = fakeSource({
+         name: "declared",
+         sourceEntityId: "bid-d",
+         annotationFields: {
+            name: "d_table",
+            sharing: "private",
+            refresh: "incremental",
+         },
+      });
+      const unset = fakeSource({ name: "unset", sourceEntityId: "bid-u" });
+      const plan = deriveBuildPlan(
+         [
+            {
+               connectionName: "duckdb",
+               nodes: [
+                  [
+                     { sourceID: "declared@m", dependsOn: [] },
+                     { sourceID: "unset@m", dependsOn: [] },
+                  ],
+               ],
+            },
+         ] as unknown as Parameters<typeof deriveBuildPlan>[0],
+         { "declared@m": declared, "unset@m": unset },
+         { duckdb: "dig" },
+      );
+
+      expect(plan.sources["declared@m"].sharing).toBe("private");
+      expect(plan.sources["declared@m"].refresh).toBe("incremental");
+      // The raw annotation map still carries every field alongside the typed
+      // projections.
+      expect(plan.sources["declared@m"].annotationFields).toEqual({
+         name: "d_table",
+         sharing: "private",
+         refresh: "incremental",
+      });
+      // Unset is null — not "shared" — on the wire.
+      expect(plan.sources["unset@m"].sharing).toBeNull();
+      expect(plan.sources["unset@m"].refresh).toBeNull();
+   });
+
    it("honors the sourceNames filter", () => {
       const a = fakeSource({ name: "a", sourceEntityId: "bid-a" });
       const b = fakeSource({ name: "b", sourceEntityId: "bid-b" });

--- a/packages/server/src/service/build_plan.ts
+++ b/packages/server/src/service/build_plan.ts
@@ -307,6 +307,7 @@ export function deriveBuildPlan(
    const wireSources: Record<string, WirePersistSourcePlan> = {};
    for (const [sourceID, source] of Object.entries(sources)) {
       if (include && !include.has(source.name)) continue;
+      const annotationFields = deriveAnnotationFields(source);
       wireSources[sourceID] = {
          name: source.name,
          sourceID: source.sourceID,
@@ -314,8 +315,16 @@ export function deriveBuildPlan(
          dialect: source.dialectName,
          sourceEntityId: computeSourceEntityId(source, connectionDigests),
          sql: source.getSQL(),
+         // Declared `#@ persist` scope/refresh knobs, reported VERBATIM (null
+         // = unset). The control plane applies the platform default (unset =>
+         // shared) itself, so the publisher must never substitute it — unset
+         // has to stay distinguishable from an explicit `shared`. The source's
+         // own annotation is the most-specific declaration layer, and the only
+         // one that exists today.
+         sharing: annotationFields.sharing ?? null,
+         refresh: annotationFields.refresh ?? null,
          columns: deriveColumns(source),
-         annotationFields: deriveAnnotationFields(source),
+         annotationFields,
          modelPath: sourceModelPaths?.[sourceID],
       };
    }

--- a/packages/server/src/service/materialization_cron_gate.spec.ts
+++ b/packages/server/src/service/materialization_cron_gate.spec.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+
+import { Environment } from "./environment";
+import type { Package } from "./package";
+
+/**
+ * The publish gate for the package-level materialization cron (§9.4
+ * artifact-anchored scheduling): a declared `materialization.schedule` is the
+ * power tier and is valid only when every persist source in the compiled
+ * build plan resolves to an explicit `sharing=private`. These tests run a real
+ * `Environment` + `Package.create` over temp dirs, so they also prove
+ * end-to-end that the pinned compiler ACCEPTS `sharing=` / `refresh=` keys in
+ * the `#@ persist` annotation and that the values survive to the wire build
+ * plan verbatim (unset stays null — never defaulted to "shared").
+ */
+describe("materialization cron gate", () => {
+   let rootDir: string;
+   let envPath: string;
+
+   async function loadPackage(model: string, schedule?: string) {
+      const dir = path.join(envPath, "pkg");
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(
+         path.join(dir, "publisher.json"),
+         JSON.stringify({
+            name: "pkg",
+            description: "fixture",
+            ...(schedule ? { materialization: { schedule } } : {}),
+         }),
+      );
+      await fs.writeFile(path.join(dir, "model.malloy"), model);
+      const env = await Environment.create("testEnv", envPath, []);
+      await env.addPackage("pkg");
+      return env.getPackage("pkg", false);
+   }
+
+   function sourceByName(pkg: Package, name: string) {
+      const sources = pkg.getBuildPlan()?.sources ?? {};
+      const found = Object.values(sources).find((s) => s.name === name);
+      if (!found) throw new Error(`persist source '${name}' not in build plan`);
+      return found;
+   }
+
+   beforeEach(async () => {
+      rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "publisher-cron-"));
+      envPath = path.join(rootDir, "env");
+      await fs.mkdir(envPath, { recursive: true });
+   });
+
+   afterEach(async () => {
+      await fs.rm(rootDir, { recursive: true, force: true }).catch(() => {});
+   });
+
+   const MIXED_MODEL = `##! experimental.persistence
+
+#@ persist name="priv_table" sharing=private refresh=incremental
+source: priv is duckdb.sql("SELECT 1 as x")
+
+#@ persist name="open_table" sharing=shared
+source: open is duckdb.sql("SELECT 2 as x")
+
+#@ persist name="unset_table"
+source: unspecified is duckdb.sql("SELECT 3 as x")
+`;
+
+   const ALL_PRIVATE_MODEL = `##! experimental.persistence
+
+#@ persist name="a_table" sharing=private
+source: a is duckdb.sql("SELECT 1 as x")
+
+#@ persist name="b_table" sharing=private refresh=full
+source: b is duckdb.sql("SELECT 2 as x")
+`;
+
+   it(
+      "surfaces declared sharing/refresh verbatim on the build plan (null when unset)",
+      async () => {
+         const pkg = await loadPackage(MIXED_MODEL);
+
+         const priv = sourceByName(pkg, "priv");
+         expect(priv.sharing).toBe("private");
+         expect(priv.refresh).toBe("incremental");
+
+         const open = sourceByName(pkg, "open");
+         expect(open.sharing).toBe("shared");
+         expect(open.refresh).toBeNull();
+
+         // Unset must be reported as null — distinguishable from an explicit
+         // "shared" — because the control plane applies the platform default
+         // (unset => shared) itself.
+         const unspecified = sourceByName(pkg, "unspecified");
+         expect(unspecified.sharing).toBeNull();
+         expect(unspecified.refresh).toBeNull();
+      },
+      { timeout: 30000 },
+   );
+
+   it(
+      "rejects a cron over shared/unset persist sources, pointing at freshness.window",
+      async () => {
+         const pkg = await loadPackage(MIXED_MODEL, "0 6 * * *");
+
+         const warnings = pkg.scheduleWarnings();
+         // One actionable message per offending source; the compliant private
+         // source is not flagged.
+         expect(warnings).toHaveLength(2);
+         const joined = pkg.formatInvalidSchedule();
+         expect(joined).toContain("'open' resolves to 'shared'");
+         expect(joined).toContain("'unspecified' resolves to unset");
+         expect(joined).not.toContain("'priv'");
+         expect(joined).toContain("materialization.freshness.window");
+      },
+      { timeout: 30000 },
+   );
+
+   it(
+      "allows a cron when every persist source is explicitly private",
+      async () => {
+         const pkg = await loadPackage(ALL_PRIVATE_MODEL, "0 6 * * *");
+         expect(pkg.scheduleWarnings()).toEqual([]);
+         expect(pkg.formatInvalidSchedule()).toBe("");
+      },
+      { timeout: 30000 },
+   );
+
+   it(
+      "is inert when no cron is declared, whatever the sources' sharing",
+      async () => {
+         const pkg = await loadPackage(MIXED_MODEL);
+         expect(pkg.scheduleWarnings()).toEqual([]);
+      },
+      { timeout: 30000 },
+   );
+});

--- a/packages/server/src/service/materialization_schedule_surface.spec.ts
+++ b/packages/server/src/service/materialization_schedule_surface.spec.ts
@@ -53,6 +53,30 @@ describe("materialization schedule surfacing", () => {
          const pkg = await env.getPackage("pkg", false);
          expect(pkg.getPackageMetadata().materialization).toEqual({
             schedule: "0 6 * * *",
+            freshness: null,
+         });
+      },
+      { timeout: 20000 },
+   );
+
+   it(
+      "surfaces the manifest's materialization.freshness on load",
+      async () => {
+         const env = await Environment.create("testEnv", envPath, []);
+         await writePackageDir({
+            materialization: {
+               freshness: { window: "24h", fallback: "stale_ok" },
+            },
+         });
+         await env.addPackage("pkg");
+
+         // Freshness rides the same channel as schedule: present-and-verbatim
+         // when declared, null when unset — the control plane owns the
+         // scheduling/gating logic and only needs the values surfaced.
+         const pkg = await env.getPackage("pkg", false);
+         expect(pkg.getPackageMetadata().materialization).toEqual({
+            schedule: null,
+            freshness: { window: "24h", fallback: "stale_ok" },
          });
       },
       { timeout: 20000 },
@@ -71,6 +95,7 @@ describe("materialization schedule surfacing", () => {
          const pkg = await env.getPackage("pkg", false);
          expect(pkg.getPackageMetadata().materialization).toEqual({
             schedule: null,
+            freshness: null,
          });
       },
       { timeout: 20000 },
@@ -91,11 +116,15 @@ describe("materialization schedule surfacing", () => {
             name: "pkg",
             description: "updated",
          });
-         expect(updated.materialization).toEqual({ schedule: "0 6 * * *" });
+         expect(updated.materialization).toEqual({
+            schedule: "0 6 * * *",
+            freshness: null,
+         });
 
          const pkg = await env.getPackage("pkg", false);
          expect(pkg.getPackageMetadata().materialization).toEqual({
             schedule: "0 6 * * *",
+            freshness: null,
          });
       },
       { timeout: 20000 },

--- a/packages/server/src/service/materialization_test_fixtures.ts
+++ b/packages/server/src/service/materialization_test_fixtures.ts
@@ -81,7 +81,10 @@ export function fakeSource(opts: {
    sql?: string;
    connectionName?: string;
    dialectName?: string;
+   /** key=value fields of the `#@ persist` annotation (e.g. sharing). */
+   annotationFields?: Record<string, string>;
 }): PersistSource {
+   const fields = opts.annotationFields;
    return {
       name: opts.name,
       sourceID: opts.name,
@@ -90,7 +93,20 @@ export function fakeSource(opts: {
       makeBuildId: () => opts.sourceEntityId,
       getSQL: () => opts.sql ?? "SELECT 1",
       annotations: {
-         parseAsTag: () => ({ tag: { text: () => undefined } }),
+         parseAsTag: () =>
+            fields
+               ? {
+                    tag: {
+                       *entries() {
+                          for (const [key, value] of Object.entries(fields)) {
+                             yield [key, { text: () => value }];
+                          }
+                       },
+                    },
+                 }
+               : // No annotation fields: entries() is absent, and
+                 // deriveAnnotationFields degrades to {}.
+                 { tag: { text: () => undefined } },
       },
    } as unknown as PersistSource;
 }

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -347,6 +347,7 @@ export class Package {
          // absence as a schedule removal. See `parsePackageMaterialization`.
          materialization: outcome.packageMetadata.materialization ?? {
             schedule: null,
+            freshness: null,
          },
       };
 
@@ -448,6 +449,16 @@ export class Package {
          logger.warn(`Package ${packageName} has invalid explores`, {
             packageName,
             detail: invalidMsg,
+         });
+      }
+      // Same fail-safe split for the materialization cron gate: an existing
+      // package whose manifest violates the private-only cron rule still loads
+      // (warn), but a publish of it is rejected (see package.controller).
+      const invalidSchedule = pkg.formatInvalidSchedule();
+      if (invalidSchedule) {
+         logger.warn(`Package ${packageName} has an invalid cron schedule`, {
+            packageName,
+            detail: invalidSchedule,
          });
       }
       pkg.logEmptyDiscoveryWarnings();
@@ -601,6 +612,41 @@ export class Package {
     */
    public formatInvalidExplores(exploresOverride?: string[]): string {
       return this.exploreWarnings(exploresOverride).join("\n");
+   }
+
+   /**
+    * Publish-gate for the package-level materialization cron (the power tier
+    * of artifact-anchored scheduling): a declared `materialization.schedule`
+    * governs every persist source in the package, so it is valid only when
+    * each source in the compiled build plan resolves to an explicit
+    * `sharing=private`. A cron over any shared/unset source would let one
+    * package dictate the refresh cadence of an artifact other packages share —
+    * those packages declare `materialization.freshness.window` instead and the
+    * control plane schedules the shared artifact from the tightest window.
+    * One actionable message per offending source (empty when the cron is
+    * valid or no cron is declared). Strict at publish (package.controller),
+    * warn-only at load/reload (loadViaWorker) — same split as explores.
+    */
+   public scheduleWarnings(): string[] {
+      const schedule = this.packageMetadata.materialization?.schedule;
+      if (!schedule) return [];
+      const sources = Object.values(this.buildPlan?.sources ?? {});
+      return sources
+         .filter((source) => source.sharing !== "private")
+         .map(
+            (source) =>
+               `materialization.schedule (cron) in ${PACKAGE_MANIFEST_NAME} requires every ` +
+               `persist source to declare '#@ persist ... sharing=private'; source ` +
+               `'${source.name}' resolves to ${
+                  source.sharing ? `'${source.sharing}'` : "unset"
+               }. Declare 'materialization.freshness.window' instead (the control plane ` +
+               `schedules refreshes from it), or mark every persist source sharing=private.`,
+         );
+   }
+
+   /** The {@link scheduleWarnings} joined into one string, or "" if none. */
+   public formatInvalidSchedule(): string {
+      return this.scheduleWarnings().join("\n");
    }
 
    /**

--- a/packages/server/src/service/package_manifest.spec.ts
+++ b/packages/server/src/service/package_manifest.spec.ts
@@ -5,7 +5,7 @@ describe("service/package_manifest", () => {
    describe("parsePackageMaterialization", () => {
       it("extracts a string schedule", () => {
          expect(parsePackageMaterialization({ schedule: "0 6 * * *" })).toEqual(
-            { schedule: "0 6 * * *" },
+            { schedule: "0 6 * * *", freshness: null },
          );
       });
 
@@ -18,21 +18,59 @@ describe("service/package_manifest", () => {
          expect(
             parsePackageMaterialization({
                schedule: "*/15 * * * *",
-               freshness: { window: "24h" },
+               retries: 3,
             }),
-         ).toEqual({ schedule: "*/15 * * * *" });
+         ).toEqual({ schedule: "*/15 * * * *", freshness: null });
       });
 
       it("degrades a non-string schedule to null", () => {
          expect(parsePackageMaterialization({ schedule: 42 })).toEqual({
             schedule: null,
+            freshness: null,
          });
-         expect(parsePackageMaterialization({})).toEqual({ schedule: null });
+         expect(parsePackageMaterialization({})).toEqual({
+            schedule: null,
+            freshness: null,
+         });
       });
 
       it("returns null for non-object input", () => {
          expect(parsePackageMaterialization("0 6 * * *")).toBeNull();
          expect(parsePackageMaterialization(7)).toBeNull();
+      });
+
+      it("extracts a full freshness block verbatim", () => {
+         expect(
+            parsePackageMaterialization({
+               freshness: { window: "24h", fallback: "stale_ok" },
+            }),
+         ).toEqual({
+            schedule: null,
+            freshness: { window: "24h", fallback: "stale_ok" },
+         });
+      });
+
+      it("keeps a partial freshness block (window only)", () => {
+         expect(
+            parsePackageMaterialization({ freshness: { window: "1h" } }),
+         ).toEqual({ schedule: null, freshness: { window: "1h" } });
+      });
+
+      it("drops invalid freshness fields rather than defaulting them", () => {
+         // A bad value is reported as absent — never substituted — so the
+         // control plane sees exactly what was (validly) declared.
+         expect(
+            parsePackageMaterialization({
+               freshness: { window: 24, fallback: "retry" },
+            }),
+         ).toEqual({ schedule: null, freshness: {} });
+      });
+
+      it("degrades a non-object freshness to null", () => {
+         expect(parsePackageMaterialization({ freshness: "24h" })).toEqual({
+            schedule: null,
+            freshness: null,
+         });
       });
    });
 });

--- a/packages/server/src/service/package_manifest.ts
+++ b/packages/server/src/service/package_manifest.ts
@@ -4,18 +4,61 @@
  * testable in isolation from the package-load worker that consumes it.
  */
 
+const FRESHNESS_FALLBACKS = ["live", "stale_ok", "fail"] as const;
+export type FreshnessFallback = (typeof FRESHNESS_FALLBACKS)[number];
+
+/**
+ * The manifest's `materialization.freshness` block, surfaced verbatim for the
+ * control plane (which owns the scheduling and query-time gating logic).
+ * Fields are kept only when valid — an invalid value is dropped, never
+ * defaulted, so absence on the wire always means "not declared".
+ */
+export interface PackageFreshnessConfig {
+   /** Maximum acceptable staleness, as a duration string (e.g. "24h"). */
+   window?: string;
+   /** Declared query-time behavior when the window is missed. */
+   fallback?: FreshnessFallback;
+}
+
 export interface PackageMaterializationConfig {
    /**
     * 5-field UNIX cron the control plane uses to schedule version-level
-    * re-materialization. Null when absent or not a string.
+    * re-materialization. Null when absent or not a string. Publish-gated:
+    * only valid when every persist source resolves to explicit
+    * `sharing=private` (see Package.scheduleWarnings).
     */
    schedule: string | null;
+   /**
+    * Freshness policy ({ window, fallback }). Null when the manifest declares
+    * none — distinct from an empty object, so the control plane can tell
+    * "no policy" from "policy with no valid fields".
+    */
+   freshness: PackageFreshnessConfig | null;
+}
+
+function parseFreshness(raw: unknown): PackageFreshnessConfig | null {
+   if (!raw || typeof raw !== "object") {
+      return null;
+   }
+   const { window, fallback } = raw as { window?: unknown; fallback?: unknown };
+   const freshness: PackageFreshnessConfig = {};
+   if (typeof window === "string") {
+      freshness.window = window;
+   }
+   if (
+      typeof fallback === "string" &&
+      (FRESHNESS_FALLBACKS as readonly string[]).includes(fallback)
+   ) {
+      freshness.fallback = fallback as FreshnessFallback;
+   }
+   return freshness;
 }
 
 /**
  * Read the manifest's `materialization` object, keeping only recognized fields.
  * Returns null when the block is absent so the API field is null rather than an
- * empty object; a non-string schedule degrades to null.
+ * empty object; a non-string schedule degrades to null, and an absent or
+ * non-object freshness degrades to null.
  */
 export function parsePackageMaterialization(
    raw: unknown,
@@ -23,6 +66,12 @@ export function parsePackageMaterialization(
    if (!raw || typeof raw !== "object") {
       return null;
    }
-   const schedule = (raw as { schedule?: unknown }).schedule;
-   return { schedule: typeof schedule === "string" ? schedule : null };
+   const { schedule, freshness } = raw as {
+      schedule?: unknown;
+      freshness?: unknown;
+   };
+   return {
+      schedule: typeof schedule === "string" ? schedule : null,
+      freshness: parseFreshness(freshness),
+   };
 }


### PR DESCRIPTION
## Summary

Unblocks the control plane's artifact-anchored refresh scheduler (persistence.md §9.4) by shipping the two missing signals. Follows #864.

- **`PersistSourcePlan.sharing` / `.refresh` (typed, verbatim):** the source's declared `#@ persist ... sharing=...` / `refresh=...` values, reported as-is with **null = unset** — the publisher never substitutes the platform default, so the CP can distinguish unset from an explicit `shared` and apply `unset ⇒ shared` itself. The source's own persist annotation is the most-specific declaration layer (and the only one that exists today) — the publisher resolves and reports that effective value. The raw `annotationFields` map still carries every field.
- **`PackageMaterializationConfig.freshness = { window, fallback }`:** parsed from `malloy-publisher.json` and surfaced exactly like `schedule` — object present whenever the package loads, `null` when unset, invalid fields dropped (never defaulted). `fallback` is validated against `live | stale_ok | fail`.
- **Publish-time cron gate (§9.4 / §10):** a package-level `materialization.schedule` is valid only when **every persist source in the compiled build plan resolves to explicit `sharing=private`**. Otherwise the publish 400s with one actionable message per offending source, pointing at `materialization.freshness.window` as the replacement. Enforcement mirrors the explores gate exactly: strict at publish (`package.controller`, inside `installPackage`'s rollback window for the location path, unload-and-reject for the pre-existing-directory path), warn-only at startup/reload so existing packages keep loading.

**Compiler acceptance verified:** the new `materialization_cron_gate.spec.ts` loads real packages through the worker with `#@ persist name=... sharing=... refresh=...` models — the pinned compiler accepts the keys today (the persist check parses the annotation as a generic tag, no key whitelist) and the values survive to the wire build plan verbatim.

**Contract discipline:** schema changes landed in the publisher's `api-doc.yaml` first and were mirrored verbatim into the service repo's `apis/dataplane-public-api-doc.yaml` (left uncommitted there alongside the in-progress `feat/runs-merge` work); the CP's Maven openapi codegen regenerates cleanly and emits `PublisherFreshness` + the new `PublisherPersistSourcePlan` fields.

Not done (called out as nice-to-have): the publish-time warning when a declared `window` is unmeetable by a declared cron — needs cron-interval math; can follow once the CP's expected-build-duration signal exists.

## Test plan

- [x] `materialization_cron_gate.spec.ts` (real compiles): sharing/refresh surfaced verbatim + null-when-unset; cron rejected over shared/unset sources with freshness.window pointer; cron allowed when all private; inert without a cron
- [x] `package.controller.spec.ts`: cron gate 400s on both publish paths, inside the same rollback windows as explores
- [x] `package_manifest.spec.ts`: freshness parse cases (full/partial/invalid/non-object)
- [x] `build_plan.spec.ts`: wire projection of sharing/refresh + annotationFields
- [x] Full server unit suite: 1069 pass / 0 fail; materialization integration suite: 12 pass / 0 fail
- [x] tsc + eslint + prettier clean (server/sdk/cli with regenerated types); CP `mvnw generate-sources` clean against the mirrored spec

Made with [Cursor](https://cursor.com)