### PR TITLE
chore: bump skills to 0.1.2 and create-malloy-package to 0.0.3

### DIFF
--- a/packages/create-malloy-package/package.json
+++ b/packages/create-malloy-package/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/create-malloy-package",
    "description": "Scaffold a Malloy Publisher package and a local agent workspace, so one command takes you from nothing to an agent that can query your data.",
-   "version": "0.0.2",
+   "version": "0.0.3",
    "license": "MIT",
    "type": "module",
    "engines": {

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/skills",
    "description": "Agent skills for Malloy and the Malloy Publisher",
-   "version": "0.1.1",
+   "version": "0.1.2",
    "license": "MIT",
    "type": "module",
    "main": "dist/index.js",


### PR DESCRIPTION
Both packages sit at exactly the version npm already serves, so neither can be published without a bump: npm versions are immutable, and a dispatch of either publish workflow dies with EPUBLISHCONFLICT.

skills has four SKILL.md files and two READMEs changed since 0.1.1 was published on 07-28, from #939, #946, #948 and #951.

create-malloy-package carries all of #946, which merged on 0.0.2 and so reaches no user until this ships.

Publish skills first. The scaffolder's publish job rewrites its workspace:* skills dep to whatever version main declares and then asks npm whether that range resolves, so dispatching it before skills is up fails on purpose.