### PR TITLE
fix(materialization): route persisted-source queries to the materialized table on Postgres

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,9 @@ COPY package.json bun.lock api-doc.yaml ./
 COPY packages/server/package.json ./packages/server/package.json
 COPY packages/app/package.json ./packages/app/package.json
 COPY packages/sdk/package.json ./packages/sdk/package.json
+# patchedDependencies (see package.json) reference files here; they must be
+# present before `bun install` or the install fails resolving the patch.
+COPY patches/ ./patches/
 
 # Install all workspace dependencies once (cached across builds)
 RUN --mount=type=cache,target=/root/.bun/install/cache \
@@ -86,6 +89,9 @@ LABEL org.opencontainers.image.title="Malloy Publisher" \
 
 # Copy built artifacts from builder
 COPY --from=builder /publisher/package.json /publisher/bun.lock ./
+# Patch files must be present before the production `bun install` below, since
+# package.json's patchedDependencies reference them (see builder stage).
+COPY --from=builder /publisher/patches/ ./patches/
 COPY --from=builder /publisher/packages/app/dist/ /publisher/packages/app/dist/
 COPY --from=builder /publisher/packages/app/package.json /publisher/packages/app/package.json
 COPY --from=builder /publisher/packages/server/dist/ /publisher/packages/server/dist/

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "malloy-publisher",
@@ -214,6 +213,9 @@
         "supertest": "^7.0.0",
       },
     },
+  },
+  "patchedDependencies": {
+    "@malloydata/malloy@0.0.421": "patches/@malloydata%2Fmalloy@0.0.421.patch",
   },
   "overrides": {
     "@malloydata/malloy-explorer": "0.0.338-dev260215172810",
@@ -3367,7 +3369,7 @@
 
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
 
-    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+    "uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
 
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
 
@@ -3666,8 +3668,6 @@
     "@malloydata/db-mysql/@types/node": ["@types/node@22.20.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g=="],
 
     "@malloydata/db-trino/gaxios": ["gaxios@4.3.3", "", { "dependencies": { "abort-controller": "^3.0.0", "extend": "^3.0.2", "https-proxy-agent": "^5.0.0", "is-stream": "^2.0.0", "node-fetch": "^2.6.7" } }, "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA=="],
-
-    "@malloydata/malloy/uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
 
     "@malloydata/malloy-explorer/@shikijs/langs": ["@shikijs/langs@3.13.0", "", { "dependencies": { "@shikijs/types": "3.13.0" } }, "sha512-672c3WAETDYHwrRP0yLy3W1QYB89Hbpj+pO4KhxK6FzIrDI2FoEXNiNCut6BQmEApYLfuYfpgOZaqbY+E9b8wQ=="],
 

--- a/package.json
+++ b/package.json
@@ -80,5 +80,8 @@
     "@malloydata/malloy-query-builder": "^0.0.421",
     "@malloydata/malloy-filter": "^0.0.421",
     "@malloydata/malloy-tag": "^0.0.421"
+  },
+  "patchedDependencies": {
+    "@malloydata/malloy@0.0.421": "patches/@malloydata%2Fmalloy@0.0.421.patch"
   }
 }

--- a/packages/server/tests/integration/materialization/manifest_binding.integration.spec.ts
+++ b/packages/server/tests/integration/materialization/manifest_binding.integration.spec.ts
@@ -91,15 +91,105 @@ describe("Manifest binding via Package.manifestLocation (E2E)", () => {
       });
    }
 
+   const ROUTING_QUERY = "run: order_summary -> { aggregate: c is count() }";
+
    async function queryOrderSummaryStatus(): Promise<number> {
       const res = await fetch(`${baseUrl}${API}/models/${MODEL_PATH}/query`, {
          method: "POST",
          headers: { "Content-Type": "application/json" },
-         body: JSON.stringify({
-            query: "run: order_summary -> { aggregate: c is count() }",
-         }),
+         body: JSON.stringify({ query: ROUTING_QUERY }),
       });
       return res.status;
+   }
+
+   /** The SQL the served query actually compiled to (routing evidence). */
+   async function executedSql(): Promise<string> {
+      const res = await fetch(`${baseUrl}${API}/models/${MODEL_PATH}/query`, {
+         method: "POST",
+         headers: { "Content-Type": "application/json" },
+         body: JSON.stringify({ query: ROUTING_QUERY }),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { result: string };
+      return (JSON.parse(body.result) as { sql: string }).sql;
+   }
+
+   /** Read the package's build plan and return the persist source's real sourceEntityId. */
+   async function orderSummarySourceEntityId(): Promise<string> {
+      const res = await fetch(url(""));
+      expect(res.status).toBe(200);
+      const pkg = (await res.json()) as {
+         buildPlan?: { sources?: Record<string, { sourceEntityId?: string }> };
+      };
+      const sources = pkg.buildPlan?.sources ?? {};
+      const sourceEntityId = Object.values(sources)[0]?.sourceEntityId;
+      expect(typeof sourceEntityId).toBe("string");
+      return sourceEntityId as string;
+   }
+
+   /** Poll a materialization until it reaches a terminal state. */
+   async function pollUntilTerminal(
+      id: string,
+      timeoutMs = 90_000,
+   ): Promise<Record<string, unknown>> {
+      const terminal = ["MANIFEST_FILE_READY", "FAILED", "CANCELLED"];
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+         const res = await fetch(url(`/materializations/${id}`));
+         expect(res.status).toBe(200);
+         const data = (await res.json()) as Record<string, unknown>;
+         if (terminal.includes(data.status as string)) return data;
+         await new Promise((r) => setTimeout(r, 250));
+      }
+      throw new Error(`Materialization ${id} did not reach a terminal state`);
+   }
+
+   /**
+    * Build + physicalise the persist source (auto-run self-assigns
+    * physicalTableName = "order_summary" from `#@ persist name=...`) so a
+    * `SELECT * FROM order_summary` is actually queryable, then revert the
+    * package to live (unbound) — keeping the table — so a subsequent
+    * manifest-URI bind is what routes the served query.
+    */
+   async function buildTableThenRevertToLive(): Promise<void> {
+      const createRes = await fetch(url("/materializations"), {
+         method: "POST",
+         headers: { "Content-Type": "application/json" },
+         body: JSON.stringify({}),
+      });
+      expect(createRes.status).toBe(201);
+      const { id } = (await createRes.json()) as { id: string };
+      const built = await pollUntilTerminal(id);
+      expect(built.status).toBe("MANIFEST_FILE_READY");
+      // Revert to live: drop the auto-load binding but leave the built table.
+      await fetch(url("?reload=true"));
+      // Retire the run record so it doesn't hold the per-package active slot.
+      await fetch(url(`/materializations/${id}`), { method: "DELETE" });
+   }
+
+   /** Write a manifest file keyed by the persist source's real sourceEntityId. */
+   async function writeRoutingManifest(
+      sourceEntityId: string,
+      physicalTableName: string,
+   ): Promise<string> {
+      const file = path.join(tmpDir, `routing-manifest-${Date.now()}.json`);
+      await fsp.writeFile(
+         file,
+         JSON.stringify({
+            builtAt: new Date().toISOString(),
+            strict: false,
+            entries: {
+               [sourceEntityId]: {
+                  sourceEntityId,
+                  sourceName: "order_summary",
+                  physicalTableName,
+                  connectionName: "duckdb",
+               },
+            },
+         }),
+         "utf8",
+      );
+      return file;
    }
 
    async function writeManifest(): Promise<string> {
@@ -169,6 +259,48 @@ describe("Manifest binding via Package.manifestLocation (E2E)", () => {
          expect(await queryOrderSummaryStatus()).toBe(200);
       },
       { timeout: 60_000 },
+   );
+
+   it(
+      "routes served queries to the materialized table after a manifest-URI bind",
+      async () => {
+         // Start from live so the baseline recomputes from the base CSV.
+         await getPackage(true);
+         expect(await executedSql()).toContain("data/orders.csv");
+
+         // Physically build the persist source, then revert to live (keeping
+         // the table) so the manifest-URI bind below is the only thing that
+         // could route the served query.
+         await buildTableThenRevertToLive();
+         expect(await executedSql()).toContain("data/orders.csv");
+
+         // Bind the CP-shaped manifest via manifestLocation, keyed by the
+         // source's REAL sourceEntityId (the value Malloy recomputes at serve
+         // time to resolve the persist reference). Anything else silently misses.
+         const sourceEntityId = await orderSummarySourceEntityId();
+         const manifestFile = await writeRoutingManifest(
+            sourceEntityId,
+            "order_summary",
+         );
+         const patchRes = await patchPackage({
+            manifestLocation: manifestFile,
+         });
+         expect(patchRes.status).toBe(200);
+         const patched = await patchRes.json();
+         expect(patched.manifestBindingStatus).toBe("bound");
+         expect(patched.manifestEntryCount).toBe(1);
+
+         // The payoff: the served query now scans the materialized table and no
+         // longer recomputes from the base CSV.
+         const routed = await executedSql();
+         expect(routed).not.toContain("data/orders.csv");
+         expect(routed).toContain("order_summary");
+
+         // Cleanup: revert to live so the dangling binding doesn't leak.
+         await patchPackage({ manifestLocation: null });
+         await getPackage(true);
+      },
+      { timeout: 120_000 },
    );
 
    it("degrades to serving live when the manifest is unreachable", async () => {

--- a/patches/@malloydata%2Fmalloy@0.0.421.patch
+++ b/patches/@malloydata%2Fmalloy@0.0.421.patch
@@ -1,0 +1,30 @@
+diff --git a/dist/api/foundation/core.js b/dist/api/foundation/core.js
+index d0b7f8728fedd9419cef87334658cbeb612f018e..dd6c999843c0dbc1b87576c63b73b1223472ea02 100644
+--- a/dist/api/foundation/core.js
++++ b/dist/api/foundation/core.js
+@@ -1298,13 +1298,23 @@ class PersistSource {
+      * @return The SQL string for this source.
+      */
+     getSQL(options) {
++        // [publisher patch] compile with finalize=false so a persist source's SQL
++        // is the bare source SELECT, not the dialect's runnable/result-serialized
++        // form. Postgres (Dialect.hasFinalStage=true) otherwise wraps the final
++        // stage in `row_to_json(...) as row`, which (1) makes CREATE TABLE AS
++        // materialize a single JSON column and (2) diverges the build-time
++        // BuildID from the serve-time lookup (which resolves persist sources from
++        // the bare SELECT), so queries never route to the materialized table.
++        // No-op where hasFinalStage=false (BigQuery/duckdb). Mirrors
++        // malloydata/malloy#2964; drop this patch once that ships in a released
++        // @malloydata/malloy and the dep is bumped.
+         const sd = this.persistableDef;
+         const queryModel = this.model.queryModel;
+         if (sd.type === 'sql_select') {
+-            return (0, model_1.getCompiledSQL)(sd, options !== null && options !== void 0 ? options : {}, (query, opts) => queryModel.compileQuery(query, opts).sql);
++            return (0, model_1.getCompiledSQL)(sd, options !== null && options !== void 0 ? options : {}, (query, opts) => queryModel.compileQuery(query, opts, false).sql);
+         }
+         else {
+-            const compiled = queryModel.compileQuery(sd.query, options);
++            const compiled = queryModel.compileQuery(sd.query, options, false);
+             return compiled.sql;
+         }
+     }

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,97 @@
+# Dependency patches
+
+Local overrides applied to installed npm dependencies via bun's
+[`patchedDependencies`](https://bun.sh/docs/install/patch). The `package.json`
+`patchedDependencies` map points each dependency version at its patch file here;
+`bun install` reapplies them automatically (in local dev and in the Docker image
+build — see the `COPY patches/` steps in `Dockerfile`).
+
+---
+
+## `@malloydata/malloy@0.0.421` — persist-source `getSQL()` uses `finalize=false`
+
+**Temporary.** Tracks upstream fix **[malloydata/malloy#2964](https://github.com/malloydata/malloy/pull/2964)**.
+Remove this patch as soon as that fix ships in a released `@malloydata/malloy`
+and the dependency is bumped past it (see teardown below).
+
+### What it changes
+
+`PersistSource.getSQL()` compiles the source's inner query with `finalize=false`
+(one argument added to the two `queryModel.compileQuery(...)` calls in
+`dist/api/foundation/core.js`), so it returns the **bare source SELECT** instead
+of the dialect's runnable / result-serialized form.
+
+### Why
+
+`getSQL()` feeds two build-time uses (see `packages/server/src/service/build_plan.ts`
+`computeBuildId` + the plan `sql` field, and `materialization_service.ts`
+`buildOneSource`'s `CREATE TABLE AS`). With the default `finalize=true`, Malloy
+appends the dialect's `sqlFinalStage` whenever `Dialect.hasFinalStage` is true.
+**Postgres is the only such dialect**, and its final stage wraps the result in
+`SELECT row_to_json(finalStage) as row ...`. That wrapper caused two
+Postgres-only failures:
+
+1. `CREATE TABLE AS (getSQL())` materialized a **single JSON `row` column**
+   instead of the real columns (BigQuery, `hasFinalStage=false`, was unaffected
+   and worked).
+2. The source's BuildID (`mkBuildID` over this SQL) no longer matched the
+   **serve-time** manifest lookup, which resolves a persist source from the bare
+   (unfinalized) SELECT — so queries fell through to a base-table scan instead of
+   routing to the materialized table.
+
+Compiling with `finalize=false` makes both the physical table (real columns) and
+the build-time BuildID agree with the serve path. It is a **no-op** for dialects
+without a final stage (BigQuery, duckdb, etc.), so it is safe across connectors.
+
+Root-cause detail lives in the service repo:
+`docs/handoffs/publisher-serve-time-manifest-binding.md`.
+
+### How to remove it (once #2964 is released)
+
+1. **Confirm the fix is in the target release.** Pick the first published
+   `@malloydata/malloy` version that contains #2964 and verify its shipped dist
+   already compiles `getSQL()` with `finalize=false`:
+
+   ```bash
+   npm view @malloydata/malloy@<version> version
+   # after bumping (step 2), spot-check the installed file:
+   grep -n "compileQuery(sd.query, options, false)" \
+     node_modules/@malloydata/malloy/dist/api/foundation/core.js
+   ```
+
+2. **Bump Malloy** (updates every `@malloydata/*` dep + resolutions, reinstalls,
+   syncs DuckDB):
+
+   ```bash
+   bun run upgrade-malloy <version>
+   ```
+
+3. **Delete the patch and its registration.** Remove this file's sibling
+   `@malloydata%2Fmalloy@0.0.421.patch`, and delete the matching entry from the
+   `patchedDependencies` map in `package.json`:
+
+   ```jsonc
+   // package.json — remove this block entirely
+   "patchedDependencies": {
+     "@malloydata/malloy@0.0.421": "patches/@malloydata%2Fmalloy@0.0.421.patch"
+   }
+   ```
+
+   (The version key is exact, so once step 2 bumps the version the patch no
+   longer matches anyway — but leaving a dangling entry makes `bun install` fail,
+   so remove it in the same change.)
+
+4. **Revert the Dockerfile `patches/` copies** if this `patches/` directory
+   becomes empty. Two `COPY patches/ ...` lines were added for this patch:
+   - builder stage, just before the first `bun install`
+   - final stage, just after `COPY --from=builder .../package.json .../bun.lock`
+
+   `COPY` of an empty/absent directory fails, so drop both lines when the last
+   patch is gone. Keep them if any other patch remains.
+
+5. **Reinstall and confirm clean:**
+
+   ```bash
+   bun install
+   git status          # bun.lock's patchedDependencies block should be gone
+   ```


### PR DESCRIPTION
## Summary

A query on a `#@ persist` source **recomputed from the base table** instead of routing to the materialized physical table on **Postgres**, even when the manifest was correctly built, bound (`manifestBindingStatus: bound`), and content-addressed. BigQuery/duckdb were unaffected — which pinned it to a dialect-specific issue.

**Root cause:** `PersistSource.getSQL()` compiles with `finalize=true`, so Malloy appends the dialect's `sqlFinalStage` when `Dialect.hasFinalStage` is set. **Postgres is the only such dialect**, and its final stage wraps the result in `SELECT row_to_json(finalStage) as row ...`. That wrapper caused two Postgres-only failures:

1. `CREATE TABLE AS (getSQL())` materialized a **single JSON `row` column** instead of the real columns.
2. The source's BuildID (`mkBuildID` over this SQL) no longer matched the **serve-time** manifest lookup (which resolves a persist source from the bare, unfinalized SELECT), so served queries fell through to a **base-table scan** instead of routing to the materialized table.

**Fix:** patch `@malloydata/malloy@0.0.421` via bun `patchedDependencies` so `PersistSource.getSQL()` compiles the inner query with `finalize=false` (returns the bare source SELECT). Both the physical table (real columns) and the build-time BuildID then agree with the serve path. It is a **no-op** for dialects without a final stage (BigQuery, duckdb), so it is safe across connectors.

This patch is **temporary** and tracks upstream **malloydata/malloy#2964**. Full rationale and step-by-step teardown (for when #2964 ships and the dep is bumped) live in `patches/README.md`.

## Changes

- **`patches/@malloydata%2Fmalloy@0.0.421.patch`** — `PersistSource.getSQL()` → `compileQuery(..., false)`.
- **`package.json` / `bun.lock`** — register the patch via bun `patchedDependencies`. (`bun.lock` also picked up incidental reinstall churn: dropped `configVersion: 0`, transitive `uuid` 11.1.0→11.1.1.)
- **`Dockerfile`** — `COPY patches/` before each `bun install` (builder + final stage) so the patch resolves during the image build.
- **`patches/README.md`** — what/why + removal procedure.
- **`manifest_binding.integration.spec.ts`** — add a serve-time **routing** assertion on the production manifest-URI bind path (fetch manifest → `reloadAllModels` → serve), which previously only checked HTTP 200, never that the query routed.

## Test plan

- [x] `bun test tests/integration/materialization/` — 13/13 pass with the patch applied (incl. auto-load and manifest-URI serve-time routing on duckdb).
- [ ] Postgres e2e routing assertion (`materialization-postgres.spec.ts`) — the dialect this actually fixes; verify against a Postgres-backed stack.
- [ ] Confirm the Docker image build resolves the patch (the `COPY patches/` steps).

Made with [Cursor](https://cursor.com)