### PR TITLE
feat(materialization): incremental persist (refresh="incremental")

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -4073,11 +4073,9 @@ components:
           type: boolean
           default: false
           description: >-
-            Escape hatch (dbt --full-refresh analog): rebuild every incremental
-            (refresh=incremental) persist source from scratch via the full
-            staging+rename path this run, instead of MERGE-ing new rows. Use
-            after a schema or logic migration. Independent of forceRefresh, which
-            only bypasses content-hash reuse for full-rebuild sources.
+            When true, incremental (refresh=incremental) persist sources are
+            fully rebuilt this run instead of applying only new or changed rows.
+            Use after a schema or definition change. Independent of forceRefresh.
         sourceNames:
           type: array
           items:

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -4069,6 +4069,15 @@ components:
           default: false
           description:
             Build a new table even when a source's sourceEntityId is unchanged.
+        forceFullRebuild:
+          type: boolean
+          default: false
+          description: >-
+            Escape hatch (dbt --full-refresh analog): rebuild every incremental
+            (refresh=incremental) persist source from scratch via the full
+            staging+rename path this run, instead of MERGE-ing new rows. Use
+            after a schema or logic migration. Independent of forceRefresh, which
+            only bypasses content-hash reuse for full-rebuild sources.
         sourceNames:
           type: array
           items:

--- a/docs/materialization-incremental.md
+++ b/docs/materialization-incremental.md
@@ -1,0 +1,136 @@
+# Incremental materialization (`refresh="incremental"`)
+
+By default a persisted Malloy source is **fully rebuilt** on every materialization run — the
+publisher stages a new table with `CREATE TABLE … AS (<source SQL>)` and atomically renames it into
+place. That is the right behavior for most sources, but it is prohibitively expensive when the
+source contains a per-row cost that dominates the build: an `ML.GENERATE_TEXT` classification, an
+embedding call, an expensive UDF. Reprocessing every row on every refresh burns that cost on rows
+that have not changed.
+
+`refresh="incremental"` makes a source **build once, then update in place**: the first run seeds the
+whole table, and every subsequent run `MERGE`s only the rows the source produces into the existing
+table. Combined with the compile-safe self-reference construct below, the source can filter itself
+down to *new* rows before the expensive step runs, so the per-row cost is paid once per row for its
+lifetime.
+
+This is a deliberately small, publisher-side realization of the `refresh` knob: it merges **in
+place** on the source's declared Malloy `primary_key`, which keeps the annotation surface minimal
+and requires no compiler change. A richer strategy (a separate `unique_key`, an event-time
+watermark predicate, or building into a cloned generation rather than in place) is possible later
+and nothing here forecloses it.
+
+## Declaring an incremental source
+
+```malloy
+##! experimental.persistence
+
+source: item_classifications_raw is bigquery.sql("""
+  WITH __malloy_incremental_keys AS (
+    -- Empty at compile time and on the first run; the publisher rewrites this
+    -- body to select the primary key from the target on incremental runs.
+    SELECT CAST(NULL AS STRING) AS item_name WHERE false
+  )
+  SELECT
+    item_name,
+    ML.GENERATE_TEXT(...) AS category
+  FROM `raw.items`
+  WHERE item_name NOT IN (SELECT item_name FROM __malloy_incremental_keys)
+""")
+
+#@ persist name="analytics.item_classifications" refresh="incremental"
+source: item_classifications is item_classifications_raw -> { select: * } extend {
+  primary_key: item_name
+}
+```
+
+Two things make this work:
+
+1. **`refresh="incremental"`** on the `#@ persist` annotation selects the incremental build path.
+   Unset or `refresh="full"` keeps the default full-rebuild path, byte-for-byte unchanged.
+2. **`primary_key`** on the source is the MERGE key. It is required for incremental sources — the
+   publisher throws a `BadRequestError` at build time if an incremental source has no primary key.
+   No new persist-level `unique_key` knob is introduced; the merge key is the source's existing
+   Malloy primary key.
+
+## The compile-safe self-reference construct
+
+The reserved CTE **`__malloy_incremental_keys`** is how a source refers to "what I have already
+materialized" without a bootstrap problem. This is the dbt `is_incremental()` + `{{ this }}` analog,
+realized with no compiler change:
+
+- **At compile time and on the first run**, the author writes the CTE with an empty body (a `WHERE
+  false`, a `LIMIT 0` — anything that returns no rows). It compiles because it references no
+  not-yet-existent target, and it matches nothing, so the first-run seed processes every row.
+- **On an incremental run**, the publisher rewrites the CTE body to `SELECT <primary_key> FROM
+  <target>`. Because the filter sits **inside** the source SQL — before the expensive step — the
+  expensive step only runs for rows not already present.
+
+The construct is optional. An incremental source that omits the CTE simply MERGEs every row it
+returns on every run (an upsert-refresh); the CTE is what turns that into "touch only new rows."
+
+## Build behavior
+
+| Run | What the publisher does |
+| --- | --- |
+| **First run** (target absent) | `CREATE TABLE <target> AS (<source SQL>)`. The empty self-reference CTE means every row is seeded, and the warehouse infers the exact schema — the publisher never derives DDL from Malloy's intrinsic column types. |
+| **Subsequent runs** (target present) | Hydrate the self-reference CTE to the target, then `MERGE INTO <target> USING (<source SQL>) ON <primary_key>`, `WHEN MATCHED THEN UPDATE`, `WHEN NOT MATCHED THEN INSERT`. |
+
+Existence is probed with a cheap `SELECT 1 FROM <target> LIMIT 0`. The MERGE runs **in place** (no
+staging table / rename) and is **idempotent under retry**: re-running the same MERGE is a no-op on
+rows already merged, unlike a raw `INSERT`, which would double-insert.
+
+Append-only vs upsert is not a separate mode — it falls out of the candidate set. A classification
+source whose candidate set (via the CTE) is "items not yet classified" only ever inserts; a dedup
+source whose candidate set is "recently changed orders" upserts. Both are the same MERGE.
+
+## Force a full rebuild (`forceFullRebuild`)
+
+After a schema or logic migration you need to rebuild an incremental table from scratch. Trigger a
+run with `forceFullRebuild: true` (the dbt `--full-refresh` analog):
+
+```
+POST /api/v0/.../packages/{pkg}/materializations   { "forceFullRebuild": true }
+```
+
+Every incremental source is then rebuilt through the **full** staging + atomic-rename path this
+run instead of MERGE-ing. Its self-reference CTE stays empty, so all rows are reprocessed, and the
+clean table is swapped in atomically.
+
+`forceFullRebuild` is deliberately distinct from `forceRefresh`. `forceRefresh` only bypasses
+content-hash reuse for full-rebuild sources, and the scheduler sets it on **every** scheduled run —
+so overloading it would silently turn every scheduled incremental refresh back into a full rebuild,
+defeating the feature. Incremental sources are always (re)built on a scheduled run regardless, and
+they stay incremental unless `forceFullRebuild` is explicitly requested.
+
+## Freshness, scope, and validation
+
+- **Freshness fallback must not be `live`.** A live serve recomputes the source, which for an
+  incremental definition returns only the delta, not the full dataset. The publish gate rejects an
+  incremental source combined with `materialization.freshness.fallback: "live"`; use `"stale_ok"`
+  or `"fail"`.
+- **Scope.** Incremental needs a physical table that persists across published versions, so use the
+  default `scope: "package"` with hosted `freshness` (the recommended cadence surface). A
+  version-scoped cron would give each version its own table and defeat the incrementality.
+- **`refresh` values.** Only `"full"` and `"incremental"` are accepted; any other value fails the
+  publish gate rather than silently degrading to full.
+
+## Dialect support
+
+The generated MERGE is standard ANSI SQL and its `SET` clause uses an **unqualified** target column
+(`SET col = S.col`, not `SET T.col = S.col`) for portability:
+
+| Warehouse | Incremental MERGE |
+| --- | --- |
+| BigQuery | ✅ (requires the unqualified `SET` form — which is what is emitted) |
+| Snowflake | ✅ |
+| Postgres 15+ | ✅ |
+| Postgres < 15 | ❌ — no `MERGE` statement; use full rebuild |
+| DuckDB | ❌ — persistence is unsupported for DuckDB generally |
+
+## Backward compatibility
+
+The feature is additive and off by default. A source with `refresh` unset dispatches to the
+unchanged full-rebuild path; `getSQL()` is not affected by the annotation, so content-addressing and
+reuse-rebind behave identically for full sources. The reuse-skip exemption and the new validation
+rules fire only for incremental sources. A publisher running this code against a package that
+declares no `refresh` behaves exactly as before.

--- a/docs/materialization-incremental.md
+++ b/docs/materialization-incremental.md
@@ -89,10 +89,12 @@ against the target table (the connection's dialect-aware introspection). Because
 is the authority on its own columns**, the MERGE covers exactly what the first-run CTAS created —
 including non-atomic (struct / array / record) columns and any name normalization the warehouse
 applied. (A Malloy-side column derivation would drop non-atomic columns, silently diverging from the
-seeded table.) A missing table is the "first run" signal; a genuine connection failure fails the run
-rather than being misread as absent. The MERGE runs **in place** (no staging table / rename) and is
-**idempotent under retry**: re-running the same MERGE is a no-op on rows already merged, unlike a raw
-`INSERT`, which would double-insert.
+seeded table.) The declared `primary_key` is resolved to the target's actual column spelling, so the
+MERGE's key and column list are all in one casing. "No schema returned" is the first-run signal; a
+transient schema-fetch error against a table that already exists therefore surfaces as a spurious
+"table already exists" failure from the seed CTAS — a failed run, never data loss or divergence. The
+MERGE runs **in place** (no staging table / rename) and is **idempotent under retry**: re-running the
+same MERGE is a no-op on rows already merged, unlike a raw `INSERT`, which would double-insert.
 
 Append-only vs upsert is not a separate mode — it falls out of the candidate set. A classification
 source whose candidate set (via the CTE) is "items not yet classified" only ever inserts; a dedup

--- a/docs/materialization-incremental.md
+++ b/docs/materialization-incremental.md
@@ -10,7 +10,7 @@ that have not changed.
 `refresh="incremental"` makes a source **build once, then update in place**: the first run seeds the
 whole table, and every subsequent run `MERGE`s only the rows the source produces into the existing
 table. Combined with the compile-safe self-reference construct below, the source can filter itself
-down to *new* rows before the expensive step runs, so the per-row cost is paid once per row for its
+down to _new_ rows before the expensive step runs, so the per-row cost is paid once per row for its
 lifetime.
 
 This is a deliberately small, publisher-side realization of the `refresh` knob: it merges **in
@@ -61,10 +61,10 @@ materialized" without a bootstrap problem. This is the dbt `is_incremental()` + 
 realized with no compiler change:
 
 - **At compile time and on the first run**, the author writes the CTE with an empty body (a `WHERE
-  false`, a `LIMIT 0` — anything that returns no rows). It compiles because it references no
+false`, a `LIMIT 0` — anything that returns no rows). It compiles because it references no
   not-yet-existent target, and it matches nothing, so the first-run seed processes every row.
 - **On an incremental run**, the publisher rewrites the CTE body to `SELECT <primary_key> FROM
-  <target>`. Because the filter sits **inside** the source SQL — before the expensive step — the
+<target>`. Because the filter sits **inside** the source SQL — before the expensive step — the
   expensive step only runs for rows not already present.
 
 Prefer a `NOT EXISTS` anti-join (as above) over `WHERE key NOT IN (SELECT key FROM
@@ -79,14 +79,20 @@ what turns that into "touch only new rows."
 
 ## Build behavior
 
-| Run | What the publisher does |
-| --- | --- |
-| **First run** (target absent) | `CREATE TABLE <target> AS (<source SQL>)`. The empty self-reference CTE means every row is seeded, and the warehouse infers the exact schema — the publisher never derives DDL from Malloy's intrinsic column types. |
-| **Subsequent runs** (target present) | Hydrate the self-reference CTE to the target, then `MERGE INTO <target> USING (<source SQL>) ON <primary_key>`, `WHEN MATCHED THEN UPDATE`, `WHEN NOT MATCHED THEN INSERT`. |
+| Run                                  | What the publisher does                                                                                                                                                                                              |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **First run** (target absent)        | `CREATE TABLE <target> AS (<source SQL>)`. The empty self-reference CTE means every row is seeded, and the warehouse infers the exact schema — the publisher never derives DDL from Malloy's intrinsic column types. |
+| **Subsequent runs** (target present) | Hydrate the self-reference CTE to the target, then `MERGE INTO <target> USING (<source SQL>) ON <primary_key>`, `WHEN MATCHED THEN UPDATE`, `WHEN NOT MATCHED THEN INSERT`.                                          |
 
-Existence is probed with a cheap `SELECT 1 FROM <target> LIMIT 0`. The MERGE runs **in place** (no
-staging table / rename) and is **idempotent under retry**: re-running the same MERGE is a no-op on
-rows already merged, unlike a raw `INSERT`, which would double-insert.
+The publisher decides seed-vs-MERGE, and derives the MERGE column set, from a single schema fetch
+against the target table (the connection's dialect-aware introspection). Because the **target table
+is the authority on its own columns**, the MERGE covers exactly what the first-run CTAS created —
+including non-atomic (struct / array / record) columns and any name normalization the warehouse
+applied. (A Malloy-side column derivation would drop non-atomic columns, silently diverging from the
+seeded table.) A missing table is the "first run" signal; a genuine connection failure fails the run
+rather than being misread as absent. The MERGE runs **in place** (no staging table / rename) and is
+**idempotent under retry**: re-running the same MERGE is a no-op on rows already merged, unlike a raw
+`INSERT`, which would double-insert.
 
 Append-only vs upsert is not a separate mode — it falls out of the candidate set. A classification
 source whose candidate set (via the CTE) is "items not yet classified" only ever inserts; a dedup
@@ -131,16 +137,24 @@ they stay incremental unless `forceFullRebuild` is explicitly requested.
 
 ## Dialect support
 
-The generated MERGE is standard ANSI SQL and its `SET` clause uses an **unqualified** target column
-(`SET col = S.col`, not `SET T.col = S.col`) for portability:
+Incremental emits a `MERGE INTO ...`, so it is **gated at publish** to MERGE-capable dialects:
+`refresh="incremental"` on any other dialect is rejected (rather than failing late with a raw
+warehouse syntax error). The generated MERGE is standard ANSI SQL and its `SET` clause uses an
+**unqualified** target column (`SET col = S.col`, not `SET T.col = S.col`) for portability.
 
-| Warehouse | Incremental MERGE |
-| --- | --- |
-| BigQuery | ✅ (requires the unqualified `SET` form — which is what is emitted) |
-| Snowflake | ✅ |
-| Postgres 15+ | ✅ |
-| Postgres < 15 | ❌ — no `MERGE` statement; use full rebuild |
-| DuckDB | ❌ — persistence is unsupported for DuckDB generally |
+| Warehouse                                   | Incremental MERGE                                                                                             |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| BigQuery                                    | ✅ allowed (requires the unqualified `SET` form — which is what is emitted)                                   |
+| Snowflake                                   | ✅ allowed — see caveat below                                                                                 |
+| Postgres 15+                                | ✅ allowed                                                                                                    |
+| Postgres < 15                               | ⚠️ not gated (the major version isn't visible from the dialect name) but has no `MERGE`; use `refresh="full"` |
+| MySQL / Trino / Databricks / DuckDB / other | ❌ rejected at publish — use `refresh="full"`                                                                 |
+
+> **Not yet warehouse-verified.** The generated SQL is unit-tested for shape but not yet executed
+> against a live engine. In particular the MERGE wraps a CTE-bearing source as `USING (WITH … SELECT
+…)`; BigQuery and Postgres accept a parenthesized leading `WITH`, but Snowflake acceptance should
+> be confirmed on a real connection before relying on it. (DuckDB does have `MERGE INTO` in recent
+> versions, but persistence is unsupported for DuckDB generally, so it is rejected here regardless.)
 
 ## Backward compatibility
 

--- a/docs/materialization-incremental.md
+++ b/docs/materialization-incremental.md
@@ -33,8 +33,10 @@ source: item_classifications_raw is bigquery.sql("""
   SELECT
     item_name,
     ML.GENERATE_TEXT(...) AS category
-  FROM `raw.items`
-  WHERE item_name NOT IN (SELECT item_name FROM __malloy_incremental_keys)
+  FROM `raw.items` s
+  WHERE NOT EXISTS (
+    SELECT 1 FROM __malloy_incremental_keys k WHERE k.item_name = s.item_name
+  )
 """)
 
 #@ persist name="analytics.item_classifications" refresh="incremental"
@@ -65,8 +67,15 @@ realized with no compiler change:
   <target>`. Because the filter sits **inside** the source SQL — before the expensive step — the
   expensive step only runs for rows not already present.
 
-The construct is optional. An incremental source that omits the CTE simply MERGEs every row it
-returns on every run (an upsert-refresh); the CTE is what turns that into "touch only new rows."
+Prefer a `NOT EXISTS` anti-join (as above) over `WHERE key NOT IN (SELECT key FROM
+__malloy_incremental_keys)`: `NOT IN` returns no rows if the subquery ever yields a `NULL` (SQL
+three-valued logic), which would silently process nothing. Primary keys are non-null so `NOT IN`
+happens to be safe here, but `NOT EXISTS` is robust regardless.
+
+Write the CTE in the canonical `WITH __malloy_incremental_keys AS ( ... )` form (the `AS` keyword may
+be any case; a column-list form is not recognized). The construct is optional: an incremental source
+that omits the CTE simply MERGEs every row it returns on every run (an upsert-refresh); the CTE is
+what turns that into "touch only new rows."
 
 ## Build behavior
 
@@ -111,6 +120,12 @@ they stay incremental unless `forceFullRebuild` is explicitly requested.
 - **Scope.** Incremental needs a physical table that persists across published versions, so use the
   default `scope: "package"` with hosted `freshness` (the recommended cadence surface). A
   version-scoped cron would give each version its own table and defeat the incrementality.
+- **Stable target name (assumption).** "Seed vs MERGE" is decided by whether the target table
+  already exists, so the source's assigned physical table name must be **stable across runs**. The
+  publisher's self-assigned name (standalone / scheduled builds) is stable. If an orchestrating
+  layer supplies the physical name instead, it must assign a stable name per incremental source — a
+  name that changes per version or per content hash makes every run miss the existing table and
+  re-seed (a silent full rebuild).
 - **`refresh` values.** Only `"full"` and `"incremental"` are accepted; any other value fails the
   publish gate rather than silently degrading to full.
 

--- a/packages/server/src/controller/materialization.controller.spec.ts
+++ b/packages/server/src/controller/materialization.controller.spec.ts
@@ -54,6 +54,21 @@ describe("MaterializationController.createMaterialization validation", () => {
       ).rejects.toThrow(BadRequestError);
    });
 
+   it("passes through forceFullRebuild (the incremental escape hatch)", async () => {
+      expect(await parse({ forceFullRebuild: true })).toEqual({
+         forceFullRebuild: true,
+      });
+   });
+
+   it("rejects a non-boolean forceFullRebuild", async () => {
+      const { controller } = build();
+      await expect(
+         controller.createMaterialization("env", "pkg", {
+            forceFullRebuild: "yes",
+         }),
+      ).rejects.toThrow(BadRequestError);
+   });
+
    it("rejects sourceNames that is not an array of strings", async () => {
       const { controller } = build();
       await expect(

--- a/packages/server/src/controller/materialization.controller.ts
+++ b/packages/server/src/controller/materialization.controller.ts
@@ -27,6 +27,7 @@ export class MaterializationController {
    // `trigger` to this parser, or an API caller could forge a scheduled run.
    private validateCreateBody(body: Record<string, unknown>): {
       forceRefresh?: boolean;
+      forceFullRebuild?: boolean;
       sourceNames?: string[];
       buildInstructions?: BuildInstruction[];
       referenceManifest?: ManifestReference[];
@@ -34,6 +35,7 @@ export class MaterializationController {
    } {
       const result: {
          forceRefresh?: boolean;
+         forceFullRebuild?: boolean;
          sourceNames?: string[];
          buildInstructions?: BuildInstruction[];
          referenceManifest?: ManifestReference[];
@@ -57,6 +59,12 @@ export class MaterializationController {
             throw new BadRequestError("forceRefresh must be a boolean");
          }
          result.forceRefresh = body.forceRefresh;
+      }
+      if (body.forceFullRebuild !== undefined) {
+         if (typeof body.forceFullRebuild !== "boolean") {
+            throw new BadRequestError("forceFullRebuild must be a boolean");
+         }
+         result.forceFullRebuild = body.forceFullRebuild;
       }
       if (body.sourceNames !== undefined) {
          if (

--- a/packages/server/src/service/materialization_incremental.spec.ts
+++ b/packages/server/src/service/materialization_incremental.spec.ts
@@ -68,7 +68,7 @@ describe("hydrateIncrementalKeysCte", () => {
    it("returns the SQL unchanged when the reserved CTE is absent", () => {
       const sql = "SELECT item_name FROM raw";
       expect(
-         hydrateIncrementalKeysCte(sql, '"ds"."t"', "item_name", "duckdb"),
+         hydrateIncrementalKeysCte(sql, '"ds"."t"', "item_name", "postgres"),
       ).toBe(sql);
    });
 
@@ -81,7 +81,7 @@ describe("hydrateIncrementalKeysCte", () => {
          sql,
          '"ds"."t"',
          "item_name",
-         "duckdb",
+         "postgres",
       );
       expect(out).toContain(
          'WITH __malloy_incremental_keys AS ( SELECT "item_name" FROM "ds"."t" )',
@@ -99,7 +99,7 @@ describe("hydrateIncrementalKeysCte", () => {
       const sql =
          "WITH __malloy_incremental_keys AS (SELECT x FROM (SELECT 1 AS x) z WHERE false) " +
          "SELECT * FROM src";
-      const out = hydrateIncrementalKeysCte(sql, '"t"', "id", "duckdb");
+      const out = hydrateIncrementalKeysCte(sql, '"t"', "id", "postgres");
       expect(out).toBe(
          'WITH __malloy_incremental_keys AS ( SELECT "id" FROM "t" ) SELECT * FROM src',
       );
@@ -124,7 +124,7 @@ describe("hydrateIncrementalKeysCte", () => {
       // hydration, leaving the filter inert and reprocessing every row.
       const sql =
          "WITH __malloy_incremental_keys as (SELECT 1 WHERE false) SELECT * FROM src";
-      const out = hydrateIncrementalKeysCte(sql, '"t"', "id", "duckdb");
+      const out = hydrateIncrementalKeysCte(sql, '"t"', "id", "postgres");
       expect(out).toBe(
          'WITH __malloy_incremental_keys as ( SELECT "id" FROM "t" ) SELECT * FROM src',
       );
@@ -136,7 +136,7 @@ describe("hydrateIncrementalKeysCte", () => {
       const sql =
          "WITH __malloy_incremental_keys AS (SELECT 1 WHERE false) " +
          "SELECT gross_sales AS revenue FROM src";
-      const out = hydrateIncrementalKeysCte(sql, '"t"', "id", "duckdb");
+      const out = hydrateIncrementalKeysCte(sql, '"t"', "id", "postgres");
       expect(out).toBe(
          'WITH __malloy_incremental_keys AS ( SELECT "id" FROM "t" ) ' +
             "SELECT gross_sales AS revenue FROM src",
@@ -153,7 +153,7 @@ describe("buildMergeSQL", () => {
          "SELECT * FROM staged",
          "order_id",
          ["order_id", "venue", "amount"],
-         "duckdb",
+         "postgres",
       );
       expect(sql).toBe(
          'MERGE INTO "ds"."t" T USING (SELECT * FROM staged) S ON T."order_id" = S."order_id" ' +
@@ -169,7 +169,7 @@ describe("buildMergeSQL", () => {
          "SELECT id FROM staged",
          "id",
          ["id"],
-         "duckdb",
+         "postgres",
       );
       expect(sql).not.toContain("WHEN MATCHED");
       expect(sql).toContain(
@@ -200,10 +200,37 @@ describe("buildOneSource incremental dispatch", () => {
       return new MaterializationService({} as unknown as EnvironmentStore);
    }
 
+   // A connection stub. `targetColumns`: null => the target table is absent, so
+   // fetchSchemaForTables reports a keyed error (first-run seed); a string[] =>
+   // the table exists with exactly those columns (MERGE). The incremental path
+   // reads the MERGE column set straight from this schema, so these ARE the
+   // columns the MERGE uses. The reserved lookup key is "__persist_target".
+   function conn(targetColumns: string[] | null): {
+      runSQL: sinon.SinonStub;
+      fetchSchemaForTables: sinon.SinonStub;
+   } {
+      const fetchSchemaForTables = sinon.stub().resolves(
+         targetColumns === null
+            ? { schemas: {}, errors: { __persist_target: "not found" } }
+            : {
+                 schemas: {
+                    __persist_target: {
+                       fields: targetColumns.map((name) => ({ name })),
+                    },
+                 },
+                 errors: {},
+              },
+      );
+      return { runSQL: sinon.stub().resolves(), fetchSchemaForTables };
+   }
+
    function callBuild(
       svc: MaterializationService,
       source: ReturnType<typeof fakeSource>,
-      connection: { runSQL: sinon.SinonStub },
+      connection: {
+         runSQL: sinon.SinonStub;
+         fetchSchemaForTables?: sinon.SinonStub;
+      },
       physicalTableName: string,
       manifest: Manifest = new Manifest(),
       forceFullRebuild = false,
@@ -229,84 +256,75 @@ describe("buildOneSource incremental dispatch", () => {
          source,
          instruction,
          connection,
-         { duckdb: "dig" },
+         { postgres: "dig" },
          manifest,
          forceFullRebuild,
       );
    }
 
    it("full (refresh unset) keeps the staging + atomic-rename path unchanged", async () => {
-      const runSQL = sinon.stub().resolves();
+      const connection = conn(null);
       const source = fakeSource({
          name: "orders",
          sourceEntityId: "abcdef1234567890",
          sql: "SELECT * FROM t",
+         dialectName: "postgres",
       });
-      await callBuild(service(), source, { runSQL }, "orders_v1");
-      const sql = runSQL.getCalls().map((c) => c.args[0] as string);
+      await callBuild(service(), source, connection, "orders_v1");
+      const sql = connection.runSQL.getCalls().map((c) => c.args[0] as string);
       expect(sql).toEqual([
          'DROP TABLE IF EXISTS "orders_v1_abcdef123456"',
          'CREATE TABLE "orders_v1_abcdef123456" AS (SELECT * FROM t)',
          'DROP TABLE IF EXISTS "orders_v1"',
          'ALTER TABLE "orders_v1_abcdef123456" RENAME TO "orders_v1"',
       ]);
+      // The full path never introspects the target schema.
+      expect(connection.fetchSchemaForTables.called).toBe(false);
    });
 
    it("incremental first run (target absent) seeds with a plain CTAS, no staging or rename", async () => {
-      // The existence probe throws when the table is absent; the seed is then a
-      // single CTAS of the source SQL directly into the target (no staging
-      // suffix, no rename), so the warehouse infers the schema.
-      const runSQL = sinon.stub().callsFake((s: string) => {
-         if (s.includes("LIMIT 0"))
-            return Promise.reject(new Error("no such table"));
-         return Promise.resolve();
-      });
+      // fetchSchemaForTables reports the target absent -> the seed is a single
+      // CTAS of the source SQL directly into the target (no staging suffix, no
+      // rename), so the warehouse infers the schema.
+      const connection = conn(null);
       const source = fakeSource({
          name: "classifications",
          sourceEntityId: "abcdef1234567890",
          sql: "SELECT item_name FROM raw",
+         dialectName: "postgres",
          annotationFields: { refresh: "incremental" },
-         explore: { primaryKey: "item_name", columns: [{ name: "item_name" }] },
+         explore: { primaryKey: "item_name" },
       });
-      const entry = await callBuild(service(), source, { runSQL }, "class_v1");
+      const entry = await callBuild(service(), source, connection, "class_v1");
 
-      const nonProbe = runSQL
-         .getCalls()
-         .map((c) => c.args[0] as string)
-         .filter((s) => !s.includes("LIMIT 0"));
-      expect(nonProbe).toEqual([
+      const sql = connection.runSQL.getCalls().map((c) => c.args[0] as string);
+      expect(sql).toEqual([
          'CREATE TABLE "class_v1" AS (SELECT item_name FROM raw)',
       ]);
-      // First run does not stage or rename.
-      expect(nonProbe.some((s) => s.includes("RENAME"))).toBe(false);
-      expect(nonProbe.some((s) => s.includes("_abcdef123456"))).toBe(false);
+      expect(sql.some((s) => s.includes("RENAME"))).toBe(false);
+      expect(sql.some((s) => s.includes("_abcdef123456"))).toBe(false);
       expect(entry.physicalTableName).toBe("class_v1");
    });
 
    it("incremental subsequent run (target present) MERGEs on the primary key", async () => {
-      // Probe resolves -> table exists -> MERGE, not CTAS. The MERGE upserts on
-      // the source's primary_key. MERGE (never raw INSERT) is idempotent under
-      // retry: re-running the same statement is a no-op on already-merged rows.
-      const runSQL = sinon.stub().resolves();
+      // Table exists -> MERGE, not CTAS. The MERGE column set comes from the
+      // target table's schema (via fetchSchemaForTables), and it upserts on the
+      // source's primary_key. MERGE (never raw INSERT) is idempotent under retry.
+      const connection = conn(["order_id", "venue", "amount"]);
       const source = fakeSource({
          name: "orders",
          sourceEntityId: "abcdef1234567890",
          sql: "SELECT order_id, venue, amount FROM raw",
+         dialectName: "postgres",
          annotationFields: { refresh: "incremental" },
-         explore: {
-            primaryKey: "order_id",
-            columns: [
-               { name: "order_id" },
-               { name: "venue" },
-               { name: "amount" },
-            ],
-         },
+         explore: { primaryKey: "order_id" },
       });
-      await callBuild(service(), source, { runSQL }, "orders_v1");
+      await callBuild(service(), source, connection, "orders_v1");
 
-      const statements = runSQL.getCalls().map((c) => c.args[0] as string);
+      const statements = connection.runSQL
+         .getCalls()
+         .map((c) => c.args[0] as string);
       const merge = statements.find((s) => s.startsWith("MERGE INTO"));
-      expect(merge).toBeDefined();
       expect(merge).toBe(
          'MERGE INTO "orders_v1" T USING (SELECT order_id, venue, amount FROM raw) S ' +
             'ON T."order_id" = S."order_id" ' +
@@ -319,27 +337,57 @@ describe("buildOneSource incremental dispatch", () => {
       expect(statements.some((s) => /^INSERT\b/.test(s))).toBe(false);
    });
 
+   it("carries NON-ATOMIC target columns (struct/array) into the MERGE", async () => {
+      // Regression guard for the deriveColumns bug: the MERGE column set is the
+      // target table's real columns, so a struct/array/record column present in
+      // the seeded table is upserted too — not silently dropped (which would
+      // diverge or fail a NOT NULL insert). Here `attrs` stands in for a
+      // non-atomic column the warehouse materialized on the first run.
+      const connection = conn(["item_name", "category", "attrs"]);
+      const source = fakeSource({
+         name: "classifications",
+         sourceEntityId: "abcdef1234567890",
+         sql: "SELECT item_name, category, attrs FROM raw",
+         dialectName: "postgres",
+         annotationFields: { refresh: "incremental" },
+         explore: { primaryKey: "item_name" },
+      });
+      await callBuild(service(), source, connection, "class_v1");
+
+      const merge = connection.runSQL
+         .getCalls()
+         .map((c) => c.args[0] as string)
+         .find((s) => s.startsWith("MERGE INTO"))!;
+      expect(merge).toContain(
+         'UPDATE SET "category" = S."category", "attrs" = S."attrs"',
+      );
+      expect(merge).toContain(
+         'INSERT ("item_name", "category", "attrs") VALUES (S."item_name", S."category", S."attrs")',
+      );
+   });
+
    it("forceFullRebuild routes an incremental source through the full staging + rename path", async () => {
       // The escape hatch: forceFullRebuild bypasses the MERGE/seed path entirely
-      // and rebuilds via staging + atomic rename. No existence probe, no MERGE —
-      // the empty self-reference CTE means the full SQL reprocesses every row.
-      const runSQL = sinon.stub().resolves();
+      // and rebuilds via staging + atomic rename. No schema fetch, no MERGE — the
+      // empty self-reference CTE means the full SQL reprocesses every row.
+      const connection = conn(["item_name"]);
       const source = fakeSource({
          name: "classifications",
          sourceEntityId: "abcdef1234567890",
          sql: "SELECT item_name FROM raw",
+         dialectName: "postgres",
          annotationFields: { refresh: "incremental" },
-         explore: { primaryKey: "item_name", columns: [{ name: "item_name" }] },
+         explore: { primaryKey: "item_name" },
       });
       await callBuild(
          service(),
          source,
-         { runSQL },
+         connection,
          "class_v1",
          new Manifest(),
          true,
       );
-      const sql = runSQL.getCalls().map((c) => c.args[0] as string);
+      const sql = connection.runSQL.getCalls().map((c) => c.args[0] as string);
       expect(sql).toEqual([
          'DROP TABLE IF EXISTS "class_v1_abcdef123456"',
          'CREATE TABLE "class_v1_abcdef123456" AS (SELECT item_name FROM raw)',
@@ -347,20 +395,21 @@ describe("buildOneSource incremental dispatch", () => {
          'ALTER TABLE "class_v1_abcdef123456" RENAME TO "class_v1"',
       ]);
       expect(sql.some((s) => s.startsWith("MERGE"))).toBe(false);
-      expect(sql.some((s) => s.includes("LIMIT 0"))).toBe(false);
+      expect(connection.fetchSchemaForTables.called).toBe(false);
    });
 
    it("incremental MERGE without a primary_key is a BadRequestError", async () => {
-      const runSQL = sinon.stub().resolves(); // probe resolves -> table exists
+      const connection = conn(["order_id"]); // table exists
       const source = fakeSource({
          name: "orders",
          sourceEntityId: "abcdef1234567890",
          sql: "SELECT order_id FROM raw",
+         dialectName: "postgres",
          annotationFields: { refresh: "incremental" },
-         explore: { columns: [{ name: "order_id" }] }, // no primaryKey
+         explore: {}, // no primaryKey
       });
       await expect(
-         callBuild(service(), source, { runSQL }, "orders_v1"),
+         callBuild(service(), source, connection, "orders_v1"),
       ).rejects.toThrow(BadRequestError);
    });
 
@@ -368,7 +417,7 @@ describe("buildOneSource incremental dispatch", () => {
       // End-to-end of the primitive: on an incremental run the source's empty
       // __malloy_incremental_keys CTE is rewritten to read the target, so the
       // MERGE's USING subquery only surfaces rows not already present.
-      const runSQL = sinon.stub().resolves();
+      const connection = conn(["item_name", "category"]);
       const source = fakeSource({
          name: "classifications",
          sourceEntityId: "abcdef1234567890",
@@ -376,15 +425,13 @@ describe("buildOneSource incremental dispatch", () => {
             "WITH __malloy_incremental_keys AS (SELECT NULL AS item_name WHERE false) " +
             "SELECT item_name, category FROM raw " +
             "WHERE item_name NOT IN (SELECT item_name FROM __malloy_incremental_keys)",
+         dialectName: "postgres",
          annotationFields: { refresh: "incremental" },
-         explore: {
-            primaryKey: "item_name",
-            columns: [{ name: "item_name" }, { name: "category" }],
-         },
+         explore: { primaryKey: "item_name" },
       });
-      await callBuild(service(), source, { runSQL }, "class_v1");
+      await callBuild(service(), source, connection, "class_v1");
 
-      const merge = runSQL
+      const merge = connection.runSQL
          .getCalls()
          .map((c) => c.args[0] as string)
          .find((s) => s.startsWith("MERGE INTO"))!;

--- a/packages/server/src/service/materialization_incremental.spec.ts
+++ b/packages/server/src/service/materialization_incremental.spec.ts
@@ -1,0 +1,371 @@
+import { Manifest } from "@malloydata/malloy";
+import { describe, expect, it } from "bun:test";
+import * as sinon from "sinon";
+import { BadRequestError } from "../errors";
+import { BuildInstruction } from "../storage/DatabaseInterface";
+import { EnvironmentStore } from "./environment_store";
+import { fakeSource } from "./materialization_test_fixtures";
+import {
+   buildMergeSQL,
+   hydrateIncrementalKeysCte,
+   MaterializationService,
+   refreshMode,
+} from "./materialization_service";
+
+/**
+ * Unit coverage for the incremental persist path (`#@ persist refresh=incremental`,
+ * persistence.md §3 / Phase E1). Three surfaces:
+ *
+ *  - `refreshMode`: the annotation-to-mode mapping, defaulting to "full".
+ *  - `hydrateIncrementalKeysCte` / `buildMergeSQL`: the pure SQL builders —
+ *    the compile-safe self-reference primitive and the upsert MERGE.
+ *  - `buildOneSource` dispatch: full-rebuild stays byte-for-byte unchanged
+ *    (back-compat), incremental seeds on first run (CTAS) and MERGEs after.
+ *
+ * The SQL builders are dialect-quoted, so the assertions pin the exact emitted
+ * text — a change to quoting or clause order is a deliberate, reviewed edit.
+ */
+
+// ── refreshMode ──────────────────────────────────────────────────────────────
+
+describe("refreshMode", () => {
+   it("defaults to full when refresh is unset", () => {
+      const s = fakeSource({ name: "s", sourceEntityId: "e" });
+      expect(refreshMode(s)).toBe("full");
+   });
+
+   it("resolves refresh=full to full", () => {
+      const s = fakeSource({
+         name: "s",
+         sourceEntityId: "e",
+         annotationFields: { refresh: "full" },
+      });
+      expect(refreshMode(s)).toBe("full");
+   });
+
+   it("resolves refresh=incremental to incremental", () => {
+      const s = fakeSource({
+         name: "s",
+         sourceEntityId: "e",
+         annotationFields: { refresh: "incremental" },
+      });
+      expect(refreshMode(s)).toBe("incremental");
+   });
+
+   it("degrades an unrecognized refresh value to full (policy rejects it separately)", () => {
+      const s = fakeSource({
+         name: "s",
+         sourceEntityId: "e",
+         annotationFields: { refresh: "merge" },
+      });
+      expect(refreshMode(s)).toBe("full");
+   });
+});
+
+// ── hydrateIncrementalKeysCte (the compile-safe self-reference primitive) ─────
+
+describe("hydrateIncrementalKeysCte", () => {
+   it("returns the SQL unchanged when the reserved CTE is absent", () => {
+      const sql = "SELECT item_name FROM raw";
+      expect(
+         hydrateIncrementalKeysCte(sql, '"ds"."t"', "item_name", "duckdb"),
+      ).toBe(sql);
+   });
+
+   it("rewrites the empty CTE body to select the primary key from the target", () => {
+      const sql =
+         "WITH __malloy_incremental_keys AS (SELECT NULL AS item_name WHERE false) " +
+         "SELECT item_name FROM raw " +
+         "WHERE item_name NOT IN (SELECT item_name FROM __malloy_incremental_keys)";
+      const out = hydrateIncrementalKeysCte(
+         sql,
+         '"ds"."t"',
+         "item_name",
+         "duckdb",
+      );
+      expect(out).toContain(
+         'WITH __malloy_incremental_keys AS ( SELECT "item_name" FROM "ds"."t" )',
+      );
+      // The downstream reference to the CTE is untouched — only the body changed.
+      expect(out).toContain(
+         "WHERE item_name NOT IN (SELECT item_name FROM __malloy_incremental_keys)",
+      );
+   });
+
+   it("balances nested parens: matches the CTE's closing paren, not the first", () => {
+      // The empty body itself contains a parenthesized subquery. A naive
+      // first-close-paren rewrite would corrupt the SQL; the balanced scan must
+      // consume the whole body.
+      const sql =
+         "WITH __malloy_incremental_keys AS (SELECT x FROM (SELECT 1 AS x) z WHERE false) " +
+         "SELECT * FROM src";
+      const out = hydrateIncrementalKeysCte(sql, '"t"', "id", "duckdb");
+      expect(out).toBe(
+         'WITH __malloy_incremental_keys AS ( SELECT "id" FROM "t" ) SELECT * FROM src',
+      );
+   });
+
+   it("quotes the primary key for a backtick dialect (BigQuery)", () => {
+      const sql =
+         "WITH __malloy_incremental_keys AS (SELECT 1 WHERE false) SELECT * FROM src";
+      const out = hydrateIncrementalKeysCte(
+         sql,
+         "`ds`.`t`",
+         "order_id",
+         "standardsql",
+      );
+      expect(out).toContain(
+         "WITH __malloy_incremental_keys AS ( SELECT `order_id` FROM `ds`.`t` )",
+      );
+   });
+});
+
+// ── buildMergeSQL (upsert on the primary key) ────────────────────────────────
+
+describe("buildMergeSQL", () => {
+   it("upserts: WHEN MATCHED updates non-key columns, WHEN NOT MATCHED inserts all", () => {
+      const sql = buildMergeSQL(
+         '"ds"."t"',
+         "SELECT * FROM staged",
+         "order_id",
+         ["order_id", "venue", "amount"],
+         "duckdb",
+      );
+      expect(sql).toBe(
+         'MERGE INTO "ds"."t" T USING (SELECT * FROM staged) S ON T."order_id" = S."order_id" ' +
+            'WHEN MATCHED THEN UPDATE SET "venue" = S."venue", "amount" = S."amount" ' +
+            'WHEN NOT MATCHED THEN INSERT ("order_id", "venue", "amount") ' +
+            'VALUES (S."order_id", S."venue", S."amount")',
+      );
+   });
+
+   it("omits the UPDATE clause when the key is the only column (insert-only append)", () => {
+      const sql = buildMergeSQL(
+         '"t"',
+         "SELECT id FROM staged",
+         "id",
+         ["id"],
+         "duckdb",
+      );
+      expect(sql).not.toContain("WHEN MATCHED");
+      expect(sql).toContain(
+         'WHEN NOT MATCHED THEN INSERT ("id") VALUES (S."id")',
+      );
+   });
+
+   it("quotes identifiers for a backtick dialect", () => {
+      const sql = buildMergeSQL(
+         "`t`",
+         "SELECT * FROM s",
+         "id",
+         ["id", "name"],
+         "standardsql",
+      );
+      expect(sql).toContain("ON T.`id` = S.`id`");
+      expect(sql).toContain("UPDATE SET `name` = S.`name`");
+      expect(sql).toContain("INSERT (`id`, `name`) VALUES (S.`id`, S.`name`)");
+   });
+});
+
+// ── buildOneSource dispatch (full unchanged; incremental seed + MERGE) ────────
+
+describe("buildOneSource incremental dispatch", () => {
+   function service(): MaterializationService {
+      // buildOneSource and its helpers never touch the environment store, so a
+      // bare stand-in is enough to reach the private build path.
+      return new MaterializationService({} as unknown as EnvironmentStore);
+   }
+
+   function callBuild(
+      svc: MaterializationService,
+      source: ReturnType<typeof fakeSource>,
+      connection: { runSQL: sinon.SinonStub },
+      physicalTableName: string,
+      manifest: Manifest = new Manifest(),
+      forceFullRebuild = false,
+   ) {
+      const instruction: BuildInstruction = {
+         sourceEntityId: "abcdef1234567890",
+         materializedTableId: "mt-1",
+         physicalTableName,
+         realization: "COPY",
+      };
+      return (
+         svc as unknown as {
+            buildOneSource: (
+               s: unknown,
+               i: BuildInstruction,
+               c: unknown,
+               d: Record<string, string>,
+               m: Manifest,
+               forceFullRebuild: boolean,
+            ) => Promise<{ sourceEntityId: string; physicalTableName: string }>;
+         }
+      ).buildOneSource(
+         source,
+         instruction,
+         connection,
+         { duckdb: "dig" },
+         manifest,
+         forceFullRebuild,
+      );
+   }
+
+   it("full (refresh unset) keeps the staging + atomic-rename path unchanged", async () => {
+      const runSQL = sinon.stub().resolves();
+      const source = fakeSource({
+         name: "orders",
+         sourceEntityId: "abcdef1234567890",
+         sql: "SELECT * FROM t",
+      });
+      await callBuild(service(), source, { runSQL }, "orders_v1");
+      const sql = runSQL.getCalls().map((c) => c.args[0] as string);
+      expect(sql).toEqual([
+         'DROP TABLE IF EXISTS "orders_v1_abcdef123456"',
+         'CREATE TABLE "orders_v1_abcdef123456" AS (SELECT * FROM t)',
+         'DROP TABLE IF EXISTS "orders_v1"',
+         'ALTER TABLE "orders_v1_abcdef123456" RENAME TO "orders_v1"',
+      ]);
+   });
+
+   it("incremental first run (target absent) seeds with a plain CTAS, no staging or rename", async () => {
+      // The existence probe throws when the table is absent; the seed is then a
+      // single CTAS of the source SQL directly into the target (no staging
+      // suffix, no rename), so the warehouse infers the schema.
+      const runSQL = sinon.stub().callsFake((s: string) => {
+         if (s.includes("LIMIT 0"))
+            return Promise.reject(new Error("no such table"));
+         return Promise.resolve();
+      });
+      const source = fakeSource({
+         name: "classifications",
+         sourceEntityId: "abcdef1234567890",
+         sql: "SELECT item_name FROM raw",
+         annotationFields: { refresh: "incremental" },
+         explore: { primaryKey: "item_name", columns: [{ name: "item_name" }] },
+      });
+      const entry = await callBuild(service(), source, { runSQL }, "class_v1");
+
+      const nonProbe = runSQL
+         .getCalls()
+         .map((c) => c.args[0] as string)
+         .filter((s) => !s.includes("LIMIT 0"));
+      expect(nonProbe).toEqual([
+         'CREATE TABLE "class_v1" AS (SELECT item_name FROM raw)',
+      ]);
+      // First run does not stage or rename.
+      expect(nonProbe.some((s) => s.includes("RENAME"))).toBe(false);
+      expect(nonProbe.some((s) => s.includes("_abcdef123456"))).toBe(false);
+      expect(entry.physicalTableName).toBe("class_v1");
+   });
+
+   it("incremental subsequent run (target present) MERGEs on the primary key", async () => {
+      // Probe resolves -> table exists -> MERGE, not CTAS. The MERGE upserts on
+      // the source's primary_key. MERGE (never raw INSERT) is idempotent under
+      // retry: re-running the same statement is a no-op on already-merged rows.
+      const runSQL = sinon.stub().resolves();
+      const source = fakeSource({
+         name: "orders",
+         sourceEntityId: "abcdef1234567890",
+         sql: "SELECT order_id, venue, amount FROM raw",
+         annotationFields: { refresh: "incremental" },
+         explore: {
+            primaryKey: "order_id",
+            columns: [
+               { name: "order_id" },
+               { name: "venue" },
+               { name: "amount" },
+            ],
+         },
+      });
+      await callBuild(service(), source, { runSQL }, "orders_v1");
+
+      const statements = runSQL.getCalls().map((c) => c.args[0] as string);
+      const merge = statements.find((s) => s.startsWith("MERGE INTO"));
+      expect(merge).toBeDefined();
+      expect(merge).toBe(
+         'MERGE INTO "orders_v1" T USING (SELECT order_id, venue, amount FROM raw) S ' +
+            'ON T."order_id" = S."order_id" ' +
+            'WHEN MATCHED THEN UPDATE SET "venue" = S."venue", "amount" = S."amount" ' +
+            'WHEN NOT MATCHED THEN INSERT ("order_id", "venue", "amount") ' +
+            'VALUES (S."order_id", S."venue", S."amount")',
+      );
+      // Never a CTAS or a raw INSERT on the incremental path once seeded.
+      expect(statements.some((s) => s.startsWith("CREATE TABLE"))).toBe(false);
+      expect(statements.some((s) => /^INSERT\b/.test(s))).toBe(false);
+   });
+
+   it("forceFullRebuild routes an incremental source through the full staging + rename path", async () => {
+      // The escape hatch: forceFullRebuild bypasses the MERGE/seed path entirely
+      // and rebuilds via staging + atomic rename. No existence probe, no MERGE —
+      // the empty self-reference CTE means the full SQL reprocesses every row.
+      const runSQL = sinon.stub().resolves();
+      const source = fakeSource({
+         name: "classifications",
+         sourceEntityId: "abcdef1234567890",
+         sql: "SELECT item_name FROM raw",
+         annotationFields: { refresh: "incremental" },
+         explore: { primaryKey: "item_name", columns: [{ name: "item_name" }] },
+      });
+      await callBuild(
+         service(),
+         source,
+         { runSQL },
+         "class_v1",
+         new Manifest(),
+         true,
+      );
+      const sql = runSQL.getCalls().map((c) => c.args[0] as string);
+      expect(sql).toEqual([
+         'DROP TABLE IF EXISTS "class_v1_abcdef123456"',
+         'CREATE TABLE "class_v1_abcdef123456" AS (SELECT item_name FROM raw)',
+         'DROP TABLE IF EXISTS "class_v1"',
+         'ALTER TABLE "class_v1_abcdef123456" RENAME TO "class_v1"',
+      ]);
+      expect(sql.some((s) => s.startsWith("MERGE"))).toBe(false);
+      expect(sql.some((s) => s.includes("LIMIT 0"))).toBe(false);
+   });
+
+   it("incremental MERGE without a primary_key is a BadRequestError", async () => {
+      const runSQL = sinon.stub().resolves(); // probe resolves -> table exists
+      const source = fakeSource({
+         name: "orders",
+         sourceEntityId: "abcdef1234567890",
+         sql: "SELECT order_id FROM raw",
+         annotationFields: { refresh: "incremental" },
+         explore: { columns: [{ name: "order_id" }] }, // no primaryKey
+      });
+      await expect(
+         callBuild(service(), source, { runSQL }, "orders_v1"),
+      ).rejects.toThrow(BadRequestError);
+   });
+
+   it("hydrates the self-reference CTE against the live target before MERGE", async () => {
+      // End-to-end of the primitive: on an incremental run the source's empty
+      // __malloy_incremental_keys CTE is rewritten to read the target, so the
+      // MERGE's USING subquery only surfaces rows not already present.
+      const runSQL = sinon.stub().resolves();
+      const source = fakeSource({
+         name: "classifications",
+         sourceEntityId: "abcdef1234567890",
+         sql:
+            "WITH __malloy_incremental_keys AS (SELECT NULL AS item_name WHERE false) " +
+            "SELECT item_name, category FROM raw " +
+            "WHERE item_name NOT IN (SELECT item_name FROM __malloy_incremental_keys)",
+         annotationFields: { refresh: "incremental" },
+         explore: {
+            primaryKey: "item_name",
+            columns: [{ name: "item_name" }, { name: "category" }],
+         },
+      });
+      await callBuild(service(), source, { runSQL }, "class_v1");
+
+      const merge = runSQL
+         .getCalls()
+         .map((c) => c.args[0] as string)
+         .find((s) => s.startsWith("MERGE INTO"))!;
+      expect(merge).toContain(
+         'WITH __malloy_incremental_keys AS ( SELECT "item_name" FROM "class_v1" )',
+      );
+   });
+});

--- a/packages/server/src/service/materialization_incremental.spec.ts
+++ b/packages/server/src/service/materialization_incremental.spec.ts
@@ -366,6 +366,48 @@ describe("buildOneSource incremental dispatch", () => {
       );
    });
 
+   it("resolves the primary key to the target's actual column spelling (case-normalizing engine)", async () => {
+      // Snowflake-style: the target stores upper-cased columns while the Malloy
+      // primary_key is lower-case. Every identifier in the MERGE (the ON key and
+      // the column list) must use the target's spelling, so they can't disagree
+      // in case. snowflake is not a backtick dialect, so identifiers double-quote.
+      const connection = conn(["ORDER_ID", "VENUE"]);
+      const source = fakeSource({
+         name: "orders",
+         sourceEntityId: "abcdef1234567890",
+         sql: "SELECT order_id, venue FROM raw",
+         dialectName: "snowflake",
+         annotationFields: { refresh: "incremental" },
+         explore: { primaryKey: "order_id" },
+      });
+      await callBuild(service(), source, connection, "orders_v1");
+
+      const merge = connection.runSQL
+         .getCalls()
+         .map((c) => c.args[0] as string)
+         .find((s) => s.startsWith("MERGE INTO"))!;
+      expect(merge).toContain('ON T."ORDER_ID" = S."ORDER_ID"');
+      expect(merge).toContain('UPDATE SET "VENUE" = S."VENUE"');
+      expect(merge).toContain(
+         'INSERT ("ORDER_ID", "VENUE") VALUES (S."ORDER_ID", S."VENUE")',
+      );
+   });
+
+   it("throws when the primary_key is not among the target columns", async () => {
+      const connection = conn(["a", "b"]); // pk "order_id" absent
+      const source = fakeSource({
+         name: "orders",
+         sourceEntityId: "abcdef1234567890",
+         sql: "SELECT a, b FROM raw",
+         dialectName: "postgres",
+         annotationFields: { refresh: "incremental" },
+         explore: { primaryKey: "order_id" },
+      });
+      await expect(
+         callBuild(service(), source, connection, "orders_v1"),
+      ).rejects.toThrow(BadRequestError);
+   });
+
    it("forceFullRebuild routes an incremental source through the full staging + rename path", async () => {
       // The escape hatch: forceFullRebuild bypasses the MERGE/seed path entirely
       // and rebuilds via staging + atomic rename. No schema fetch, no MERGE — the

--- a/packages/server/src/service/materialization_incremental.spec.ts
+++ b/packages/server/src/service/materialization_incremental.spec.ts
@@ -118,6 +118,30 @@ describe("hydrateIncrementalKeysCte", () => {
          "WITH __malloy_incremental_keys AS ( SELECT `order_id` FROM `ds`.`t` )",
       );
    });
+
+   it("matches the AS keyword case-insensitively (a lowercase `as` still hydrates)", () => {
+      // `as` is a valid SQL spelling; a case-sensitive scan would silently skip
+      // hydration, leaving the filter inert and reprocessing every row.
+      const sql =
+         "WITH __malloy_incremental_keys as (SELECT 1 WHERE false) SELECT * FROM src";
+      const out = hydrateIncrementalKeysCte(sql, '"t"', "id", "duckdb");
+      expect(out).toBe(
+         'WITH __malloy_incremental_keys as ( SELECT "id" FROM "t" ) SELECT * FROM src',
+      );
+   });
+
+   it("does not anchor on an `AS` substring in an unrelated upstream identifier", () => {
+      // A column alias containing "AS" before the reserved CTE must not be
+      // mistaken for the CTE's AS keyword.
+      const sql =
+         "WITH __malloy_incremental_keys AS (SELECT 1 WHERE false) " +
+         "SELECT gross_sales AS revenue FROM src";
+      const out = hydrateIncrementalKeysCte(sql, '"t"', "id", "duckdb");
+      expect(out).toBe(
+         'WITH __malloy_incremental_keys AS ( SELECT "id" FROM "t" ) ' +
+            "SELECT gross_sales AS revenue FROM src",
+      );
+   });
 });
 
 // ── buildMergeSQL (upsert on the primary key) ────────────────────────────────

--- a/packages/server/src/service/materialization_service.spec.ts
+++ b/packages/server/src/service/materialization_service.spec.ts
@@ -164,6 +164,7 @@ describe("MaterializationService", () => {
             "PENDING",
             {
                forceRefresh: true,
+               forceFullRebuild: false,
                sourceNames: ["orders"],
                mode: "auto",
                trigger: "ON_DEMAND",
@@ -182,6 +183,7 @@ describe("MaterializationService", () => {
          expect(ctx.repository.createMaterialization.firstCall.args[3]).toEqual(
             {
                forceRefresh: false,
+               forceFullRebuild: false,
                sourceNames: null,
                mode: "auto",
                trigger: "ON_DEMAND",

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -102,6 +102,15 @@ const INCREMENTAL_KEYS_CTE = "__malloy_incremental_keys";
  * source did not opt into the self-reference; the MERGE then upserts every row
  * the source returns). Boundary-safe: balances parentheses from the CTE's
  * opening paren.
+ *
+ * The CTE must be written in the canonical `WITH <name> AS ( ... )` form. The
+ * anchor matches the name + `AS` keyword + opening paren together and is
+ * case-INSENSITIVE on `AS`: a lowercase `as` is valid SQL, and a case-sensitive
+ * scan would silently skip hydration, leaving the incremental filter inert (the
+ * MERGE would then reprocess every row). Matching name+`AS` as a unit also
+ * avoids anchoring on an `AS` substring inside an unrelated upstream identifier.
+ * A column-list form (`<name> (cols) AS (...)`) is not recognized — the reserved
+ * CTE needs no column list.
  */
 export function hydrateIncrementalKeysCte(
    sql: string,
@@ -109,10 +118,11 @@ export function hydrateIncrementalKeysCte(
    primaryKey: string,
    dialect: string,
 ): string {
-   const marker = sql.indexOf(INCREMENTAL_KEYS_CTE);
-   if (marker === -1) return sql;
-   const asOpen = sql.indexOf("(", sql.indexOf("AS", marker));
-   if (asOpen === -1) return sql;
+   const anchor = new RegExp(`${INCREMENTAL_KEYS_CTE}\\s+AS\\s*\\(`, "i").exec(
+      sql,
+   );
+   if (!anchor) return sql;
+   const asOpen = anchor.index + anchor[0].length - 1; // index of the "("
    let depth = 0;
    let close = asOpen;
    for (; close < sql.length; close++) {

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -1092,17 +1092,33 @@ export class MaterializationService {
                   `${physicalTableName} reported no columns; cannot build a MERGE.`,
             );
          }
+         // Resolve the declared primary_key to the target's ACTUAL column
+         // spelling (a case-normalizing engine such as Snowflake may store it
+         // upper-cased). Every identifier in the MERGE — the ON key and the
+         // column list — then comes from one authority (the target schema), so
+         // they can't disagree in case. The source subquery `S` produces the
+         // same physical spelling because the target was created from it.
+         const pkColumn = targetColumns.find(
+            (c) => c.toLowerCase() === primaryKey.toLowerCase(),
+         );
+         if (!pkColumn) {
+            throw new BadRequestError(
+               `Incremental persist source "${persistSource.name}": primary_key ` +
+                  `"${primaryKey}" is not among the target table's columns ` +
+                  `[${targetColumns.join(", ")}].`,
+            );
+         }
          const hydrated = hydrateIncrementalKeysCte(
             buildSQL,
             quotedPhysical,
-            primaryKey,
+            pkColumn,
             dialect,
          );
          await connection.runSQL(
             buildMergeSQL(
                quotedPhysical,
                hydrated,
-               primaryKey,
+               pkColumn,
                targetColumns,
                dialect,
             ),
@@ -1133,13 +1149,19 @@ export class MaterializationService {
 
    /**
     * The target table's actual column names via the connection's dialect-aware
-    * schema introspection, or `null` if the table does not exist. On the
-    * incremental path this both decides seed-vs-MERGE (null => first run) and
-    * yields the MERGE column set from the physical table — the same authority the
-    * first-run CTAS used, so non-atomic columns and any warehouse name
-    * normalization are preserved. A missing table is reported as a keyed error
-    * (the expected first-run signal); a genuine connection failure rejects and
-    * fails the run loudly rather than being misread as "absent".
+    * schema introspection, or `null` if no schema comes back. On the incremental
+    * path this both decides seed-vs-MERGE (null => first run) and yields the
+    * MERGE column set from the physical table — the same authority the first-run
+    * CTAS used, so non-atomic columns and any warehouse name normalization are
+    * preserved.
+    *
+    * `fetchSchemaForTables` collapses every per-table failure (a missing table,
+    * but also a transient metadata error) into its `errors` map rather than
+    * throwing, so "no schema" is treated as first run. The benign miss — a
+    * transient fetch error against a table that DOES exist — then surfaces as a
+    * spurious "table already exists" failure from the first-run CTAS: a failed
+    * run, never data loss or divergence. Distinguishing not-found from transient
+    * would need dialect-specific error classification (a possible refinement).
     */
    private async fetchTargetColumns(
       connection: MalloyConnection,

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -38,7 +38,6 @@ import {
    compilePackageBuildPlan,
    computeSourceEntityId,
    deriveAnnotationFields,
-   deriveColumns,
    iterGraphSources,
 } from "./build_plan";
 import { EnvironmentStore } from "./environment_store";
@@ -110,7 +109,12 @@ const INCREMENTAL_KEYS_CTE = "__malloy_incremental_keys";
  * MERGE would then reprocess every row). Matching name+`AS` as a unit also
  * avoids anchoring on an `AS` substring inside an unrelated upstream identifier.
  * A column-list form (`<name> (cols) AS (...)`) is not recognized — the reserved
- * CTE needs no column list.
+ * CTE needs no column list. The anchor is a `\b`-bounded name match, so it does
+ * not fire on a longer identifier that merely contains the reserved name; but it
+ * is a textual scan, not a SQL parse, so the reserved name must appear ONLY as
+ * this CTE — the first textual occurrence (e.g. inside a comment or string
+ * literal) is what anchors the rewrite. Authors should not reference the name
+ * anywhere but the CTE definition and its filter.
  */
 export function hydrateIncrementalKeysCte(
    sql: string,
@@ -118,9 +122,10 @@ export function hydrateIncrementalKeysCte(
    primaryKey: string,
    dialect: string,
 ): string {
-   const anchor = new RegExp(`${INCREMENTAL_KEYS_CTE}\\s+AS\\s*\\(`, "i").exec(
-      sql,
-   );
+   const anchor = new RegExp(
+      `\\b${INCREMENTAL_KEYS_CTE}\\s+AS\\s*\\(`,
+      "i",
+   ).exec(sql);
    if (!anchor) return sql;
    const asOpen = anchor.index + anchor[0].length - 1; // index of the "("
    let depth = 0;
@@ -1055,8 +1060,19 @@ export class MaterializationService {
       const quotedPhysical = quoteTablePath(physicalTableName, dialect);
 
       const startTime = performance.now();
-      const exists = await this.tableExists(connection, quotedPhysical);
-      if (!exists) {
+      // The target table is the authority on its own columns. One schema fetch
+      // tells us both whether the table exists (seed vs MERGE) and its exact
+      // column set — including non-atomic (struct/array/record) columns that a
+      // Malloy-side derivation would drop, plus any name normalization the
+      // warehouse applied. This mirrors the first-run CTAS, which likewise lets
+      // the warehouse own the schema (we never derive DDL from Malloy types).
+      const targetColumns = await this.fetchTargetColumns(
+         connection,
+         physicalTableName,
+      );
+      const firstRun = targetColumns === null;
+
+      if (firstRun) {
          // First run: full seed. The self-reference CTE is empty, so the source
          // processes every row; the warehouse infers the target schema.
          await connection.runSQL(
@@ -1070,13 +1086,10 @@ export class MaterializationService {
                   `primary_key to MERGE on; declare one on the source.`,
             );
          }
-         const columns = deriveColumns(persistSource)
-            .map((c) => c.name)
-            .filter((n): n is string => n !== undefined);
-         if (columns.length === 0) {
+         if (targetColumns.length === 0) {
             throw new BadRequestError(
-               `Incremental persist source "${persistSource.name}" has no ` +
-                  `resolvable columns; cannot build a MERGE.`,
+               `Incremental persist source "${persistSource.name}": target table ` +
+                  `${physicalTableName} reported no columns; cannot build a MERGE.`,
             );
          }
          const hydrated = hydrateIncrementalKeysCte(
@@ -1090,7 +1103,7 @@ export class MaterializationService {
                quotedPhysical,
                hydrated,
                primaryKey,
-               columns,
+               targetColumns,
                dialect,
             ),
          );
@@ -1104,7 +1117,7 @@ export class MaterializationService {
       recordSourceBuildDuration(durationMs);
       logger.info(
          `Built incremental materialized source ${persistSource.name}`,
-         { physicalTableName, firstRun: !exists, durationMs },
+         { physicalTableName, firstRun, durationMs },
       );
 
       return {
@@ -1119,20 +1132,33 @@ export class MaterializationService {
    }
 
    /**
-    * Cheap, dialect-agnostic existence probe: `SELECT 1 FROM <t> LIMIT 0` scans
-    * nothing and throws if the table is absent. Distinguishes an incremental
-    * first-run seed from a MERGE.
+    * The target table's actual column names via the connection's dialect-aware
+    * schema introspection, or `null` if the table does not exist. On the
+    * incremental path this both decides seed-vs-MERGE (null => first run) and
+    * yields the MERGE column set from the physical table — the same authority the
+    * first-run CTAS used, so non-atomic columns and any warehouse name
+    * normalization are preserved. A missing table is reported as a keyed error
+    * (the expected first-run signal); a genuine connection failure rejects and
+    * fails the run loudly rather than being misread as "absent".
     */
-   private async tableExists(
+   private async fetchTargetColumns(
       connection: MalloyConnection,
-      quotedTable: string,
-   ): Promise<boolean> {
-      try {
-         await connection.runSQL(`SELECT 1 FROM ${quotedTable} LIMIT 0`);
-         return true;
-      } catch {
-         return false;
+      tableName: string,
+   ): Promise<string[] | null> {
+      const key = "__persist_target";
+      const { schemas, errors } = await connection.fetchSchemaForTables(
+         { [key]: tableName },
+         {},
+      );
+      const schema = schemas[key];
+      if (!schema) {
+         logger.debug(
+            "Incremental target schema not found; treating as first run",
+            { tableName, error: errors[key] },
+         );
+         return null;
       }
+      return schema.fields.map((f) => f.name);
    }
 
    // ==================== CANCELLATION ====================

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -38,6 +38,7 @@ import {
    compilePackageBuildPlan,
    computeSourceEntityId,
    deriveAnnotationFields,
+   deriveColumns,
    iterGraphSources,
 } from "./build_plan";
 import { EnvironmentStore } from "./environment_store";
@@ -70,6 +71,93 @@ export function stagingSuffix(sourceEntityId: string): string {
  */
 function selfAssignTableName(persistSource: PersistSource): string {
    return deriveAnnotationFields(persistSource).name || persistSource.name;
+}
+
+/** The declared `#@ persist ... refresh=...` value, defaulting to "full". */
+export function refreshMode(
+   persistSource: PersistSource,
+): "full" | "incremental" {
+   return deriveAnnotationFields(persistSource).refresh === "incremental"
+      ? "incremental"
+      : "full";
+}
+
+/**
+ * Reserved CTE name for the compile-safe self-reference primitive. An
+ * incremental source's SQL declares
+ * `WITH __malloy_incremental_keys AS (<empty placeholder>)` and references it
+ * (e.g. `WHERE key NOT IN (SELECT key FROM __malloy_incremental_keys)`). The
+ * empty body compiles with no reference to the not-yet-existent target and, on
+ * the first-run seed, matches nothing so every row is processed. On an
+ * incremental MERGE the publisher hydrates the body to select the primary key
+ * from the already-materialized target, so only new rows are computed — crucially
+ * before an expensive step like ML.GENERATE_TEXT. This is the dbt
+ * `is_incremental()` + `{{ this }}` analog, realized without a compiler change.
+ */
+const INCREMENTAL_KEYS_CTE = "__malloy_incremental_keys";
+
+/**
+ * Rewrite the reserved {@link INCREMENTAL_KEYS_CTE} body to select the primary
+ * key from the target. Returns the SQL unchanged if the CTE is absent (the
+ * source did not opt into the self-reference; the MERGE then upserts every row
+ * the source returns). Boundary-safe: balances parentheses from the CTE's
+ * opening paren.
+ */
+export function hydrateIncrementalKeysCte(
+   sql: string,
+   quotedTarget: string,
+   primaryKey: string,
+   dialect: string,
+): string {
+   const marker = sql.indexOf(INCREMENTAL_KEYS_CTE);
+   if (marker === -1) return sql;
+   const asOpen = sql.indexOf("(", sql.indexOf("AS", marker));
+   if (asOpen === -1) return sql;
+   let depth = 0;
+   let close = asOpen;
+   for (; close < sql.length; close++) {
+      if (sql[close] === "(") depth++;
+      else if (sql[close] === ")") {
+         depth--;
+         if (depth === 0) break;
+      }
+   }
+   const body = ` SELECT ${quoteIdentifier(primaryKey, dialect)} FROM ${quotedTarget} `;
+   return sql.slice(0, asOpen + 1) + body + sql.slice(close);
+}
+
+/**
+ * A standard SQL MERGE that upserts the source rows into the target on the
+ * primary key: update non-key columns on match, insert on no-match. Append-once
+ * (classify) falls out naturally when the source's candidate set excludes
+ * already-present keys (via {@link INCREMENTAL_KEYS_CTE}); dedup upserts changed
+ * rows. Idempotent under retry, unlike a raw INSERT.
+ */
+export function buildMergeSQL(
+   quotedTarget: string,
+   usingSQL: string,
+   primaryKey: string,
+   columns: string[],
+   dialect: string,
+): string {
+   const q = (c: string) => quoteIdentifier(c, dialect);
+   const pk = q(primaryKey);
+   const nonKey = columns.filter((c) => c !== primaryKey);
+   // The target column on the LHS of SET is UNQUALIFIED: BigQuery and Postgres 15+
+   // reject a target-alias-qualified column there ("... cannot reference table
+   // alias"), and Snowflake accepts the unqualified form too — so this is the
+   // portable spelling. The RHS is source-qualified (S.col).
+   const setClause = nonKey.map((c) => `${q(c)} = S.${q(c)}`).join(", ");
+   const colList = columns.map(q).join(", ");
+   const valList = columns.map((c) => `S.${q(c)}`).join(", ");
+   const whenMatched = setClause
+      ? `WHEN MATCHED THEN UPDATE SET ${setClause} `
+      : "";
+   return (
+      `MERGE INTO ${quotedTarget} T USING (${usingSQL}) S ON T.${pk} = S.${pk} ` +
+      whenMatched +
+      `WHEN NOT MATCHED THEN INSERT (${colList}) VALUES (${valList})`
+   );
 }
 
 /** Classify a thrown build error as cancelled (cooperative abort) or failed. */
@@ -252,6 +340,16 @@ export class MaterializationService {
       packageName: string,
       options: {
          forceRefresh?: boolean;
+         /**
+          * Escape hatch (dbt `--full-refresh` analog): rebuild every incremental
+          * source from scratch via the full staging+rename path this run, instead
+          * of MERGE-ing. Use after a schema or logic migration. Distinct from
+          * `forceRefresh` (which only bypasses content-hash reuse for full
+          * sources): the scheduler sets `forceRefresh` on every run, so it must
+          * NOT force incremental sources full, or scheduled refreshes would stop
+          * being incremental.
+          */
+         forceFullRebuild?: boolean;
          sourceNames?: string[];
          buildInstructions?: BuildInstruction[];
          referenceManifest?: ManifestReference[];
@@ -288,9 +386,11 @@ export class MaterializationService {
       }
 
       const forceRefresh = options.forceRefresh ?? false;
+      const forceFullRebuild = options.forceFullRebuild ?? false;
       const trigger = options.trigger ?? "ON_DEMAND";
       const metadata = {
          forceRefresh,
+         forceFullRebuild,
          sourceNames: options.sourceNames ?? null,
          mode: orchestrated ? "orchestrated" : "auto",
          trigger,
@@ -323,6 +423,7 @@ export class MaterializationService {
             {
                sourceNames: options.sourceNames,
                forceRefresh,
+               forceFullRebuild,
                buildInstructions,
                referenceManifest: options.referenceManifest,
                strictUpstreams: options.strictUpstreams,
@@ -350,6 +451,7 @@ export class MaterializationService {
       opts: {
          sourceNames: string[] | undefined;
          forceRefresh: boolean;
+         forceFullRebuild: boolean;
          buildInstructions: BuildInstruction[] | undefined;
          referenceManifest: ManifestReference[] | undefined;
          strictUpstreams: boolean | undefined;
@@ -418,6 +520,7 @@ export class MaterializationService {
             carried,
             signal,
             opts.strictUpstreams ?? false,
+            opts.forceFullRebuild,
          );
 
          const sourcesBuilt = instructions.length;
@@ -491,8 +594,17 @@ export class MaterializationService {
             if (seen.has(sourceEntityId)) continue;
             seen.add(sourceEntityId);
 
+            // Content-hash reuse assumes "same SQL => reusable table". That holds
+            // for full rebuilds but NOT for incremental sources, whose table is a
+            // function of run history, not just SQL: carrying one forward would
+            // silently stop it advancing on a non-forced run. Incremental sources
+            // are always (re)built.
             const prior = priorEntries[sourceEntityId];
-            if (prior && prior.physicalTableName) {
+            if (
+               prior &&
+               prior.physicalTableName &&
+               refreshMode(persistSource) !== "incremental"
+            ) {
                carried[sourceEntityId] = prior;
                continue;
             }
@@ -696,6 +808,7 @@ export class MaterializationService {
       seedEntries: Record<string, ManifestEntry>,
       signal: AbortSignal,
       strict = false,
+      forceFullRebuild = false,
    ): Promise<Record<string, ManifestEntry>> {
       const { graphs, sources, connectionDigests, connections } = compiled;
 
@@ -776,6 +889,7 @@ export class MaterializationService {
                connection,
                connectionDigests,
                manifest,
+               forceFullRebuild,
             );
             entries[sourceEntityId] = entry;
          }
@@ -786,10 +900,49 @@ export class MaterializationService {
 
    /**
     * Build a single instructed source into its assigned physical table.
-    * COPY uses a staging table + atomic rename for crash-safety; the staging
-    * name derives from the sourceEntityId. Records and returns the manifest entry.
+    * Dispatches on the source's `#@ persist ... refresh=...` mode: "incremental"
+    * takes the MERGE path ({@link buildIncrementalSource}); unset/"full" keeps the
+    * unchanged full-rebuild path ({@link buildFullSource}).
+    *
+    * `forceFullRebuild` is the escape hatch (dbt `--full-refresh` analog): when
+    * the run requests it, an incremental source is rebuilt from scratch via the
+    * full staging+rename path. Its self-reference CTE stays empty, so every row
+    * is reprocessed and the table is atomically swapped — the way to recover
+    * from a schema or logic migration without hand-dropping the table.
     */
    private async buildOneSource(
+      persistSource: PersistSource,
+      instruction: BuildInstruction,
+      connection: MalloyConnection,
+      connectionDigests: Record<string, string>,
+      manifest: Manifest,
+      forceFullRebuild = false,
+   ): Promise<ManifestEntry> {
+      if (!forceFullRebuild && refreshMode(persistSource) === "incremental") {
+         return this.buildIncrementalSource(
+            persistSource,
+            instruction,
+            connection,
+            connectionDigests,
+            manifest,
+         );
+      }
+      return this.buildFullSource(
+         persistSource,
+         instruction,
+         connection,
+         connectionDigests,
+         manifest,
+      );
+   }
+
+   /**
+    * Full rebuild (default; `refresh` unset or "full"): staging table + atomic
+    * rename for crash-safety; the staging name derives from the sourceEntityId.
+    * Records and returns the manifest entry. Behavior is byte-for-byte unchanged
+    * from before the incremental feature.
+    */
+   private async buildFullSource(
       persistSource: PersistSource,
       instruction: BuildInstruction,
       connection: MalloyConnection,
@@ -864,6 +1017,112 @@ export class MaterializationService {
          realization: instruction.realization,
          rowCount: null,
       };
+   }
+
+   /**
+    * Incremental build (`refresh="incremental"`): seed on first run, MERGE
+    * thereafter. First run (target absent) is a plain CTAS of the source SQL —
+    * the compile-safe self-reference CTE is empty, so all rows seed and the
+    * warehouse infers the exact schema (no derived DDL). Subsequent runs hydrate
+    * the self-reference to the target and MERGE on the source's primary_key, so
+    * only new rows are computed. In-place (no staging swap); a single MERGE is
+    * statement-atomic and idempotent under retry.
+    */
+   private async buildIncrementalSource(
+      persistSource: PersistSource,
+      instruction: BuildInstruction,
+      connection: MalloyConnection,
+      connectionDigests: Record<string, string>,
+      manifest: Manifest,
+   ): Promise<ManifestEntry> {
+      const sourceEntityId = instruction.sourceEntityId;
+      const physicalTableName = instruction.physicalTableName;
+      const buildSQL = persistSource.getSQL({
+         buildManifest: manifest.buildManifest,
+         connectionDigests,
+      });
+      const dialect = persistSource.dialectName;
+      const quotedPhysical = quoteTablePath(physicalTableName, dialect);
+
+      const startTime = performance.now();
+      const exists = await this.tableExists(connection, quotedPhysical);
+      if (!exists) {
+         // First run: full seed. The self-reference CTE is empty, so the source
+         // processes every row; the warehouse infers the target schema.
+         await connection.runSQL(
+            `CREATE TABLE ${quotedPhysical} AS (${buildSQL})`,
+         );
+      } else {
+         const primaryKey = persistSource._explore.primaryKey;
+         if (!primaryKey) {
+            throw new BadRequestError(
+               `Incremental persist source "${persistSource.name}" requires a ` +
+                  `primary_key to MERGE on; declare one on the source.`,
+            );
+         }
+         const columns = deriveColumns(persistSource)
+            .map((c) => c.name)
+            .filter((n): n is string => n !== undefined);
+         if (columns.length === 0) {
+            throw new BadRequestError(
+               `Incremental persist source "${persistSource.name}" has no ` +
+                  `resolvable columns; cannot build a MERGE.`,
+            );
+         }
+         const hydrated = hydrateIncrementalKeysCte(
+            buildSQL,
+            quotedPhysical,
+            primaryKey,
+            dialect,
+         );
+         await connection.runSQL(
+            buildMergeSQL(
+               quotedPhysical,
+               hydrated,
+               primaryKey,
+               columns,
+               dialect,
+            ),
+         );
+      }
+
+      // Downstream sources built later in this run resolve their FROM against
+      // the live target (incremental mutates in place; there is no staging).
+      manifest.update(sourceEntityId, { tableName: quotedPhysical });
+
+      const durationMs = Math.round(performance.now() - startTime);
+      recordSourceBuildDuration(durationMs);
+      logger.info(
+         `Built incremental materialized source ${persistSource.name}`,
+         { physicalTableName, firstRun: !exists, durationMs },
+      );
+
+      return {
+         sourceEntityId,
+         sourceName: persistSource.name,
+         materializedTableId: instruction.materializedTableId,
+         physicalTableName,
+         connectionName: persistSource.connectionName,
+         realization: instruction.realization,
+         rowCount: null,
+      };
+   }
+
+   /**
+    * Cheap, dialect-agnostic existence probe: `SELECT 1 FROM <t> LIMIT 0` scans
+    * nothing and throws if the table is absent. Distinguishes an incremental
+    * first-run seed from a MERGE.
+    */
+   private async tableExists(
+      connection: MalloyConnection,
+      quotedTable: string,
+   ): Promise<boolean> {
+      try {
+         await connection.runSQL(`SELECT 1 FROM ${quotedTable} LIMIT 0`);
+         return true;
+      } catch {
+         return false;
+      }
    }
 
    // ==================== CANCELLATION ====================

--- a/packages/server/src/service/materialization_test_fixtures.ts
+++ b/packages/server/src/service/materialization_test_fixtures.ts
@@ -126,9 +126,20 @@ export function fakeSource(opts: {
     * assert what physical name a downstream build sees for its upstream.
     */
    onGetSQL?: (sqlOpts: unknown) => void;
+   /**
+    * The source's compiled `_explore` shape the incremental build path reads:
+    * `primaryKey` (the MERGE key) and `columns` (fed through `deriveColumns`,
+    * which filters to atomic fields). Omit for the full-rebuild path, which
+    * touches neither — keeping `_explore` undefined preserves today's behavior
+    * for every existing caller.
+    */
+   explore?: {
+      primaryKey?: string;
+      columns?: Array<{ name: string; type?: string }>;
+   };
 }): PersistSource {
    const fields = opts.annotationFields;
-   return {
+   const source: Record<string, unknown> = {
       name: opts.name,
       sourceID: opts.name,
       connectionName: opts.connectionName ?? "duckdb",
@@ -148,7 +159,18 @@ export function fakeSource(opts: {
             tag: fakeTag(undefined, opts.modelFreshnessSchedule),
          }),
       },
-   } as unknown as PersistSource;
+   };
+   if (opts.explore) {
+      source._explore = {
+         primaryKey: opts.explore.primaryKey,
+         intrinsicFields: (opts.explore.columns ?? []).map((c) => ({
+            name: c.name,
+            type: c.type ?? "string",
+            isAtomicField: () => true,
+         })),
+      };
+   }
+   return source as unknown as PersistSource;
 }
 
 /**

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -68,6 +68,19 @@ type PackageConnectionInput =
    | (() => MalloyConfig);
 
 /**
+ * Malloy dialect names whose engines support the `MERGE INTO ...` the
+ * incremental persist path emits. Gated at publish (Rule 7 in
+ * {@link Package.persistencePolicyWarnings}). Postgres < 15 lacks MERGE, but the
+ * major version is not visible from the dialect name, so it remains a documented
+ * caveat rather than a hard gate. (`standardsql` is BigQuery's dialect name.)
+ */
+const INCREMENTAL_MERGE_DIALECTS = new Set([
+   "standardsql",
+   "snowflake",
+   "postgres",
+]);
+
+/**
  * Project the full wire entries down to the Malloy-runtime binding map
  * (`sourceEntityId -> { tableName }`) used to hydrate models. The freshness
  * fields are dropped here — they gate the serve path per query, not model
@@ -917,6 +930,27 @@ export class Package {
                   `freshness fallback "live", which is invalid: a live serve of an ` +
                   `incremental source returns only the delta, not the full dataset. ` +
                   `Use "stale_ok" or "fail".`,
+            );
+         }
+      }
+
+      // Rule 7: incremental builds emit a `MERGE INTO ...`, so the source's
+      // dialect must support that statement. Gate at publish, since dispatch
+      // otherwise keys only off `refresh=` and an unsupported dialect would fail
+      // late with a raw warehouse syntax error (possibly after the first-run
+      // CTAS already created a table). The supported set is the MERGE-capable
+      // dialects; Postgres < 15 lacks MERGE but the version isn't visible from
+      // the dialect name, so it stays a documented caveat rather than a gate.
+      for (const source of sources) {
+         if ((source.annotationFields ?? {}).refresh !== "incremental")
+            continue;
+         const dialect = source.dialect;
+         if (dialect && !INCREMENTAL_MERGE_DIALECTS.has(dialect)) {
+            warnings.push(
+               `Incremental #@ persist source "${source.name}" targets dialect ` +
+                  `"${dialect}", which does not support incremental materialization. ` +
+                  `Incremental requires a MERGE-capable engine (BigQuery, Snowflake, ` +
+                  `or Postgres 15+); use refresh="full" for this source.`,
             );
          }
       }

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -884,6 +884,38 @@ export class Package {
          );
       }
 
+      // Rule 5: refresh must be a supported value (persistence.md §3:
+      // refresh ∈ {"full", "incremental"}). An unknown value would otherwise be
+      // dropped silently, degrading incremental to full.
+      for (const source of sources) {
+         const refresh = (source.annotationFields ?? {}).refresh;
+         if (
+            refresh !== undefined &&
+            refresh !== "full" &&
+            refresh !== "incremental"
+         ) {
+            warnings.push(
+               `#@ persist source "${source.name}" declares refresh="${refresh}" ` +
+                  `which is not supported: use "full" or "incremental".`,
+            );
+         }
+      }
+
+      // Rule 6: an incremental source with freshness fallback "live" is invalid.
+      // A live serve recomputes the source, which for an incremental definition
+      // returns only the delta, not the full dataset. Require stale_ok or fail.
+      const hasIncremental = sources.some(
+         (s) => (s.annotationFields ?? {}).refresh === "incremental",
+      );
+      if (hasIncremental && packageFreshness?.fallback === "live") {
+         warnings.push(
+            `An incremental #@ persist source with materialization.freshness.` +
+               `fallback "live" is invalid: a live serve of an incremental source ` +
+               `returns only the delta, not the full dataset. Use "stale_ok" or ` +
+               `"fail".`,
+         );
+      }
+
       return warnings;
    }
 

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -901,19 +901,24 @@ export class Package {
          }
       }
 
-      // Rule 6: an incremental source with freshness fallback "live" is invalid.
-      // A live serve recomputes the source, which for an incremental definition
-      // returns only the delta, not the full dataset. Require stale_ok or fail.
-      const hasIncremental = sources.some(
-         (s) => (s.annotationFields ?? {}).refresh === "incremental",
-      );
-      if (hasIncremental && packageFreshness?.fallback === "live") {
-         warnings.push(
-            `An incremental #@ persist source with materialization.freshness.` +
-               `fallback "live" is invalid: a live serve of an incremental source ` +
-               `returns only the delta, not the full dataset. Use "stale_ok" or ` +
-               `"fail".`,
-         );
+      // Rule 6: an incremental source that resolves to freshness fallback "live"
+      // is invalid. A live serve recomputes the source, which for an incremental
+      // definition returns only the delta, not the full dataset. Require stale_ok
+      // or fail. The fallback can be set on the source itself or inherited from
+      // the package (source wins, most-specific-first, §3.1), so resolve both.
+      for (const source of sources) {
+         if ((source.annotationFields ?? {}).refresh !== "incremental")
+            continue;
+         const effectiveFallback =
+            source.freshness?.fallback ?? packageFreshness?.fallback;
+         if (effectiveFallback === "live") {
+            warnings.push(
+               `Incremental #@ persist source "${source.name}" resolves to ` +
+                  `freshness fallback "live", which is invalid: a live serve of an ` +
+                  `incremental source returns only the delta, not the full dataset. ` +
+                  `Use "stale_ok" or "fail".`,
+            );
+         }
       }
 
       return warnings;

--- a/packages/server/src/service/persistence_policy.spec.ts
+++ b/packages/server/src/service/persistence_policy.spec.ts
@@ -284,18 +284,25 @@ source: i is duckdb.sql("SELECT 1 as x")
    );
 
    // ── Rule 5: refresh must be a supported value (full | incremental) ────
+   // ── Rule 7: incremental requires a MERGE-capable dialect ──────────────
 
    it(
-      "accepts refresh=incremental and surfaces it on the build plan",
+      "surfaces refresh=incremental to the wire plan and rejects it on a non-MERGE dialect (duckdb)",
       async () => {
+         // This harness compiles against duckdb, which is not a MERGE-capable
+         // dialect for incremental (Rule 7), so an incremental source here is
+         // rejected — and this doubles as the dialect-gate test. It also proves
+         // the pinned compiler carries `refresh` through to the wire plan
+         // (annotationFields), which the whole incremental path keys off.
          const pkg = await loadPackage(INCREMENTAL_MODEL, { scope: "package" });
-         expect(pkg.persistencePolicyWarnings()).toEqual([]);
-         // Proves the pinned compiler carries `refresh` through to the wire plan
-         // (annotationFields) — the publisher's whole incremental path keys off it.
          const source = sourceByName(pkg, "i") as Record<string, unknown>;
          expect(
             (source.annotationFields as Record<string, string>).refresh,
          ).toBe("incremental");
+         const joined = pkg.formatInvalidPersistencePolicy();
+         expect(joined).toContain('"i"');
+         expect(joined).toContain("does not support incremental");
+         expect(joined).toContain("MERGE-capable");
       },
       { timeout: 30000 },
    );
@@ -333,15 +340,18 @@ source: i is duckdb.sql("SELECT 1 as x")
    );
 
    it(
-      "accepts an incremental source with freshness fallback stale_ok",
+      "does not flag freshness fallback stale_ok on an incremental source (Rule 6)",
       async () => {
+         // Rule 6 targets the "live" fallback only; stale_ok must not trip it.
+         // (A separate Rule 7 dialect warning is present because this harness is
+         // duckdb-only, so assert on Rule 6's signature rather than emptiness.)
          const pkg = await loadPackage(INCREMENTAL_MODEL, {
             scope: "package",
             materialization: {
                freshness: { window: "24h", fallback: "stale_ok" },
             },
          });
-         expect(pkg.persistencePolicyWarnings()).toEqual([]);
+         expect(pkg.formatInvalidPersistencePolicy()).not.toContain("delta");
       },
       { timeout: 30000 },
    );

--- a/packages/server/src/service/persistence_policy.spec.ts
+++ b/packages/server/src/service/persistence_policy.spec.ts
@@ -99,6 +99,14 @@ source: i is duckdb.sql("SELECT 1 as x")
 source: b is duckdb.sql("SELECT 1 as x")
 `;
 
+   // Incremental with a SOURCE-level freshness fallback of "live" (no package
+   // freshness) — Rule 6 must catch the source-level declaration too.
+   const INCREMENTAL_SRC_LIVE_MODEL = `##! experimental.persistence
+
+#@ persist name="i_table" refresh=incremental freshness.window="24h" freshness.fallback="live"
+source: i is duckdb.sql("SELECT 1 as x")
+`;
+
    // ── scope parsing + surfacing ─────────────────────────────────────────
 
    it(
@@ -334,6 +342,22 @@ source: b is duckdb.sql("SELECT 1 as x")
             },
          });
          expect(pkg.persistencePolicyWarnings()).toEqual([]);
+      },
+      { timeout: 30000 },
+   );
+
+   it(
+      "rejects an incremental source whose OWN freshness fallback is live",
+      async () => {
+         // No package freshness — the dangerous fallback is declared on the
+         // source itself, which Rule 6 must still catch.
+         const pkg = await loadPackage(INCREMENTAL_SRC_LIVE_MODEL, {
+            scope: "package",
+         });
+         const joined = pkg.formatInvalidPersistencePolicy();
+         expect(joined).toContain('"i"');
+         expect(joined).toContain("live");
+         expect(joined).toContain("delta");
       },
       { timeout: 30000 },
    );

--- a/packages/server/src/service/persistence_policy.spec.ts
+++ b/packages/server/src/service/persistence_policy.spec.ts
@@ -87,6 +87,18 @@ source: s is duckdb.sql("SELECT 1 as x")
 source: f is duckdb.sql("SELECT 1 as x")
 `;
 
+   const INCREMENTAL_MODEL = `##! experimental.persistence
+
+#@ persist name="i_table" refresh=incremental
+source: i is duckdb.sql("SELECT 1 as x")
+`;
+
+   const BAD_REFRESH_MODEL = `##! experimental.persistence
+
+#@ persist name="b_table" refresh=weekly
+source: b is duckdb.sql("SELECT 1 as x")
+`;
+
    // ── scope parsing + surfacing ─────────────────────────────────────────
 
    it(
@@ -259,6 +271,69 @@ source: f is duckdb.sql("SELECT 1 as x")
          });
          expect(pkg.persistencePolicyWarnings()).toEqual([]);
          expect(sourceByName(pkg, "f").freshness).toEqual({ window: "1h" });
+      },
+      { timeout: 30000 },
+   );
+
+   // ── Rule 5: refresh must be a supported value (full | incremental) ────
+
+   it(
+      "accepts refresh=incremental and surfaces it on the build plan",
+      async () => {
+         const pkg = await loadPackage(INCREMENTAL_MODEL, { scope: "package" });
+         expect(pkg.persistencePolicyWarnings()).toEqual([]);
+         // Proves the pinned compiler carries `refresh` through to the wire plan
+         // (annotationFields) — the publisher's whole incremental path keys off it.
+         const source = sourceByName(pkg, "i") as Record<string, unknown>;
+         expect(
+            (source.annotationFields as Record<string, string>).refresh,
+         ).toBe("incremental");
+      },
+      { timeout: 30000 },
+   );
+
+   it(
+      "rejects an unsupported refresh value, naming the allowed set",
+      async () => {
+         const pkg = await loadPackage(BAD_REFRESH_MODEL, { scope: "package" });
+         const joined = pkg.formatInvalidPersistencePolicy();
+         expect(joined).toContain('"b"');
+         expect(joined).toContain("weekly");
+         expect(joined).toContain("full");
+         expect(joined).toContain("incremental");
+      },
+      { timeout: 30000 },
+   );
+
+   // ── Rule 6: incremental + freshness fallback "live" is invalid ────────
+
+   it(
+      "rejects an incremental source with freshness fallback live",
+      async () => {
+         // A live serve recomputes the source, which for an incremental
+         // definition returns only the delta, not the full dataset.
+         const pkg = await loadPackage(INCREMENTAL_MODEL, {
+            scope: "package",
+            materialization: { freshness: { window: "24h", fallback: "live" } },
+         });
+         const joined = pkg.formatInvalidPersistencePolicy();
+         expect(joined).toContain("incremental");
+         expect(joined).toContain("live");
+         expect(joined).toContain("delta");
+      },
+      { timeout: 30000 },
+   );
+
+   it(
+      "accepts an incremental source with freshness fallback stale_ok",
+      async () => {
+         const pkg = await loadPackage(INCREMENTAL_MODEL, {
+            scope: "package",
+            materialization: {
+               freshness: { window: "24h", fallback: "stale_ok" },
+            },
+         });
+         expect(pkg.persistencePolicyWarnings()).toEqual([]);
       },
       { timeout: 30000 },
    );


### PR DESCRIPTION
## Summary

Realizes the `refresh="incremental"` value of the persist `refresh` knob on the publisher build
path. Today a persisted source is always fully rebuilt (staging + atomic rename) on every run — fine
for most sources, but prohibitive when a per-row cost dominates the build (an `ML.GENERATE_TEXT`
classification, an embedding call, an expensive UDF): every refresh re-pays that cost for rows that
have not changed. `refresh="incremental"` makes such a source **build once, then update in place**.

## Behavior

- **`refresh="incremental"`** (on `#@ persist`) selects the incremental path. Unset / `"full"` keeps
  the default full-rebuild path, unchanged.
- **First run** (target absent): `CREATE TABLE <target> AS (<source SQL>)` — the warehouse infers the
  schema; DDL is never derived from Malloy intrinsic types.
- **Subsequent runs**: `MERGE INTO <target> USING (<source SQL>) ON <primary_key>`, `WHEN MATCHED
  THEN UPDATE` + `WHEN NOT MATCHED THEN INSERT`. In place (no staging), and idempotent under retry
  (a re-run is a no-op on already-merged rows, unlike a raw `INSERT`).
- The merge key is the source's Malloy **`primary_key`** — no new persist-level `unique_key` knob.
  An incremental source with no primary key is a `BadRequestError` at build time.

### Compile-safe self-reference construct

The reserved CTE **`__malloy_incremental_keys`** lets a source refer to "what I have already
materialized" without a bootstrap problem — the dbt `is_incremental()` + `{{ this }}` analog, with no
compiler change. The author writes it with an empty body (matches nothing → compiles, and seeds
everything on the first run); on an incremental run the publisher rewrites the body to `SELECT
<primary_key> FROM <target>`. Because the filter sits **inside** the source SQL, an expensive step
runs only for new rows. The construct is optional (omit it → upsert every returned row). Write it in
the canonical `WITH __malloy_incremental_keys AS ( ... )` form; the `AS` keyword is matched
case-insensitively and anchored to the CTE name (a lowercase `as` still hydrates).

### Force full rebuild (`forceFullRebuild`)

A new run flag (dbt `--full-refresh` analog) rebuilds every incremental source through the full
staging + rename path this run. Deliberately distinct from `forceRefresh`: the scheduler sets
`forceRefresh` on every run, so overloading it would silently turn scheduled incremental refreshes
back into full rebuilds.

## Backward compatibility

Additive and off by default. The current full-rebuild body is extracted **verbatim** as
`buildFullSource`; `refresh` unset dispatches straight to it. `getSQL()` is unaffected by the
annotation, so content-addressing and reuse-rebind are identical for full sources. The reuse-skip
exemption and the new validation rules fire only for incremental sources.

## Validation & dialects

- Publish gate: `refresh` must be `full` | `incremental`; an incremental source that resolves to
  freshness `fallback: "live"` is rejected — whether the fallback is declared on the source or
  inherited from the package (a live serve returns the delta, not the dataset).
- The generated MERGE uses an **unqualified** `SET` target column (`SET col = S.col`) for
  portability: BigQuery and Postgres 15+ reject a target-alias-qualified column there; Snowflake
  accepts unqualified. Supported on BigQuery / Snowflake / Postgres 15+; DuckDB persistence is
  unsupported generally, and Postgres < 15 has no `MERGE`.

## Testing

- New `materialization_incremental.spec.ts`: `refreshMode`, the SQL builders
  (`hydrateIncrementalKeysCte` incl. nested-paren balancing, case-insensitive `AS`, and the
  `AS`-substring guard; `buildMergeSQL`), and the `buildOneSource` dispatch (full unchanged /
  first-run CTAS seed / MERGE / `forceFullRebuild` / missing-pk error / CTE hydration).
- Policy Rules for `refresh` and incremental+`live` (package-level and source-level) in
  `persistence_policy.spec.ts` (also proves the compiler carries `refresh` through to the wire plan).
- `forceFullRebuild` validation in the controller spec; run-metadata shape updated.
- `tsc --noEmit` clean; all affected suites green.

## Docs

- `docs/materialization-incremental.md` — the annotation surface, the self-reference construct
  (incl. a `NOT EXISTS` anti-join recommendation over the NULL-fragile `NOT IN`), build behavior, the
  escape hatch, validation, dialects, the stable-target-name assumption, and back-compat.

## Notes

- Two commits: the feature, then a self-review pass (case-insensitive CTE `AS` matching,
  source-level `live`-fallback rejection, and doc hardening — `NOT EXISTS` guidance + the
  stable-target-name assumption).
- All commits are DCO signed-off.
- Based on `main` and independent of the CLI schedule work (#909) — it needs only the scheduler
  service already merged in #888. For a hosted refresh cadence, pair with `scope: package` + hosted
  `freshness` (not the version-scoped cron).
- Deliberately small: it merges in place on the source's `primary_key`. A richer strategy (a
  separate `unique_key`, an event-time watermark predicate, or building into a cloned generation
  rather than in place) is possible later and nothing here forecloses it.
