### PR TITLE
Report configured packages and environments that failed to load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,11 @@ Poll until the server reports `serving` rather than assuming a fixed wait. From 
 curl -s http://localhost:4000/api/v0/status | jq .operationalState   # -> "serving"
 ```
 
+`serving` does not mean everything loaded. A package that fails to load is skipped, not fatal, so the
+server serves whatever did load and the package is simply absent. If data you expect is missing, check
+`curl -s http://localhost:4000/api/v0/status | jq .loadErrors`, which is absent when everything loaded
+and otherwise names each environment or package that did not load, and why.
+
 ## 2. Connect your agent
 
 Publisher exposes one MCP endpoint: `http://localhost:4040/mcp` (streamable HTTP, stateless, unauthenticated; put it behind a gateway if you expose it beyond localhost).

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -2453,6 +2453,34 @@ components:
             governor). Already-loaded packages remain serviceable while throttled;
             callers can treat a throttled server as unhealthy for new load.
             Only reported when the memory governor is enabled.
+        loadErrors:
+          type: array
+          readOnly: true
+          description:
+            Configured packages and environments that did not load, and why. A
+            load failure is not fatal to the server, so operationalState stays
+            serving and the affected packages are simply absent from
+            environments; this is the only place that difference is reported, so
+            check it before treating a serving server as complete. Present only
+            when something failed to load, so a healthy server omits the field.
+          items:
+            type: object
+            properties:
+              environment:
+                type: string
+                description:
+                  Name of the configured environment the failure belongs to.
+              package:
+                type: string
+                description:
+                  Name of the configured package that did not load. Absent when
+                  the whole environment was skipped, which is what happens when a
+                  package location cannot be mounted at all; in that case no
+                  package in the environment loads, including ones that would
+                  otherwise have succeeded.
+              message:
+                type: string
+                description: Why it did not load.
         frozenConfig:
           type: boolean
           description:

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -37,7 +37,7 @@ put the server behind your own gateway before exposing it beyond localhost.
 
 | Method & path | Does |
 | --- | --- |
-| `GET /api/v0/status` | Server lifecycle (`operationalState`). |
+| `GET /api/v0/status` | Server lifecycle (`operationalState`), plus `loadErrors` for anything configured that did not load. |
 | `GET /api/v0/environments` | List environments, each with its packages. |
 | `GET /api/v0/environments/{env}/packages/{pkg}` | Package metadata (models, `explores`, `buildPlan`, …). |
 | `GET  …/packages/{pkg}/models/{path}` | A model's compiled metadata (sources, views, givens). |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -36,6 +36,37 @@ curl -s http://localhost:4000/api/v0/environments | jq '.[].name'    # → list 
   drops. Only reported when the memory governor is enabled (see
   [configuration.md](configuration.md#operational-tuning-oom-guards)).
 
+### `serving` does not mean everything loaded
+
+A package or environment that fails to load is skipped rather than fatal, so the server still reports
+`serving` and simply serves whatever did load. Check `loadErrors` before you treat a `serving` server
+as complete:
+
+```bash
+curl -s http://localhost:4000/api/v0/status | jq .loadErrors
+```
+
+The field is absent when everything loaded. Otherwise it lists what is missing and why:
+
+```json
+[
+  {
+    "environment": "sales",
+    "message": "Failed to download or mount location: ./sales-models"
+  },
+  {
+    "environment": "examples",
+    "package": "storefront",
+    "message": "Package manifest for /publisher_data/examples/storefront does not exist"
+  }
+]
+```
+
+An entry with no `package` means the whole environment was skipped, which also takes down its healthy
+packages. An entry with a `package` means that package alone is missing and its siblings are serving.
+Either way the fix is usually the `location` in `publisher.config.json`, or a missing
+`publisher.json` in the package directory.
+
 ## Docker
 
 Two ways to run Publisher in Docker: build the image from source, or pull the pre-built image from

--- a/packages/server/src/service/connection.spec.ts
+++ b/packages/server/src/service/connection.spec.ts
@@ -868,15 +868,16 @@ describe("connection integration tests", () => {
                   const envStore = new EnvironmentStore(tempServerRoot);
                   await envStore.finishedInitialization;
 
-                  // operationalState=serving is the only signal that
-                  // initialize() actually succeeded. initialize swallows
-                  // top-level errors and just calls markNotReady() (see
-                  // environment_store.ts:297-301), so
-                  // finishedInitialization always resolves regardless of
-                  // success. By construction (env_store:288-292), serving
-                  // also implies all configured environments loaded.
+                  // initialize() swallows top-level errors and just calls
+                  // markNotReady(), so finishedInitialization always resolves
+                  // regardless of success; operationalState is what says it
+                  // succeeded. It does NOT imply every configured environment
+                  // and package loaded: a load failure is skipped and still
+                  // reports "serving", which is why loadErrors exists. Assert
+                  // on both, and on the package list below.
                   const status = await envStore.getStatus();
                   expect(status.operationalState).toBe("serving");
+                  expect(status.loadErrors).toBeUndefined();
 
                   const env = await envStore.getEnvironment("malloy-samples");
                   const apiPackages = await env.listPackages();

--- a/packages/server/src/service/environment.ts
+++ b/packages/server/src/service/environment.ts
@@ -1005,6 +1005,10 @@ export class Environment {
          throw error;
       }
       this.setPackageStatus(packageName, PackageStatus.SERVING);
+      // Same reasoning as the load and install paths: it is serving now, so an
+      // earlier boot failure is stale. Without this, a package fixed on disk
+      // and re-added keeps its loadError for the life of the process.
+      this.failedPackages.delete(packageName);
       return this.packages.get(packageName);
    }
 
@@ -1564,6 +1568,14 @@ export class Environment {
    public async deletePackage(packageName: string): Promise<void> {
       assertSafePackageName(packageName);
       return this.withPackageLock(packageName, async () => {
+         // Clear the load failure before the early return, not after it. A
+         // package that failed to load is not in `packages` (the load catch
+         // evicts it), so deleting it takes the early return every time, while
+         // the controller still drops its config row. Leaving the entry would
+         // make getStatus report a loadError for a package that is no longer
+         // configured, which is the one thing that channel must not do.
+         this.failedPackages.delete(packageName);
+
          const _package = this.packages.get(packageName);
          if (!_package) {
             return;

--- a/packages/server/src/service/environment.ts
+++ b/packages/server/src/service/environment.ts
@@ -21,6 +21,7 @@ import {
    ServiceUnavailableError,
 } from "../errors";
 import { logger } from "../logger";
+import { redactPgSecrets } from "../pg_helpers";
 import { recordManifestBind } from "../materialization_metrics";
 import {
    assertSafeEnvironmentPath,
@@ -138,6 +139,16 @@ export class Environment {
    // AB/BA deadlock path.
    private packageMutexes = new Map<string, Mutex>();
    private packageStatuses: Map<string, PackageInfo> = new Map();
+   /**
+    * Configured packages that failed to load, keyed by name, with the reason.
+    *
+    * A load failure is not fatal: the package is omitted and its siblings serve
+    * on. It is also observable exactly once, because the failing load deletes
+    * the `packageStatuses` entry that `listPackages` enumerates, so the next
+    * listing no longer knows the package was ever configured. That makes this
+    * the only lasting record. Read by EnvironmentStore.getStatus.
+    */
+   private failedPackages: Map<string, string> = new Map();
    private malloyConfig: EnvironmentMalloyConfig;
    private connectionMutex = new Mutex();
    private retiredConnectionGenerations =
@@ -629,6 +640,18 @@ export class Environment {
                   );
                   // Directory did not contain a valid package.json file -- therefore, it's not a package.
                   // Or it timed out
+                  // Redact before this reaches getStatus: compiling a model
+                  // resolves the package's connections, so a Postgres/DuckLake
+                  // ATTACH failure surfaces here, and that command carries
+                  // `password=` (connection.ts builds it, and redacts it before
+                  // logging for the same reason). A log line was the old
+                  // destination; this one is an HTTP response body.
+                  this.failedPackages.set(
+                     packageName,
+                     redactPgSecrets(
+                        error instanceof Error ? error.message : String(error),
+                     ),
+                  );
                   return undefined;
                }
             }),
@@ -892,6 +915,9 @@ export class Environment {
          }
          this.packages.set(packageName, _package);
          this.setPackageStatus(packageName, PackageStatus.SERVING);
+         // It loaded, so any earlier failure is stale. A package that failed at
+         // boot can be fixed on disk and reloaded without a restart.
+         this.failedPackages.delete(packageName);
          logger.debug(`Successfully loaded package ${packageName}`);
 
          return _package;
@@ -1161,6 +1187,8 @@ export class Environment {
 
          this.packages.set(packageName, newPackage);
          this.setPackageStatus(packageName, PackageStatus.SERVING);
+         // Publishing a fixed package clears the boot failure it replaces.
+         this.failedPackages.delete(packageName);
 
          if (oldPackage) {
             this.retireConnectionGeneration(`package ${packageName}`, () =>
@@ -1507,6 +1535,11 @@ export class Environment {
 
    public getPackageStatus(packageName: string): PackageInfo | undefined {
       return this.packageStatuses.get(packageName);
+   }
+
+   /** Packages configured for this environment that did not load, and why. */
+   public getFailedPackages(): ReadonlyMap<string, string> {
+      return this.failedPackages;
    }
 
    public setPackageStatus(packageName: string, status: PackageStatus): void {

--- a/packages/server/src/service/environment.ts
+++ b/packages/server/src/service/environment.ts
@@ -642,10 +642,16 @@ export class Environment {
                   // Or it timed out
                   // Redact before this reaches getStatus: compiling a model
                   // resolves the package's connections, so a Postgres/DuckLake
-                  // ATTACH failure surfaces here, and that command carries
-                  // `password=` (connection.ts builds it, and redacts it before
-                  // logging for the same reason). A log line was the old
-                  // destination; this one is an HTTP response body.
+                  // ATTACH failure surfaces here carrying the connection string
+                  // (connection.ts builds it, and redacts it before logging for
+                  // the same reason). A log line was the old destination; this
+                  // one is an HTTP response body.
+                  //
+                  // Reduces the exposure, does not remove it: redactPgSecrets
+                  // only covers keyword-form `password=`, which is what
+                  // buildPgConnectionString emits. A URL-form connectionString
+                  // supplied verbatim in config still carries its credentials
+                  // through. Widen the helper rather than trusting this call.
                   this.failedPackages.set(
                      packageName,
                      redactPgSecrets(

--- a/packages/server/src/service/environment_store.spec.ts
+++ b/packages/server/src/service/environment_store.spec.ts
@@ -609,6 +609,110 @@ describe("EnvironmentStore Service", () => {
       expect(status.loadErrors?.[0]?.message).toBeTruthy();
    });
 
+   it("should stop reporting a failed package once it is deleted", async () => {
+      const goodPackageName = "good-package";
+      const badPackageName = "bad-package";
+      const goodPackagePath = path.join(serverRootPath, goodPackageName);
+      const badPackagePath = path.join(serverRootPath, badPackageName);
+
+      mkdirSync(goodPackagePath, { recursive: true });
+      writeFileSync(
+         path.join(goodPackagePath, "publisher.json"),
+         JSON.stringify({ name: goodPackageName }),
+      );
+      mkdirSync(badPackagePath, { recursive: true });
+
+      writeFileSync(
+         path.join(serverRootPath, "publisher.config.json"),
+         JSON.stringify({
+            frozenConfig: false,
+            environments: [
+               {
+                  name: projectName,
+                  packages: [
+                     { name: goodPackageName, location: goodPackagePath },
+                     { name: badPackageName, location: badPackagePath },
+                  ],
+                  connections: [],
+               },
+            ],
+         }),
+      );
+
+      const newEnvironmentStore = new EnvironmentStore(serverRootPath);
+      await newEnvironmentStore.finishedInitialization;
+
+      const environment = await newEnvironmentStore.getEnvironment(projectName);
+      expect((await newEnvironmentStore.getStatus()).loadErrors).toHaveLength(
+         1,
+      );
+
+      // A package that failed to load was evicted from `packages`, so the
+      // delete takes deletePackage's early return. The failure entry has to be
+      // cleared anyway: the caller goes on to drop the package's config row,
+      // and a loadError naming a package that is no longer configured sends
+      // whoever reads /status hunting for something that isn't there.
+      await environment.deletePackage(badPackageName);
+
+      const status = await newEnvironmentStore.getStatus();
+      expect(status.operationalState).toBe("serving");
+      expect(status.loadErrors).toBeUndefined();
+      expect((await environment.listPackages()).map((p) => p.name)).toEqual([
+         goodPackageName,
+      ]);
+   });
+
+   it("should stop reporting a failed package once it loads", async () => {
+      const badPackageName = "bad-package";
+      const badPackagePath = path.join(serverRootPath, badPackageName);
+
+      // No manifest, so it fails to load and lands in loadErrors.
+      mkdirSync(badPackagePath, { recursive: true });
+
+      writeFileSync(
+         path.join(serverRootPath, "publisher.config.json"),
+         JSON.stringify({
+            frozenConfig: false,
+            environments: [
+               {
+                  name: projectName,
+                  packages: [
+                     { name: badPackageName, location: badPackagePath },
+                  ],
+                  connections: [],
+               },
+            ],
+         }),
+      );
+
+      const newEnvironmentStore = new EnvironmentStore(serverRootPath);
+      await newEnvironmentStore.finishedInitialization;
+
+      const environment = await newEnvironmentStore.getEnvironment(projectName);
+      expect((await newEnvironmentStore.getStatus()).loadErrors).toHaveLength(
+         1,
+      );
+
+      // Fix the package where the environment actually reads it, then re-add
+      // it. A package that is serving must not still be reported as failed.
+      writeFileSync(
+         path.join(
+            environment.metadata.location as string,
+            badPackageName,
+            "publisher.json",
+         ),
+         JSON.stringify({ name: badPackageName }),
+      );
+      await environment.addPackage(badPackageName);
+
+      const status = await newEnvironmentStore.getStatus();
+      expect(status.operationalState).toBe("serving");
+      expect(status.loadErrors).toBeUndefined();
+      expect((await environment.listPackages()).map((p) => p.name)).toEqual([
+         badPackageName,
+      ]);
+   });
+
    it("should handle project updates", async () => {
       // Create a project directory
       const projectPath = path.join(serverRootPath, projectName);

--- a/packages/server/src/service/environment_store.spec.ts
+++ b/packages/server/src/service/environment_store.spec.ts
@@ -11,6 +11,13 @@ import { EnvironmentStore, resolvePackageLocation } from "./environment_store";
 
 type MockData = Record<string, unknown>;
 
+// Environments the mock database reports at boot. Empty by default, which makes
+// initialize() fall back to the config file — the path every other test here
+// exercises. Set it to reach the database-restore branch instead, which is the
+// one a real restart against an existing publisher.db takes. Read at call time,
+// so a test can assign it before constructing the store.
+let mockDbEnvironments: unknown[] = [];
+
 mock.module("../storage/StorageManager", () => {
    return {
       StorageManager: class MockStorageManager {
@@ -21,7 +28,8 @@ mock.module("../storage/StorageManager", () => {
          getRepository() {
             return {
                // ===== PROJECT METHODS =====
-               listEnvironments: async (): Promise<unknown[]> => [],
+               listEnvironments: async (): Promise<unknown[]> =>
+                  mockDbEnvironments,
 
                getEnvironmentById: async (
                   id: string,
@@ -194,6 +202,10 @@ describe("EnvironmentStore Service", () => {
          rmSync(serverRootPath, { recursive: true, force: true });
       }
       mkdirSync(serverRootPath);
+      // Default every test back to the config-file boot path. bun runs all specs
+      // in one process, so a leaked value would silently switch later tests onto
+      // the database-restore branch.
+      mockDbEnvironments = [];
       sandbox = sinon.createSandbox();
 
       // Mock the configuration to prevent initialization errors
@@ -212,6 +224,7 @@ describe("EnvironmentStore Service", () => {
          rmSync(serverRootPath, { recursive: true, force: true });
       }
       mkdirSync(serverRootPath);
+      mockDbEnvironments = [];
       sandbox.restore();
    });
 
@@ -410,6 +423,190 @@ describe("EnvironmentStore Service", () => {
       await expect(
          newEnvironmentStore.getEnvironment(invalidProjectName),
       ).rejects.toThrow();
+
+      // The skip is not fatal, so the server still serves. getStatus is the
+      // only place that says the environment is missing rather than never
+      // configured: without loadErrors the two are indistinguishable.
+      const status = await newEnvironmentStore.getStatus();
+      expect(status.operationalState).toBe("serving");
+      expect(status.environments.map((e) => e.name)).toEqual([
+         validProjectName,
+      ]);
+      expect(status.loadErrors).toHaveLength(1);
+      expect(status.loadErrors?.[0]?.environment).toBe(invalidProjectName);
+      expect(status.loadErrors?.[0]?.package).toBeUndefined();
+      expect(status.loadErrors?.[0]?.message).toBeTruthy();
+   });
+
+   it("should omit loadErrors when every environment loads", async () => {
+      const projectPath = path.join(serverRootPath, projectName);
+      mkdirSync(projectPath, { recursive: true });
+      writeFileSync(
+         path.join(projectPath, "publisher.json"),
+         JSON.stringify({ name: projectName, description: "Test package" }),
+      );
+      writeFileSync(
+         path.join(serverRootPath, "publisher.config.json"),
+         JSON.stringify({
+            frozenConfig: false,
+            environments: [
+               {
+                  name: projectName,
+                  packages: [{ name: projectName, location: projectPath }],
+                  connections: [],
+               },
+            ],
+         }),
+      );
+
+      const newEnvironmentStore = new EnvironmentStore(serverRootPath);
+      await newEnvironmentStore.finishedInitialization;
+
+      // Absent, not an empty array: a healthy status is unchanged by this
+      // field's existence.
+      const status = await newEnvironmentStore.getStatus();
+      expect(status.operationalState).toBe("serving");
+      expect(status.loadErrors).toBeUndefined();
+      expect("loadErrors" in status).toBe(false);
+   });
+
+   it("should not report an environment that is serving even if its database sync fails", async () => {
+      // An environment reaches this.environments before addEnvironmentToDatabase
+      // runs, so a throw from that tail is caught by the same handler that
+      // records load failures. The environment is live and listed, so reporting
+      // it as a load failure would make the status contradict itself.
+      const projectPath = path.join(serverRootPath, projectName);
+      mkdirSync(projectPath, { recursive: true });
+      writeFileSync(
+         path.join(projectPath, "publisher.json"),
+         JSON.stringify({ name: projectName }),
+      );
+      writeFileSync(
+         path.join(serverRootPath, "publisher.config.json"),
+         JSON.stringify({
+            frozenConfig: false,
+            environments: [
+               {
+                  name: projectName,
+                  packages: [{ name: projectName, location: projectPath }],
+                  connections: [],
+               },
+            ],
+         }),
+      );
+
+      // Stub the prototype before constructing: the constructor starts
+      // initialize() immediately, so stubbing the instance would race it.
+      sandbox
+         .stub(EnvironmentStore.prototype, "addEnvironmentToDatabase")
+         .rejects(new Error("database write failed"));
+
+      const newEnvironmentStore = new EnvironmentStore(serverRootPath);
+      await newEnvironmentStore.finishedInitialization;
+
+      const status = await newEnvironmentStore.getStatus();
+      expect(status.operationalState).toBe("serving");
+      // Still serving it, so it must not also be reported as not loaded.
+      expect(status.environments.map((e) => e.name)).toEqual([projectName]);
+      expect(status.loadErrors).toBeUndefined();
+   });
+
+   it("should report an environment that failed to restore from the database", async () => {
+      // The database-restore branch, not the config branch: initialize() takes
+      // this one whenever INITIALIZE_STORAGE is not "true" and the database
+      // already holds environments, which is every restart of a server with a
+      // persisted publisher.db. It has its own catch, so a failure recorded only
+      // on the config path would be dropped on the path production actually
+      // takes.
+      const envName = "restored-env";
+      const envPath = path.join(serverRootPath, envName);
+
+      // Exists, so the "files missing" branch is skipped, but is a file rather
+      // than a directory, so Environment.create throws. Stands in for any stored
+      // path that goes bad between restarts.
+      writeFileSync(envPath, "not a directory");
+
+      writeFileSync(
+         path.join(serverRootPath, "publisher.config.json"),
+         JSON.stringify({
+            frozenConfig: false,
+            environments: [
+               {
+                  name: envName,
+                  packages: [{ name: envName, location: envPath }],
+                  connections: [],
+               },
+            ],
+         }),
+      );
+
+      mockDbEnvironments = [
+         {
+            id: "restored-env-id",
+            name: envName,
+            path: envPath,
+            metadata: {},
+         },
+      ];
+
+      const newEnvironmentStore = new EnvironmentStore(serverRootPath);
+      await newEnvironmentStore.finishedInitialization;
+
+      const status = await newEnvironmentStore.getStatus();
+      expect(status.operationalState).toBe("serving");
+      expect(status.environments.map((e) => e.name)).toEqual([]);
+      expect(status.loadErrors).toHaveLength(1);
+      expect(status.loadErrors?.[0]?.environment).toBe(envName);
+      expect(status.loadErrors?.[0]?.message).toBeTruthy();
+   });
+
+   it("should report a package that failed to load while its siblings serve", async () => {
+      const goodPackageName = "good-package";
+      const badPackageName = "bad-package";
+      const goodPackagePath = path.join(serverRootPath, goodPackageName);
+      const badPackagePath = path.join(serverRootPath, badPackageName);
+
+      mkdirSync(goodPackagePath, { recursive: true });
+      writeFileSync(
+         path.join(goodPackagePath, "publisher.json"),
+         JSON.stringify({ name: goodPackageName }),
+      );
+      // The directory exists, so the environment mounts; the package inside it
+      // has no manifest, so only that package fails. This is the second, and
+      // quieter, failure mode: the environment is present and serving, with a
+      // package missing from it.
+      mkdirSync(badPackagePath, { recursive: true });
+
+      writeFileSync(
+         path.join(serverRootPath, "publisher.config.json"),
+         JSON.stringify({
+            frozenConfig: false,
+            environments: [
+               {
+                  name: projectName,
+                  packages: [
+                     { name: goodPackageName, location: goodPackagePath },
+                     { name: badPackageName, location: badPackagePath },
+                  ],
+                  connections: [],
+               },
+            ],
+         }),
+      );
+
+      const newEnvironmentStore = new EnvironmentStore(serverRootPath);
+      await newEnvironmentStore.finishedInitialization;
+
+      const environment = await newEnvironmentStore.getEnvironment(projectName);
+      const packages = await environment.listPackages();
+      expect(packages.map((p) => p.name)).toEqual([goodPackageName]);
+
+      const status = await newEnvironmentStore.getStatus();
+      expect(status.operationalState).toBe("serving");
+      expect(status.loadErrors).toHaveLength(1);
+      expect(status.loadErrors?.[0]?.environment).toBe(projectName);
+      expect(status.loadErrors?.[0]?.package).toBe(badPackageName);
+      expect(status.loadErrors?.[0]?.message).toBeTruthy();
    });
 
    it("should handle project updates", async () => {

--- a/packages/server/src/service/environment_store.ts
+++ b/packages/server/src/service/environment_store.ts
@@ -29,6 +29,7 @@ import {
 } from "../errors";
 import { getOperationalState, markNotReady, markReady } from "../health";
 import { formatDuration, logger } from "../logger";
+import { redactPgSecrets } from "../pg_helpers";
 import {
    assertSafeEnvironmentPath,
    assertSafePackageName,
@@ -39,6 +40,9 @@ import { StorageConfig, StorageManager } from "../storage/StorageManager";
 import { Environment, PackageStatus } from "./environment";
 import type { PackageMemoryGovernor } from "./package_memory_governor";
 type ApiEnvironment = components["schemas"]["Environment"];
+type LoadError = NonNullable<
+   components["schemas"]["ServerStatus"]["loadErrors"]
+>[number];
 
 const AZURE_SUPPORTED_SCHEMES = ["https://", "http://", "abfss://", "az://"];
 const AZURE_DATA_EXTENSIONS = [
@@ -150,6 +154,16 @@ export function resolvePackageLocation(
 export class EnvironmentStore {
    public serverRootPath: string;
    private environments: Map<string, Environment> = new Map();
+   /**
+    * Environments that were configured but did not load, keyed by name.
+    *
+    * A load failure is not fatal: the environment is skipped and the server
+    * still reports `serving`. Nothing else remembers it, because the throw
+    * happens before the environment reaches `this.environments` or the
+    * database, so this is the only record that a configured environment is
+    * missing rather than never asked for. Surfaced on `getStatus`.
+    */
+   private failedEnvironments = new Map<string, string>();
    private environmentMutexes = new Map<string, Mutex>();
    public publisherConfigIsFrozen: boolean;
    public finishedInitialization: Promise<void>;
@@ -250,11 +264,21 @@ export class EnvironmentStore {
             true,
          );
       } catch (error) {
-         this.logEnvironmentInitializationError(environment.name, error);
+         this.recordEnvironmentInitializationFailure(environment.name, error);
       }
    }
 
-   private logEnvironmentInitializationError(
+   /**
+    * Log a skipped environment AND remember why, for getStatus to report.
+    *
+    * Both boot paths funnel through here: the config path
+    * ({@link addConfiguredEnvironment}) and the database-restore path taken by
+    * every restart against an existing publisher.db. Keeping the record here
+    * rather than in the callers is deliberate: recording it in only one of them
+    * would leave the other silently dropping failures, which is the bug this is
+    * meant to fix.
+    */
+   private recordEnvironmentInitializationFailure(
       environmentName: string | undefined,
       error: unknown,
    ) {
@@ -263,6 +287,24 @@ export class EnvironmentStore {
          `Error initializing environment${label}; skipping environment`,
          this.extractErrorDataFromError(error),
       );
+      // Only record an environment that is genuinely not there. An environment
+      // reaches `this.environments` before the rest of its setup (the database
+      // sync, its package listing) is done, and a throw from that tail lands
+      // here while the environment is live and serving. Reporting it would
+      // contradict `environments`, which still lists it, and a loadErrors entry
+      // with no `package` means the whole environment was skipped. It also could
+      // never be cleared: the clear below only runs when an environment is
+      // created, so a live one would carry the entry until restart.
+      if (environmentName && !this.environments.has(environmentName)) {
+         // Redacted because this is bound for an HTTP response body, not just a
+         // log line; see the same call in environment.ts.
+         this.failedEnvironments.set(
+            environmentName,
+            redactPgSecrets(
+               error instanceof Error ? error.message : String(error),
+            ),
+         );
+      }
    }
 
    private async initialize() {
@@ -381,7 +423,7 @@ export class EnvironmentStore {
 
                         return environmentInstance.listPackages();
                      } catch (error) {
-                        this.logEnvironmentInitializationError(
+                        this.recordEnvironmentInitializationFailure(
                            dbEnvironment.name,
                            error,
                         );
@@ -800,9 +842,16 @@ export class EnvironmentStore {
             : baseState
       ) as components["schemas"]["ServerStatus"]["operationalState"];
 
-      const status = {
+      const status: {
+         timestamp: number;
+         environments: Array<components["schemas"]["Environment"]>;
+         initialized: boolean;
+         frozenConfig: boolean;
+         operationalState: components["schemas"]["ServerStatus"]["operationalState"];
+         loadErrors?: LoadError[];
+      } = {
          timestamp: Date.now(),
-         environments: [] as Array<components["schemas"]["Environment"]>,
+         environments: [],
          initialized: this.isInitialized,
          frozenConfig: isPublisherConfigFrozen(this.serverRootPath),
          operationalState,
@@ -844,6 +893,34 @@ export class EnvironmentStore {
             }
          }),
       );
+
+      // Collected AFTER listEnvironments, not before: serialize() awaits
+      // listPackages(), which is what loads an environment's packages and so
+      // records their failures. Reading the maps at the top of this method risks
+      // reading them before the failures they report have been recorded.
+      //
+      // A read-time overlay over live state, like "throttled" above, so there is
+      // no fourth stored status to keep in sync.
+      const loadErrors: LoadError[] = [];
+      for (const [environmentName, message] of this.failedEnvironments) {
+         loadErrors.push({ environment: environmentName, message });
+      }
+      for (const [environmentName, environment] of this.environments) {
+         for (const [packageName, message] of environment.getFailedPackages()) {
+            loadErrors.push({
+               environment: environmentName,
+               package: packageName,
+               message,
+            });
+         }
+      }
+      // Left unset when nothing failed, so the key is absent from the response
+      // and a healthy server's status body is byte-for-byte what it was before
+      // this field existed.
+      if (loadErrors.length > 0) {
+         status.loadErrors = loadErrors;
+      }
+
       return status;
    }
 
@@ -962,6 +1039,11 @@ export class EnvironmentStore {
       newEnvironment.metadata.location = absoluteEnvironmentPath;
 
       this.environments.set(environmentName, newEnvironment);
+      // It loaded, so any earlier failure for this name is stale. A boot
+      // failure can be followed by a successful POST or lazy load of the same
+      // environment, and a status that keeps reporting the old error would lie
+      // in the other direction.
+      this.failedEnvironments.delete(environmentName);
 
       environment?.packages?.forEach((_package) => {
          if (_package.name) {


### PR DESCRIPTION
## What this fixes

A package or environment that fails to load is skipped rather than fatal, so the server reports `operationalState: "serving"` and simply omits it. The only signal is a log line. That has hidden real bugs repeatedly: a server can serve one of three configured packages and still look completely healthy.

## What this adds

An optional `loadErrors` array on `ServerStatus`, listing what did not load and why:

```json
{
  "operationalState": "serving",
  "loadErrors": [
    { "environment": "sales", "message": "Failed to download or mount location: ./sales-models" },
    { "environment": "examples", "package": "storefront", "message": "Package manifest ... does not exist" }
  ]
}
```

An entry with no `package` means the whole environment was skipped, which also takes down its healthy packages. An entry with a `package` means that package alone is missing while its siblings serve.

## Scope: signal only

Nothing changes about what loads or what serves. `operationalState` is deliberately untouched: the control plane maps unrecognised states to HEALTHY, the example compose healthcheck greps the raw `"operationalState":"serving"` substring, and the Playwright global setup gates on it with a 5 minute ceiling, so reporting a new state on partial load would break more than it fixed. Whether an unmountable location *should* take down healthy sibling packages is a real question and a separate change.

The field is collected at read time in `getStatus` from live state, following the existing `throttled` precedent, so there is no fourth stored status to keep in sync. It is omitted entirely when nothing failed, so a healthy server's status body is byte-for-byte what it was before.

## Notes for review

Both boot paths record through one helper. The config path runs on `--init` or an empty database; the database-restore path runs on every restart of a server with a persisted `publisher.db`. Recording in only one of them would drop failures on the path production actually takes, so they share a single funnel rather than two call sites that can drift apart.

An environment enters the live map before its database sync runs, so a throw from that tail would otherwise report a serving environment as skipped and contradict the `environments` list. Only an environment that is genuinely absent is recorded.

Messages pass through the existing `redactPgSecrets` before reaching the response body. Compiling a model resolves the package's connections, so a Postgres or DuckLake ATTACH failure surfaces here and that command embeds the connection string. Worth knowing, and called out in a comment: the helper only covers keyword-form `password=`, which is what `buildPgConnectionString` emits, so a URL-form `connectionString` supplied verbatim in config still carries its credentials through. The fix belongs in the helper rather than at this call site.

## Verification

Full gate green: typecheck, lint, prettier, 1130 unit tests, 207 integration tests. Each fix is pinned by a test that fails without it. Verified live against a running server with a healthy environment, an unmountable environment, and an environment with one bad package: both failure modes reported, siblings still serving, a fixed package cleared by reload, a healthy server omitting the field entirely, and the database-restore path reporting correctly after a restart.
