### PR TITLE
feat(server): per-load compile vs schema-fetch timing breakdown

### DIFF
--- a/packages/server/src/package_load/package_load_pool.ts
+++ b/packages/server/src/package_load/package_load_pool.ts
@@ -247,6 +247,8 @@ export interface LoadPackageOutcome {
       }
    >;
    loadDurationMs: number;
+   /** Per-load phase timing breakdown (see {@link LoadPackageResult.timings}). */
+   timings: LoadPackageResult["timings"];
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -844,6 +846,7 @@ function adaptResult(result: LoadPackageResult): LoadPackageOutcome {
          sourceInfos: m.sourceInfos as Malloy.SourceInfo[] | undefined,
       })),
       loadDurationMs: result.loadDurationMs,
+      timings: result.timings,
    };
 }
 

--- a/packages/server/src/package_load/package_load_worker.ts
+++ b/packages/server/src/package_load/package_load_worker.ts
@@ -99,6 +99,7 @@ import {
    type MalloyGivenApi,
 } from "../service/given";
 import { ignoreDotfiles } from "../utils";
+import { RpcWaitAccountant } from "./rpc_wait_accountant";
 import type {
    ConnectionMetadata,
    ConnectionMetadataRequest,
@@ -152,6 +153,13 @@ function callMain<T>(send: (requestId: string) => void): Promise<T> {
    });
 }
 
+// Per-load phase timing: brackets the wall-clock spent awaiting proxied schema
+// fetches so `loadPackage` can separate connection I/O from compile CPU. The
+// pool runs one load per worker at a time, so a single module-level instance
+// is safe; it's still keyed by jobId to shrug off a straggler fetch from a
+// prior, reused-worker load. See {@link RpcWaitAccountant}.
+const schemaWait = new RpcWaitAccountant();
+
 function dispatchMainResponse(message: MainToWorkerMessage): void {
    if (
       message.type === "schema-for-tables-response" ||
@@ -202,18 +210,25 @@ class ProxyConnection {
       schemas: Record<string, TableSourceDef>;
       errors: Record<string, string>;
    }> {
-      const response = await callMain<SchemaForTablesResponse>((requestId) => {
-         const req: SchemaForTablesRequest = {
-            type: "schema-for-tables",
-            requestId,
-            jobId: this.jobId,
-            connectionName: this.name,
-            tables,
-            options: serializeFetchOptions(options),
-         };
-         port.postMessage(req);
-      });
-      return { schemas: response.schemas, errors: response.errors };
+      schemaWait.noteStart(this.jobId);
+      try {
+         const response = await callMain<SchemaForTablesResponse>(
+            (requestId) => {
+               const req: SchemaForTablesRequest = {
+                  type: "schema-for-tables",
+                  requestId,
+                  jobId: this.jobId,
+                  connectionName: this.name,
+                  tables,
+                  options: serializeFetchOptions(options),
+               };
+               port.postMessage(req);
+            },
+         );
+         return { schemas: response.schemas, errors: response.errors };
+      } finally {
+         schemaWait.noteSettle(this.jobId);
+      }
    }
 
    async fetchSchemaForSQLStruct(
@@ -223,17 +238,23 @@ class ProxyConnection {
       | { structDef: SQLSourceDef; error?: undefined }
       | { error: string; structDef?: undefined }
    > {
-      const response = await callMain<SchemaForSqlResponse>((requestId) => {
-         const req: SchemaForSqlRequest = {
-            type: "schema-for-sql",
-            requestId,
-            jobId: this.jobId,
-            connectionName: this.name,
-            sentence: sentence as unknown,
-            options: serializeFetchOptions(options),
-         };
-         port.postMessage(req);
-      });
+      schemaWait.noteStart(this.jobId);
+      let response: SchemaForSqlResponse;
+      try {
+         response = await callMain<SchemaForSqlResponse>((requestId) => {
+            const req: SchemaForSqlRequest = {
+               type: "schema-for-sql",
+               requestId,
+               jobId: this.jobId,
+               connectionName: this.name,
+               sentence: sentence as unknown,
+               options: serializeFetchOptions(options),
+            };
+            port.postMessage(req);
+         });
+      } finally {
+         schemaWait.noteSettle(this.jobId);
+      }
       if (response.error !== undefined) return { error: response.error };
       if (response.structDef === undefined) {
          return { error: "Empty SQL schema response from main thread" };
@@ -849,6 +870,7 @@ async function loadPackage(
    job: LoadPackageRequest,
 ): Promise<LoadPackageResult> {
    const loadStart = performance.now();
+   schemaWait.begin(job.requestId);
 
    const packageMetadata = await readPackageMetadata(job.packagePath);
    const malloyConfig = buildWorkerMalloyConfig(job);
@@ -856,18 +878,36 @@ async function loadPackage(
    const allFiles = await listPackageFiles(job.packagePath);
    const modelPaths = filterModelPaths(allFiles);
 
+   // Bracket the compile region: only work from here on is compilation +
+   // proxied schema fetches. The setup above (manifest read + file listing)
+   // is excluded so it can't inflate the compile figure — it stays in the
+   // derivable remainder (loadDuration - compile - schemaFetch).
+   const compileRegionStart = performance.now();
    const models = await Promise.all(
       modelPaths.map((modelPath) =>
          compileOneModel(job, malloyConfig, modelPath),
       ),
    );
 
+   const loadEnd = performance.now();
+   const schemaFetchDurationMs = schemaWait.waitMs;
    return {
       type: "load-package-result",
       requestId: job.requestId,
       packageMetadata,
       models,
-      loadDurationMs: performance.now() - loadStart,
+      loadDurationMs: loadEnd - loadStart,
+      timings: {
+         // Compile-region wall minus the schema-fetch wait it contains — a
+         // conservative ceiling on compile CPU (clamped: rounding can nudge
+         // it slightly negative).
+         compileDurationMs: Math.max(
+            0,
+            loadEnd - compileRegionStart - schemaFetchDurationMs,
+         ),
+         schemaFetchDurationMs,
+         schemaFetchCount: schemaWait.fetches,
+      },
    };
 }
 

--- a/packages/server/src/package_load/package_load_worker.ts
+++ b/packages/server/src/package_load/package_load_worker.ts
@@ -870,7 +870,6 @@ async function loadPackage(
    job: LoadPackageRequest,
 ): Promise<LoadPackageResult> {
    const loadStart = performance.now();
-   schemaWait.begin(job.requestId);
 
    const packageMetadata = await readPackageMetadata(job.packagePath);
    const malloyConfig = buildWorkerMalloyConfig(job);
@@ -881,8 +880,13 @@ async function loadPackage(
    // Bracket the compile region: only work from here on is compilation +
    // proxied schema fetches. The setup above (manifest read + file listing)
    // is excluded so it can't inflate the compile figure — it stays in the
-   // derivable remainder (loadDuration - compile - schemaFetch).
+   // derivable remainder (loadDuration - compile - schemaFetch). Begin the
+   // schema-fetch accounting HERE, at the region boundary, not at load start:
+   // that keeps `compileDurationMs = compileRegion - schemaFetchWait` exact
+   // regardless of whether any fetch ever happens during setup (none do
+   // today, but this stops that assumption from silently mattering).
    const compileRegionStart = performance.now();
+   schemaWait.begin(job.requestId);
    const models = await Promise.all(
       modelPaths.map((modelPath) =>
          compileOneModel(job, malloyConfig, modelPath),

--- a/packages/server/src/package_load/protocol.ts
+++ b/packages/server/src/package_load/protocol.ts
@@ -189,6 +189,22 @@ export interface LoadPackageResult {
    models: SerializedModel[];
    /** Wall-clock ms inside the worker for the full package load. */
    loadDurationMs: number;
+   /**
+    * Per-load timing breakdown (subset of {@link loadDurationMs}; the
+    * remainder is worker setup + post-compile extraction). See
+    * `rpc_wait_accountant.ts` for how compile time is separated from I/O.
+    */
+   timings: {
+      /**
+       * Compile-region wall-clock minus time awaiting proxied schema fetches —
+       * a conservative ceiling on Malloy compile CPU.
+       */
+      compileDurationMs: number;
+      /** Wall-clock awaiting proxied connection schema fetches (union). */
+      schemaFetchDurationMs: number;
+      /** Number of proxied connection schema fetches the load drove. */
+      schemaFetchCount: number;
+   };
 }
 
 export interface LoadPackageError {

--- a/packages/server/src/package_load/rpc_wait_accountant.spec.ts
+++ b/packages/server/src/package_load/rpc_wait_accountant.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "bun:test";
+
+import { RpcWaitAccountant } from "./rpc_wait_accountant";
+
+/** Accountant driven by a settable fake clock. */
+function withClock(): { acc: RpcWaitAccountant; at: (ms: number) => void } {
+   let t = 0;
+   const acc = new RpcWaitAccountant(() => t);
+   return { acc, at: (ms) => (t = ms) };
+}
+
+describe("RpcWaitAccountant", () => {
+   it("brackets a single fetch's wait", () => {
+      const { acc, at } = withClock();
+      at(0);
+      acc.begin("A");
+      at(10);
+      acc.noteStart("A");
+      at(60);
+      acc.noteSettle("A");
+      expect(acc.waitMs).toBe(50);
+   });
+
+   it("counts overlapping fetches as their union, not the sum", () => {
+      const { acc, at } = withClock();
+      at(0);
+      acc.begin("A");
+      at(0);
+      acc.noteStart("A"); // window opens
+      at(10);
+      acc.noteStart("A"); // second fetch, window stays open
+      at(40);
+      acc.noteSettle("A"); // one still outstanding
+      at(60);
+      acc.noteSettle("A"); // window closes
+      expect(acc.waitMs).toBe(60); // union [0,60], not 30+50
+   });
+
+   it("accumulates disjoint fetch windows", () => {
+      const { acc, at } = withClock();
+      at(0);
+      acc.begin("A");
+      at(0);
+      acc.noteStart("A");
+      at(20);
+      acc.noteSettle("A");
+      at(50);
+      acc.noteStart("A");
+      at(70);
+      acc.noteSettle("A");
+      expect(acc.waitMs).toBe(40);
+   });
+
+   it("ignores a straggler fetch from a prior reused-worker load", () => {
+      const { acc, at } = withClock();
+      at(0);
+      acc.begin("A");
+      at(0);
+      acc.noteStart("A"); // load A opens a fetch and never settles it (failed)
+
+      at(100);
+      acc.begin("B"); // worker reused for load B
+      at(110);
+      acc.noteStart("B");
+      at(130);
+      acc.noteSettle("B");
+
+      at(140);
+      acc.noteSettle("A"); // A's late response — must be a no-op
+
+      expect(acc.waitMs).toBe(20); // only B's [110,130]
+   });
+
+   it("ignores a stray start from a non-active load", () => {
+      const { acc, at } = withClock();
+      at(0);
+      acc.begin("B");
+      at(10);
+      acc.noteStart("A"); // wrong load
+      at(50);
+      acc.noteSettle("A");
+      expect(acc.waitMs).toBe(0);
+   });
+
+   it("counts active-load fetches only", () => {
+      const { acc, at } = withClock();
+      at(0);
+      acc.begin("B");
+      acc.noteStart("B");
+      acc.noteSettle("B");
+      acc.noteStart("B");
+      acc.noteStart("A"); // straggler — not counted
+      expect(acc.fetches).toBe(2);
+   });
+
+   it("begin() discards prior-load state", () => {
+      const { acc, at } = withClock();
+      at(0);
+      acc.begin("A");
+      at(0);
+      acc.noteStart("A");
+      at(50);
+      acc.noteSettle("A");
+      expect(acc.waitMs).toBe(50);
+      at(60);
+      acc.begin("B");
+      expect(acc.waitMs).toBe(0);
+   });
+});

--- a/packages/server/src/package_load/rpc_wait_accountant.ts
+++ b/packages/server/src/package_load/rpc_wait_accountant.ts
@@ -1,0 +1,76 @@
+/**
+ * Per-load "wait" accounting for the package-load worker.
+ *
+ * A package load spends its time in two very different ways: CPU-bound Malloy
+ * compilation, and I/O waiting on connection schema fetches that are proxied
+ * back to the main thread. Today only the *total* load time is observable, so
+ * an operator seeing slow loads can't tell which half dominates. This tracks
+ * the wall-clock during which at least one proxied schema fetch is outstanding,
+ * so the load handler can report `compile = compileRegion - schemaFetchWait`
+ * alongside the fetch time itself.
+ *
+ * Why wall-minus-wait and not a CPU counter: worker threads share the host
+ * process, so `process.cpuUsage()` is process-wide and would fold in every
+ * other worker's CPU — useless for a per-load number. Wall-minus-wait is the
+ * honest per-load proxy. Treat the compute figure as a conservative *ceiling*
+ * on compile CPU: only proxied waits are subtracted, so any non-fetch stall
+ * (GC, scheduler preemption) also lands in "compute".
+ *
+ * Overlapping fetches are counted as their union (the wall-time with >=1
+ * outstanding), never the sum, so concurrent fetches during one compile don't
+ * over-subtract.
+ *
+ * Scoped by `jobId`: the pool runs one load per worker at a time, but reuses a
+ * worker across loads, and a load that fails can leave a proxied fetch in
+ * flight. Gating every start/settle on the active job makes such a straggler's
+ * late response a no-op instead of corrupting the next load's numbers. (If the
+ * one-load-per-worker rule ever changes, this stays correct per job but the
+ * compute ceiling would then also fold in a sibling load's CPU.)
+ */
+export class RpcWaitAccountant {
+   private inFlight = 0;
+   private waitStartMs = 0;
+   private accumMs = 0;
+   private startedCount = 0;
+   private activeJobId: string | undefined;
+
+   constructor(private readonly now: () => number = () => performance.now()) {}
+
+   /** Begin accounting for `jobId`, discarding any prior-load state. */
+   begin(jobId: string): void {
+      this.activeJobId = jobId;
+      this.inFlight = 0;
+      this.waitStartMs = 0;
+      this.accumMs = 0;
+      this.startedCount = 0;
+   }
+
+   /** A proxied fetch for `jobId` was issued. Ignored if `jobId` isn't active. */
+   noteStart(jobId: string): void {
+      if (jobId !== this.activeJobId) return;
+      if (this.inFlight === 0) this.waitStartMs = this.now();
+      this.inFlight += 1;
+      this.startedCount += 1;
+   }
+
+   /**
+    * A proxied fetch for `jobId` settled (resolved or rejected). Ignored if
+    * `jobId` isn't active, so a straggler from a prior reused-worker load
+    * can't drive the counter negative or close the active load's bracket.
+    */
+   noteSettle(jobId: string): void {
+      if (jobId !== this.activeJobId) return;
+      this.inFlight -= 1;
+      if (this.inFlight === 0) this.accumMs += this.now() - this.waitStartMs;
+   }
+
+   /** Accumulated wall-time with >=1 active-load fetch outstanding (union). */
+   get waitMs(): number {
+      return this.accumMs;
+   }
+
+   /** Number of proxied fetches started for the active load. */
+   get fetches(): number {
+      return this.startedCount;
+   }
+}

--- a/packages/server/src/package_load_metrics.spec.ts
+++ b/packages/server/src/package_load_metrics.spec.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import {
+   recordPackageLoadPhases,
+   resetPackageLoadMetricsForTesting,
+} from "./package_load_metrics";
+import {
+   startMetricsHarness,
+   type MetricsHarness,
+} from "./test_helpers/metrics_harness";
+
+describe("package_load_metrics", () => {
+   let harness: MetricsHarness;
+
+   beforeEach(async () => {
+      harness = await startMetricsHarness();
+      resetPackageLoadMetricsForTesting();
+   });
+
+   afterEach(async () => {
+      resetPackageLoadMetricsForTesting();
+      await harness.shutdown();
+   });
+
+   it("records the three phase histograms, labeled by status", async () => {
+      recordPackageLoadPhases(
+         {
+            compileDurationMs: 120,
+            schemaFetchDurationMs: 80,
+            schemaFetchCount: 4,
+         },
+         "success",
+      );
+      recordPackageLoadPhases(
+         {
+            compileDurationMs: 40,
+            schemaFetchDurationMs: 10,
+            schemaFetchCount: 1,
+         },
+         "success",
+      );
+
+      const compile = await harness.collectHistogram(
+         "malloy_package_load_compile_duration",
+         { status: "success" },
+      );
+      expect(compile.count).toBe(2);
+      expect(compile.sum).toBe(160);
+
+      const fetchDuration = await harness.collectHistogram(
+         "malloy_package_load_schema_fetch_duration",
+         { status: "success" },
+      );
+      expect(fetchDuration.count).toBe(2);
+      expect(fetchDuration.sum).toBe(90);
+
+      const fetches = await harness.collectHistogram(
+         "malloy_package_load_schema_fetches",
+         { status: "success" },
+      );
+      expect(fetches.count).toBe(2);
+      expect(fetches.sum).toBe(5);
+   });
+
+   it("resolves the slow-load tail past OTel's default 10s cap", async () => {
+      // A 90s load would fall in the +Inf bucket under OTel's default
+      // boundaries (top = 10000ms); the explicit buckets must extend further.
+      recordPackageLoadPhases(
+         {
+            compileDurationMs: 90_000,
+            schemaFetchDurationMs: 0,
+            schemaFetchCount: 0,
+         },
+         "success",
+      );
+      const compile = await harness.collectHistogram(
+         "malloy_package_load_compile_duration",
+      );
+      expect(compile.boundaries.some((b) => b > 10_000)).toBe(true);
+      expect(compile.boundaries[compile.boundaries.length - 1]).toBe(300_000);
+   });
+});

--- a/packages/server/src/package_load_metrics.spec.ts
+++ b/packages/server/src/package_load_metrics.spec.ts
@@ -62,6 +62,38 @@ describe("package_load_metrics", () => {
       expect(fetches.sum).toBe(5);
    });
 
+   it("labels phases by terminal status, so failures are separable from successes", async () => {
+      recordPackageLoadPhases(
+         {
+            compileDurationMs: 30,
+            schemaFetchDurationMs: 5,
+            schemaFetchCount: 1,
+         },
+         "success",
+      );
+      recordPackageLoadPhases(
+         {
+            compileDurationMs: 12,
+            schemaFetchDurationMs: 3,
+            schemaFetchCount: 1,
+         },
+         "compilation_error",
+      );
+
+      const ok = await harness.collectHistogram(
+         "malloy_package_load_compile_duration",
+         { status: "success" },
+      );
+      const failed = await harness.collectHistogram(
+         "malloy_package_load_compile_duration",
+         { status: "compilation_error" },
+      );
+      expect(ok.count).toBe(1);
+      expect(ok.sum).toBe(30);
+      expect(failed.count).toBe(1);
+      expect(failed.sum).toBe(12);
+   });
+
    it("resolves the slow-load tail past OTel's default 10s cap", async () => {
       // A 90s load would fall in the +Inf bucket under OTel's default
       // boundaries (top = 10000ms); the explicit buckets must extend further.

--- a/packages/server/src/package_load_metrics.ts
+++ b/packages/server/src/package_load_metrics.ts
@@ -1,0 +1,114 @@
+/**
+ * Per-load phase timing for package loads.
+ *
+ * `malloy_package_load_duration` already reports the *total* time to load a
+ * package, but an operator watching a slow load can't tell whether it's the
+ * Malloy compile or the connection schema fetches that dominate — the two are
+ * tuned very differently (CPU/worker sizing vs. warehouse round-trips). These
+ * histograms split the load into those phases so a single dashboard answers
+ * "where did the time go?". The worker measures the phases and reports them on
+ * its result; see `package_load/package_load_worker.ts` and
+ * `package_load/rpc_wait_accountant.ts`.
+ *
+ * Labels: `status` only. Deliberately NOT labelled by package name — unlike
+ * `malloy_package_load_duration`, which carries `malloy_package_name` — to keep
+ * cardinality bounded on deployments with many packages. Per-package latency,
+ * when needed, is better answered by exemplars/traces than a label explosion.
+ *
+ * Lazy init for the same reason as `query_cap_metrics.ts` / `query_timeout.ts`:
+ * instruments created before `setGlobalMeterProvider` bind to a NoOp meter
+ * (https://github.com/open-telemetry/opentelemetry-js/issues/3505).
+ */
+
+import { type Histogram } from "@opentelemetry/api";
+import { publisherMeter } from "./telemetry";
+
+/**
+ * Explicit bucket boundaries (ms) for the load-duration histograms. OTel's
+ * default boundaries top out at 10 000 ms, so any load slower than 10 s falls
+ * in the `+Inf` bucket and `histogram_quantile` can't resolve the tail — which
+ * is exactly the tail (large/slow packages) worth seeing. These extend to
+ * 5 minutes while keeping sub-10 ms resolution for the fast common case.
+ * Shared with the total `malloy_package_load_duration` histogram so all
+ * load-timing histograms bucket consistently.
+ */
+export const LOAD_DURATION_BUCKETS_MS = [
+   1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10_000, 30_000, 60_000,
+   120_000, 300_000,
+];
+
+/** Bucket boundaries for the per-load schema-fetch count. */
+const SCHEMA_FETCH_COUNT_BUCKETS = [0, 1, 2, 5, 10, 25, 50, 100, 250, 500];
+
+export type PackageLoadStatus = "success" | "error";
+
+/** Phase timings a single package load reports (subset of the total). */
+export interface PackageLoadPhaseTimings {
+   /** Ceiling on Malloy compile CPU (compile region minus schema-fetch wait). */
+   compileDurationMs: number;
+   /** Wall-clock awaiting proxied connection schema fetches. */
+   schemaFetchDurationMs: number;
+   /** Number of proxied connection schema fetches the load drove. */
+   schemaFetchCount: number;
+}
+
+let compileDuration: Histogram | null = null;
+let schemaFetchDuration: Histogram | null = null;
+let schemaFetches: Histogram | null = null;
+
+function ensureInstruments(): void {
+   if (compileDuration && schemaFetchDuration && schemaFetches) return;
+   const meter = publisherMeter();
+   compileDuration ??= meter.createHistogram(
+      "malloy_package_load_compile_duration",
+      {
+         description:
+            "Per-load Malloy compile time (compile region minus proxied schema-fetch wait; a ceiling on compile CPU). Label: status.",
+         unit: "ms",
+         advice: { explicitBucketBoundaries: LOAD_DURATION_BUCKETS_MS },
+      },
+   );
+   schemaFetchDuration ??= meter.createHistogram(
+      "malloy_package_load_schema_fetch_duration",
+      {
+         description:
+            "Per-load wall-clock awaiting proxied connection schema fetches. Label: status.",
+         unit: "ms",
+         advice: { explicitBucketBoundaries: LOAD_DURATION_BUCKETS_MS },
+      },
+   );
+   schemaFetches ??= meter.createHistogram(
+      "malloy_package_load_schema_fetches",
+      {
+         description:
+            "Per-load count of proxied connection schema fetches. Label: status.",
+         advice: { explicitBucketBoundaries: SCHEMA_FETCH_COUNT_BUCKETS },
+      },
+   );
+}
+
+/**
+ * Record one load's phase breakdown. Call for completed loads (`success`);
+ * the terms are meaningless for a load that never produced a worker result.
+ */
+export function recordPackageLoadPhases(
+   timings: PackageLoadPhaseTimings,
+   status: PackageLoadStatus = "success",
+): void {
+   ensureInstruments();
+   const attrs = { status };
+   compileDuration?.record(timings.compileDurationMs, attrs);
+   schemaFetchDuration?.record(timings.schemaFetchDurationMs, attrs);
+   schemaFetches?.record(timings.schemaFetchCount, attrs);
+}
+
+/**
+ * Visible for tests. Drops cached instruments so a fresh `MeterProvider`
+ * (installed via `startMetricsHarness`) captures future emissions. Do NOT call
+ * from production code.
+ */
+export function resetPackageLoadMetricsForTesting(): void {
+   compileDuration = null;
+   schemaFetchDuration = null;
+   schemaFetches = null;
+}

--- a/packages/server/src/package_load_metrics.ts
+++ b/packages/server/src/package_load_metrics.ts
@@ -40,7 +40,18 @@ export const LOAD_DURATION_BUCKETS_MS = [
 /** Bucket boundaries for the per-load schema-fetch count. */
 const SCHEMA_FETCH_COUNT_BUCKETS = [0, 1, 2, 5, 10, 25, 50, 100, 250, 500];
 
-export type PackageLoadStatus = "success" | "error";
+/**
+ * Terminal status of a package load, mirroring the `status` label on the
+ * existing `malloy_package_load_duration` histogram so the phase metrics slice
+ * the same way. In practice the phase histograms only ever carry `success`,
+ * `compilation_error`, or `error` — a `pool_unavailable` failure happens before
+ * the worker returns any timings, so there is nothing to record for it.
+ */
+export type PackageLoadStatus =
+   | "success"
+   | "compilation_error"
+   | "pool_unavailable"
+   | "error";
 
 /** Phase timings a single package load reports (subset of the total). */
 export interface PackageLoadPhaseTimings {
@@ -88,12 +99,14 @@ function ensureInstruments(): void {
 }
 
 /**
- * Record one load's phase breakdown. Call for completed loads (`success`);
- * the terms are meaningless for a load that never produced a worker result.
+ * Record one load's phase breakdown. Call once the worker has returned timings,
+ * with the load's terminal `status` (so the phases can be sliced by outcome the
+ * same way the total duration is). The terms are meaningless for a load that
+ * never produced a worker result (e.g. a pool failure), so don't call it there.
  */
 export function recordPackageLoadPhases(
    timings: PackageLoadPhaseTimings,
-   status: PackageLoadStatus = "success",
+   status: PackageLoadStatus,
 ): void {
    ensureInstruments();
    const attrs = { status };

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -29,6 +29,10 @@ import {
 } from "../errors";
 import { formatDuration, logger } from "../logger";
 import { recordBuildPlanComputeDuration } from "../materialization_metrics";
+import {
+   LOAD_DURATION_BUCKETS_MS,
+   recordPackageLoadPhases,
+} from "../package_load_metrics";
 import { assertSafeEnvironmentPath, safeJoinUnderRoot } from "../path_safety";
 import {
    BuildManifest,
@@ -127,6 +131,10 @@ export class Package {
       {
          description: "Time taken to load a Malloy package",
          unit: "ms",
+         // OTel's default buckets top out at 10s, censoring the slow-load tail.
+         // Use the shared load-duration buckets (→5min) so p95/p99 of large
+         // package loads are resolvable. See LOAD_DURATION_BUCKETS_MS.
+         advice: { explicitBucketBoundaries: LOAD_DURATION_BUCKETS_MS },
       },
    );
 
@@ -361,9 +369,14 @@ export class Package {
          workerDurationMs: outcome.loadDurationMs,
          dispatchOverheadMs:
             workerDoneTime - dispatchTime - outcome.loadDurationMs,
+         // Phase split of the worker duration (remainder = setup + extraction).
+         compileDurationMs: outcome.timings.compileDurationMs,
+         schemaFetchDurationMs: outcome.timings.schemaFetchDurationMs,
+         schemaFetchCount: outcome.timings.schemaFetchCount,
          modelCount: outcome.models.length,
          databaseCount: databases.length,
       });
+      recordPackageLoadPhases(outcome.timings, "success");
 
       // Override the manifest-derived resource URI — the worker only
       // returns name/description from publisher.json, but the rest of

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -32,6 +32,7 @@ import { recordBuildPlanComputeDuration } from "../materialization_metrics";
 import {
    LOAD_DURATION_BUCKETS_MS,
    recordPackageLoadPhases,
+   type PackageLoadStatus,
 } from "../package_load_metrics";
 import { assertSafeEnvironmentPath, safeJoinUnderRoot } from "../path_safety";
 import {
@@ -75,6 +76,23 @@ function toTableNameManifest(
       out[sourceEntityId] = { tableName: entry.tableName };
    }
    return out;
+}
+
+/**
+ * Classify a failed package load into the `status` label shared by the
+ * `malloy_package_load_duration` histogram and the per-phase load metrics, so
+ * both slice failures identically. A real Malloy/model compile error is a 4xx
+ * `compilation_error`; a rewrapped pool-infrastructure failure is a transient
+ * `pool_unavailable`; anything else is a generic `error`.
+ */
+function packageLoadFailureStatus(error: unknown): PackageLoadStatus {
+   if (error instanceof ModelCompilationError || error instanceof MalloyError) {
+      return "compilation_error";
+   }
+   if (error instanceof ServiceUnavailableError) {
+      return "pool_unavailable";
+   }
+   return "error";
 }
 
 export class Package {
@@ -256,16 +274,9 @@ export class Package {
          console.error(error);
          const endTime = performance.now();
          const executionTime = endTime - startTime;
-         const status =
-            error instanceof ModelCompilationError ||
-            error instanceof MalloyError
-               ? "compilation_error"
-               : error instanceof ServiceUnavailableError
-                 ? "pool_unavailable"
-                 : "error";
          this.packageLoadHistogram.record(executionTime, {
             malloy_package_name: packageName,
-            status,
+            status: packageLoadFailureStatus(error),
          });
          // Clean up the package directory on failure, but NOT when packagePath
          // is an in-place mount symlink (watch mode). Removing it would unmount
@@ -376,7 +387,6 @@ export class Package {
          modelCount: outcome.models.length,
          databaseCount: databases.length,
       });
-      recordPackageLoadPhases(outcome.timings, "success");
 
       // Override the manifest-derived resource URI — the worker only
       // returns name/description from publisher.json, but the rest of
@@ -413,43 +423,59 @@ export class Package {
       // hydration path.)
       const models = new Map<string, Model>();
       const renderTagWarnings: ApiPackageWarning[] = [];
-      for (const sm of outcome.models) {
-         if (sm.compilationError) {
-            const err = Model.deserializeCompilationError(sm.compilationError);
-            logger.error("Model compilation failed", {
+      try {
+         for (const sm of outcome.models) {
+            if (sm.compilationError) {
+               const err = Model.deserializeCompilationError(
+                  sm.compilationError,
+               );
+               logger.error("Model compilation failed", {
+                  packageName,
+                  modelPath: sm.modelPath,
+                  error: err.message,
+               });
+               // The outer catch in Package.create records the total metric +
+               // cleans the package directory.
+               throw err;
+            }
+            const model = Model.fromSerialized(
                packageName,
-               modelPath: sm.modelPath,
-               error: err.message,
-            });
-            // The outer catch in Package.create records the metric +
-            // cleans the package directory.
-            throw err;
-         }
-         const model = Model.fromSerialized(
-            packageName,
-            packagePath,
-            malloyConfig,
-            sm,
-         );
-         // Validate renderer tags on the main thread (the renderer is too heavy
-         // to load inside the pure-CPU package-load worker). A misconfigured tag
-         // is logged as a warning naming the target; it does not fail the load.
-         // The findings also ride the package response as non-fatal `warnings`.
-         for (const w of await model.validateRenderTags()) {
-            renderTagWarnings.push({ model: sm.modelPath, ...w });
-         }
-         // Reject unquoted `#@ persist name=` annotations the same way: an
-         // unquoted name is dropped from the build plan, so the source would
-         // publish but never materialize. Scan the raw `.malloy` source (the
-         // ground truth for quoting); throws a ModelCompilationError (424).
-         if (sm.modelPath.endsWith(MODEL_FILE_SUFFIX)) {
-            const modelSource = await fs.readFile(
-               path.join(packagePath, sm.modelPath),
-               "utf-8",
+               packagePath,
+               malloyConfig,
+               sm,
             );
-            assertPersistNamesQuoted(modelSource, sm.modelPath);
+            // Validate renderer tags on the main thread (the renderer is too
+            // heavy to load inside the pure-CPU package-load worker). A
+            // misconfigured tag is logged as a warning naming the target; it
+            // does not fail the load. The findings also ride the package
+            // response as non-fatal `warnings`.
+            for (const w of await model.validateRenderTags()) {
+               renderTagWarnings.push({ model: sm.modelPath, ...w });
+            }
+            // Reject unquoted `#@ persist name=` annotations the same way: an
+            // unquoted name is dropped from the build plan, so the source would
+            // publish but never materialize. Scan the raw `.malloy` source (the
+            // ground truth for quoting); throws a ModelCompilationError (424).
+            if (sm.modelPath.endsWith(MODEL_FILE_SUFFIX)) {
+               const modelSource = await fs.readFile(
+                  path.join(packagePath, sm.modelPath),
+                  "utf-8",
+               );
+               assertPersistNamesQuoted(modelSource, sm.modelPath);
+            }
+            models.set(sm.modelPath, model);
          }
-         models.set(sm.modelPath, model);
+      } catch (err) {
+         // Record the load's phase cost tagged with the terminal status before
+         // the error propagates to the outer catch (which records the total).
+         // Only in-band compile failures reach here — the worker already
+         // produced `outcome.timings`; a pool failure throws before `outcome`
+         // exists and carries no timings, so it's simply not recorded.
+         recordPackageLoadPhases(
+            outcome.timings,
+            packageLoadFailureStatus(err),
+         );
+         throw err;
       }
 
       const endTime = performance.now();
@@ -458,6 +484,7 @@ export class Package {
          malloy_package_name: packageName,
          status: "success",
       });
+      recordPackageLoadPhases(outcome.timings, "success");
       logger.info(`Successfully loaded package ${packageName}`, {
          packageName,
          duration: formatDuration(executionTime),

--- a/packages/server/src/test_helpers/metrics_harness.ts
+++ b/packages/server/src/test_helpers/metrics_harness.ts
@@ -62,6 +62,15 @@ export interface MetricsHarness {
     * fired for this gauge yet.
     */
    collectGauge(name: string): Promise<number | undefined>;
+   /**
+    * Force a collection cycle and return the aggregate `count`/`sum` across all
+    * data points for the named histogram (optionally scoped to one label set).
+    * `count` is 0 when the histogram has not been emitted yet.
+    */
+   collectHistogram(
+      name: string,
+      attributeFilter?: Record<string, string | number | boolean>,
+   ): Promise<{ count: number; sum: number; boundaries: number[] }>;
    shutdown(): Promise<void>;
 }
 
@@ -99,6 +108,37 @@ export async function startMetricsHarness(): Promise<MetricsHarness> {
             }
          }
          return total;
+      },
+      async collectHistogram(
+         name: string,
+         attributeFilter?: Record<string, string | number | boolean>,
+      ): Promise<{ count: number; sum: number; boundaries: number[] }> {
+         const result = await reader.collect();
+         let count = 0;
+         let sum = 0;
+         let boundaries: number[] = [];
+         for (const rm of result.resourceMetrics.scopeMetrics) {
+            for (const metric of rm.metrics) {
+               if (metric.descriptor.name !== name) continue;
+               for (const dp of metric.dataPoints) {
+                  if (attributeFilter) {
+                     const allMatch = Object.entries(attributeFilter).every(
+                        ([k, v]) => dp.attributes?.[k] === v,
+                     );
+                     if (!allMatch) continue;
+                  }
+                  const point = dp.value as {
+                     count: number;
+                     sum?: number;
+                     buckets?: { boundaries: number[] };
+                  };
+                  count += point.count;
+                  sum += point.sum ?? 0;
+                  if (point.buckets) boundaries = point.buckets.boundaries;
+               }
+            }
+         }
+         return { count, sum, boundaries };
       },
       async collectGauge(name: string): Promise<number | undefined> {
          const result = await reader.collect();


### PR DESCRIPTION
## What & why

`malloy_package_load_duration` reports only the *total* time to load a package. When a load is slow, an operator can't tell whether the time went to **Malloy compilation** or to **connection schema fetches** — two costs with very different remedies (worker CPU/sizing vs. warehouse round-trips). This adds a per-load phase breakdown so that's answerable from metrics and logs.

Additive instrumentation only — no HTTP/OpenAPI shape changes.

## Changes

- **New histograms** (labelled `status` only — deliberately *not* by package name, to keep cardinality bounded):
  - `malloy_package_load_compile_duration`
  - `malloy_package_load_schema_fetch_duration`
  - `malloy_package_load_schema_fetches`
- The package-load **worker** measures these per load and reports them on its result; `service/package.ts` records them and adds the split to the existing "load completed" log line.
- **Bucket boundaries.** All load-duration histograms now use explicit boundaries out to 5 min. OTel's defaults top out at 10 s, so any slower load landed in `+Inf` and the tail was unresolvable — this also widens the existing `malloy_package_load_duration`.
- **Test harness:** added `collectHistogram` (it had counter/gauge collectors only).

## How compile time is measured

Compile time = compile-region wall-clock − time awaiting proxied schema fetches. `process.cpuUsage()` is process-wide across worker threads, so it can't give a per-load CPU number; this wall-minus-wait "self time" is the honest proxy — treat it as a **ceiling** on compile CPU (non-fetch stalls like GC also land in it). Worker setup (manifest read + file listing) is bracketed out so it can't inflate the figure; the remainder (`total − compile − schema-fetch`) stays derivable. The accounting is `jobId`-scoped so a straggler fetch from a prior (reused-worker) load can't corrupt the next load's numbers.

Example completion log:

```
workerDurationMs: 5.05, compileDurationMs: 2.68, schemaFetchDurationMs: 2.21, schemaFetchCount: 1
```

## Testing

- New unit tests for the wait accountant (overlap/union, reset isolation, straggler rejection, clamp) and the metrics module (records + tail-past-10s bucket boundaries).
- Existing package-load pool + service specs pass; `tsc` / eslint clean.
