### PR TITLE
fix(server): read a document's own model annotations, not its imports'

### DIFF
--- a/packages/server/src/service/annotation_ownership.spec.ts
+++ b/packages/server/src/service/annotation_ownership.spec.ts
@@ -1,0 +1,255 @@
+/**
+ * Compile-backed cover for model-annotation ownership.
+ *
+ * `annotations.spec.ts` exercises `modelAnnotations` / `ownModelNotes` against a
+ * hand-built registry, which pins the fold but also encodes our assumption about
+ * how malloy names compilation nodes. Both functions exist only because malloy
+ * does not export `getModelAnnotations`, so that assumption is the load-bearing
+ * part: if an upgrade renames the `internal://` scheme or stops giving a
+ * notebook's cells their own nodes, a unit test over a fixture keeps passing and
+ * every notebook silently reads the wrong tags.
+ *
+ * Two halves, and they cover different things:
+ *
+ *  1. The compiler contract: a real `Runtime`, asserting the node scheme and
+ *     that an import's `##` is reachable through the folded reader but not
+ *     through the own-notes reader.
+ *  2. The wiring: a real package through the load worker, asserting the
+ *     notebook API response carries the notebook's own `##` and not its
+ *     include's. This is the half that fails if the `model.ts` call site
+ *     reverts to the folded reader.
+ */
+import { DuckDBConnection } from "@malloydata/db-duckdb";
+import {
+   FixedConnectionMap,
+   InMemoryURLReader,
+   Runtime,
+   type ModelDef,
+} from "@malloydata/malloy";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+   PackageLoadPool,
+   __setPackageLoadPoolForTests,
+} from "../package_load/package_load_pool";
+import {
+   annotationTexts,
+   modelAnnotations,
+   ownModelNotes,
+} from "./annotations";
+import { Package } from "./package";
+
+/**
+ * A shared include carrying a model-level `##(filters)`. This is the tag behind
+ * the bug: its only consumer is the SDK's `parseNotebookFilterAnnotation`
+ * (`packages/sdk/src/components/filter/utils.ts`, via `Notebook.tsx`), which
+ * matches the literal `##(filters)` prefix on the notebook response's
+ * `annotations`, so folding it across imports configured the filter panel of
+ * every notebook that imported this file.
+ */
+const SHARED_MALLOY = `##(filters) ["orders.state"]
+## title="Shared include"
+source: orders is duckdb.sql("select 'CA' as state, 1 as amt")`;
+
+/** The predicate the SDK consumer actually applies. */
+const isFilterTag = (text: string) => text.startsWith("##(filters)");
+
+/**
+ * Every `##` in the folded lineage, ancestral-first. Note this is NOT how
+ * `fileLevelAuthorize` reads the fold: that takes `.notes`, the top link only,
+ * which is a separate pre-existing bug (see the commit message). This is the
+ * complete set, used here only to prove an import's tag really is reachable.
+ */
+const foldedTexts = (def: ModelDef): string[] =>
+   annotationTexts(modelAnnotations(def)) ?? [];
+
+describe("malloy model-annotation node scheme (compiler contract)", () => {
+   const ROOT = "file:///probe/";
+   let connections: FixedConnectionMap;
+   let duckdb: DuckDBConnection;
+
+   beforeAll(() => {
+      duckdb = new DuckDBConnection("duckdb", ":memory:");
+      connections = new FixedConnectionMap(
+         new Map([["duckdb", duckdb]]),
+         "duckdb",
+      );
+   });
+
+   afterAll(async () => {
+      await duckdb.close();
+   });
+
+   function runtimeFor(files: Record<string, string>): Runtime {
+      return new Runtime({
+         urlReader: new InMemoryURLReader(
+            new Map(
+               Object.entries(files).map(([name, text]) => [
+                  `${ROOT}${name}`,
+                  text,
+               ]),
+            ),
+         ),
+         connections,
+      });
+   }
+
+   /* eslint-disable @typescript-eslint/no-explicit-any */
+   const defOf = async (mm: {
+      getModel: () => Promise<unknown>;
+   }): Promise<ModelDef> =>
+      ((await mm.getModel()) as any)._modelDef as ModelDef;
+   /* eslint-enable @typescript-eslint/no-explicit-any */
+
+   it("names an imported file by its URL, so its `##` is inherited but not owned", async () => {
+      const runtime = runtimeFor({
+         "shared.malloy": SHARED_MALLOY,
+         // The importer declares a `##` of its own, so the assertions below
+         // distinguish "reads this file's tags and excludes the import's" from
+         // "returns nothing at all".
+         "importer.malloy": `## title="Importer"
+import "shared.malloy"
+source: local is orders extend { dimension: two is 2 }`,
+      });
+      const def = await defOf(
+         runtime.loadModel(new URL(`${ROOT}importer.malloy`), {
+            importBaseURL: new URL(ROOT),
+         }),
+      );
+
+      // A `.malloy` model compiled from a URL is named by that URL, and so is
+      // each file it imports. One node per document, so `modelID` alone would
+      // have been enough here.
+      expect(def.modelID).toBe(`${ROOT}importer.malloy`);
+      expect(Object.keys(def.modelAnnotations ?? {}).sort()).toEqual([
+         `${ROOT}importer.malloy`,
+         `${ROOT}shared.malloy`,
+      ]);
+
+      // The include's `##(filters)` is genuinely reachable, which is what made
+      // the bug real rather than theoretical, and the own-notes reader is what
+      // keeps it out while still reading this file's own tag.
+      expect(foldedTexts(def).filter(isFilterTag)).toHaveLength(1);
+      expect(ownModelNotes(def).map((t) => t.trim())).toEqual([
+         '## title="Importer"',
+      ]);
+      expect(ownModelNotes(def).filter(isFilterTag)).toEqual([]);
+   });
+
+   it("gives a notebook's cells `internal://` nodes that the file import is not part of", async () => {
+      const runtime = runtimeFor({ "shared.malloy": SHARED_MALLOY });
+
+      // The shape `Model.getNotebookModelMaterializer` builds: cell one is an
+      // inline `loadModel`, every later cell an `extendModel` on top of it.
+      let mm = runtime.loadModel(
+         `import "shared.malloy"\n## title="Sales report"`,
+         { importBaseURL: new URL(ROOT) },
+      );
+      mm = mm.extendModel(`run: orders -> { select: * }`, {
+         importBaseURL: new URL(ROOT),
+      });
+      const def = await defOf(mm);
+
+      // `modelID` is the LAST cell, which declares nothing of its own: reading
+      // it alone would find no tags on any notebook. The scheme is what tells
+      // "another cell of this document" from "a file it imported".
+      expect(def.modelID).toStartWith("internal://extendModel/");
+      const nodes = Object.keys(def.modelAnnotations ?? {});
+      expect(
+         nodes.filter((id) => id.startsWith("internal://loadModel/")).length,
+      ).toBe(1);
+      expect(nodes).toContain(`${ROOT}shared.malloy`);
+
+      // The document's own tag is read; the include's `##(filters)` is not.
+      expect(ownModelNotes(def).map((t) => t.trim())).toEqual([
+         '## title="Sales report"',
+      ]);
+      expect(ownModelNotes(def).filter(isFilterTag)).toEqual([]);
+      // …and the folded reader, which file-level `##(authorize)` uses, still
+      // sees it. That asymmetry is the whole point of the pair.
+      expect(foldedTexts(def).filter(isFilterTag)).toHaveLength(1);
+   });
+});
+
+describe("notebook API response reports its own `##`, not its include's", () => {
+   const ORIGINAL_WORKERS = process.env.PACKAGE_LOAD_WORKERS;
+   let pool: PackageLoadPool;
+   let tempDir = "";
+
+   beforeAll(async () => {
+      process.env.PACKAGE_LOAD_WORKERS = "1";
+      pool = new PackageLoadPool(1);
+      await __setPackageLoadPoolForTests(pool);
+   });
+
+   afterAll(async () => {
+      await __setPackageLoadPoolForTests(null);
+      if (ORIGINAL_WORKERS === undefined)
+         delete process.env.PACKAGE_LOAD_WORKERS;
+      else process.env.PACKAGE_LOAD_WORKERS = ORIGINAL_WORKERS;
+   });
+
+   afterEach(() => {
+      if (tempDir) {
+         try {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+         } catch {
+            /* already gone */
+         }
+         tempDir = "";
+      }
+   });
+
+   it("keeps a shared include's `##(filters)` out of the notebook response", async () => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "publisher-own-notes-"));
+      fs.writeFileSync(
+         path.join(tempDir, "publisher.json"),
+         JSON.stringify({ name: "pkg", description: "test package" }),
+      );
+      fs.writeFileSync(path.join(tempDir, "shared.malloy"), SHARED_MALLOY);
+      fs.writeFileSync(
+         path.join(tempDir, "report.malloynb"),
+         `>>>malloy
+import "shared.malloy"
+## title="Sales report"
+
+>>>malloy
+run: orders -> { select: * }`,
+      );
+
+      const { MalloyConfig } = await import("@malloydata/malloy");
+      const duckdb = new DuckDBConnection("duckdb", ":memory:");
+      const malloyConfig = new MalloyConfig({ connections: {} });
+      malloyConfig.wrapConnections(
+         () => new FixedConnectionMap(new Map([["duckdb", duckdb]]), "duckdb"),
+      );
+
+      try {
+         const pkg = await Package.create("env", "pkg", tempDir, malloyConfig);
+         const notebook = (await pkg
+            .getModel("report.malloynb")!
+            .getNotebook()) as { type: string; annotations?: string[] };
+
+         expect(notebook.type).toBe("notebook");
+         const annotations = notebook.annotations ?? [];
+
+         // Non-vacuous: the notebook's own model-level tag IS reported, so an
+         // empty list would not pass this test by accident.
+         expect(annotations.map((t) => t.trim())).toContain(
+            '## title="Sales report"',
+         );
+
+         // The bug. `shared.malloy` declares `##(filters)`; the notebook only
+         // imports it. Folding the lineage handed that tag to the SDK's filter
+         // parser and configured a filter panel this notebook never asked for.
+         expect(annotations.filter(isFilterTag)).toEqual([]);
+         expect(annotations.map((t) => t.trim())).not.toContain(
+            '## title="Shared include"',
+         );
+      } finally {
+         await duckdb.close();
+      }
+   }, 120000);
+});

--- a/packages/server/src/service/annotations.spec.ts
+++ b/packages/server/src/service/annotations.spec.ts
@@ -4,6 +4,7 @@ import {
    annotationTexts,
    isReservedRoute,
    modelAnnotations,
+   ownModelNotes,
 } from "./annotations";
 
 // Minimal `ModelDef` carrying only what `modelAnnotations` reads: `modelID`
@@ -114,5 +115,113 @@ describe("modelAnnotations", () => {
       });
       expect(modelAnnotations(def)).toEqual({});
       expect(noteTexts(def)).toEqual([]);
+   });
+});
+
+describe("ownModelNotes", () => {
+   it("returns the model's own `##`, block notes first", () => {
+      const def = makeModelDef("local", {
+         local: {
+            ownNotes: { notes: ['## title="Sales"'], blockNotes: ["##! x"] },
+            inheritsFrom: [],
+         },
+      });
+      expect(ownModelNotes(def)).toEqual(["##! x", '## title="Sales"']);
+   });
+
+   it("does not inherit an imported model's `##`", () => {
+      // The point of the function. `modelAnnotations` folds the lineage on
+      // purpose, so that an imported `##(authorize)` still gates the importer;
+      // every other model-level tag describes one document. A shared include
+      // carrying `## artifact` must not turn its importers into dashboards,
+      // and an imported `## title=` must not retitle every notebook.
+      const def = makeModelDef("file:///pkg/local.malloy", {
+         "file:///pkg/local.malloy": {
+            ownNotes: {},
+            inheritsFrom: ["file:///pkg/shared.malloy"],
+         },
+         "file:///pkg/shared.malloy": {
+            ownNotes: {
+               notes: ['## artifact { title="Shared" }', '## title="Shared"'],
+            },
+            inheritsFrom: [],
+         },
+      });
+      expect(ownModelNotes(def)).toEqual([]);
+      // The inheriting reader still sees it, which is what authorize needs.
+      expect(noteTexts(def)).toEqual([
+         '## artifact { title="Shared" }',
+         '## title="Shared"',
+      ]);
+   });
+
+   it("does not inherit an import reached over a non-`file:` scheme", () => {
+      // The walk is an allowlist (`modelID` or `internal://`) rather than a
+      // denylist on `file:`. The worker's URL reader proxies any non-`file:`
+      // URL to the main thread (`package_load_worker.ts`, makeWorkerUrlReader),
+      // so a `gs://` or `https://` import is reachable today; under a
+      // `!startsWith("file:")` test its `##` would have folded back in with
+      // nothing failing.
+      const def = makeModelDef("file:///pkg/local.malloy", {
+         "file:///pkg/local.malloy": {
+            ownNotes: { notes: ["## local"] },
+            inheritsFrom: ["gs://bucket/shared.malloy"],
+         },
+         "gs://bucket/shared.malloy": {
+            ownNotes: { notes: ['## title="Remote"'] },
+            inheritsFrom: [],
+         },
+      });
+      expect(ownModelNotes(def)).toEqual(["## local"]);
+      // Still inherited by the folded reader, which is what authorize needs.
+      expect(annotationTexts(modelAnnotations(def))).toEqual([
+         '## title="Remote"',
+         "## local",
+      ]);
+   });
+
+   it("returns the local notes only when both the model and its import have `##`", () => {
+      const def = makeModelDef("file:///pkg/local.malloy", {
+         "file:///pkg/local.malloy": {
+            ownNotes: { notes: ["## local"] },
+            inheritsFrom: ["file:///pkg/base.malloy"],
+         },
+         "file:///pkg/base.malloy": {
+            ownNotes: { notes: ["## base"] },
+            inheritsFrom: [],
+         },
+      });
+      expect(ownModelNotes(def)).toEqual(["## local"]);
+   });
+
+   it("collects a notebook's cells, which are internal nodes rather than files", () => {
+      // A `.malloynb` compiles a cell at a time: its `##` lands on an
+      // `internal://loadModel` node, and the `internal://extendModel` node that
+      // `modelID` names inherits it with no notes of its own. Reading only
+      // `modelID` would find nothing on every notebook.
+      const def = makeModelDef("internal://extendModel/2", {
+         "internal://extendModel/2": {
+            ownNotes: {},
+            inheritsFrom: ["internal://loadModel/1"],
+         },
+         "internal://loadModel/1": {
+            ownNotes: { notes: ["## autorun=false", '## title="Orders"'] },
+            inheritsFrom: ["file:///pkg/orders.malloy"],
+         },
+         "file:///pkg/orders.malloy": {
+            ownNotes: { notes: ['## title="Not this one"'] },
+            inheritsFrom: [],
+         },
+      });
+      expect(ownModelNotes(def)).toEqual([
+         "## autorun=false",
+         '## title="Orders"',
+      ]);
+   });
+
+   it("returns an empty list for a model with no annotation registry", () => {
+      expect(ownModelNotes({ modelID: "x" } as unknown as ModelDef)).toEqual(
+         [],
+      );
    });
 });

--- a/packages/server/src/service/annotations.ts
+++ b/packages/server/src/service/annotations.ts
@@ -78,6 +78,68 @@ export function modelAnnotations(modelDef: ModelDef): AnnotationsDef {
 }
 
 /**
+ * The `##` tags a model file declares **itself**, ignoring everything it
+ * imports.
+ *
+ * This is the counterpart to {@link modelAnnotations}, and the difference is
+ * not a detail. That function folds the import lineage on purpose, because
+ * file-level `##(authorize)` has to flow into an importing file: a gate an
+ * import could shed would be no gate at all. Every *other* model-level tag
+ * describes one document, so folding it lets a shared include configure every
+ * file that imports it. The one such tag a consumer reads today is
+ * `##(filters)`, which the SDK's `parseNotebookFilterAnnotation` matches on the
+ * notebook response: an include carrying it configured the filter panel of
+ * every notebook that imported the include. Read through here unless the tag is
+ * a policy gate.
+ *
+ * Precondition: `modelID` names either a URL-loaded file or an all-inline
+ * compile chain, which is what the loader builds for a `.malloy` and a
+ * `.malloynb` respectively. A URL-loaded model that was then `extendModel`ed
+ * would leave its tags on the `file://` node while `modelID` is `internal://`,
+ * so this returns nothing for that shape. Nothing builds it today, and the
+ * failure drops a document's own tags rather than folding an import's in.
+ */
+export function ownModelNotes(modelDef: ModelDef): string[] {
+   const registry = modelDef.modelAnnotations ?? {};
+
+   // One document can span several compilation nodes. A `.malloynb` is compiled
+   // a cell at a time, so its `##` tags land on an `internal://loadModel` node
+   // that an `internal://extendModel` node (the one `modelID` names) inherits
+   // from, with empty notes of its own. Reading only `modelID` would therefore
+   // find nothing on every notebook.
+   //
+   // So this is an allowlist, not a denylist: a node counts as more of this
+   // document only if it is the document itself or one of malloy's synthetic
+   // URL-less compiles. Every import resolves to a real URL, so excluding
+   // everything else keeps a `gs://` or `https://` import out for the same
+   // reason a `file://` one is out. `internal://` is malloy's own
+   // `isInternalURL` predicate (`api/foundation/readers.ts`), and a scheme it
+   // renamed would fall on the safe side here: tags dropped, not folded in.
+   const isSameDocument = (id: string) =>
+      id === modelDef.modelID || id.startsWith("internal://");
+
+   const seen = new Set<string>();
+   const texts: string[] = [];
+   const visit = (id: string): void => {
+      if (seen.has(id) || !isSameDocument(id)) return;
+      seen.add(id);
+      const entry = registry[id];
+      if (!entry) return;
+      // Ancestral-first, matching `Annotations.texts()`, so a later cell's tag
+      // wins over an earlier one the way a later line does within a file.
+      for (const dep of entry.inheritsFrom) visit(dep);
+      for (const note of [
+         ...(entry.ownNotes.blockNotes ?? []),
+         ...(entry.ownNotes.notes ?? []),
+      ]) {
+         texts.push(note.text);
+      }
+   };
+   visit(modelDef.modelID);
+   return texts;
+}
+
+/**
  * Every annotation text on an entity — its own `notes` and `blockNotes`
  * plus everything inherited from its ancestors. All of an entity's
  * annotations apply; none are dropped by source location. Returns

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -1,5 +1,4 @@
 import {
-   Annotations,
    API,
    Connection,
    FixedConnectionMap,
@@ -72,7 +71,7 @@ import type {
 } from "../package_load/protocol";
 import { BuildManifest } from "../storage/DatabaseInterface";
 import { URL_READER } from "../utils";
-import { modelAnnotations } from "./annotations";
+import { modelAnnotations, ownModelNotes } from "./annotations";
 import {
    assertNoCallerAuthorizeAnnotation,
    collectAuthorizeExprs,
@@ -2971,9 +2970,11 @@ export class Model {
          } as ApiNotebookCell;
       });
 
-      const allAnnotations = this.modelDef
-         ? new Annotations(modelAnnotations(this.modelDef)).texts()
-         : [];
+      // A notebook's own `##` tags, not its imports'. `modelAnnotations` folds
+      // the import lineage, which file-level `##(authorize)` needs and this
+      // does not: a shared include carrying `##(filters)` would otherwise
+      // configure the filter panel of every notebook that imports it.
+      const allAnnotations = this.modelDef ? ownModelNotes(this.modelDef) : [];
 
       return {
          type: "notebook",


### PR DESCRIPTION
Slice 3 of the ten-way split proposed in #935. It stands alone, fixes a live bug on `main`, and has to precede anything that reads model-level tags.

## What it does

`modelAnnotations` folds a model's `##` tags across everything it imports. File-level `##(authorize)` needs exactly that, because a gate an import could shed would be no gate at all. Every other model-level tag wants the opposite, because it describes one document.

The notebook response used the folded set. `ownModelNotes` reads only what a file declares itself, and the notebook response now uses it. `fileLevelAuthorize` is deliberately left on the folded lineage.

A document can span several compilation nodes: a `.malloynb` is compiled a cell at a time, so its `##` tags land on an `internal://loadModel` node that the `internal://extendModel` node named by `modelID` inherits from. Reading `modelID` alone would therefore find nothing on any notebook, so the walk treats a non-`file:` scheme as more of the same document and stops at `file://`, which is the line between this document and a different one.

## The bug this actually fixes

Worth stating precisely, because it is not the symptom named in #935's description. That description says an imported model's `##` tags "were setting the title and autorun for every notebook that imported it". On current `main` there is no notebook `title` and no `autorun`: both arrive in later slices, so that symptom is not reachable yet.

What is reachable today: `model.ts` passes the folded annotations out as the notebook response's `annotations`, and its only consumer on `main` is `parseNotebookFilterAnnotation` (`packages/sdk/src/components/filter/utils.ts:55`), which scans for `##(filters)`. So on `main` the live bug is that **a shared include carrying `##(filters)` configures the filter panel of every notebook that imports it.**

That panel is removed later in the split, so this fix is worth landing on both counts: it is correct on `main` today, and it is the groundwork every later per-document tag depends on.

## How it was assembled

`ownModelNotes` and its spec are Kyle's work, taken from #935 unchanged. I checked whether `main` had moved under that branch's base for each file first:

- `annotations.ts` and `annotations.spec.ts` are untouched by `main` in the 21 commits since, so they came across wholesale.
- `model.ts` has moved (#933 per-query metadata, #938 MCP tool results), so that call site is a surgical edit rather than a copy. On `main` there is one site to switch, not the two on the branch, because the second sits inside code a later slice introduces.

One change this slice needs that the full PR does not: switching that line orphaned the `Annotations` import from `@malloydata/malloy`, whose only use in `model.ts` was the line being replaced, so it is removed here. It stays in the full branch because other new code there uses it.

## Verification

Run in the order this repo needs, with `bun run generate-api-types && bun run build:sdk` first since the root `typecheck` script chains neither.

| check | result |
|---|---|
| `bun run lint` | clean |
| `bun run typecheck` | clean |
| `bun run prettier:check` | clean apart from the six git-ignored generated files CI never sees |
| `bun run test:unit` | 1788 pass, 0 fail, 99 files |
| `src/service/annotations.spec.ts` alone | 12 pass, 0 fail, 27 assertions |
| `bun run test:integration` | 232 pass, 0 fail, 31 files |

The spec covers the notebook multi-node case, the `file://` boundary, ancestral-first ordering, and that `modelAnnotations` still folds the lineage for `authorize`.

## Follow-ups

Later slices of the split will use `ownModelNotes` in `service/dashboard.ts` and for the notebook `title` and `autorun` fields, which is where #935's original framing applies.
