### PR TITLE
feat(scaffolder): accept JSON for --data, and name the files it skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ against your package, in watch mode, so edits to the model take effect as you sa
 
 Run bare like that, the package comes with a small sample dataset, so there is something to query
 before you have wired up anything of your own. To start from one of your own files instead, pass
-`--data` (CSV, Parquet, or Excel `.xlsx`):
+`--data` (CSV, Parquet, JSON, newline-delimited JSON, or Excel `.xlsx` - DuckDB reads all of them
+in place, so nothing needs converting first):
 
 ```bash
 npm create @malloy-publisher/malloy-package sales -- --data ./orders.csv

--- a/packages/create-malloy-package/README.md
+++ b/packages/create-malloy-package/README.md
@@ -305,12 +305,12 @@ npx @malloy-publisher/create-malloy-package sales --data mydata.csv
 - `name` (positional): the package name. Omit it to only set up the agent workspace in
   the current directory (write the MCP connection, agent instructions, and skills)
   without scaffolding a package.
-- `--data <file>`: seed the package from your own CSV, Parquet, JSON, NDJSON, or XLSX file instead of
-  the built-in sample. The file is copied into the package and the starter model points
-  at it. DuckDB reads all three formats in place; an Excel file is read as its first
-  sheet. It seeds a new package, so it requires a package name: it cannot be combined
-  with the setup-only mode above, and passing it without a name is an error rather than
-  a silently ignored flag.
+- `--data <file>`: seed the package from your own CSV, Parquet, JSON, NDJSON, or XLSX
+  file instead of the built-in sample. The file is copied into the package and the
+  starter model points at it. DuckDB reads all of them in place, so nothing needs
+  converting first; an Excel file is read as its first sheet. It seeds a new package,
+  so it requires a package name: it cannot be combined with the setup-only mode above,
+  and passing it without a name is an error rather than a silently ignored flag.
 - `--client <claude-code|cursor>`: which agent client to wire up. Defaults to
   `claude-code`. `AGENTS.md` and the skills in `.claude/skills/` are written for every
   client; the MCP config file (`.mcp.json` for Claude Code, `.cursor/mcp.json` for

--- a/packages/create-malloy-package/README.md
+++ b/packages/create-malloy-package/README.md
@@ -305,7 +305,7 @@ npx @malloy-publisher/create-malloy-package sales --data mydata.csv
 - `name` (positional): the package name. Omit it to only set up the agent workspace in
   the current directory (write the MCP connection, agent instructions, and skills)
   without scaffolding a package.
-- `--data <file>`: seed the package from your own CSV, Parquet, or XLSX file instead of
+- `--data <file>`: seed the package from your own CSV, Parquet, JSON, NDJSON, or XLSX file instead of
   the built-in sample. The file is copied into the package and the starter model points
   at it. DuckDB reads all three formats in place; an Excel file is read as its first
   sheet. It seeds a new package, so it requires a package name: it cannot be combined

--- a/packages/create-malloy-package/src/index.spec.ts
+++ b/packages/create-malloy-package/src/index.spec.ts
@@ -98,6 +98,30 @@ describe("formatSuccess: the readiness check", () => {
       );
    });
 
+   test("names loadable files --data left behind, and how to add them", () => {
+      // Silence here read as "those files are not supported" rather than
+      // "--data takes one and you picked this one".
+      const output = formatSuccess(
+         resultFor({
+            packageName: "wine",
+            siblingDataFiles: ["wine-130k.json", "wine-150k.csv"],
+         }),
+      );
+      expect(output).toContain("Not included: wine-130k.json, wine-150k.csv");
+      expect(output).toContain("wine/data/");
+   });
+
+   test("caps the list instead of printing a whole directory", () => {
+      const many = Array.from({ length: 9 }, (_, i) => `f${i}.csv`);
+      const output = formatSuccess(resultFor({ siblingDataFiles: many }));
+      expect(output).toContain("and 4 more");
+      expect(output).not.toContain("f7.csv");
+   });
+
+   test("says nothing when there were no other files", () => {
+      expect(formatSuccess(resultFor())).not.toContain("Not included:");
+   });
+
    test("a setup-only run says the package list 404s instead of offering it", () => {
       const result = scaffold({
          name: undefined,

--- a/packages/create-malloy-package/src/index.ts
+++ b/packages/create-malloy-package/src/index.ts
@@ -55,7 +55,7 @@ function resolveDataFile(cwd: string, data?: string): string | undefined {
    }
    if (data.trim() === "") {
       throw new ScaffoldError(
-         `--data was given an empty filename. Pass the CSV, Parquet, or XLSX ` +
+         `--data was given an empty filename. Pass the CSV, Parquet, JSON, NDJSON, or XLSX ` +
             `file to seed the package from, or leave --data off to use the ` +
             `sample data.`,
       );
@@ -684,6 +684,21 @@ export function formatSuccess(result: ScaffoldResult): string {
          ),
       );
    }
+   if (result.siblingDataFiles) {
+      // --data takes exactly one file. Pointing it at a folder of related
+      // exports modelled one and said nothing about the rest, so the omission
+      // read as "those formats are not supported" rather than "you picked one".
+      const shown = result.siblingDataFiles.slice(0, 5);
+      const rest = result.siblingDataFiles.length - shown.length;
+      lines.push(
+         log.dim(
+            `  Not included: ${shown.join(", ")}${
+               rest > 0 ? ` and ${rest} more` : ""
+            }. --data takes one file; copy any others into ` +
+               `${result.packageName}/data/ and add a source for each.`,
+         ),
+      );
+   }
    if (result.configExtended) {
       lines.push(
          `${log.green("✓")} Registered ${log.bold(
@@ -1057,7 +1072,7 @@ program
    )
    .option(
       "--data <file>",
-      "seed the package from a CSV, Parquet, or XLSX file",
+      "seed the package from a CSV, Parquet, JSON, NDJSON, or XLSX file",
    )
    // Not --host: Publisher's own server takes `--host <address>` for the
    // interface it binds to, and the start command this tool writes now passes

--- a/packages/create-malloy-package/src/scaffold.spec.ts
+++ b/packages/create-malloy-package/src/scaffold.spec.ts
@@ -376,7 +376,9 @@ describe("scaffold: --data", () => {
       fs.mkdirSync(dir);
       const src = path.join(dir, "orders.csv");
       fs.writeFileSync(src, "id\n1\n");
-      expect(run({ name: "shop", dataFile: src }).siblingDataFiles).toBeUndefined();
+      expect(
+         run({ name: "shop", dataFile: src }).siblingDataFiles,
+      ).toBeUndefined();
    });
 
    test("rejects a missing --data file", () => {

--- a/packages/create-malloy-package/src/scaffold.spec.ts
+++ b/packages/create-malloy-package/src/scaffold.spec.ts
@@ -320,13 +320,63 @@ describe("scaffold: --data", () => {
       expect(model).toContain("duckdb.table('data/budget.xlsx')");
    });
 
+   test("copies a json file and points the model at it", () => {
+      // DuckDB reads .json in place exactly like .csv, so there is no reason to
+      // refuse it: doing so taught agents that only CSV worked and sent them to
+      // python to read a .json file rather than modelling it.
+      const src = path.join(tmp, "reviews.json");
+      fs.writeFileSync(src, '[{"id":1}]');
+      const result = run({ name: "shop", dataFile: src });
+      expect(result.packageCreated).toBe(true);
+      expect(exists("shop/data/reviews.json")).toBe(true);
+      const model = fs.readFileSync(path.join(tmp, "shop/shop.malloy"), "utf8");
+      expect(model).toContain("duckdb.table('data/reviews.json')");
+   });
+
+   test("copies an ndjson file and points the model at it", () => {
+      const src = path.join(tmp, "events.ndjson");
+      fs.writeFileSync(src, '{"id":1}\n{"id":2}\n');
+      run({ name: "shop", dataFile: src });
+      expect(exists("shop/data/events.ndjson")).toBe(true);
+      const model = fs.readFileSync(path.join(tmp, "shop/shop.malloy"), "utf8");
+      expect(model).toContain("duckdb.table('data/events.ndjson')");
+   });
+
    test("rejects an unsupported file type with nothing created", () => {
       const src = path.join(tmp, "notes.txt");
       fs.writeFileSync(src, "hello");
       expect(() => run({ name: "shop", dataFile: src })).toThrow(
-         /\.csv, \.parquet, or \.xlsx/i,
+         /\.csv, \.parquet, \.json, \.ndjson, \.xlsx/i,
       );
       expect(exists("shop")).toBe(false);
+   });
+
+   test("names other loadable files in the same directory", () => {
+      // --data takes exactly one file. Pointing it at a folder of related
+      // exports modelled one and said nothing about the rest, so the omission
+      // read as "unsupported" rather than "you picked one of these".
+      const dir = path.join(tmp, "exports");
+      fs.mkdirSync(dir);
+      const src = path.join(dir, "wine-130k.csv");
+      fs.writeFileSync(src, "id\n1\n");
+      fs.writeFileSync(path.join(dir, "wine-150k.csv"), "id\n1\n");
+      fs.writeFileSync(path.join(dir, "wine-130k.json"), "[]");
+      fs.writeFileSync(path.join(dir, "notes.txt"), "ignored");
+
+      const result = run({ name: "shop", dataFile: src });
+      // Sorted, the chosen file excluded, and non-loadable files ignored.
+      expect(result.siblingDataFiles).toEqual([
+         "wine-130k.json",
+         "wine-150k.csv",
+      ]);
+   });
+
+   test("says nothing about siblings when the file is alone", () => {
+      const dir = path.join(tmp, "solo");
+      fs.mkdirSync(dir);
+      const src = path.join(dir, "orders.csv");
+      fs.writeFileSync(src, "id\n1\n");
+      expect(run({ name: "shop", dataFile: src }).siblingDataFiles).toBeUndefined();
    });
 
    test("rejects a missing --data file", () => {

--- a/packages/create-malloy-package/src/scaffold.ts
+++ b/packages/create-malloy-package/src/scaffold.ts
@@ -113,7 +113,7 @@ export interface ScaffoldOptions {
    name?: string;
    /** Directory the workspace files are written to; also the server root. */
    cwd: string;
-   /** A CSV, Parquet, or XLSX file to seed the package from instead of the sample. */
+   /** A CSV, Parquet, JSON, NDJSON, or XLSX file to seed the package from instead of the sample. */
    dataFile?: string;
    host: Host;
    /** Overwrite existing workspace files instead of leaving them in place. */
@@ -129,6 +129,11 @@ export interface ScaffoldResult {
    dataPath?: string;
    /** The --data file's own name, set only when copying it in had to rename it. */
    dataFileRenamedFrom?: string;
+   /**
+    * Other loadable data files alongside the --data file, which this run did
+    * NOT include. Set only when there is at least one.
+    */
+   siblingDataFiles?: string[];
    /** The environment the package is registered in, which may not be "default". */
    envName: string;
    /**
@@ -487,6 +492,10 @@ function createPackage(options: ScaffoldOptions, result: ScaffoldResult): void {
          // The copy is what the model reads, so the name in the package is the
          // one the user has to look for. Silently renaming it hid their file.
          result.dataFileRenamedFrom = sourceBase;
+      }
+      const siblings = findSiblingDataFiles(options.dataFile);
+      if (siblings.length > 0) {
+         result.siblingDataFiles = siblings;
       }
       writeFile(
          path.join(packageDir, modelFile),
@@ -2018,20 +2027,64 @@ function claudeFile(agentsFile: string): string {
    );
 }
 
+/**
+ * Extensions the generated `duckdb.table('<path>')` reads with no extra setup.
+ *
+ * One list, used both to validate --data and to spot loadable files sitting
+ * next to it. DuckDB reads all of these in place, so a package never needs a
+ * file converted first; keeping JSON off this list is what taught agents that
+ * only CSV worked and sent them to python to read a .json.
+ */
+const LOADABLE_DATA_EXTENSIONS = [
+   ".csv",
+   ".parquet",
+   ".json",
+   ".ndjson",
+   ".xlsx",
+] as const;
+
+function isLoadableDataFile(file: string): boolean {
+   return (LOADABLE_DATA_EXTENSIONS as readonly string[]).includes(
+      path.extname(file).toLowerCase(),
+   );
+}
+
 function validateDataFile(dataFile: string): void {
    if (!fs.existsSync(dataFile) || !fs.statSync(dataFile).isFile()) {
       // printable(), because the path is echoed to a terminal and a filename can
       // hold ESC or CR: see printable() in names.ts.
       throw new ScaffoldError(`--data file not found: ${printable(dataFile)}`);
    }
-   const ext = path.extname(dataFile).toLowerCase();
-   if (ext !== ".csv" && ext !== ".parquet" && ext !== ".xlsx") {
+   if (!isLoadableDataFile(dataFile)) {
       throw new ScaffoldError(
-         `--data must be a .csv, .parquet, or .xlsx file (got "${printable(
+         `--data must be one of ${LOADABLE_DATA_EXTENSIONS.join(", ")} (got "${printable(
             path.basename(dataFile),
          )}").`,
       );
    }
+}
+
+/**
+ * Other loadable files in the --data file's own directory.
+ *
+ * --data takes exactly one file and said nothing about the rest, so pointing it
+ * at a folder of related exports silently modelled one of them. Naming the
+ * others does not change what gets scaffolded; it just stops the omission from
+ * being invisible.
+ */
+function findSiblingDataFiles(dataFile: string): string[] {
+   let entries: string[];
+   try {
+      entries = fs.readdirSync(path.dirname(dataFile));
+   } catch {
+      // An unreadable directory is not worth failing a successful scaffold over.
+      return [];
+   }
+   const chosen = path.basename(dataFile);
+   return entries
+      .filter((e) => e !== chosen && isLoadableDataFile(e))
+      .sort()
+      .map(printable);
 }
 
 /** npm names are lowercase and url-safe; fall back if nothing survives. */


### PR DESCRIPTION
Two ways the scaffolder taught agents something false about the data it can model. Both come from one session, where an agent pointed at a folder of three wine datasets, got one, and concluded JSON was unsupported.

## 1. `--data` rejected `.json`

DuckDB reads JSON in place exactly like CSV, and the generated `duckdb.table('<path>')` template needs **no change at all** to handle it, so the refusal was arbitrary. It was also the loudest of four signals telling agents only CSV worked, which is how one ended up shelling out to `python3` to read a `.json` file rather than querying it.

`.json` and `.ndjson` now scaffold and produce a working model. Verified by running the scaffolder for real:

```
$ create-malloy-package wine --data ./reviews.json
✓ Created package wine in ./wine

source: wine is duckdb.table('data/reviews.json') extend {
  measure: record_count is count()
  ...
```

## 2. `--data` silently ignored everything else in the directory

It takes exactly one file and never said so at the point it mattered, so pointing it at an export folder modelled one and left the omission invisible. Reproducing the original scenario:

```
$ create-malloy-package wine --data ./exports/winemag-130k.csv
✓ Created package wine in ./wine
  Not included: winemag-130k.json, winemag-150k.csv. --data takes one file;
  copy any others into wine/data/ and add a source for each.
```

This does not change what gets scaffolded, only what the run tells you. Capped at five names so a large directory does not flood the output.

## Notes

- The accepted extensions are now **one list** (`LOADABLE_DATA_EXTENSIONS`) used both to validate `--data` and to find siblings, rather than a literal repeated per call site.
- **`README.md`'s `--data` line moves here, with the validator**, rather than in #939's docs commit. Documenting JSON as accepted while the CLI still refused it would have been wrong in the other direction.
- `findSiblingDataFiles` swallows an unreadable directory rather than failing an otherwise successful scaffold, and runs filenames through the existing `printable()` so a crafted name cannot inject escapes into the terminal.

## Tests

327 pass, lint and typecheck clean. New coverage: `.json` and `.ndjson` scaffold to a correct model path; the rejection message lists the new extensions; siblings are sorted, exclude the chosen file, and ignore non-loadable ones; no `siblingDataFiles` key when the file is alone; the output caps at five with "and N more"; and no line at all when there were no siblings.

## Follow-up, not in this PR

The same session's bigger onboarding problem is still open: "Next steps" prints `npm start` with no indication it is a long-running process, then two `curl` checks below it that return nothing until it is running. That is the next PR, along with the MCP/skills registration remedies.