### PR TITLE
fix(readme): point the walkthrough video at a publicly accessible asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Serve governed data models to applications, BI tools, and AI agents — over RES
 </p>
 
 <p align="center">
-  <video src="https://github.com/user-attachments/assets/76dcb1c7-7195-48dd-8c7a-667f4f9abb78" poster="docs/malloy-publisher-demo.png" width="800" controls muted loop playsinline>
+  <video src="https://github.com/user-attachments/assets/376a809d-8016-41a7-9464-a5634ea0589d" poster="docs/malloy-publisher-demo.png" width="800" controls muted loop playsinline>
     <img src="docs/malloy-publisher-demo.png" alt="Malloy Publisher serving the bundled storefront dashboard" width="800">
   </video>
 </p>


### PR DESCRIPTION
The README hero walkthrough video (merged in #909) played only for signed-in maintainers and was blank for anonymous visitors (incognito, logged-out). Root cause: the `user-attachments` asset was orphaned to the uploader's session, so anonymous requests to it returned `404`.

This swaps in a re-uploaded asset that is publicly accessible.

**Verified anonymously (no auth):**
- `curl -L` -> `302` to `github-production-user-asset…s3.amazonaws.com/…?response-content-type=video%2Fmp4`
- ranged `GET` -> `HTTP 206`, `Content-Type: video/mp4`, `Content-Range: bytes 0-1/1072721` (~1 MB, the same clip)

Only the `<video src>` on line 11 changes; the poster, fallback `<img>`, and caption are untouched. No binary added to the repo.