### PR TITLE
docs(mcp): tell malloy_compile callers how to check part of a source

### DIFF
--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -26,6 +26,20 @@ The server listens at `http://localhost:4040/mcp` (set the port with `--mcp_port
 ### Authoring tools
 
 - `malloy_compile`: compile Malloy source against a model and return structured diagnostics (`severity`, `message`, `line`, `character`) without running a query, so an agent can validate a change while authoring instead of firing a throwaway query. Positions are 0-based and relative to the model file with the submitted source appended to it.
+
+  Because the source is *appended*, it has to stand on its own as top-level Malloy, and the two most natural ways to check an edit both fail for reasons that have nothing to do with the edit. A bare `view:` / `dimension:` / `measure:` is not a top-level statement (`no viable alternative at input 'view:'`), and resubmitting the source you are editing collides with the model's own copy (`Cannot redefine '<name>'`). To check part of a source, either send the view body as a top-level query:
+
+  ```malloy
+  query: check is orders -> { group_by: status, aggregate: revenue }
+  ```
+
+  or wrap the fragment in a throwaway extension, which puts it in the namespace the real edit will live in:
+
+  ```malloy
+  source: check is orders extend { measure: aov is revenue / nullif(order_count, 0) }
+  ```
+
+  Both compile against the real source, so inherited measures resolve and `private:` fields stay hidden exactly as they would in place. An extension *adds* to a source's namespace rather than overriding it, so a fragment reusing an existing view name reports `Cannot redefine` too; rename it for the check.
 - `malloy_reloadPackage`: recompile a package from its on-disk content so a source or view added after boot becomes queryable by name, without restarting the server. This is the other half of the authoring loop: validate with `malloy_compile`, save, reload, then query. A reload that fails to compile leaves the package's files alone and keeps serving the previously compiled model, returning the compile errors.
 
 ### Skills as MCP prompts

--- a/packages/server/src/mcp/tools/compile_tool.ts
+++ b/packages/server/src/mcp/tools/compile_tool.ts
@@ -51,8 +51,13 @@ const COMPILE_DESCRIPTION = `Compile-check Malloy source against a model and ret
 - source (required): the Malloy text to validate.
 - includeSql (optional): also return the generated SQL when the source ends in a runnable query. The query is still not executed and no data is scanned.
 
+## Checking part of a source
+Your source is APPENDED to the model, so it has to stand on its own as top-level Malloy. Two things follow, and both have error messages that name the symptom rather than the cause:
+- A bare \`view:\`, \`dimension:\`, or \`measure:\` is not a top-level statement. Submitted alone it fails with "no viable alternative at input 'view:'". To check a view's body, send it as a top-level query instead: \`query: check is <source> -> { ... }\`. To check a field or view in the namespace it will actually live in, wrap it in a throwaway extension: \`source: check is <source> extend { <your fragment> }\`. Both compile against the real source, so inherited measures resolve and \`private:\` fields stay hidden exactly as they would in place.
+- Resubmitting the whole source you are editing fails with "Cannot redefine '<name>'", because the model already declares that name. Use one of the two forms above instead. Note an extension ADDS to a source's namespace rather than overriding it, so a fragment reusing an existing view name reports the same error; rename it for the check.
+
 ## Response
-A JSON object with status ("success" or "error") and diagnostics: an array of { severity ("error" / "warn" / "debug"), message, code, line, character, endLine, endCharacter, replacement }. Positions are 0-based (line and character start at 0) and relative to the model file with your source appended to it, so a diagnostic in your submitted source lands after the model's own line count, and a diagnostic may point at pre-existing content in the model rather than at your source. A clean compile can still return warnings; status is "error" only when at least one diagnostic has error severity.`;
+A JSON object with status ("success" or "error") and diagnostics: an array of { severity ("error" / "warn" / "debug"), message, code, line, character, endLine, endCharacter, replacement }. Positions are 0-based (line and character start at 0) and relative to the model file with your source appended to it, so a diagnostic in your submitted source lands after the model's own line count, and a diagnostic may point at pre-existing content in the model rather than at your source. Any wrapper you add counts toward that offset too. A clean compile can still return warnings; status is "error" only when at least one diagnostic has error severity.`;
 
 /**
  * Registers the malloy_compile MCP tool: validates Malloy source against a model

--- a/packages/server/src/service/compile_fragment_techniques.spec.ts
+++ b/packages/server/src/service/compile_fragment_techniques.spec.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { Environment } from "./environment";
+
+/**
+ * The fragment-checking advice in malloy_compile's tool description, pinned
+ * against the REAL compiler.
+ *
+ * That description tells an agent how to validate part of a source: send a view
+ * body as a top-level `query:`, or wrap a field in a throwaway `extend`, and do
+ * not resubmit the source being edited. None of that is enforced by code, so
+ * nothing but a test stops it from quietly becoming false. Asserting it against
+ * a hand-written checker would be worthless: only Malloy decides what compiles.
+ */
+
+const PUBLISHER_JSON = JSON.stringify({
+   name: "pkg",
+   description: "fragments",
+});
+
+// `secret` is private on the base source, so nothing downstream may read it.
+const MODEL = `##! experimental.access_modifiers
+source: base is duckdb.sql("SELECT 1.5 as price, 90 as points, 'shh' as secret") include {
+  public: price, points
+  private: secret
+}
+
+source: sales is base extend {
+  measure: record_count is count()
+  measure: avg_price is avg(price)
+  view: overview is { aggregate: record_count }
+}
+`;
+
+describe("malloy_compile: checking part of a source", () => {
+   let rootDir: string;
+   let env: Environment;
+
+   beforeEach(async () => {
+      rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "publisher-frag-"));
+      const envPath = path.join(rootDir, "env");
+      await fs.mkdir(envPath, { recursive: true });
+      env = await Environment.create("testEnv", envPath, []);
+      await env.installPackage("pkg", async (stagingPath) => {
+         await fs.mkdir(stagingPath, { recursive: true });
+         await fs.writeFile(
+            path.join(stagingPath, "publisher.json"),
+            PUBLISHER_JSON,
+         );
+         await fs.writeFile(path.join(stagingPath, "model.malloy"), MODEL);
+      });
+   });
+
+   afterEach(async () => {
+      await fs.rm(rootDir, { recursive: true, force: true }).catch(() => {});
+   });
+
+   /** Error-severity messages from compiling `source` against the fixture. */
+   async function errorsFor(source: string): Promise<string[]> {
+      const result = await env.compileSource("pkg", "model.malloy", source);
+      return (result.problems ?? [])
+         .filter((p) => p.severity === "error")
+         .map((p) => p.message);
+   }
+
+   describe("the two failures the description exists to explain", () => {
+      it("rejects a bare view: fragment, naming only the symptom", async () => {
+         const errors = await errorsFor(
+            "view: by_pts is { group_by: points, aggregate: record_count }",
+         );
+         expect(errors.join(" ")).toContain("view:");
+      });
+
+      it("rejects resubmitting the source being edited", async () => {
+         // The natural move when validating an edit, and it fails for a reason
+         // that has nothing to do with the edit.
+         const errors = await errorsFor(`source: sales is base extend {
+  measure: record_count is count()
+  view: by_pts is { group_by: points }
+}`);
+         expect(errors.join(" ")).toContain("Cannot redefine 'sales'");
+      });
+   });
+
+   describe("the top-level query: form", () => {
+      it("compiles a view body with no wrapper at all", async () => {
+         expect(
+            await errorsFor(
+               "query: check is sales -> { group_by: points, aggregate: record_count }",
+            ),
+         ).toEqual([]);
+      });
+
+      it("still resolves measures the source inherits", async () => {
+         expect(
+            await errorsFor(
+               "query: check is sales -> { aggregate: avg_price }",
+            ),
+         ).toEqual([]);
+      });
+   });
+
+   describe("the throwaway extend form", () => {
+      const wrap = (fragment: string, into = "sales") =>
+         `source: check is ${into} extend {\n${fragment}\n}`;
+
+      it("compiles bare view, measure, and dimension fragments", async () => {
+         expect(
+            await errorsFor(
+               wrap(
+                  "view: by_pts is { group_by: points, aggregate: record_count }",
+               ),
+            ),
+         ).toEqual([]);
+         expect(
+            await errorsFor(wrap("measure: max_price is max(price)")),
+         ).toEqual([]);
+         expect(
+            await errorsFor(wrap("dimension: pricey is price > 1")),
+         ).toEqual([]);
+      });
+
+      it("resolves measures the source inherits", async () => {
+         expect(
+            await errorsFor(wrap("view: v is { aggregate: avg_price }")),
+         ).toEqual([]);
+      });
+
+      it("hides a private field exactly as an in-place extension does", async () => {
+         // The fidelity claim in the description: the wrapper must not widen or
+         // narrow visibility versus the edit it stands in for.
+         const wrapped = await errorsFor(wrap("dimension: s is secret"));
+         const inPlace = await errorsFor(
+            "source: probe is base extend { dimension: s is secret }",
+         );
+         expect(wrapped.join(" ")).toContain("private");
+         expect(inPlace.join(" ")).toContain("private");
+      });
+
+      it("reports a redefinition when the fragment reuses an existing name", async () => {
+         // The documented caveat: an extension adds to the namespace rather
+         // than overriding it, so checking an EDIT needs the fragment renamed.
+         expect(
+            await errorsFor(wrap("view: overview is { aggregate: avg_price }")),
+         ).toEqual(["Cannot redefine 'overview'"]);
+
+         expect(
+            await errorsFor(
+               wrap("view: overview__check is { aggregate: avg_price }"),
+            ),
+         ).toEqual([]);
+      });
+   });
+});


### PR DESCRIPTION
`malloy_compile` **appends** the submitted source to the model, so it has to stand on its own as top-level Malloy. The two most natural ways to validate an edit both fail, and both messages name the symptom rather than the cause:

```malloy
view: by_pts is { group_by: points }   ->  no viable alternative at input 'view:'
source: sales is base extend { ... }   ->  Cannot redefine 'sales'
```

Nothing in the tool description or the docs said so, or said what to do instead. Two forms work:

```malloy
query: check is sales -> { group_by: points }              // no wrapper needed
source: check is sales extend { measure: m is max(price) } // fragment in its real namespace
```

Both compile against the real source, so inherited measures resolve and `private:` fields stay hidden exactly as they do in place.

## This started as a parameter, and shouldn't have been one

The first draft added an `extendSource` param that generated the wrapper. Testing what an agent can already do **today, with no server change**, killed it:

| Approach | Result |
|---|---|
| Resubmit the whole edited source | ❌ `Cannot redefine 'sales'` |
| Write the `extend` wrapper by hand | ✅ works |
| Copy the source under a new name | ✅ works |
| Top-level `query:` instead of a `view:` | ✅ works, **no wrapper at all** |

The parameter added **zero capability** — it emitted exactly the string in row 2, which an agent can type. It would have been permanent public surface duplicating a technique it doesn't even do best: the top-level `query:` form is simpler and needs no wrapper. The real gap was that nothing taught any of this.

So the production diff is **7 lines**: a "Checking part of a source" section in `COMPILE_DESCRIPTION`, mirrored in `docs/ai-agents.md`.

## The test drives the real compiler

`compile_fragment_techniques.spec.ts` runs against a real `Environment` and package, not a mock, because only Malloy decides what compiles and a hand-written checker would drift from it and could pass on the exact case it exists to catch. Advice that lives only in prose rots silently; this is what stops it. It pins:

- both documented failures, by their real messages
- both working forms
- that inherited measures resolve through each form
- that a `private:` field stays hidden in the wrapper **exactly as it does in an in-place extension** (the fidelity claim the description makes)
- the redefinition caveat, plus the rename workaround

## Verification

1581 server unit tests pass, lint and typecheck clean (typecheck has two pre-existing errors in `src/service/package.ts`, confirmed identical on a clean tree).

## Note for the reviewer

This touches `compile_tool.ts`'s description constant only, so it should not conflict with #938, which changes that file's return statements.