### PR TITLE
fix(server): treat sourceName/queryName as names, not Malloy text

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3295,15 +3295,28 @@ components:
             set, the queryName parameter must be empty.
         sourceName:
           type: string
-          description:
+          description: |
             Name of the source in the model to use for queryName, search, and
             topValue requests.
+
+            A NAME, not Malloy code: a single source name exactly as the model
+            response's `sources` listing returns it. The server quotes it as a
+            Malloy identifier, so a name that needs quoting (a hyphen, a space,
+            a reserved word, a leading digit) works as-is and must be sent bare
+            — do not add backticks of your own. Anything richer than one name
+            (a parameterized source, an inline extension, a second statement)
+            belongs in `query`, and here is refused as an unresolvable name.
         queryName:
           type: string
-          description:
+          description: |
             Name of a query to execute on a source in the model. Requires the
             sourceName parameter is set. If the queryName parameter is set, the
             query parameter must be empty.
+
+            A NAME, not Malloy code, on the same terms as `sourceName`: one
+            view name as the model response lists it, quoted for you, sent
+            bare. A dotted path, a refinement (`by_carrier + { limit: 10 }`),
+            or any additional statement belongs in `query`.
         compactJson:
           type: boolean
           default: false

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -63,10 +63,14 @@ curl -s -X POST \
 
 The query body takes one of two shapes: `query` alone (ad-hoc Malloy, compiled in the model's
 context), or `queryName` without `query` (a named view when `sourceName` is set; a model-level
-named query when it is not). Any other combination returns a 400. The response's `result` field is
-a JSON string, so parse it; with `"compactJson": true` it holds plain row objects, without it the
-full Malloy result envelope with type metadata. `givens` rides on either shape to supply
-model-declared [runtime parameters](givens.md).
+named query when it is not). Any other combination returns a 400. On the named shape, `sourceName`
+and `queryName` are names and not Malloy code: send one name per field, bare, exactly as the model
+response's `sources` listing returns it — the server quotes it, so a name needing quotes works and
+backticks of your own do not. Anything richer than a name goes in `query`.
+
+The response's `result` field is a JSON string, so parse it; with `"compactJson": true` it holds
+plain row objects, without it the full Malloy result envelope with type metadata. `givens` rides on
+either shape to supply model-declared [runtime parameters](givens.md).
 
 ## Live API explorer
 

--- a/packages/create-malloy-package/src/names.ts
+++ b/packages/create-malloy-package/src/names.ts
@@ -246,9 +246,12 @@ function describeUnsafeCharacter(name: string): string {
  *   with "Cannot redefine '<word>'". A parse-only sweep does not see these, which
  *   is why they were missing for so long.
  *
- * A derived source name landing on either is suffixed (below) rather than quoted,
- * so the source stays queryable by a plain name through the REST/MCP query API,
- * which composes `run: <source> -> <view>` without quoting.
+ * A derived source name landing on either is suffixed (below) rather than quoted.
+ * The query API no longer requires that — it quotes `sourceName`/`queryName` as
+ * identifiers when it composes `run: <source> -> <view>`, so a name needing
+ * quotes is queryable there — but a quote-requiring name is still hostile to
+ * every place Malloy is written by hand (ad-hoc `query` text, notebooks, the
+ * model's own views), so the generator keeps producing plain names.
  *
  * This list is derived from the installed @malloydata/malloy rather than curated
  * by hand, and names.spec.ts re-derives both sets from that package on every run.

--- a/packages/server/src/mcp/tools/execute_query_tool.ts
+++ b/packages/server/src/mcp/tools/execute_query_tool.ts
@@ -49,8 +49,18 @@ const executeQueryShape = {
       ),
    modelPath: z.string().describe("Path to the .malloy model file"),
    query: z.string().optional().describe("Ad-hoc Malloy query code"),
-   sourceName: z.string().optional().describe("Source name for a view"),
-   queryName: z.string().optional().describe("Named query or view"),
+   sourceName: z
+      .string()
+      .optional()
+      .describe(
+         "Source name for a view. A NAME, not Malloy code: one name exactly as malloy_getContext returned it, sent bare (the server quotes it, so a hyphen or a reserved word is fine — do not add backticks yourself). Anything richer, such as a parameterized source or an inline extension, goes in query.",
+      ),
+   queryName: z
+      .string()
+      .optional()
+      .describe(
+         "Named query or view. A NAME, not Malloy code, on the same terms as sourceName: one view name as malloy_getContext returned it. A dotted path (carriers.by_name), a refinement (by_carrier + { limit: 10 }), or anything containing a newline goes in query instead.",
+      ),
    filterParams: z
       .record(z.union([z.string(), z.array(z.string())]))
       .optional()
@@ -68,23 +78,23 @@ const executeQueryShape = {
 const EXECUTE_QUERY_DESCRIPTION = `Run a Malloy query against a model and return the rows. Takes either ad-hoc Malloy in query, or a named view/query via queryName (with sourceName for a view).
 
 ## Contract rules
-- Check _limit_hit before reporting any total, count, or "top N". True means the server's default row cap cut the result off and more rows exist, so the numbers in front of you are a partial set, not the answer. A query that set its own limit: or top: does not set it, and returning exactly that many rows is a complete answer to what was asked.
+- Check _limit_hit before reporting any total, count, or "top N". True means the server's default cap cut the result off and more rows exist, so what came back is a partial set, not the answer.
 - Never sum or count the returned rows to state a total when _limit_hit or _rows_truncated is set. Aggregate in the query instead.
 - _returned_rows: 0 with _rows_truncated set means one row was too large to send, NOT that nothing matched. Do not report it as an empty result.
-- Use source, view, and field names exactly as malloy_getContext returned them.
+- Use source, view, and field names exactly as malloy_getContext returned them. sourceName/queryName take one NAME each, never Malloy code — they are quoted for you, so send even a hyphenated name bare, and put anything richer (a dotted path, a refinement, a second statement) in query.
 
 ## Response
-A JSON object, the same shape Credible's execute_query returns, so a data app behaves the same authored locally and served in production:
-- rows: flat objects keyed by column name, the shape an in-package data app receives.
+A JSON object, the same shape Credible's execute_query and an in-package data app receive:
+- rows: flat objects keyed by column name.
 - _meta: the Malloy metadata flat rows drop (schema with field types and render tags, annotations, connection_name, query_timezone).
 - _query_row_limit: the cap pushed into the SQL, from the query's own limit: or the server default.
 - _limit_source: "query" when the cap came from the query's own limit:/top:, "server_default" otherwise.
-- _limit_hit: the row count equals that cap AND the cap was the server default.
+- _limit_hit: the row count equals that cap AND the cap was the server default, so a query carrying its own limit:/top: never sets it and exactly that many rows is a complete answer.
 - _rows_truncated / _total_rows / _returned_rows: present only when the payload cap dropped rows.
 - _query_id: this query's id in the warehouse's own query history. Present only where enabled.
 - warning, renderLogErrors: present only when they apply.
 
-A query with no limit: of its own gets the server default, so a result landing exactly on _query_row_limit is almost never the whole table. Values above 2^53 are returned as JSON strings so their digits survive.`;
+Values above 2^53 are returned as JSON strings so their digits survive.`;
 
 // Type inference is handled automatically by the MCP server based on the executeQueryShape
 

--- a/packages/server/src/service/filter_bypass.spec.ts
+++ b/packages/server/src/service/filter_bypass.spec.ts
@@ -99,6 +99,29 @@ source: metrics is duckdb.table('events') extend {
 }
 `;
 
+// Protected and unprotected side by side, both named views, for the named-path
+// injection regression: the request names the UNPROTECTED source (so filter
+// lookup finds nothing to inject) while the statement that actually runs reads
+// the PROTECTED one.
+const MIXED_MODEL = `
+#(filter) name=Organization dimension=org_id type=equal implicit required
+source: products is duckdb.table('products') extend {
+   measure: n is count()
+   view: by_org is {
+      group_by: org_id, product_name
+      aggregate: n
+   }
+}
+
+source: metrics is duckdb.table('events') extend {
+   measure: c is count()
+   view: by_kind is {
+      group_by: kind
+      aggregate: c
+   }
+}
+`;
+
 beforeAll(async () => {
    await fs.mkdir(TEST_DB_DIR, { recursive: true });
    await fs.mkdir(TEST_PKG_DIR, { recursive: true });
@@ -119,6 +142,11 @@ beforeAll(async () => {
    await fs.writeFile(
       path.join(TEST_PKG_DIR, "analytics.malloy"),
       ANALYTICS_MODEL,
+      "utf-8",
+   );
+   await fs.writeFile(
+      path.join(TEST_PKG_DIR, "mixed.malloy"),
+      MIXED_MODEL,
       "utf-8",
    );
 });
@@ -387,6 +415,96 @@ describe("alias/extend/chain of a protected source is enforced (not restricted)"
          });
       });
    }
+});
+
+// ===========================================================================
+// Enforced: the named `sourceName`/`queryName` request shape.
+//
+// Issue #964. Filters resolve from the RAW `sourceName` on this path
+// (`getFilters(sourceName)`), and that lookup is a plain map read: a miss
+// returns `[]`, so nothing is injected and the query runs unfiltered. That is
+// the opposite failure direction from the query boundary's identical
+// exact-match miss, which 404s — so a statement smuggled through either field
+// reads the protected source with NO filter clause at all. Nothing here
+// depends on `explores`: `Model.create` leaves the boundary inert, which is
+// exactly the default deployment shape.
+// ===========================================================================
+
+/**
+ * Assert a named-path request is refused and returns no rows, reporting the
+ * leaked count on failure the way `expectFilterRejected` does — a success here
+ * is the bypass. The error class is not pinned: after the fix these fields are
+ * quoted as identifiers, so the request dies as an unresolvable name rather
+ * than as a missing-filter 400.
+ */
+async function expectNamedInjectionRejected(
+   model: Model,
+   sourceName: string | undefined,
+   queryName: string | undefined,
+): Promise<void> {
+   let leaked: Row[] | undefined;
+   try {
+      const { compactResult } = await model.getQueryResults(
+         sourceName,
+         queryName,
+      );
+      leaked = asRows(compactResult);
+   } catch {
+      return;
+   }
+   const orgs = [...new Set(leaked.map((r) => r.org_id))].join(", ");
+   throw new Error(
+      `Expected { sourceName: ${JSON.stringify(sourceName)}, queryName: ` +
+         `${JSON.stringify(queryName)} } to be rejected, but it succeeded and ` +
+         `returned ${leaked.length} rows across orgs [${orgs}] ` +
+         `(FILTER BYPASS / LEAK).`,
+   );
+}
+
+describe("a name field cannot smuggle a statement past filter injection", () => {
+   it("rejects a second run: statement opened through queryName", async () => {
+      const model = await makeModel("mixed.malloy");
+      // The request names the unprotected `metrics`, so `getFilters` finds
+      // nothing to inject — while the statement Malloy actually runs (the last
+      // one) reads the protected `products`.
+      await expectNamedInjectionRejected(
+         model,
+         "metrics",
+         "by_kind\nrun: products -> by_org",
+      );
+   });
+
+   it("rejects a second run: statement opened through sourceName", async () => {
+      const model = await makeModel("mixed.malloy");
+      // Same lookup miss, reached through the other field: the raw string
+      // `products->by_org\nrun: products` matches no source, so no filters.
+      await expectNamedInjectionRejected(
+         model,
+         "products->by_org\nrun: products",
+         "by_org",
+      );
+   });
+
+   it("still enforces and scopes the honest named read of the protected source", async () => {
+      const model = await makeModel("mixed.malloy");
+      let rejected = false;
+      try {
+         await model.getQueryResults("products", "by_org");
+      } catch (error) {
+         rejected = true;
+         expect(error).toBeInstanceOf(BadRequestError);
+         expect((error as Error).message).toContain("Organization");
+      }
+      expect(rejected).toBe(true);
+
+      const { compactResult } = await model.getQueryResults(
+         "products",
+         "by_org",
+         undefined,
+         { Organization: "acme" },
+      );
+      expectAcmeScoped(asRows(compactResult), 2);
+   });
 });
 
 // ===========================================================================

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -2340,10 +2340,13 @@ export class Model {
          // Before any compile: caller text may not declare an authorize gate (it
          // would override the author's — see the function's doc). Every
          // caller-supplied fragment that reaches the compiler is checked, not
-         // just the ad-hoc `query`: `sourceName`/`queryName` are interpolated
-         // verbatim into the `run:` statement below, so an annotation smuggled
-         // through either one lands in the compiled text exactly as one in
-         // `query` would.
+         // just the ad-hoc `query`. `sourceName`/`queryName` are quoted as
+         // identifiers below, so an annotation smuggled through either one can
+         // no longer become syntax — it is part of a name, and the request dies
+         // as an unresolvable one. Checking them anyway is defence in depth:
+         // it is cheap, it rejects the attempt before compilation rather than
+         // after, and it keeps the guard correct if the builder below ever
+         // changes shape again.
          for (const [field, callerText] of [
             ["query", query],
             ["source_name", sourceName],
@@ -2367,7 +2370,21 @@ export class Model {
          if (!sourceName && !queryName && query) {
             queryString = "\n" + query;
          } else if (queryName && !query) {
-            queryString = `\nrun: ${sourceName ? sourceName + "->" : ""}${queryName}`;
+            // These fields are NAMES, not Malloy text. Quote both as
+            // identifiers so a caller-supplied name can only ever lex as one
+            // identifier: without this a newline (or a space) in either field
+            // opens a SECOND top-level statement and Malloy runs the LAST
+            // `run:`, reading a source this request never named. The gates
+            // above key off the raw strings by exact match, and the two lookups
+            // fail in opposite directions — the curated-source lookup misses
+            // and 404s, but getFilters() misses and returns NO filters, so the
+            // smuggled statement reads its target unfiltered. Quoting also
+            // makes a name that REQUIRES Malloy quoting (hyphen, space,
+            // reserved word, leading digit) work on this path for the first
+            // time. Empty `sourceName` stays falsy-means-absent.
+            queryString = `\nrun: ${
+               sourceName ? `${quoteMalloyIdentifier(sourceName)} -> ` : ""
+            }${quoteMalloyIdentifier(queryName)}`;
          } else {
             const endTime = performance.now();
             const executionTime = endTime - startTime;

--- a/packages/server/src/service/query_boundary.spec.ts
+++ b/packages/server/src/service/query_boundary.spec.ts
@@ -324,6 +324,28 @@ export { customers }`,
             undefined,
             "v\nrun: helper -> { aggregate: c }",
          );
+         // The escape itself, which is what the whole fix rests on: a payload
+         // carrying its own BACKTICK, trying to close the quote we opened and
+         // resume as syntax. quoteMalloyIdentifier escapes `\` before `` ` ``
+         // (the same order, and the same function body, as malloy's internal
+         // escapeIdentifier), so the backtick becomes ``\` `` inside the
+         // identifier instead of terminating it. Escaping in the other order
+         // would let `\` + `` ` `` reopen the hole.
+         await expectNamedRejected(
+            model,
+            "customers",
+            "v` -> `hv`\nrun: `helper",
+         );
+         await expectNamedRejected(
+            model,
+            "customers` -> `v`\nrun: `helper",
+            "hv",
+         );
+         // A backslash-escape payload: ``` is a backtick in JSON-style
+         // unescaping, and malloy's decoder (ParseUtil.parseString) honors
+         // \uXXXX inside the quotes. Escaping the backslash FIRST is what keeps
+         // it a literal six-character name rather than a closing quote.
+         await expectNamedRejected(model, "customers", "v\\u0060 -> \\u0060hv");
          // The ad-hoc equivalent: settled by the compiled backstop instead.
          await expect(
             model.getQueryResults(

--- a/packages/server/src/service/query_boundary.spec.ts
+++ b/packages/server/src/service/query_boundary.spec.ts
@@ -38,6 +38,7 @@ import {
    __setPackageLoadPoolForTests,
 } from "../package_load/package_load_pool";
 import { NotQueryableError } from "../errors";
+import type { Model } from "./model";
 import { Package } from "./package";
 
 const ORIGINAL_ENV = process.env.PACKAGE_LOAD_WORKERS;
@@ -127,6 +128,38 @@ export { customers }`,
       fs.writeFileSync(
          path.join(tempDir, "report.malloynb"),
          `>>>markdown\n# Report\nAlways public.`,
+      );
+   }
+
+   /**
+    * Assert a named (`sourceName`/`queryName`) request is refused and returns
+    * nothing. Deliberately does NOT pin the error class: these fields are
+    * quoted as identifiers, so an injected statement is refused at the lexer as
+    * an unresolvable/unlexable NAME (a Malloy compile error) rather than by the
+    * boundary (`NotQueryableError`) — and which one fires depends only on which
+    * gate the shape happens to reach first. What must hold is that it threw and
+    * no rows came back. Reports the leaked row count on failure, since a
+    * success here IS the leak.
+    */
+   async function expectNamedRejected(
+      model: Model,
+      sourceName: string | undefined,
+      queryName: string | undefined,
+   ): Promise<void> {
+      let leakedRows: number | undefined;
+      try {
+         const { compactResult } = await model.getQueryResults(
+            sourceName,
+            queryName,
+         );
+         leakedRows = (compactResult as unknown[] | undefined)?.length ?? 0;
+      } catch {
+         return;
+      }
+      throw new Error(
+         `Expected the named request { sourceName: ${JSON.stringify(sourceName)}, ` +
+            `queryName: ${JSON.stringify(queryName)} } to be rejected, but it ` +
+            `succeeded and returned ${leakedRows} rows (INJECTION / LEAK).`,
       );
    }
 
@@ -243,6 +276,99 @@ export { customers }`,
             undefined,
             "run: customers -> { aggregate: total }\nrun: customers -> { group_by: id }",
          );
+         expect(result.data).toBeDefined();
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("declared: a newline in queryName cannot smuggle a second run: statement (issue #964)", async () => {
+      writeManifest({ explores: ["index.malloy"] });
+      writeLayeredModels();
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const model = pkg.getModel("index.malloy")!;
+
+         // Positive control: the legitimate named request works.
+         const before = await model.getQueryResults("customers", "v");
+         expect(before.result.data).toBeDefined();
+
+         // The reported repro. `sourceName` is curated, so the early gate
+         // returns "cleared" and the compiled backstop is deliberately skipped
+         // — nothing ever re-checks the statement the newline opened, and
+         // Malloy runs the LAST `run:`. Quoting `queryName` is what stops it
+         // becoming a second statement at all.
+         await expectNamedRejected(
+            model,
+            "customers",
+            "v\nrun: helper -> { aggregate: c }",
+         );
+
+         // The reporter's verified variant table. Each of these is already
+         // blocked (an exact-string curated lookup that misses fails closed
+         // with a 404), so these pin the matrix against future drift.
+         //
+         // Injection through `sourceName`, swallowing `queryName` into the
+         // smuggled statement…
+         await expectNamedRejected(model, "customers -> v\nrun: helper", "hv");
+         // …and with the smuggled statement self-contained.
+         await expectNamedRejected(
+            model,
+            "customers\nrun: helper -> { aggregate: c }",
+            "v",
+         );
+         // `queryName` alone (no source prefix): misses the curated-QUERY set.
+         await expectNamedRejected(
+            model,
+            undefined,
+            "v\nrun: helper -> { aggregate: c }",
+         );
+         // The ad-hoc equivalent: settled by the compiled backstop instead.
+         await expect(
+            model.getQueryResults(
+               undefined,
+               undefined,
+               "run: customers -> v\nrun: helper -> { aggregate: c }",
+            ),
+         ).rejects.toBeInstanceOf(NotQueryableError);
+
+         // The hidden source is still refused when named honestly, i.e. the
+         // boundary itself is intact and the rejections above are the injection
+         // being refused, not the boundary firing twice.
+         await expect(
+            model.getQueryResults("helper", "hv"),
+         ).rejects.toBeInstanceOf(NotQueryableError);
+
+         // …and the legitimate request still works after all of it.
+         const after = await model.getQueryResults("customers", "v");
+         expect(after.result.data).toBeDefined();
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("declared: a name that needs Malloy quoting is queryable on the named path", async () => {
+      // The named path composes `run: <source> -> <view>`; unquoted, a name
+      // that REQUIRES Malloy quoting (here a hyphen) does not even lex, so it
+      // was unreachable through `sourceName`/`queryName`. The caller sends the
+      // bare names the model's `sources` listing returns — quoting is the
+      // server's job.
+      writeManifest({ explores: ["index.malloy"] });
+      fs.writeFileSync(
+         path.join(tempDir, "index.malloy"),
+         `source: \`customer-orders\` is duckdb.sql("select 1 as id, 100 as amt") extend {
+  measure: total is amt.sum()
+  view: \`by-total\` is { aggregate: total }
+}
+export { \`customer-orders\` }`,
+      );
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const { result } = await pkg
+            .getModel("index.malloy")!
+            .getQueryResults("customer-orders", "by-total");
          expect(result.data).toBeDefined();
       } finally {
          await duckdb.close();
@@ -463,6 +589,35 @@ export { \`customer-orders\` }`,
             .getModel("index.malloy")!
             .getQueryResults("helper", "hv", undefined);
          expect(helper.result.data).toBeDefined();
+      } finally {
+         await duckdb.close();
+      }
+   });
+
+   it("declared default + no explores: a newline in queryName still cannot smuggle a statement", async () => {
+      // The default deployment shape: no `explores`, so the boundary is inert
+      // and quoting the caller's names is the only thing holding the line.
+      // Nothing here is about hiding `helper` — it is legitimately queryable in
+      // this mode — it is that a request naming ONE source must not run a
+      // statement naming another.
+      writeManifest(); // no explores → boundary inert
+      writeLayeredModels();
+      const { malloyConfig, duckdb } = await makeMalloyConfig();
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const model = pkg.getModel("index.malloy")!;
+
+         // Control: with no explores, `helper` really is queryable by name…
+         const helper = await model.getQueryResults("helper", "hv");
+         expect(helper.result.data).toBeDefined();
+
+         // …so these rejections are the injection being refused, not a boundary.
+         await expectNamedRejected(
+            model,
+            "customers",
+            "v\nrun: helper -> { aggregate: c }",
+         );
+         await expectNamedRejected(model, "customers -> v\nrun: helper", "hv");
       } finally {
          await duckdb.close();
       }

--- a/packages/server/src/service/restricted_mode.spec.ts
+++ b/packages/server/src/service/restricted_mode.spec.ts
@@ -170,10 +170,15 @@ async function expectBlocked(model: Model, query: string): Promise<void> {
 }
 
 /**
- * Same assertion as `expectBlocked`, but exercised through the named
- * `sourceName`/`queryName` request shape rather than the free-form `query`
- * field — those identifiers are concatenated into a `run: …` string and so are
- * just as caller-controlled.
+ * Same intent as `expectBlocked` — nothing unpublished comes back — but through
+ * the named `sourceName`/`queryName` request shape.
+ *
+ * Deliberately does NOT require a restricted-construct error. Those fields are
+ * quoted as identifiers when the `run: …` string is built, so a disallowed
+ * construct written into them is refused earlier and on different grounds: it
+ * is now part of a NAME, and the request dies resolving it ("Reference to
+ * undefined object …"). Restricted mode is the second line here, not the first.
+ * What must hold is that it was blocked by some means and returned no rows.
  */
 async function expectNamedBlocked(
    model: Model,
@@ -187,13 +192,12 @@ async function expectNamedBlocked(
          queryName,
       );
       leakedRows = asRows(compactResult).length;
-   } catch (error) {
-      expect(looksRestricted(error)).toBe(true);
+   } catch {
       return;
    }
    throw new Error(
-      `Expected the named-path request to be blocked by restricted mode, but ` +
-         `it succeeded and returned ${leakedRows} rows (escaped the curated surface).`,
+      `Expected the named-path request to be blocked, but it succeeded and ` +
+         `returned ${leakedRows} rows (escaped the curated surface).`,
    );
 }
 
@@ -272,13 +276,15 @@ describe("an untrusted query cannot reach data the model never published", () =>
 });
 
 // ===========================================================================
-// The named `sourceName`/`queryName` request shape reaches the same compiler
-// path as ad-hoc text, so it must inherit the same restriction. A real name is
-// a bare identifier; anything that smuggles in a disallowed construct must be
-// blocked, while legitimate published names keep working.
+// A real name is a bare identifier, and the server now ENFORCES that rather
+// than hoping: `sourceName`/`queryName` are quoted as identifiers when the
+// `run: …` string is built, so anything richer written into them is refused
+// while resolving the name (issue #964). Restricted mode is the second line —
+// the named path reaches the same compiler as ad-hoc text and inherits the
+// same construct restrictions — and legitimate published names keep working.
 // ===========================================================================
 
-describe("the named source/view path is restricted too", () => {
+describe("the named source/view path takes names, and is restricted too", () => {
    it("blocks a disallowed construct supplied through the sourceName/queryName fields", async () => {
       const model = await makeModel("catalog.malloy");
       await expectNamedBlocked(


### PR DESCRIPTION
> **Series:** stacked on #963 — this targets `nathan/fix-caller-forged-authorize-override`, not `main`. Review/merge that one first; the diff here is just the commit on top.

Fixes #964.

## What it does

`sourceName` and `queryName` were treated as identifiers by the gate logic and as free text by the string builder. A newline in either opens a second top-level statement, and Malloy runs the **last** `run:` — so this returned rows from `helper`, a source the package never exported:

```json
{ "sourceName": "customers", "queryName": "v\nrun: helper -> { aggregate: c }" }
```

Two gates key off the raw caller strings by exact match, and they fail in **opposite directions** when that match misses:

- the query boundary's curated-source lookup misses and 404s — but a `cleared` admission deliberately skips the compiled backstop, so on the `sourceName` + `queryName` shape nothing ever re-checked the statement that actually ran;
- `getFilters()` misses and returns **no** filters, so the smuggled statement reads its target completely unfiltered. That lane needs no `explores` at all, which makes it the default deployment shape, and it's reachable through either field.

The fix quotes both fields as Malloy identifiers at the single place caller strings become syntax, so a name can only ever lex as one identifier. `quoteMalloyIdentifier` already existed for the render-tag validator.

The compiled `#(authorize)` gate was never bypassed — with `#(authorize) "false"` the same injection already returned 403.

## Accepted behavior changes

1. **Malloy text in these fields now 400s** as an unresolved or unlexable name instead of being compiled. That's the fix. It also changes the *gated* variant: hidden + gated goes 403 → 400, because the request no longer compiles at all.
2. **Four shapes that happen to work today stop working:** a parameterized source (`customers(p is 1)`), a dotted view path (`carriers.by_name`), a view refinement (`by_carrier + { limit: 10 }`), and an inline source extension. No producer in the repo uses any of them — the SDK's query builder sends `.toMalloy()` text in `query` and explicitly nulls both name fields. The residual risk is an MCP agent improvising, so the doc and tool-description updates are part of the fix, not a nicety.
3. **Pre-backticked names are not unwrapped.** A caller sending `` "`gated-source`" `` now gets a 404 instead of today's accidental success. Deliberate: `sourceName` is *also* a lookup key in the curated-source, filter and authorize gates, all of which expect the bare name — so that "workaround" already skipped filter injection.

New capability from the same change: a name that *requires* Malloy quoting (hyphen, space, reserved word, leading digit) is queryable on the named path for the first time.

### Tested

Wrote each test first and confirmed it failed *in the wrong way* before touching `model.ts`:

- **`query_boundary.spec.ts`** — the reported repro returned 1 row from the unexported `helper`, both under `explores` and with none declared. Adds the reporter's verified variant table (injection through each field, `queryName` alone, the ad-hoc equivalent) as stays-blocked guards, plus a test that a hyphenated name is queryable by its bare name.
- **`filter_bypass.spec.ts`** — both vectors returned **4 rows across all three tenants**, unfiltered. This is the test that *proves* the filter lane rather than assuming it.
- **`restricted_mode.spec.ts`** — widened the named-path assertion: a disallowed construct in these fields is now refused while resolving the name, so restricted mode becomes the second line of defence rather than the first.

Full `packages/server` sweep **1898 pass / 0 fail**. `bun run test:integration` 233 pass with one pre-existing failure (`concurrent_package`, needs GCS credentials — verified failing identically on the base commit). eslint clean, and `grep 'sourceName + "->"'` finds nothing.

End-to-end against a running server on a package declaring `explores`, over REST **and** again through `malloy_executeQuery`:

| request | before | now |
| --- | --- | --- |
| the reported injection | `200 [{"c":1}]` | `400` |
| injection via `sourceName` | — | `404` |
| `helper`/`hv` named honestly | `404` | `404` |
| legitimate `customers`/`v` | rows | `200 [{"total":100}]` |

### On the tool description

`malloy_executeQuery`'s description was sitting at 1998 of the 2000-char truncation budget `server.protocol.spec.ts` enforces, leaving no room for the new contract rule. Rather than raise the budget — that cap belongs to the client, not the model, so a newer model on our end isn't a reason to move it — I applied the template's own "prefer merging over adding": the row-cap rule was stated three times over, and two clauses were rationale written for a human reader. Now 1926 chars with the *full* rule in and no fact dropped.

`malloy_compile` is at 1964 with the same latent squeeze. Left alone here to keep this diff to the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
