### PR TITLE
chore(create-malloy-package): pin server 0.0.233, release 0.0.4

### DIFF
--- a/packages/create-malloy-package/package.json
+++ b/packages/create-malloy-package/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/create-malloy-package",
    "description": "Scaffold a Malloy Publisher package and a local agent workspace, so one command takes you from nothing to an agent that can query your data.",
-   "version": "0.0.3",
+   "version": "0.0.4",
    "license": "MIT",
    "type": "module",
    "engines": {

--- a/packages/create-malloy-package/src/scaffold.ts
+++ b/packages/create-malloy-package/src/scaffold.ts
@@ -275,7 +275,7 @@ const BIND_HOST = "127.0.0.1";
  * and confirm the new version still honours --host. A generated workspace can
  * move itself off it by editing the scripts in its own package.json.
  */
-export const SERVER_VERSION = "0.0.232";
+export const SERVER_VERSION = "0.0.233";
 
 function startCommandFor(envName: string): string {
    return (


### PR DESCRIPTION
Server 0.0.233 is on npm and is `latest`. The scaffolder bakes its server pin into the published dist, so until this ships every generated workspace keeps booting 0.0.232 and misses everything released since: the MCP tool-description ordering, the reference-file prompts, the row-truncation signal, and the corrected spreadsheet guidance in the bundled skills.

0.0.3 is already published, so the version has to move for the release workflow to run at all.

### The `--host` check the comment asks for

The comment above `SERVER_VERSION` asks whoever bumps it to confirm the new server still honours `--host`, so I ran it rather than assuming. Booted published 0.0.233 with `--host 127.0.0.1`: both listeners bind loopback only, and the machine's LAN address refuses, which is the negative control that makes the result mean something.

That check matters because the server accepts an unknown flag without a word and falls back to binding `0.0.0.0`. If `--host` were ever renamed or dropped, every generated workspace would serve an unauthenticated REST API and MCP endpoint on every interface while its own `package.json`, `AGENTS.md` and README all still said 127.0.0.1.

### Verified end to end, not just built

Scaffolded a workspace with the built bin and booted it on the pinned server: `packages=1 load_errors=0`, a real query returned `{"record_count":10,"total_amount":1653.95}`, and all five `malloy_*` tools are exposed on the MCP endpoint. Both generated start scripts (`start` and `reset`) carry the new pin, not just the first.

Also checked that `0.0.4` is free on npm and that the `^0.1.2` skills range the publish job writes still resolves, since both would otherwise fail the dispatch after every gate had passed.

### One gap this surfaced, not fixed here

Nothing validates that `SERVER_VERSION` points at a version that exists. No spec references it, `check-pack` does not check it, and the publish path only validates dependency ranges, which this is not: it is a string in a generated script. A typo like `0.0.323` would pass every gate, publish successfully, and then fail at `npm start` for every user, on a version that cannot be replaced. Happy to follow up with a registry check in `check-pack --publish-ready` alongside the existing dependency check.
