### PR TITLE
docs: add a security policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,12 @@ information on using pull requests.
 This project follows
 [The Linux Foundation's Code of Conduct](https://lfprojects.org/policies/code-of-conduct/).
 
+## Security
+
+Report a security vulnerability privately rather than as a public issue.
+[SECURITY.md](SECURITY.md) has the reporting form, what's in scope, and when filing in the open is
+fine.
+
 ## Contributing to the Python SDK (`packages/python-client`)
 
 The Python SDK is **auto-generated** from `api-doc.yaml` using OpenAPI Generator plus a thin build script.

--- a/README.md
+++ b/README.md
@@ -258,3 +258,5 @@ process and sign-off are in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 - Join the [Malloy Slack](https://join.slack.com/t/malloy-community/shared_invite/zt-1kgfwgi5g-CrsdaRqs81QY67QW0~t_uw)
 - Report issues on [GitHub](https://github.com/malloydata/publisher/issues)
+- Report a security vulnerability privately — see [SECURITY.md](SECURITY.md) for the reporting form
+  and what's in scope

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,84 @@
+# Security policy
+
+## Supported versions
+
+Publisher releases continuously off `main`; there are no maintenance branches. Fixes land in the next
+release, and the ask is that you upgrade rather than expect a backport.
+
+| Version             | Supported |
+| ------------------- | --------- |
+| Latest release      | ✅         |
+| Any earlier release | ❌         |
+
+## Reporting a vulnerability
+
+> Report privately: **[Report a vulnerability](https://github.com/malloydata/publisher/security/advisories/new)**
+> (repo → Security → Advisories → Report a vulnerability).
+
+What to include, as much as you have:
+
+- The affected version or commit.
+- How Publisher was configured and reached — flags, host binding, gateway or none.
+- Reproduction steps, or a proof of concept.
+- The impact you believe it has.
+
+## Private or public?
+
+- If you're unsure, report privately. We'd rather triage a non-issue in private than have a real one
+  land in public.
+- Maintainers may move a report into a public issue once it's clear it isn't sensitive.
+- Anything that exposes data or credentials, or executes code across a boundary Publisher claims,
+  goes private — always.
+- An issue that only weakens defense in depth behind the documented trusted tier is reasonable to
+  file in the open.
+
+## Scope
+
+Publisher is unauthenticated by design, and several of its governance features are documented as
+caller-asserted conventions rather than boundaries. That shapes what is and isn't a vulnerability
+here. Each item below defers to the doc that already documents the behavior.
+
+### Working as documented (not vulnerabilities)
+
+- The REST and MCP surfaces being unauthenticated, and the server binding `0.0.0.0` by default
+  ([README.md § Point your agent at it](README.md#point-your-agent-at-it),
+  [docs/ai-agents.md](docs/ai-agents.md)). The supported posture is loopback plus an
+  authenticating gateway.
+- `givens`, `#(authorize)`, and row-level access being caller-asserted
+  ([docs/authorize.md § Security model](docs/authorize.md#security-model),
+  [docs/row-level-access.md](docs/row-level-access.md)).
+- Broad reach for whoever can publish a package or `PATCH` a connection on a bare Publisher
+  ([docs/query-metadata.md](docs/query-metadata.md), [docs/packages.md](docs/packages.md)).
+- The default `Content-Security-Policy: frame-ancestors *`, which `PUBLISHER_FRAME_ANCESTORS` exists
+  to tighten ([docs/html-data-apps.md § Security model](docs/html-data-apps.md#security-model),
+  [docs/configuration.md](docs/configuration.md)).
+- Findings that require an operator to have ignored the documented deployment guidance.
+
+### In scope
+
+Anything that breaks a boundary Publisher does claim, including:
+
+- A request that reaches or returns rows from a source the package never exported — the
+  **queryable == discoverable** rule in
+  [docs/discovery-and-access.md](docs/discovery-and-access.md).
+- An `#(authorize)` gate that fails open when the given _is_ supplied.
+- Connection credentials or secrets leaking through an API response, log line, or error.
+- Escaping a package's static root — path traversal or symlink past the 403s in
+  [docs/html-data-apps.md § Security model](docs/html-data-apps.md#security-model).
+- Remote code execution via package load or model compile.
+- A reachable vulnerability in a bundled dependency.
+
+## What to expect
+
+- We acknowledge a report within 5 business days.
+- Within 10 business days, an in-scope / not-in-scope assessment and a rough timeline.
+- The advisory stays private until a fix ships.
+- You're credited in the published GHSA unless you'd rather not be.
+
+## Hardening
+
+Running Publisher somewhere it can be reached? Start with
+[docs/deployment.md](docs/deployment.md), then the trust models in
+[docs/authorize.md § Security model](docs/authorize.md#security-model),
+[docs/row-level-access.md](docs/row-level-access.md), and
+[docs/discovery-and-access.md](docs/discovery-and-access.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,8 @@
 
 ## Supported versions
 
-Publisher releases continuously off `main`; there are no maintenance branches. Fixes land in the next
-release, and the ask is that you upgrade rather than expect a backport.
+Publisher releases continuously off `main`; there are no maintenance branches, so only the latest
+release is supported. Fixes land in the next release — upgrade rather than expect a backport.
 
 | Version             | Supported |
 | ------------------- | --------- |
@@ -24,9 +24,8 @@ What to include, as much as you have:
 
 ## Private or public?
 
-- If you're unsure, report privately. We'd rather triage a non-issue in private than have a real one
-  land in public.
-- Maintainers may move a report into a public issue once it's clear it isn't sensitive.
+- If you're unsure, report privately — we'd rather triage a non-issue in private, and we'll move it
+  into the open once it's clearly not sensitive.
 - Anything that exposes data or credentials, or executes code across a boundary Publisher claims,
   goes private — always.
 - An issue that only weakens defense in depth behind the documented trusted tier is reasonable to
@@ -34,51 +33,51 @@ What to include, as much as you have:
 
 ## Scope
 
-Publisher is unauthenticated by design, and several of its governance features are documented as
-caller-asserted conventions rather than boundaries. That shapes what is and isn't a vulnerability
-here. Each item below defers to the doc that already documents the behavior.
+Publisher is unauthenticated by design, and several governance features are documented as
+caller-asserted conventions rather than boundaries — that shapes what counts as a vulnerability here.
 
 ### Working as documented (not vulnerabilities)
 
 - The REST and MCP surfaces being unauthenticated, and the server binding `0.0.0.0` by default
   ([README.md § Point your agent at it](README.md#point-your-agent-at-it),
-  [docs/ai-agents.md](docs/ai-agents.md)). The supported posture is loopback plus an
-  authenticating gateway.
-- `givens`, `#(authorize)`, and row-level access being caller-asserted
-  ([docs/authorize.md § Security model](docs/authorize.md#security-model),
-  [docs/row-level-access.md](docs/row-level-access.md)).
+  [docs/ai-agents.md](docs/ai-agents.md)). The supported posture is loopback for local use, an
+  authenticating gateway in front for anything wider.
+- `givens`, `#(authorize)`, and row-level access being caller-asserted, including the gaps in
+  [docs/authorize.md § Security model](docs/authorize.md#security-model) and
+  [§ Known limitations](docs/authorize.md#known-limitations), and in
+  [docs/row-level-access.md](docs/row-level-access.md).
 - Broad reach for whoever can publish a package or `PATCH` a connection on a bare Publisher
   ([docs/query-metadata.md](docs/query-metadata.md), [docs/packages.md](docs/packages.md)).
 - The default `Content-Security-Policy: frame-ancestors *`, which `PUBLISHER_FRAME_ANCESTORS` exists
   to tighten ([docs/html-data-apps.md § Security model](docs/html-data-apps.md#security-model),
   [docs/configuration.md](docs/configuration.md)).
-- Findings that require an operator to have ignored the documented deployment guidance.
+- Findings that require ignoring the deployment posture above.
 
 ### In scope
 
 Anything that breaks a boundary Publisher does claim, including:
 
-- A request that reaches or returns rows from a source the package never exported — the
-  **queryable == discoverable** rule in
+- A direct query succeeding against a source the package never exported — past the
+  **queryable == discoverable** boundary in
   [docs/discovery-and-access.md](docs/discovery-and-access.md).
-- An `#(authorize)` gate that fails open when the given _is_ supplied.
+- An `#(authorize)` gate granting access its expression should deny for the givens actually sent,
+  including none.
 - Connection credentials or secrets leaking through an API response, log line, or error.
-- Escaping a package's static root — path traversal or symlink past the 403s in
+- Escaping a package's static root — path traversal or symlink past the rejections in
   [docs/html-data-apps.md § Security model](docs/html-data-apps.md#security-model).
 - Remote code execution via package load or model compile.
 - A reachable vulnerability in a bundled dependency.
 
 ## What to expect
 
-- We acknowledge a report within 5 business days.
-- Within 10 business days, an in-scope / not-in-scope assessment and a rough timeline.
+- Acknowledgement within 5 business days.
+- An in-scope-or-not call, with a rough timeline, within 10.
 - The advisory stays private until a fix ships.
-- You're credited in the published GHSA unless you'd rather not be.
+- You're credited in the published advisory unless you'd rather not be.
 
 ## Hardening
 
-Running Publisher somewhere it can be reached? Start with
-[docs/deployment.md](docs/deployment.md), then the trust models in
-[docs/authorize.md § Security model](docs/authorize.md#security-model),
-[docs/row-level-access.md](docs/row-level-access.md), and
+Running Publisher where it can be reached? The deployment posture is in
+[README.md § Point your agent at it](README.md#point-your-agent-at-it), and the trust models behind
+givens are in [docs/authorize.md § Security model](docs/authorize.md#security-model) and
 [docs/discovery-and-access.md](docs/discovery-and-access.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,10 +61,11 @@ there for the primitive, then follow the application you need.
 
 ## Develop & contribute
 
-| Doc                              | Read it when you want to…                      |
-| -------------------------------- | ---------------------------------------------- |
-| [development.md](development.md) | Build and hack on Publisher from a clone.      |
-| [agent-skills/](agent-skills/)   | Author or contribute the bundled agent skills. |
+| Doc                              | Read it when you want to…                                  |
+| -------------------------------- | ---------------------------------------------------------- |
+| [development.md](development.md) | Build and hack on Publisher from a clone.                  |
+| [agent-skills/](agent-skills/)   | Author or contribute the bundled agent skills.             |
+| [../SECURITY.md](../SECURITY.md) | Report a security vulnerability, or check what's in scope. |
 
 ## Full public docs
 


### PR DESCRIPTION
Private vulnerability reporting is on for this repo, but nothing pointed at it and nothing
told a reporter what's in scope. This adds the written half.

## What it does

- New root `SECURITY.md`. GitHub picks it up from the root (matching the existing
  `CONTRIBUTING.md`) and surfaces it on the Security tab and in the new-issue flow.
  Supported versions, the private reporting form as the only channel, when public is fine,
  scope, what to expect, and where to look for hardening.
- Links it from the three places someone actually looks: the README's Community section
  (right beside "Report issues on GitHub", which is where you land with the wrong instinct),
  the docs index, and `CONTRIBUTING.md`.

The scope section is the part that's specific to Publisher. The server is unauthenticated by
design, and `givens` / `#(authorize)` / row-level access are documented as caller-asserted
conventions rather than boundaries. Without saying so out loud, the first thing a security
policy attracts is a stream of "the REST API has no auth!" reports. So there are two lists:
what's working as documented, and what breaks a boundary Publisher does claim — a direct
query succeeding against a source the package never exported, an `#(authorize)` gate granting
what its expression should deny, credentials in a response or log, escaping a package's
static root, RCE via package load or compile, a reachable dependency vuln.

Each scope item links the doc that already documents the behavior, so the policy stays a
pointer rather than a second source of truth that can drift.

Reporting is GitHub's private advisory form only — no security@ alias to maintain.

## Where the line sits

Drawing it took two passes. The first draft got both scope bullets subtly wrong in opposite
directions, so the second commit fixes them against the docs they defer to:

- **Overstated.** "Reaches or returns rows from a source the package never exported" would
  have called a documented feature a vulnerability — an unexported source "still compiles,
  imports, joins, and extends" (`docs/discovery-and-access.md`), and `governed-analytics`
  ships a model that does exactly that. Only a *direct* query 404s, so that's the boundary.
- **Understated.** "Fails open when the given *is* supplied" correctly excludes the
  caller-asserted non-boundary, but it also waived a gate that passes when no given is sent
  at all — which `docs/authorize.md` documents as always denying. Now it reads "for the
  givens actually sent, including none."

Also added authorize's § Known limitations to the caller-asserted bullet. It documents an
ungated `/compile` raw-SQL path as a tracked follow-up, which is a real gray zone that's
better named than left for someone to discover and report.

## One deviation worth flagging

`## Hardening` deliberately does **not** link `docs/deployment.md`, though that's the obvious
target. That doc has zero security or auth content — no host binding, loopback, or gateway
anywhere in its 147 lines — so pointing an operator there dead-ends the exact reader the
section exists for. It points at the README posture instead.

## Tested

Docs only, no code touched, so no build or test run applies (CI's prettier check covers
`packages/**/*.{ts,tsx}` and there's no markdownlint).

- All 9 relative links in `SECURITY.md` resolve on disk.
- Every section anchor the policy leans on exists: `README.md#point-your-agent-at-it`,
  `docs/authorize.md#security-model`, `docs/authorize.md#known-limitations`,
  `docs/html-data-apps.md#security-model`.
- Every scope claim re-read against the doc it cites — that's what caught the two above.
- `https://github.com/malloydata/publisher/security/advisories/new` returns 200, so the
  reporting link isn't a dead end.
- Tables padded by hand rather than running prettier, which would have churned unrelated
  README content.

Worth a look at the rendered links in the preview, and confirming the Security tab shows the
policy as defined after merge.

## One thing to confirm

The response times are a proposal, not something I can commit on the maintainers' behalf:
acknowledge within 5 business days, in-scope assessment plus rough timeline within 10. Happy
to change or drop them.

## Not in this PR

Fixing `docs/deployment.md` itself — see the deviation above. The trust-model prose lives in
`docs/authorize.md`, where a self-hoster won't find it. Worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
