### PR TITLE
feat(persistence): per-source dispatch + per-source freshness/schedule (Phase D)

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -4124,6 +4124,25 @@ components:
             The source's declared `#@ persist ... refresh=...` value
             ("full" | "incremental"), reported verbatim; null = unset.
             Metadata pass-through — inert to the publisher today.
+        freshness:
+          oneOf:
+            - $ref: "#/components/schemas/Freshness"
+            - type: "null"
+          description: >-
+            The source's EFFECTIVE freshness objective after most-specific-wins
+            resolution (source > model-file > package). Null = unset at every
+            level; the control plane applies the platform default. Reported
+            verbatim (invalid fields dropped, never defaulted).
+        schedule:
+          type: ["string", "null"]
+          description: >-
+            The source's EFFECTIVE power-tier cron after most-specific-wins
+            resolution of the source's OWN declaration (source > model-file).
+            The package-level cron (PackageMaterializationConfig.schedule) is a
+            distinct package-grain concept and is NOT folded in here. Null =
+            unset. Valid only when the source resolves to sharing="private" (a
+            cron on a shared or unset source is rejected at publish; declare
+            freshness.window instead).
         columns:
           type: array
           description: Output schema of the source.
@@ -4162,6 +4181,45 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/BuildInstruction"
+        referenceManifest:
+          type: array
+          description: >-
+            Already-materialized persist upstreams the built sources may
+            reference but which are NOT rebuilt in this run. The publisher seeds
+            the build Manifest with these so a downstream source's upstream
+            persist reference resolves to the existing physical table instead of
+            recomputing it live. Only consumed on the orchestrated
+            (buildInstructions) path; auto-run seeds its own reference set from
+            the most-recent manifest.
+          items:
+            $ref: "#/components/schemas/ManifestReference"
+        strictUpstreams:
+          type: boolean
+          default: false
+          description: >-
+            When true, a persist upstream that is neither built here nor present
+            in referenceManifest fails the build (compiler strict mode) instead
+            of silently recomputing it live. Per-unit dispatch should set this
+            true.
+
+    ManifestReference:
+      type: object
+      description: >-
+        A reference to an already-materialized persist upstream that the built
+        sources may read but which is not rebuilt in this run.
+      required: [sourceEntityId, physicalTableName]
+      properties:
+        sourceEntityId:
+          type: string
+          description: >-
+            The upstream's content id AS REPORTED BY THE PUBLISHER in
+            PersistSourcePlan.sourceEntityId. It MUST equal what the compiler
+            recomputes for the manifest lookup (mkBuildID over the upstream's
+            manifest-ignorant SQL); do not substitute any other identity here.
+        physicalTableName:
+          type: string
+          description: >-
+            Fully-qualified physical table the upstream currently serves.
 
     BuildInstruction:
       type: object

--- a/packages/server/src/controller/materialization.controller.spec.ts
+++ b/packages/server/src/controller/materialization.controller.spec.ts
@@ -85,6 +85,78 @@ describe("MaterializationController.createMaterialization validation", () => {
       expect(await parse({ buildInstructions: null })).toEqual({});
    });
 
+   it("parses referenceManifest and strictUpstreams alongside sources", async () => {
+      const parsed = await parse({
+         buildInstructions: {
+            sources: [
+               {
+                  sourceEntityId: "b2",
+                  materializedTableId: "mt-2",
+                  physicalTableName: "downstream_v1",
+                  realization: "COPY",
+               },
+            ],
+            referenceManifest: [
+               { sourceEntityId: "b1", physicalTableName: "upstream_table" },
+            ],
+            strictUpstreams: true,
+         },
+      });
+      expect(parsed).toEqual({
+         buildInstructions: [
+            {
+               sourceEntityId: "b2",
+               sourceID: undefined,
+               materializedTableId: "mt-2",
+               physicalTableName: "downstream_v1",
+               realization: "COPY",
+            },
+         ],
+         referenceManifest: [
+            { sourceEntityId: "b1", physicalTableName: "upstream_table" },
+         ],
+         strictUpstreams: true,
+      });
+   });
+
+   it("rejects a referenceManifest entry missing a required field", async () => {
+      const { controller } = build();
+      await expect(
+         controller.createMaterialization("env", "pkg", {
+            buildInstructions: {
+               sources: [
+                  {
+                     sourceEntityId: "b2",
+                     materializedTableId: "mt-2",
+                     physicalTableName: "downstream_v1",
+                     realization: "COPY",
+                  },
+               ],
+               referenceManifest: [{ sourceEntityId: "b1" }],
+            },
+         }),
+      ).rejects.toThrow(BadRequestError);
+   });
+
+   it("rejects a non-boolean strictUpstreams", async () => {
+      const { controller } = build();
+      await expect(
+         controller.createMaterialization("env", "pkg", {
+            buildInstructions: {
+               sources: [
+                  {
+                     sourceEntityId: "b2",
+                     materializedTableId: "mt-2",
+                     physicalTableName: "downstream_v1",
+                     realization: "COPY",
+                  },
+               ],
+               strictUpstreams: "yes",
+            },
+         }),
+      ).rejects.toThrow(BadRequestError);
+   });
+
    it("rejects buildInstructions without a non-empty sources array", async () => {
       const { controller } = build();
       await expect(

--- a/packages/server/src/controller/materialization.controller.ts
+++ b/packages/server/src/controller/materialization.controller.ts
@@ -1,5 +1,8 @@
 import { BadRequestError } from "../errors";
-import { BuildInstruction } from "../storage/DatabaseInterface";
+import {
+   BuildInstruction,
+   ManifestReference,
+} from "../storage/DatabaseInterface";
 import { MaterializationService } from "../service/materialization_service";
 
 export class MaterializationController {
@@ -21,19 +24,28 @@ export class MaterializationController {
       forceRefresh?: boolean;
       sourceNames?: string[];
       buildInstructions?: BuildInstruction[];
+      referenceManifest?: ManifestReference[];
+      strictUpstreams?: boolean;
    } {
       const result: {
          forceRefresh?: boolean;
          sourceNames?: string[];
          buildInstructions?: BuildInstruction[];
+         referenceManifest?: ManifestReference[];
+         strictUpstreams?: boolean;
       } = {};
       if (
          body.buildInstructions !== undefined &&
          body.buildInstructions !== null
       ) {
-         result.buildInstructions = this.validateBuildInstructions(
-            body.buildInstructions,
-         );
+         const parsed = this.validateBuildInstructions(body.buildInstructions);
+         result.buildInstructions = parsed.sources;
+         if (parsed.referenceManifest !== undefined) {
+            result.referenceManifest = parsed.referenceManifest;
+         }
+         if (parsed.strictUpstreams !== undefined) {
+            result.strictUpstreams = parsed.strictUpstreams;
+         }
       }
       if (body.forceRefresh !== undefined) {
          if (typeof body.forceRefresh !== "boolean") {
@@ -57,22 +69,74 @@ export class MaterializationController {
 
    /**
     * Validate the orchestrated `buildInstructions` payload (BuildInstructions:
-    * `{ sources: BuildInstruction[] }`) and flatten it to the instruction list
-    * the service consumes.
+    * `{ sources: BuildInstruction[], referenceManifest?, strictUpstreams? }`)
+    * into the parts the service consumes: the flattened instruction list, the
+    * optional upstream reference manifest, and the strict flag.
     */
-   private validateBuildInstructions(raw: unknown): BuildInstruction[] {
+   private validateBuildInstructions(raw: unknown): {
+      sources: BuildInstruction[];
+      referenceManifest?: ManifestReference[];
+      strictUpstreams?: boolean;
+   } {
       if (typeof raw !== "object" || raw === null) {
          throw new BadRequestError("buildInstructions must be an object");
       }
-      const sources = (raw as Record<string, unknown>).sources;
+      const obj = raw as Record<string, unknown>;
+      const sources = obj.sources;
       if (!Array.isArray(sources) || sources.length === 0) {
          throw new BadRequestError(
             "buildInstructions requires a non-empty 'sources' array of BuildInstruction",
          );
       }
-      return sources.map((instruction) =>
-         this.validateInstruction(instruction),
-      );
+      const result: {
+         sources: BuildInstruction[];
+         referenceManifest?: ManifestReference[];
+         strictUpstreams?: boolean;
+      } = {
+         sources: sources.map((instruction) =>
+            this.validateInstruction(instruction),
+         ),
+      };
+      if (
+         obj.referenceManifest !== undefined &&
+         obj.referenceManifest !== null
+      ) {
+         if (!Array.isArray(obj.referenceManifest)) {
+            throw new BadRequestError(
+               "buildInstructions.referenceManifest must be an array of ManifestReference",
+            );
+         }
+         result.referenceManifest = obj.referenceManifest.map((ref) =>
+            this.validateManifestReference(ref),
+         );
+      }
+      if (obj.strictUpstreams !== undefined) {
+         if (typeof obj.strictUpstreams !== "boolean") {
+            throw new BadRequestError(
+               "buildInstructions.strictUpstreams must be a boolean",
+            );
+         }
+         result.strictUpstreams = obj.strictUpstreams;
+      }
+      return result;
+   }
+
+   private validateManifestReference(raw: unknown): ManifestReference {
+      if (typeof raw !== "object" || raw === null) {
+         throw new BadRequestError("Each manifest reference must be an object");
+      }
+      const ref = raw as Record<string, unknown>;
+      for (const field of ["sourceEntityId", "physicalTableName"] as const) {
+         if (typeof ref[field] !== "string") {
+            throw new BadRequestError(
+               `Manifest reference is missing required string field '${field}'`,
+            );
+         }
+      }
+      return {
+         sourceEntityId: ref.sourceEntityId as string,
+         physicalTableName: ref.physicalTableName as string,
+      };
    }
 
    private validateInstruction(raw: unknown): BuildInstruction {

--- a/packages/server/src/service/build_plan.spec.ts
+++ b/packages/server/src/service/build_plan.spec.ts
@@ -10,6 +10,7 @@ import {
    deriveBuildPlan,
    flattenDependsOn,
    iterGraphSources,
+   resolveFreshnessSchedule,
    resolvePackageConnections,
 } from "./build_plan";
 import { fakeSource } from "./materialization_test_fixtures";
@@ -293,6 +294,124 @@ describe("deriveBuildPlan", () => {
       // Mapped source gets its model path; an unmapped source stays undefined.
       expect(plan.sources["a@m"].modelPath).toBe("rollup.malloy");
       expect(plan.sources["b@m"].modelPath).toBeUndefined();
+   });
+});
+
+describe("resolveFreshnessSchedule", () => {
+   it("reports source-level freshness + schedule verbatim", () => {
+      const source = fakeSource({
+         name: "s",
+         sourceEntityId: "bid",
+         freshnessSchedule: {
+            freshness: { window: "1h", fallback: "stale_ok" },
+            schedule: "0 */6 * * *",
+         },
+      });
+      expect(resolveFreshnessSchedule(source, null)).toEqual({
+         freshness: { window: "1h", fallback: "stale_ok" },
+         schedule: "0 */6 * * *",
+      });
+   });
+
+   it("returns null for both when unset at every level", () => {
+      const source = fakeSource({ name: "s", sourceEntityId: "bid" });
+      expect(resolveFreshnessSchedule(source, null)).toEqual({
+         freshness: null,
+         schedule: null,
+      });
+   });
+
+   it("falls back to model-file then package per field (most-specific-wins)", () => {
+      // freshness.window from source, freshness.fallback from model-file. The
+      // package-level cron is NOT inherited as the source's effective schedule;
+      // schedule here comes only from the source's own model-file default.
+      const source = fakeSource({
+         name: "s",
+         sourceEntityId: "bid",
+         freshnessSchedule: { freshness: { window: "1h" } },
+         modelFreshnessSchedule: {
+            freshness: { fallback: "fail" },
+            schedule: "0 3 * * *",
+         },
+      });
+      const pkg = {
+         schedule: "0 0 * * *",
+         freshness: { window: "24h", fallback: "live" as const },
+      };
+      expect(resolveFreshnessSchedule(source, pkg)).toEqual({
+         freshness: { window: "1h", fallback: "fail" },
+         schedule: "0 3 * * *",
+      });
+   });
+
+   it("does not inherit the package-level cron as the source's schedule", () => {
+      const source = fakeSource({ name: "s", sourceEntityId: "bid" });
+      const pkg = { schedule: "0 0 * * *", freshness: { window: "24h" } };
+      // Freshness inherits from the package; schedule stays null (the package
+      // cron is gated separately, not folded into the per-source cron).
+      expect(resolveFreshnessSchedule(source, pkg)).toEqual({
+         freshness: { window: "24h" },
+         schedule: null,
+      });
+   });
+
+   it("inherits the package freshness when the source and model are unset", () => {
+      const source = fakeSource({ name: "s", sourceEntityId: "bid" });
+      const pkg = { schedule: null, freshness: { window: "24h" } };
+      expect(resolveFreshnessSchedule(source, pkg)).toEqual({
+         freshness: { window: "24h" },
+         schedule: null,
+      });
+   });
+
+   it("drops an invalid fallback rather than defaulting it", () => {
+      const source = fakeSource({
+         name: "s",
+         sourceEntityId: "bid",
+         freshnessSchedule: { freshness: { window: "1h", fallback: "bogus" } },
+      });
+      expect(resolveFreshnessSchedule(source, null)).toEqual({
+         freshness: { window: "1h" },
+         schedule: null,
+      });
+   });
+});
+
+describe("deriveBuildPlan freshness/schedule", () => {
+   it("projects the resolved per-source freshness + schedule onto the plan", () => {
+      const source = fakeSource({
+         name: "s",
+         sourceEntityId: "bid",
+         annotationFields: { name: "s_table", sharing: "private" },
+         freshnessSchedule: {
+            freshness: { window: "1h" },
+            schedule: "0 */6 * * *",
+         },
+      });
+      const plan = deriveBuildPlan(
+         [
+            {
+               connectionName: "duckdb",
+               nodes: [[{ sourceID: "s@m", dependsOn: [] }]],
+            },
+         ] as unknown as Parameters<typeof deriveBuildPlan>[0],
+         { "s@m": source },
+         { duckdb: "dig" },
+         undefined,
+         undefined,
+         {
+            schedule: null,
+            freshness: { window: "24h", fallback: "live" as const },
+         },
+      );
+
+      // Source window wins over the package default; package fallback fills the
+      // unset source fallback; source schedule reported verbatim.
+      expect(plan.sources["s@m"].freshness).toEqual({
+         window: "1h",
+         fallback: "live",
+      });
+      expect(plan.sources["s@m"].schedule).toBe("0 */6 * * *");
    });
 });
 

--- a/packages/server/src/service/build_plan.ts
+++ b/packages/server/src/service/build_plan.ts
@@ -17,6 +17,25 @@ type WireBuildGraph = components["schemas"]["BuildGraph"];
 type WirePersistSourcePlan = components["schemas"]["PersistSourcePlan"];
 type WireColumn = components["schemas"]["Column"];
 type BuildPlan = components["schemas"]["BuildPlan"];
+type WireFreshness = components["schemas"]["Freshness"];
+type WirePackageMaterialization =
+   components["schemas"]["PackageMaterializationConfig"];
+
+/** The freshness `fallback` values the publisher recognizes; others are dropped. */
+const FRESHNESS_FALLBACKS = ["live", "stale_ok", "fail"] as const;
+type FreshnessFallback = (typeof FRESHNESS_FALLBACKS)[number];
+
+/** One layer's contribution to the resolved freshness/schedule (all optional). */
+interface FreshnessScheduleLayer {
+   window?: string;
+   fallback?: FreshnessFallback;
+   schedule?: string;
+}
+
+/** Minimal path-reader over a Malloy `Tag` (see `@malloydata/malloy-tag`). */
+interface ReadableTag {
+   text(...path: string[]): string | undefined;
+}
 
 /**
  * Minimal surface a package must expose to compile its build plan. Both
@@ -28,6 +47,13 @@ export interface BuildPlanPackage {
    getPackagePath(): string;
    getMalloyConfig(): MalloyConfig;
    getMalloyConnection(name: string): Promise<MalloyConnection>;
+   /**
+    * The package-level `materialization` config (from malloy-publisher.json),
+    * used as the least-specific layer when resolving per-source freshness /
+    * schedule. Optional so existing fixtures/callers that don't track it still
+    * typecheck (they resolve without a package default).
+    */
+   getMaterializationConfig?(): WirePackageMaterialization | null;
 }
 
 /**
@@ -92,6 +118,110 @@ export function deriveAnnotationFields(
       // Degrade to {} — mirrors deriveColumns / selfAssignTableName.
    }
    return out;
+}
+
+/**
+ * Read the freshness/schedule keys (`freshness.window`, `freshness.fallback`,
+ * `schedule`) from one Malloy tag layer, keeping only recognized values. These
+ * are dotted/nested tag properties, so they are NOT captured by the scalar
+ * {@link deriveAnnotationFields} loop and must be read by path here.
+ */
+function tagFreshnessScheduleLayer(
+   tag: ReadableTag | undefined,
+): FreshnessScheduleLayer {
+   if (!tag || typeof tag.text !== "function") return {};
+   const layer: FreshnessScheduleLayer = {};
+   const window = tag.text("freshness", "window");
+   if (typeof window === "string") layer.window = window;
+   const fallback = tag.text("freshness", "fallback");
+   if (
+      typeof fallback === "string" &&
+      (FRESHNESS_FALLBACKS as readonly string[]).includes(fallback)
+   ) {
+      layer.fallback = fallback as FreshnessFallback;
+   }
+   const schedule = tag.text("schedule");
+   if (typeof schedule === "string") layer.schedule = schedule;
+   return layer;
+}
+
+/**
+ * The package-level `materialization` config as a freshness resolution layer.
+ * Only `freshness` inherits down to a source: the package-level cron
+ * (`materialization.schedule`) is a distinct package-grain concept surfaced on
+ * `PackageMaterializationConfig.schedule` and gated on its own, so it is NOT
+ * folded into a source's effective per-source cron (doing so would double-count
+ * against the package cron gate).
+ */
+function packageFreshnessLayer(
+   cfg: WirePackageMaterialization | null | undefined,
+): Pick<FreshnessScheduleLayer, "window" | "fallback"> {
+   if (!cfg) return {};
+   const layer: Pick<FreshnessScheduleLayer, "window" | "fallback"> = {};
+   if (cfg.freshness?.window) layer.window = cfg.freshness.window;
+   const fallback = cfg.freshness?.fallback;
+   if (
+      typeof fallback === "string" &&
+      (FRESHNESS_FALLBACKS as readonly string[]).includes(fallback)
+   ) {
+      layer.fallback = fallback as FreshnessFallback;
+   }
+   return layer;
+}
+
+/** The source's `#@` tag, or undefined if it fails to parse (degrade to unset). */
+function safeSourceTag(source: PersistSource): ReadableTag | undefined {
+   try {
+      return source.annotations.parseAsTag("@").tag as ReadableTag;
+   } catch {
+      return undefined;
+   }
+}
+
+/**
+ * The model-file-level (`##`) tag resolved for the source, or undefined on a
+ * parse failure. The model-file layer sits between the source annotation and
+ * the package default in most-specific-wins resolution.
+ */
+function safeModelTag(source: PersistSource): ReadableTag | undefined {
+   try {
+      return source.modelAnnotations.parseAsTag().tag as ReadableTag;
+   } catch {
+      return undefined;
+   }
+}
+
+/**
+ * Resolve a source's EFFECTIVE freshness + schedule, reported verbatim (unset
+ * at every level stays null so the control plane can distinguish "unset" —
+ * apply platform default — from an explicit declaration). Invalid `fallback`
+ * values are dropped, never defaulted. Precedence, per field, most-specific-wins:
+ *
+ *  - `freshness`: source annotation > model-file default > package default.
+ *  - `schedule`: source annotation > model-file default (the source's OWN cron).
+ *    The package-level cron is a package-grain concept, surfaced and gated
+ *    separately, so it is not folded into the per-source effective cron.
+ */
+export function resolveFreshnessSchedule(
+   source: PersistSource,
+   packageMaterialization: WirePackageMaterialization | null | undefined,
+): { freshness: WireFreshness | null; schedule: string | null } {
+   const sourceLayer = tagFreshnessScheduleLayer(safeSourceTag(source));
+   const modelLayer = tagFreshnessScheduleLayer(safeModelTag(source));
+   const pkgLayer = packageFreshnessLayer(packageMaterialization);
+
+   const window = sourceLayer.window ?? modelLayer.window ?? pkgLayer.window;
+   const fallback =
+      sourceLayer.fallback ?? modelLayer.fallback ?? pkgLayer.fallback;
+   const schedule = sourceLayer.schedule ?? modelLayer.schedule ?? null;
+
+   let freshness: WireFreshness | null = null;
+   if (window !== undefined || fallback !== undefined) {
+      freshness = {};
+      if (window !== undefined) freshness.window = window;
+      if (fallback !== undefined) freshness.fallback = fallback;
+   }
+   return { freshness, schedule };
 }
 
 /** Flatten Malloy's nested BuildNode.dependsOn into a list of sourceIDs. */
@@ -291,6 +421,7 @@ export function deriveBuildPlan(
    connectionDigests: Record<string, string>,
    sourceNames?: string[],
    sourceModelPaths?: Record<string, string>,
+   packageMaterialization?: WirePackageMaterialization | null,
 ): BuildPlan {
    const include = sourceNames ? new Set(sourceNames) : null;
 
@@ -308,6 +439,15 @@ export function deriveBuildPlan(
    for (const [sourceID, source] of Object.entries(sources)) {
       if (include && !include.has(source.name)) continue;
       const annotationFields = deriveAnnotationFields(source);
+      // EFFECTIVE per-source freshness + schedule, resolved most-specific-wins
+      // (source > model-file > package) and reported verbatim (null = unset at
+      // every level). Unlike `sharing`/`refresh` these are dotted/nested tag
+      // keys, so they come from resolveFreshnessSchedule rather than the scalar
+      // annotationFields map.
+      const { freshness, schedule } = resolveFreshnessSchedule(
+         source,
+         packageMaterialization,
+      );
       wireSources[sourceID] = {
          name: source.name,
          sourceID: source.sourceID,
@@ -323,6 +463,8 @@ export function deriveBuildPlan(
          // one that exists today.
          sharing: annotationFields.sharing ?? null,
          refresh: annotationFields.refresh ?? null,
+         freshness,
+         schedule,
          columns: deriveColumns(source),
          annotationFields,
          modelPath: sourceModelPaths?.[sourceID],
@@ -351,5 +493,6 @@ export async function computePackageBuildPlan(
       compiled.connectionDigests,
       undefined,
       compiled.sourceModelPaths,
+      pkg.getMaterializationConfig?.() ?? null,
    );
 }

--- a/packages/server/src/service/materialization_cron_gate.spec.ts
+++ b/packages/server/src/service/materialization_cron_gate.spec.ts
@@ -7,17 +7,22 @@ import { Environment } from "./environment";
 import type { Package } from "./package";
 
 /**
- * The publish gate for the package-level materialization cron. At Phase B the
- * package-level cron (`materialization.schedule`) is replaced outright by
- * `materialization.freshness.window` (persistence.md §9.4), so ANY declared cron
- * is rejected regardless of the sources' sharing. The `sharing=private`
- * carve-out arrives whole with Phase A (persistence-phase-b-design.md §3.4);
- * until then there is no private artifact for a cron to own, so the B→A rule is
- * reject-all. These tests run a real `Environment` + `Package.create` over temp
- * dirs, so they also prove end-to-end that the pinned compiler ACCEPTS
- * `sharing=` / `refresh=` keys in the `#@ persist` annotation and that the
- * values survive to the wire build plan verbatim (unset stays null — never
- * defaulted to "shared").
+ * The publish gate for materialization crons (Phase A carve-out,
+ * persistence.md §9.4). A cron is the power tier of artifact-anchored
+ * scheduling and is valid only over `sharing="private"` artifacts:
+ *
+ *  - a package-level cron (`materialization.schedule`) is valid only when
+ *    EVERY governed persist source resolves to explicit `sharing="private"`;
+ *  - a per-source cron (`#@ persist ... schedule=`) is valid only when THAT
+ *    source resolves to explicit `sharing="private"`;
+ *  - a cron on a shared/unset artifact is rejected, pointing at
+ *    `freshness.window` as the shared-tier replacement.
+ *
+ * These tests run a real `Environment` + `Package.create` over temp dirs, so
+ * they also prove end-to-end that the pinned compiler ACCEPTS `sharing=` /
+ * `refresh=` / `schedule=` / `freshness.*` keys in the `#@ persist` annotation
+ * and that the values survive to the wire build plan verbatim (unset stays null
+ * — never defaulted to "shared").
  */
 describe("materialization cron gate", () => {
    let rootDir: string;
@@ -78,6 +83,20 @@ source: a is duckdb.sql("SELECT 1 as x")
 source: b is duckdb.sql("SELECT 2 as x")
 `;
 
+   // Per-source crons: valid on the private source, rejected on the shared and
+   // the unset (⇒ shared) sources.
+   const PER_SOURCE_CRON_MODEL = `##! experimental.persistence
+
+#@ persist name="p_table" sharing=private schedule="0 */6 * * *"
+source: p is duckdb.sql("SELECT 1 as x")
+
+#@ persist name="s_table" sharing=shared schedule="0 0 * * *"
+source: s is duckdb.sql("SELECT 2 as x")
+
+#@ persist name="u_table" schedule="0 0 * * *"
+source: u is duckdb.sql("SELECT 3 as x")
+`;
+
    it(
       "surfaces declared sharing/refresh verbatim on the build plan (null when unset)",
       async () => {
@@ -102,12 +121,13 @@ source: b is duckdb.sql("SELECT 2 as x")
    );
 
    it(
-      "rejects any declared cron, pointing at freshness.window",
+      "rejects a package cron on a mixed package, pointing at freshness.window",
       async () => {
+         // Phase A: a package cron governs every persist source, so it is valid
+         // only when all resolve to explicit private. MIXED has a shared and an
+         // unset source, so the package cron is rejected.
          const pkg = await loadPackage(MIXED_MODEL, "0 6 * * *");
 
-         // One actionable message for the whole package — the B→A rule is
-         // reject-all, not per-source.
          const warnings = pkg.scheduleWarnings();
          expect(warnings).toHaveLength(1);
          const joined = pkg.formatInvalidSchedule();
@@ -118,15 +138,34 @@ source: b is duckdb.sql("SELECT 2 as x")
    );
 
    it(
-      "rejects a declared cron even when every persist source is private",
+      "accepts a package cron when every persist source is private",
       async () => {
-         // The sharing=private carve-out arrives with Phase A; during B→A even
-         // an all-private package's cron is rejected outright.
+         // Phase A carve-out: an all-private package legitimately carries a
+         // package-level cron (the power tier for its own private artifacts).
          const pkg = await loadPackage(ALL_PRIVATE_MODEL, "0 6 * * *");
-         expect(pkg.scheduleWarnings()).toHaveLength(1);
-         expect(pkg.formatInvalidSchedule()).toContain(
-            "materialization.freshness.window",
-         );
+         expect(pkg.scheduleWarnings()).toEqual([]);
+      },
+      { timeout: 30000 },
+   );
+
+   it(
+      "rejects a per-source cron unless that source resolves to private",
+      async () => {
+         // No package cron here — only per-source `schedule=` declarations. The
+         // private source's cron is accepted; the shared and unset sources' are
+         // rejected, each pointing at freshness.window.
+         const pkg = await loadPackage(PER_SOURCE_CRON_MODEL);
+
+         const warnings = pkg.scheduleWarnings();
+         expect(warnings).toHaveLength(2);
+         const joined = warnings.join("\n");
+         expect(joined).toContain('"s"');
+         expect(joined).toContain('"u"');
+         expect(joined).not.toContain('"p"');
+         expect(joined).toContain("freshness.window");
+
+         // The resolved per-source schedule is surfaced verbatim on the plan.
+         expect(sourceByName(pkg, "p").schedule).toBe("0 */6 * * *");
       },
       { timeout: 30000 },
    );

--- a/packages/server/src/service/materialization_service.spec.ts
+++ b/packages/server/src/service/materialization_service.spec.ts
@@ -921,6 +921,10 @@ describe("runBuild (branch behavior)", () => {
             sourceNames: string[] | undefined;
             forceRefresh: boolean;
             buildInstructions: BuildInstruction[] | undefined;
+            referenceManifest?:
+               | { sourceEntityId: string; physicalTableName: string }[]
+               | undefined;
+            strictUpstreams?: boolean | undefined;
          },
          signal: AbortSignal,
       ) => Promise<void>;
@@ -970,6 +974,44 @@ describe("runBuild (branch behavior)", () => {
       });
       // Orchestrated leaves distribution to the caller.
       expect(svc.autoLoadManifest.called).toBe(false);
+   });
+
+   it("orchestrated: seeds the build from referenceManifest and honors strictUpstreams", async () => {
+      const svc = stubEngine();
+      const instructions = [makeInstruction()];
+
+      await svc.runBuild(
+         "mat-1",
+         "my-env",
+         "pkg",
+         {
+            sourceNames: undefined,
+            forceRefresh: false,
+            buildInstructions: instructions,
+            referenceManifest: [
+               { sourceEntityId: "up-1", physicalTableName: "upstream_tbl" },
+            ],
+            strictUpstreams: true,
+         },
+         new AbortController().signal,
+      );
+
+      // The reference manifest becomes the seed (carried) entries so a
+      // downstream build resolves its upstream to the existing physical table.
+      expect(svc.executeInstructedBuild.firstCall.args[2]).toEqual({
+         "up-1": {
+            sourceEntityId: "up-1",
+            physicalTableName: "upstream_tbl",
+         },
+      });
+      // strictUpstreams flows through as the strict flag (5th arg).
+      expect(svc.executeInstructedBuild.firstCall.args[4]).toBe(true);
+      // Reused upstreams are counted as carried, not built.
+      expect(svc.commitManifest.firstCall.args[2]).toMatchObject({
+         mode: "orchestrated",
+         sourcesBuilt: 1,
+         sourcesReused: 1,
+      });
    });
 
    it("auto-run: derives instructions and auto-loads the manifest", async () => {

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -28,6 +28,7 @@ import {
    MaterializationStatus,
    MaterializationUpdate,
    ManifestEntry,
+   ManifestReference,
    ResourceRepository,
 } from "../storage/DatabaseInterface";
 import { DuplicateActiveMaterializationError } from "../storage/duckdb/MaterializationRepository";
@@ -216,6 +217,8 @@ export class MaterializationService {
          forceRefresh?: boolean;
          sourceNames?: string[];
          buildInstructions?: BuildInstruction[];
+         referenceManifest?: ManifestReference[];
+         strictUpstreams?: boolean;
       } = {},
    ): Promise<Materialization> {
       const environmentId = await this.resolveEnvironmentId(environmentName);
@@ -275,6 +278,8 @@ export class MaterializationService {
                sourceNames: options.sourceNames,
                forceRefresh,
                buildInstructions,
+               referenceManifest: options.referenceManifest,
+               strictUpstreams: options.strictUpstreams,
             },
             signal,
          ),
@@ -299,6 +304,8 @@ export class MaterializationService {
          sourceNames: string[] | undefined;
          forceRefresh: boolean;
          buildInstructions: BuildInstruction[] | undefined;
+         referenceManifest: ManifestReference[] | undefined;
+         strictUpstreams: boolean | undefined;
       },
       signal: AbortSignal,
    ): Promise<void> {
@@ -333,7 +340,12 @@ export class MaterializationService {
          let carried: Record<string, ManifestEntry>;
          if (orchestrated) {
             instructions = opts.buildInstructions!;
-            carried = {};
+            // Seed the build Manifest with the caller-supplied upstream
+            // references so a downstream source's persist upstream (built in a
+            // prior run, not rebuilt here) resolves to its existing physical
+            // table instead of recomputing live. The reference key is the
+            // compiler's manifest-lookup sourceEntityId (see ManifestReference).
+            carried = this.referenceManifestToEntries(opts.referenceManifest);
          } else {
             // Skip-if-unchanged: reuse tables from the most recent successful
             // manifest for sources whose sourceEntityId is unchanged, unless
@@ -357,6 +369,7 @@ export class MaterializationService {
             instructions,
             carried,
             signal,
+            opts.strictUpstreams ?? false,
          );
 
          const sourcesBuilt = instructions.length;
@@ -448,6 +461,26 @@ export class MaterializationService {
       }
 
       return { instructions, carried };
+   }
+
+   /**
+    * Project the caller-supplied upstream reference manifest into the seed
+    * entry map `executeInstructedBuild` consumes. Each reference is keyed by the
+    * compiler's manifest-lookup sourceEntityId and carries only the physical
+    * table name — enough for the build Manifest to resolve a downstream persist
+    * reference to the existing table without rebuilding the upstream.
+    */
+   private referenceManifestToEntries(
+      referenceManifest: ManifestReference[] | undefined,
+   ): Record<string, ManifestEntry> {
+      const entries: Record<string, ManifestEntry> = {};
+      for (const ref of referenceManifest ?? []) {
+         entries[ref.sourceEntityId] = {
+            sourceEntityId: ref.sourceEntityId,
+            physicalTableName: ref.physicalTableName,
+         };
+      }
+      return entries;
    }
 
    /**
@@ -565,6 +598,7 @@ export class MaterializationService {
       instructions: BuildInstruction[],
       seedEntries: Record<string, ManifestEntry>,
       signal: AbortSignal,
+      strict = false,
    ): Promise<Record<string, ManifestEntry>> {
       const { graphs, sources, connectionDigests, connections } = compiled;
 
@@ -587,8 +621,12 @@ export class MaterializationService {
 
       // Accumulates physical names as sources are built so downstream sources
       // resolve their upstream references to the freshly-assigned tables. Seed
-      // it with carried-forward entries so reused upstreams resolve too.
+      // it with carried-forward entries so reused upstreams resolve too. In
+      // strict mode, an upstream persist reference that is neither built here
+      // nor seeded fails the compile (runtime-manifest-strict-miss) instead of
+      // silently recomputing live.
       const manifest = new Manifest();
+      manifest.strict = strict;
       const entries: Record<string, ManifestEntry> = {};
       for (const [sourceEntityId, entry] of Object.entries(seedEntries)) {
          if (entry.physicalTableName) {

--- a/packages/server/src/service/materialization_test_fixtures.ts
+++ b/packages/server/src/service/materialization_test_fixtures.ts
@@ -75,6 +75,41 @@ export function makeInstruction(
  * build internals touch (name/id, deterministic sourceEntityId, SQL, and the
  * `#@ persist name=` annotation reader, defaulted to "unset").
  */
+/** A freshness/schedule layer for the fake source's `#@` or `##` tag. */
+interface FakeFreshnessSchedule {
+   freshness?: { window?: string; fallback?: string };
+   schedule?: string;
+}
+
+/**
+ * Build a fake Malloy `Tag` supporting both readers the build plan uses:
+ * `entries()` (scalar `#@ persist` key=value pairs, for deriveAnnotationFields)
+ * and the path-based `text(...at)` (dotted `freshness.window` / `schedule`, for
+ * resolveFreshnessSchedule).
+ */
+function fakeTag(
+   fields: Record<string, string> | undefined,
+   fs: FakeFreshnessSchedule | undefined,
+) {
+   return {
+      *entries() {
+         for (const [key, value] of Object.entries(fields ?? {})) {
+            yield [key, { text: () => value }];
+         }
+      },
+      text(...at: string[]): string | undefined {
+         if (at.length === 1) {
+            if (at[0] === "schedule") return fs?.schedule;
+            return fields?.[at[0]];
+         }
+         if (at.length === 2 && at[0] === "freshness") {
+            return fs?.freshness?.[at[1] as "window" | "fallback"];
+         }
+         return undefined;
+      },
+   };
+}
+
 export function fakeSource(opts: {
    name: string;
    sourceEntityId: string;
@@ -83,6 +118,10 @@ export function fakeSource(opts: {
    dialectName?: string;
    /** key=value fields of the `#@ persist` annotation (e.g. sharing). */
    annotationFields?: Record<string, string>;
+   /** Source-level (`#@`) freshness/schedule (dotted keys). */
+   freshnessSchedule?: FakeFreshnessSchedule;
+   /** Model-file-level (`##`) freshness/schedule default. */
+   modelFreshnessSchedule?: FakeFreshnessSchedule;
 }): PersistSource {
    const fields = opts.annotationFields;
    return {
@@ -93,20 +132,14 @@ export function fakeSource(opts: {
       makeBuildId: () => opts.sourceEntityId,
       getSQL: () => opts.sql ?? "SELECT 1",
       annotations: {
-         parseAsTag: () =>
-            fields
-               ? {
-                    tag: {
-                       *entries() {
-                          for (const [key, value] of Object.entries(fields)) {
-                             yield [key, { text: () => value }];
-                          }
-                       },
-                    },
-                 }
-               : // No annotation fields: entries() is absent, and
-                 // deriveAnnotationFields degrades to {}.
-                 { tag: { text: () => undefined } },
+         parseAsTag: () => ({
+            tag: fakeTag(fields, opts.freshnessSchedule),
+         }),
+      },
+      modelAnnotations: {
+         parseAsTag: () => ({
+            tag: fakeTag(undefined, opts.modelFreshnessSchedule),
+         }),
       },
    } as unknown as PersistSource;
 }

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -521,6 +521,17 @@ export class Package {
       return this.buildPlan;
    }
 
+   /**
+    * The package-level `materialization` config (from malloy-publisher.json),
+    * the least-specific layer for resolving per-source freshness/schedule in the
+    * build plan. Null when the package declares no policy.
+    */
+   public getMaterializationConfig(): NonNullable<
+      ApiPackage["materialization"]
+   > | null {
+      return this.packageMetadata.materialization ?? null;
+   }
+
    public getPackageMetadata(): ApiPackage {
       // Overlay the server-computed fields onto the stored metadata: the
       // explores misconfig warnings (loading is fail-safe — the package still
@@ -706,27 +717,61 @@ export class Package {
    }
 
    /**
-    * Publish-gate for the package-level materialization cron. The package-level
-    * cron (`materialization.schedule`) is replaced outright at Phase B by
-    * `materialization.freshness.window` (persistence.md §9.4), so any declared
-    * cron is rejected. The `sharing=private` carve-out — a cron may legitimately
-    * own a package's own private artifacts — arrives whole with Phase A; until
-    * `sharing=private` is declarable there is no private artifact for a cron to
-    * own, so the B→A rule is to reject any declared cron outright
-    * (persistence-phase-b-design.md §3.4). One actionable message pointing at
-    * `materialization.freshness.window` (empty when no cron is declared). Strict
-    * at publish (package.controller), warn-only at load/reload (loadViaWorker) —
-    * same split as explores.
+    * Publish-gate for materialization crons (Phase A carve-out, persistence.md
+    * §9.4). A cron is the power tier of artifact-anchored scheduling and is
+    * valid only over `sharing="private"` artifacts; a cron on a shared (or unset
+    * ⇒ shared) artifact is rejected, pointing at `freshness.window` as the
+    * shared-tier replacement. Two grains, both enforced off the resolved build
+    * plan (per-source `sharing`/`schedule` are effective, most-specific-wins):
+    *
+    *  - Per-source: a source's own `schedule` is valid only when that source
+    *    resolves to explicit `sharing="private"`.
+    *  - Package: `materialization.schedule` governs every persist source, so it
+    *    is valid only when every governed source resolves to explicit
+    *    `sharing="private"` (a mixed/shared/unset package cannot carry it).
+    *
+    * Strict at publish (package.controller), warn-only at load/reload
+    * (loadViaWorker) — same split as explores.
     */
    public scheduleWarnings(): string[] {
-      const schedule = this.packageMetadata.materialization?.schedule;
-      if (!schedule) return [];
-      return [
-         `materialization.schedule (cron) in ${PACKAGE_MANIFEST_NAME} is not accepted: ` +
-            `package-level crons are rejected in Phase B. Declare ` +
-            `'materialization.freshness.window' instead (the control plane schedules ` +
-            `refreshes from it).`,
-      ];
+      const warnings: string[] = [];
+      const sources = this.buildPlan?.sources
+         ? Object.values(this.buildPlan.sources)
+         : [];
+
+      for (const source of sources) {
+         if (source.schedule && source.sharing !== "private") {
+            warnings.push(
+               `#@ persist source "${source.name}" declares a schedule (cron) but ` +
+                  `resolves to sharing="${
+                     source.sharing ?? "shared (unset default)"
+                  }": a per-source cron is valid only for sharing="private". ` +
+                  `Declare 'freshness.window' instead (the control plane schedules ` +
+                  `refreshes from it).`,
+            );
+         }
+      }
+
+      const packageSchedule = this.packageMetadata.materialization?.schedule;
+      if (packageSchedule) {
+         const nonPrivate = sources.filter((s) => s.sharing !== "private");
+         if (sources.length === 0 || nonPrivate.length > 0) {
+            const detail =
+               sources.length === 0
+                  ? "the package declares no persist source for it to govern"
+                  : `sources [${nonPrivate
+                       .map((s) => s.name)
+                       .join(", ")}] resolve to shared/unset`;
+            warnings.push(
+               `materialization.schedule (cron) in ${PACKAGE_MANIFEST_NAME} is valid ` +
+                  `only when every persist source resolves to sharing="private": ` +
+                  `${detail}. Declare 'materialization.freshness.window' instead ` +
+                  `(the control plane schedules refreshes from it).`,
+            );
+         }
+      }
+
+      return warnings;
    }
 
    /** The {@link scheduleWarnings} joined into one string, or "" if none. */

--- a/packages/server/src/storage/DatabaseInterface.ts
+++ b/packages/server/src/storage/DatabaseInterface.ts
@@ -116,6 +116,7 @@ export type BuildPlan = components["schemas"]["BuildPlan"];
 export type BuildManifestResult = components["schemas"]["BuildManifest"];
 export type ManifestEntry = components["schemas"]["ManifestEntry"];
 export type BuildInstruction = components["schemas"]["BuildInstruction"];
+export type ManifestReference = components["schemas"]["ManifestReference"];
 export type Realization = components["schemas"]["Realization"];
 
 export interface Materialization {

--- a/packages/server/tests/fixtures/persist-multi-level/data/orders.csv
+++ b/packages/server/tests/fixtures/persist-multi-level/data/orders.csv
@@ -1,0 +1,5 @@
+category,amount
+electronics,100
+clothing,50
+electronics,200
+clothing,75

--- a/packages/server/tests/fixtures/persist-multi-level/multi_level.malloy
+++ b/packages/server/tests/fixtures/persist-multi-level/multi_level.malloy
@@ -1,0 +1,18 @@
+##! experimental.persistence
+
+source: raw_orders is duckdb.table('data/orders.csv')
+
+// Upstream persist source: an aggregate over the base CSV.
+#@ persist name="orders_base"
+source: orders_base is raw_orders -> {
+  group_by: category
+  aggregate: total_amount is amount.sum()
+}
+
+// Downstream persist source: references the persist upstream `orders_base`.
+// A per-unit build of `orders_rollup` alone must REFERENCE orders_base's
+// materialized table (via referenceManifest) rather than recompute it live.
+#@ persist name="orders_rollup"
+source: orders_rollup is orders_base -> {
+  aggregate: category_count is count()
+}

--- a/packages/server/tests/fixtures/persist-multi-level/publisher.json
+++ b/packages/server/tests/fixtures/persist-multi-level/publisher.json
@@ -1,0 +1,5 @@
+{
+  "name": "persist-multi-level",
+  "version": "1.0.0",
+  "description": "DuckDB two-level persist DAG fixture (orders_base -> orders_rollup)"
+}

--- a/packages/server/tests/integration/materialization/reference_manifest.integration.spec.ts
+++ b/packages/server/tests/integration/materialization/reference_manifest.integration.spec.ts
@@ -1,0 +1,251 @@
+/// <reference types="bun-types" />
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import path from "path";
+import { fileURLToPath } from "url";
+import { RestE2EEnv, startRestE2E } from "../../harness/rest_e2e";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const PROJECT_NAME = "test-project-refmanifest";
+const PACKAGE_NAME = "persist-multi-level";
+const API = `/api/v0/environments/${PROJECT_NAME}/packages/${PACKAGE_NAME}`;
+
+const TERMINAL_STATUSES = ["MANIFEST_FILE_READY", "FAILED", "CANCELLED"];
+
+/**
+ * WI-1 (Phase D): the orchestrated build seeds its build Manifest from
+ * `referenceManifest` and honors `strictUpstreams`. Proven end-to-end over a
+ * two-level persist DAG (`orders_base` -> `orders_rollup`):
+ *
+ *  - Build the downstream `orders_rollup` ALONE with a `referenceManifest`
+ *    pointing at the already-materialized `orders_base` table and
+ *    `strictUpstreams=true` -> the build SUCCEEDS, which under strict mode is
+ *    only possible if the upstream reference resolved to the physical table
+ *    (a strict miss would throw).
+ *  - Build `orders_rollup` ALONE under `strictUpstreams=true` with NO
+ *    `referenceManifest` -> the build FAILS loudly (runtime-manifest-strict-miss)
+ *    instead of silently recomputing the upstream live.
+ */
+describe("Materialization reference manifest + strictUpstreams (E2E)", () => {
+   let env: (RestE2EEnv & { stop(): Promise<void> }) | null = null;
+   let baseUrl: string;
+
+   beforeAll(async () => {
+      env = await startRestE2E();
+      baseUrl = env.baseUrl;
+
+      const fixtureDir = path.resolve(
+         __dirname,
+         "../../fixtures/persist-multi-level",
+      );
+      const createRes = await fetch(`${baseUrl}/api/v0/environments`, {
+         method: "POST",
+         headers: { "Content-Type": "application/json" },
+         body: JSON.stringify({
+            name: PROJECT_NAME,
+            packages: [{ name: PACKAGE_NAME, location: fixtureDir }],
+            connections: [],
+         }),
+      });
+      if (!createRes.ok) {
+         const body = await createRes.text();
+         throw new Error(
+            `Failed to create test project (${createRes.status}): ${body}`,
+         );
+      }
+
+      const deadline = Date.now() + 30_000;
+      let pkgReady = false;
+      while (!pkgReady && Date.now() < deadline) {
+         try {
+            const res = await fetch(`${baseUrl}${API}`);
+            if (res.ok) {
+               pkgReady = true;
+               break;
+            }
+         } catch {
+            // not ready yet
+         }
+         await new Promise((r) => setTimeout(r, 500));
+      }
+      if (!pkgReady) {
+         throw new Error("Test package did not become available in time");
+      }
+   });
+
+   afterAll(async () => {
+      if (baseUrl) {
+         try {
+            await fetch(`${baseUrl}/api/v0/environments/${PROJECT_NAME}`, {
+               method: "DELETE",
+            });
+         } catch {
+            // best-effort cleanup
+         }
+      }
+      await env?.stop();
+      env = null;
+   });
+
+   function url(p: string): string {
+      return `${baseUrl}${API}${p}`;
+   }
+
+   async function createMaterialization(
+      body: Record<string, unknown> = {},
+   ): Promise<Response> {
+      return fetch(url("/materializations"), {
+         method: "POST",
+         headers: { "Content-Type": "application/json" },
+         body: JSON.stringify(body),
+      });
+   }
+
+   async function pollUntilTerminal(
+      id: string,
+      timeoutMs = 90_000,
+   ): Promise<Record<string, unknown>> {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+         const res = await fetch(url(`/materializations/${id}`));
+         expect(res.status).toBe(200);
+         const data = (await res.json()) as Record<string, unknown>;
+         if (TERMINAL_STATUSES.includes(data.status as string)) return data;
+         await new Promise((r) => setTimeout(r, 250));
+      }
+      throw new Error(`Materialization ${id} did not reach a terminal state`);
+   }
+
+   /** Delete a terminal materialization record (optionally dropping its tables). */
+   async function deleteRun(id: string, dropTables = false): Promise<void> {
+      await fetch(
+         url(`/materializations/${id}${dropTables ? "?dropTables=true" : ""}`),
+         { method: "DELETE" },
+      );
+   }
+
+   /** Build one source alone and drive it to a terminal state. */
+   async function buildOneAlone(
+      body: Record<string, unknown>,
+   ): Promise<Record<string, unknown>> {
+      const createRes = await createMaterialization(body);
+      expect(createRes.status).toBe(201);
+      const { id } = (await createRes.json()) as { id: string };
+      const settled = await pollUntilTerminal(id);
+      return { id, ...settled };
+   }
+
+   /** The planned sources keyed by name (off Package.buildPlan). */
+   async function planSourcesByName(): Promise<
+      Record<string, Record<string, unknown>>
+   > {
+      const res = await fetch(url(""));
+      expect(res.status).toBe(200);
+      const pkg = (await res.json()) as Record<string, unknown>;
+      const plan = pkg.buildPlan as Record<string, unknown>;
+      expect(plan).toBeDefined();
+      const sources = plan.sources as Record<string, Record<string, unknown>>;
+      const byName: Record<string, Record<string, unknown>> = {};
+      for (const s of Object.values(sources)) {
+         byName[s.name as string] = s;
+      }
+      return byName;
+   }
+
+   const UPSTREAM_TABLE = "orders_base_built";
+
+   it(
+      "builds a downstream source alone, referencing the upstream's physical table under strict",
+      async () => {
+         const sources = await planSourcesByName();
+         const base = sources["orders_base"];
+         const rollup = sources["orders_rollup"];
+         expect(base).toBeDefined();
+         expect(rollup).toBeDefined();
+
+         // 1) Materialize the upstream `orders_base` into a known physical table.
+         const baseRun = await buildOneAlone({
+            buildInstructions: {
+               sources: [
+                  {
+                     sourceEntityId: base.sourceEntityId,
+                     sourceID: base.sourceID,
+                     materializedTableId: "mt-base",
+                     physicalTableName: UPSTREAM_TABLE,
+                     realization: "COPY",
+                  },
+               ],
+            },
+         });
+         expect(baseRun.status).toBe("MANIFEST_FILE_READY");
+         await deleteRun(baseRun.id as string); // keep the physical table
+
+         // 2) Build the downstream `orders_rollup` ALONE, referencing the
+         // upstream's physical table under strictUpstreams. Success is only
+         // possible if the reference resolved (strict forbids the live fallback).
+         const rollupRun = await buildOneAlone({
+            buildInstructions: {
+               sources: [
+                  {
+                     sourceEntityId: rollup.sourceEntityId,
+                     sourceID: rollup.sourceID,
+                     materializedTableId: "mt-rollup",
+                     physicalTableName: "orders_rollup_built",
+                     realization: "COPY",
+                  },
+               ],
+               referenceManifest: [
+                  {
+                     sourceEntityId: base.sourceEntityId,
+                     physicalTableName: UPSTREAM_TABLE,
+                  },
+               ],
+               strictUpstreams: true,
+            },
+         });
+         expect(rollupRun.status).toBe("MANIFEST_FILE_READY");
+
+         // Cleanup both physical tables and records.
+         await deleteRun(rollupRun.id as string, true);
+         // Drop the upstream table via a fresh no-op build+drop is overkill;
+         // the environment teardown removes the project. Best-effort direct drop
+         // is unnecessary for correctness here.
+      },
+      { timeout: 120_000 },
+   );
+
+   it(
+      "fails loudly when a strict upstream is neither built nor referenced",
+      async () => {
+         const sources = await planSourcesByName();
+         const rollup = sources["orders_rollup"];
+         expect(rollup).toBeDefined();
+
+         // Build `orders_rollup` ALONE under strictUpstreams with NO
+         // referenceManifest for its upstream -> the compile throws
+         // runtime-manifest-strict-miss and the run FAILS.
+         const run = await buildOneAlone({
+            buildInstructions: {
+               sources: [
+                  {
+                     sourceEntityId: rollup.sourceEntityId,
+                     sourceID: rollup.sourceID,
+                     materializedTableId: "mt-rollup-strict",
+                     physicalTableName: "orders_rollup_strict",
+                     realization: "COPY",
+                  },
+               ],
+               strictUpstreams: true,
+            },
+         });
+
+         expect(run.status).toBe("FAILED");
+         expect(String(run.error ?? "")).toContain("manifest");
+
+         await deleteRun(run.id as string, true);
+      },
+      { timeout: 120_000 },
+   );
+});


### PR DESCRIPTION
## Summary

Implements the publisher portion of **Phase D** (per-source dispatch + per-source knobs), landed in the publisher's own OpenAPI (`api-doc.yaml`) plus code and tests. Mirror to `~/service/apis`, control-plane client regen, the malloy WI-2 confirm-test, and the image bump are follow-ups (out of scope here).

### WI-1 — reference manifest + `strictUpstreams`
- `BuildInstructions` gains `referenceManifest` (array of a new `ManifestReference` `{sourceEntityId, physicalTableName}`) and `strictUpstreams` (bool, default false).
- The orchestrated build seeds its build `Manifest` from `referenceManifest`, so a downstream source in a partial build resolves its upstream persist reference to the **existing** physical table instead of recomputing it live.
- Under `strictUpstreams=true`, an upstream that is neither built here nor referenced fails the build (`runtime-manifest-strict-miss`) instead of silently falling back.
- Auto-run is unchanged (seeds from the most-recent manifest, non-strict).

### WI-3 — per-source effective freshness/schedule + Phase A cron gate
- `PersistSourcePlan` now carries the **effective** `freshness` and `schedule`, resolved most-specific-wins:
  - `freshness`: source > model-file > package
  - `schedule`: source > model-file (the package-level cron is a distinct grain, surfaced/gated separately, so it is not folded into the per-source cron to avoid double-counting)
- `scheduleWarnings()` reworked from reject-all to the **Phase A carve-out**: a per-source or package cron is valid only over `sharing="private"` artifacts; otherwise rejected with a pointer to `freshness.window`.

### Notes
- Generated `api.ts` / SDK client are gitignored; consumers regenerate from `api-doc.yaml`.
- The per-source `schedule` intentionally resolves source > model-file only (documented in the OpenAPI description and code) — the plan's literal "source > model-file > package" for schedule caused the per-source and package cron gates to double-count.

## Test plan
- [x] `tsc --noEmit` clean; eslint clean on touched files
- [x] Unit suite: 1094 pass / 0 fail
- [x] Materialization integration suite: 19 pass / 0 fail
- [x] New two-level persist fixture (`orders_base → orders_rollup`)
- [x] WI-1 integration: downstream built alone with `referenceManifest` under strict succeeds; omission under strict fails loudly (also confirms WI-2 compiler behavior E2E)
- [x] WI-1 unit: controller parsing + service seeding/strict propagation
- [x] WI-3 unit: most-specific-wins resolution + Phase A per-source/package cron gate

Made with [Cursor](https://cursor.com)