### PR TITLE
fix(server): redact secrets from axios error logs

### DIFF
--- a/packages/server/src/logger.spec.ts
+++ b/packages/server/src/logger.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { redactSensitive } from "./logger";
+import type { AxiosError } from "axios";
+import { buildAxiosErrorLog, redactSensitive } from "./logger";
 
 describe("redactSensitive", () => {
    it("masks every known credential field at the top level", () => {
@@ -120,5 +121,73 @@ describe("redactSensitive", () => {
       const out = redactSensitive(input) as Record<string, unknown>;
       expect(out.password).toBe("[REDACTED]");
       expect(out.self).toBe("[Circular]");
+   });
+
+   it("matches credential keys case-insensitively", () => {
+      const out = redactSensitive({
+         Password: "hunter2",
+         Authorization: "Bearer abc",
+      }) as Record<string, unknown>;
+      expect(out.Password).toBe("[REDACTED]");
+      expect(out.Authorization).toBe("[REDACTED]");
+   });
+
+   it("masks credential HTTP headers", () => {
+      const out = redactSensitive({
+         "content-type": "application/json",
+         authorization: "Bearer secret-token",
+         cookie: "session=abc",
+      }) as Record<string, unknown>;
+      expect(out["content-type"]).toBe("application/json");
+      expect(out.authorization).toBe("[REDACTED]");
+      expect(out.cookie).toBe("[REDACTED]");
+   });
+});
+
+describe("buildAxiosErrorLog", () => {
+   it("redacts response data and headers on a server-side error", () => {
+      const error = {
+         response: {
+            config: { url: "http://worker/api" },
+            status: 500,
+            headers: { authorization: "Bearer abc", "content-type": "json" },
+            data: { connection: { serviceAccountKeyJson: "PRIVATE_KEY" } },
+         },
+      } as unknown as AxiosError;
+      const { message, meta } = buildAxiosErrorLog(error);
+      expect(message).toBe("Axios server-side error");
+      expect(meta).toEqual({
+         url: "http://worker/api",
+         status: 500,
+         headers: { authorization: "[REDACTED]", "content-type": "json" },
+         data: { connection: { serviceAccountKeyJson: "[REDACTED]" } },
+      });
+   });
+
+   it("never logs the raw request object on a client-side error", () => {
+      const error = {
+         request: { _header: "GET / HTTP/1.1\r\nAuthorization: Bearer abc" },
+         config: { method: "get", url: "http://worker/api" },
+         code: "ECONNABORTED",
+      } as unknown as AxiosError;
+      const { message, meta } = buildAxiosErrorLog(error);
+      expect(message).toBe("Axios client-side error");
+      expect(meta).toEqual({
+         method: "get",
+         url: "http://worker/api",
+         code: "ECONNABORTED",
+      });
+      expect(JSON.stringify(meta)).not.toContain("Bearer abc");
+   });
+
+   it("logs only the message on a setup error", () => {
+      const error = {
+         message: "getaddrinfo ENOTFOUND",
+         config: { headers: { Authorization: "Bearer abc" } },
+      } as unknown as AxiosError;
+      const { message, meta } = buildAxiosErrorLog(error);
+      expect(message).toBe("Axios unknown error");
+      expect(meta).toEqual({ message: "getaddrinfo ENOTFOUND" });
+      expect(JSON.stringify(meta)).not.toContain("Bearer abc");
    });
 });

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -87,9 +87,12 @@ export function formatDuration(durationMs: number): string {
 // Connection endpoints carry provider credentials in their request/response
 // bodies (BigQuery serviceAccountKeyJson, Snowflake privateKey/password, Postgres
 // password/connectionString, S3 secretAccessKey/sessionToken, Azure clientSecret/
-// sasUrl, Databricks token, ...). The middleware below logs the full body, so
-// those values are masked by key name before they reach a log transport.
-const SENSITIVE_KEYS: ReadonlySet<string> = new Set([
+// sasUrl, Databricks token, ...), and axios error logs can carry credential HTTP
+// headers (Authorization, Cookie). Those values are masked by key name before
+// they reach a log transport. Matching is case-insensitive so header casing
+// (Authorization vs authorization) does not slip through.
+const SENSITIVE_KEY_NAMES = [
+   // connection config credentials
    "password",
    "connectionString",
    "serviceAccountKeyJson",
@@ -104,16 +107,26 @@ const SENSITIVE_KEYS: ReadonlySet<string> = new Set([
    "peakaKey",
    "token",
    "accessToken",
-]);
+   // credential-bearing HTTP headers
+   "authorization",
+   "proxy-authorization",
+   "cookie",
+   "set-cookie",
+   "x-api-key",
+];
+const SENSITIVE_KEYS: ReadonlySet<string> = new Set(
+   SENSITIVE_KEY_NAMES.map((name) => name.toLowerCase()),
+);
 
 const REDACTED = "[REDACTED]";
 
 /**
  * Deep-copy `value`, replacing any property whose key names a credential
- * (SENSITIVE_KEYS) with a placeholder. The match is by key name and recurses
- * through nested objects and arrays, since connections arrive nested under
- * `connections[]`. Primitives and Dates pass through unchanged and the input is
- * never mutated; used to keep secrets out of the request/response logs.
+ * (SENSITIVE_KEYS) with a placeholder. The match is by key name (case-
+ * insensitive) and recurses through nested objects and arrays, since
+ * connections arrive nested under `connections[]`. Primitives and Dates pass
+ * through unchanged and the input is never mutated; used to keep secrets out of
+ * the request/response and axios-error logs.
  */
 export function redactSensitive(
    value: unknown,
@@ -131,7 +144,7 @@ export function redactSensitive(
    }
    const result: Record<string, unknown> = {};
    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
-      result[key] = SENSITIVE_KEYS.has(key)
+      result[key] = SENSITIVE_KEYS.has(key.toLowerCase())
          ? REDACTED
          : redactSensitive(val, seen);
    }
@@ -184,23 +197,53 @@ export const loggerMiddleware: RequestHandler = (req, res, next) => {
    next();
 };
 
-export const logAxiosError = (error: AxiosError) => {
+/**
+ * Build the message + metadata logged for an AxiosError, with secrets removed.
+ * A failing upstream call can echo a connection config in `response.data` or
+ * return credential headers, and the raw `error.request` / `error` objects hold
+ * the outgoing Authorization header. Response fields are redacted and the raw
+ * request object is reduced to a few safe descriptors, so credentials never
+ * reach the log. Split out from `logAxiosError` so it can be unit tested.
+ */
+export function buildAxiosErrorLog(error: AxiosError): {
+   message: string;
+   meta: Record<string, unknown>;
+} {
    if (error.response) {
       // The request was made and the server responded with a status code
-      // that falls out of the range of 2xx
-      logger.error("Axios server-side error", {
-         url: error.response.config.url,
-         status: error.response.status,
-         headers: error.response.headers,
-         data: error.response.data,
-      });
-   } else if (error.request) {
-      // The request was made but no response was received
-      // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-      // http.ClientRequest in node.js
-      logger.error("Axios client-side error", { error: error.request });
-   } else {
-      // Something happened in setting up the request that triggered an Error
-      logger.error("Axios unknown error", { error });
+      // that falls out of the range of 2xx.
+      return {
+         message: "Axios server-side error",
+         meta: {
+            url: error.response.config.url,
+            status: error.response.status,
+            headers: redactSensitive(error.response.headers),
+            data: redactSensitive(error.response.data),
+         },
+      };
    }
+   if (error.request) {
+      // The request was made but no response was received. `error.request` is
+      // the raw ClientRequest/XHR and carries the outgoing headers (including
+      // Authorization), so log only safe descriptors from the config.
+      return {
+         message: "Axios client-side error",
+         meta: {
+            method: error.config?.method,
+            url: error.config?.url,
+            code: error.code,
+         },
+      };
+   }
+   // Something happened setting up the request. The AxiosError still holds
+   // `config.headers`, so log only the message.
+   return {
+      message: "Axios unknown error",
+      meta: { message: error.message },
+   };
+}
+
+export const logAxiosError = (error: AxiosError) => {
+   const { message, meta } = buildAxiosErrorLog(error);
+   logger.error(message, meta);
 };


### PR DESCRIPTION
Follow-up to the request/response log redaction PR. Same class of leak, a different code path.

## Problem

`logAxiosError` logs the details of every failed outbound call, and those details can carry credentials:

- `error.response.data` can echo a connection config (with `serviceAccountKeyJson`, `password`, and so on) when an upstream worker returns it in an error body.
- `error.request` (the client-side-error branch) is the raw request object, which holds the outgoing `Authorization` header.
- the setup-error branch logged the whole `error`, whose `config.headers` also holds `Authorization`.

## Fix

Extract `buildAxiosErrorLog(error)` as the single place that shapes the log metadata, with secrets removed:

- server-side error: `response.data` and `response.headers` run through `redactSensitive`.
- client-side error: log only `method`, `url`, and `code`, never the raw request object.
- setup error: log only `error.message`.

`redactSensitive` now matches keys case-insensitively and covers credential HTTP headers (`authorization`, `proxy-authorization`, `cookie`, `set-cookie`, `x-api-key`), so an `Authorization` bearer token cannot slip through on header casing.

## Tests

`logger.spec.ts` adds: case-insensitive matching, HTTP-header redaction, and `buildAxiosErrorLog` for all three branches (response data and headers redacted, the raw request never logged, the setup error reduced to its message).

## Stacked PR

This branch is built on the request/response redaction PR because both share the `redactSensitive` helper. Review and merge that one first; this diff is only the axios-error change and will retarget to `main` once the base lands.

## Verification

Full publisher gate green (typecheck, lint, prettier, tests). Redaction confirmed end to end by running the real `logAxiosError` through winston with secret-bearing errors and checking the emitted log: no bearer token, no service-account key, non-secret fields preserved.
