### PR TITLE
chore: release skills 0.1.3 and create-malloy-package 0.0.5

### DIFF
--- a/packages/create-malloy-package/package.json
+++ b/packages/create-malloy-package/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/create-malloy-package",
    "description": "Scaffold a Malloy Publisher package and a local agent workspace, so one command takes you from nothing to an agent that can query your data.",
-   "version": "0.0.4",
+   "version": "0.0.5",
    "license": "MIT",
    "type": "module",
    "engines": {

--- a/packages/create-malloy-package/src/scaffold.ts
+++ b/packages/create-malloy-package/src/scaffold.ts
@@ -275,7 +275,7 @@ const BIND_HOST = "127.0.0.1";
  * and confirm the new version still honours --host. A generated workspace can
  * move itself off it by editing the scripts in its own package.json.
  */
-export const SERVER_VERSION = "0.0.233";
+export const SERVER_VERSION = "0.0.234";
 
 function startCommandFor(envName: string): string {
    return (

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/skills",
    "description": "Agent skills for Malloy and the Malloy Publisher",
-   "version": "0.1.2",
+   "version": "0.1.3",
    "license": "MIT",
    "type": "module",
    "main": "dist/index.js",


### PR DESCRIPTION
Two version bumps and the server pin. Neither package can publish at the version main currently declares.

## skills 0.1.3

0.1.2 is published, and the `malloy-analysis` and `malloy-gotchas-queries` corrections landed after it was cut. Checked against the published tarball rather than the commit graph: 0.1.2 unpacks 30 skills and does not contain the new text, so an agent installing the package today gets neither correction. npm versions are immutable, so that content reaches an installed workspace only under a new one.

## create-malloy-package 0.0.5, and 0.0.4 is skipped

0.0.4 is on main but was never published, and it pins server 0.0.233. Server 0.0.234 went out today, so publishing 0.0.4 would bake in a pin one release behind on the day it shipped and need another bump immediately. Going straight to 0.0.5 moves the pin once instead of twice. npm has no objection to a version gap.

What that does for a user: published 0.0.3 pins server 0.0.232, so a fresh `npm create` currently generates a workspace two server releases behind. 0.0.5 pins 0.0.234, which picks up both.

## The --host check the SERVER_VERSION comment asks for

Run, not assumed. Booted published 0.0.234 with `--host 127.0.0.1`: `lsof` reports both listeners on `127.0.0.1:<port>` specifically rather than `*:`, loopback answers 200 on both REST and MCP, and the machine's LAN address refuses on both.

The negative control is the part that makes the result mean anything. The server accepts an unknown flag without a word and falls back to binding `0.0.0.0`, so if `--host` were ever renamed or dropped, every generated workspace would serve an unauthenticated REST API and MCP endpoint on every interface while its own package.json, AGENTS.md and README all still said 127.0.0.1.

## The lockfile is deliberately untouched

main already records 0.1.1 and 0.0.2 for these two workspace packages while their package.json files read 0.1.2 and 0.0.4, and CI installs with `--frozen-lockfile` against exactly that, so bun does not enforce a workspace package's version there. Editing it would be a re-resolve with no gate behind it, and a broad re-resolve is what turned CI red on #926.

## Publish order is not optional: skills first

The scaffolder's publish job pins its `workspace:*` skills dependency to whatever main declares and then asks npm whether `^0.1.3` resolves, so dispatching the scaffolder before skills is up fails by design.

## Gate

Run after `generate-api-types` and `build:sdk`, since the root typecheck chains neither: typecheck clean, lint clean, prettier clean over tracked files, and 2404 tests pass with 0 failures (1783 server unit, 232 integration, 362 create-malloy-package, 20 hammer, 7 skills).

One consequence worth stating. The registry version check that shipped in 0.0.3 has had nothing to report until now, because 0.0.4 never published. Once 0.0.5 is out, anyone still on 0.0.3 gets told they are behind.
