### PR TITLE
Show render tag warnings alongside query results

### DIFF
--- a/packages/sdk/src/components/Model/ModelCell.tsx
+++ b/packages/sdk/src/components/Model/ModelCell.tsx
@@ -179,6 +179,7 @@ export function ModelCell({
                      result={queryData.data.result}
                      maxHeight={600}
                      maxResultSize={maxResultSize}
+                     renderLogs={queryData.data.renderLogs}
                   />
                )}
          </CleanMetricCard>
@@ -188,6 +189,7 @@ export function ModelCell({
             open={resultsDialogOpen}
             onClose={() => setResultsDialogOpen(false)}
             result={queryData?.data?.result || ""}
+            renderLogs={queryData?.data?.renderLogs}
             title={`Query: ${queryName}`}
          />
       </CleanNotebookCell>

--- a/packages/sdk/src/components/QueryResult/QueryResult.tsx
+++ b/packages/sdk/src/components/QueryResult/QueryResult.tsx
@@ -99,7 +99,11 @@ export default function QueryResult({
          )}
          {isSuccess && (
             <Suspense fallback={<div>Loading...</div>}>
-               <ResultContainer result={data.data.result} maxHeight={height} />
+               <ResultContainer
+                  result={data.data.result}
+                  maxHeight={height}
+                  renderLogs={data.data.renderLogs}
+               />
             </Suspense>
          )}
          {isError && (

--- a/packages/sdk/src/components/RenderedResult/ResultContainer.tsx
+++ b/packages/sdk/src/components/RenderedResult/ResultContainer.tsx
@@ -1,7 +1,10 @@
 import { Warning } from "@mui/icons-material";
-import { Box, Button, Typography } from "@mui/material";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import { Box, Button, IconButton, Tooltip, Typography } from "@mui/material";
 import { lazy, Suspense, useRef, useState } from "react";
+import { LogMessage } from "../../client";
 import { Loading } from "../Loading";
+import { summarizeRenderLogs } from "./renderLogs";
 
 const RenderedResult = lazy(() => import("../RenderedResult/RenderedResult"));
 
@@ -12,6 +15,9 @@ interface ResultContainerProps {
    // this is to prevent performance issues with large results.
    // the default is 0, which means no warning will be shown.
    maxResultSize?: number;
+   // Render tag findings from the query response. Callers whose result did not
+   // come from a query response have none to pass.
+   renderLogs?: LogMessage[];
 }
 
 // ResultContainer is a component that renders a result, with a toggle button to expand/collapse the result.
@@ -22,10 +28,12 @@ export default function ResultContainer({
    result,
    maxHeight,
    maxResultSize = 0,
+   renderLogs,
 }: ResultContainerProps) {
    const containerRef = useRef<HTMLDivElement>(null);
    const [measuredHeight, setMeasuredHeight] = useState(maxHeight);
    const [userAcknowledged, setUserAcknowledged] = useState(false);
+   const renderLogSummary = summarizeRenderLogs(renderLogs);
 
    if (!result) {
       return null;
@@ -89,6 +97,37 @@ export default function ResultContainer({
                   onSizeChange={setMeasuredHeight}
                />
             </Suspense>
+         )}
+         {renderLogSummary && (
+            // Overlaid rather than stacked, so the note cannot change the height
+            // the container just measured. The button is what makes the message
+            // reachable: an icon alone is aria-hidden and cannot take focus.
+            <Box sx={{ position: "absolute", top: 4, right: 4, zIndex: 1 }}>
+               <Tooltip
+                  title={renderLogSummary.title}
+                  slotProps={{ tooltip: { sx: { whiteSpace: "pre-line" } } }}
+               >
+                  <IconButton
+                     size="small"
+                     aria-label="Render tag warnings"
+                     sx={{
+                        backgroundColor: "rgba(255, 255, 255, 0.9)",
+                        "&:hover": {
+                           backgroundColor: "rgba(255, 255, 255, 1)",
+                        },
+                     }}
+                  >
+                     <InfoOutlinedIcon
+                        fontSize="small"
+                        color={
+                           renderLogSummary.severity === "error"
+                              ? "error"
+                              : "warning"
+                        }
+                     />
+                  </IconButton>
+               </Tooltip>
+            </Box>
          )}
       </Box>
    );

--- a/packages/sdk/src/components/RenderedResult/renderLogs.spec.ts
+++ b/packages/sdk/src/components/RenderedResult/renderLogs.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { summarizeRenderLogs } from "./renderLogs";
+
+describe("summarizeRenderLogs", () => {
+   it("returns nothing when there are no logs", () => {
+      expect(summarizeRenderLogs(undefined)).toBeUndefined();
+      expect(summarizeRenderLogs([])).toBeUndefined();
+   });
+
+   it("surfaces a warning, which is the severity a bad render tag reports", () => {
+      expect(
+         summarizeRenderLogs([
+            {
+               severity: "warn",
+               message: "Unknown render tag 'viz.stack.y' on field 'root'",
+            },
+         ]),
+      ).toEqual({
+         severity: "warn",
+         title: "Unknown render tag 'viz.stack.y' on field 'root'",
+      });
+   });
+
+   it("reports the worst severity when both are present", () => {
+      const summary = summarizeRenderLogs([
+         { severity: "warn", message: "first" },
+         { severity: "error", message: "second" },
+      ]);
+      expect(summary?.severity).toBe("error");
+      expect(summary?.title).toBe("first\nsecond");
+   });
+
+   it("drops debug and info, which are not worth interrupting for", () => {
+      expect(
+         summarizeRenderLogs([
+            { severity: "debug", message: "noise" },
+            { severity: "info", message: "more noise" },
+         ]),
+      ).toBeUndefined();
+   });
+
+   it("drops entries with no message or no severity rather than showing an empty tooltip", () => {
+      // Every LogMessage field is optional in the generated client.
+      expect(summarizeRenderLogs([{ severity: "warn" }])).toBeUndefined();
+      expect(summarizeRenderLogs([{ message: "orphan" }])).toBeUndefined();
+   });
+
+   it("dedupes repeated messages", () => {
+      const summary = summarizeRenderLogs([
+         { severity: "warn", message: "same" },
+         { severity: "warn", message: "same" },
+      ]);
+      expect(summary?.title).toBe("same");
+   });
+});

--- a/packages/sdk/src/components/RenderedResult/renderLogs.ts
+++ b/packages/sdk/src/components/RenderedResult/renderLogs.ts
@@ -1,0 +1,40 @@
+import { LogMessage } from "../../client";
+
+export interface RenderLogSummary {
+   severity: "warn" | "error";
+   title: string;
+}
+
+// Severity describes the tag defect, not whether the chart drew, so findings are
+// only ever annotated, never used to withhold a result.
+const SHOWN_SEVERITIES = new Set(["warn", "error"]);
+
+// Every LogMessage field is optional, so entries without a severity we show or
+// without a message are dropped rather than rendered as an empty tooltip.
+export function summarizeRenderLogs(
+   logs: LogMessage[] | undefined,
+): RenderLogSummary | undefined {
+   if (!logs?.length) {
+      return undefined;
+   }
+   const messages: string[] = [];
+   let hasError = false;
+   for (const log of logs) {
+      if (!log.message || !SHOWN_SEVERITIES.has(log.severity ?? "")) {
+         continue;
+      }
+      if (log.severity === "error") {
+         hasError = true;
+      }
+      if (!messages.includes(log.message)) {
+         messages.push(log.message);
+      }
+   }
+   if (!messages.length) {
+      return undefined;
+   }
+   return {
+      severity: hasError ? "error" : "warn",
+      title: messages.join("\n"),
+   };
+}

--- a/packages/sdk/src/components/ResultsDialog.tsx
+++ b/packages/sdk/src/components/ResultsDialog.tsx
@@ -1,5 +1,6 @@
 import CloseIcon from "@mui/icons-material/Close";
 import { Dialog, DialogContent, DialogTitle, IconButton } from "@mui/material";
+import { LogMessage } from "../client";
 import ResultContainer from "./RenderedResult/ResultContainer";
 
 interface ResultsDialogProps {
@@ -7,6 +8,7 @@ interface ResultsDialogProps {
    onClose: () => void;
    result: string;
    title?: string;
+   renderLogs?: LogMessage[];
 }
 
 export default function ResultsDialog({
@@ -14,6 +16,7 @@ export default function ResultsDialog({
    onClose,
    result,
    title = "Results",
+   renderLogs,
 }: ResultsDialogProps) {
    return (
       <Dialog
@@ -52,6 +55,7 @@ export default function ResultsDialog({
                result={result}
                maxHeight={800}
                maxResultSize={1000000}
+               renderLogs={renderLogs}
             />
          </DialogContent>
       </Dialog>


### PR DESCRIPTION
## What

Every query response already carries `renderLogs` — the render tag validation findings for that result — and has since #635. It's in `api-doc.yaml`, in all four generated clients, and the MCP `execute_query` tool already reports it, so an AI agent gets told when a tag is wrong. Nothing in the UI ever read it, so a human got a broken chart and no explanation. The only way to find out was the network tab, which is exactly how this surfaced: a user hit a blank chart and had to open devtools to discover the renderer had been telling us the whole time.

This surfaces those findings as a non-blocking note over the result.

<!-- drop chip-tooltip.png here -->

Above: a bad tag renders a blank chart, now with the reason attached. Below it, a clean query, no note.

## Design: annotate, never withhold

Severity describes the *tag defect*, not whether the chart drew, and it fails to predict the render in both directions. The case that prompted this was `severity: "warn"` **and** produced a blank chart. Meanwhile a benign warning can accompany a perfectly good chart, and `error`-severity findings coexist with a drawn result — `model.ts` notes they affect "only how a field renders, never whether the model compiles or a query runs".

So any rule that used severity to withhold a result would be guessing, and wrong either way: it would blank charts the renderer is actively drawing, replacing a visible result with nothing. Annotating is wrong in neither direction. A blank chart plus a note is recoverable — the user reads it and fixes the tag. A withheld good chart is not.

This also keeps faith with #861, which deliberately made render findings non-fatal after the fatal treatment caused package-load failures and a control-plane retry loop. `debug` and `info` are dropped; only `warn` and `error` are worth a user's attention.

## Shape

`ResultContainer` takes an optional `renderLogs?: LogMessage[]`. `summarizeRenderLogs` (a pure helper, unit tested) filters to warn/error entries that have a message, dedupes them, and picks the worst severity — every `LogMessage` field is optional in the generated client, so entries without a severity or message are dropped rather than rendered as an empty tooltip.

The note is an overlay, not a sibling. `ResultContainer` measures `renderedHeight` and feeds it to `RenderedResult`, so a block-level element would change the height it just measured and shift every embedding surface.

It's a button rather than a bare icon for two reasons. MUI's `SvgIcon` renders `focusable="false"` and `aria-hidden="true"`, so a bare icon can't take focus and never reaches the accessibility tree — the tooltip is the only channel for this message, so a keyboard or screen-reader user would get nothing at all. And it carries the same translucent backdrop as the sibling overlays in `ModelCell` and `NotebookCell`; the comment at `NotebookCell.tsx:463-470` records why ("the white-on-white made it invisible").

`QueryResult`, `ModelCell` and `ResultsDialog` execute queries and pass their findings through. `NotebookCell` and `MutableCell` render a stored `cell.result` from `executeNotebookCell`, whose `NotebookCellResult` schema has no `renderLogs`, so they have nothing to pass and the prop stays optional.

## Not covered

- **Notebook cells** get no findings at all, because the notebook endpoint never returns them. Closing that means adding `renderLogs` to `NotebookCellResult` and regenerating the clients — a bigger change, happy to do it separately if you want it.
- **The query builder preview** (`SourcesExplorer`) renders through `@malloydata/malloy-explorer`'s own `ResultPanel` rather than `ResultContainer`, so this doesn't reach it.

## Tests

Six unit tests on the summarizer (`bun test`, 70 pass), covering the real warning payload, worst-severity selection, dropping debug/info, dropping entries with missing optional fields, and dedupe.

Verified live against a package with a deliberately bad tag: the wire returned `severity: "warn"`, `"Unknown render tag 'viz.stack.y' on field 'root'"`; the note appeared with that exact text; a clean query in the same model produced no note.

Two traps for anyone adding a Playwright test later. `svg[data-testid="InfoOutlinedIcon"]` matches nothing in a production build, since `@mui/icons-material` only emits `data-testid` when `NODE_ENV !== "production"` — locate by role and accessible name instead. And assert keyboard reachability with a real `keyboard.press("Tab")`, not `locator.focus()`: MUI's Tooltip gates its focus listener on `:focus-visible`, which programmatic focus doesn't set, so `focus()` looks like a failure when the behaviour is correct.
