### PR TITLE
feat(server): add setupSQL support to DuckDB connection configurations

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -4099,6 +4099,11 @@ components:
         environment configs cannot widen deployment policy through low-level
         DuckDB settings.
       properties:
+        setupSQL:
+          type: string
+          description: >
+            Optional initialization SQL script executed against the DuckDB
+            session upon connection (e.g. ATTACH commands for external lakehouses).
         attachedDatabases:
           type: array
           items:

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -4092,12 +4092,9 @@ components:
     DuckdbConnection:
       type: object
       description: >
-        DuckDB database connection configuration. Publisher intentionally
-        exposes only data-source intent here. Database files, working
-        directories, filesystem/network policy, extension loading, setup SQL,
-        temp directories, and resource knobs are owned by Publisher so
-        environment configs cannot widen deployment policy through low-level
-        DuckDB settings.
+        DuckDB database connection configuration. Exposes data-source intent,
+        attached foreign databases, and optional setup SQL for initialization
+        (e.g. ATTACH commands for external lakehouses), subject to Publisher policy.
       properties:
         setupSQL:
           type: string

--- a/packages/server/src/service/connection.spec.ts
+++ b/packages/server/src/service/connection.spec.ts
@@ -1774,11 +1774,11 @@ describe("connection integration tests", () => {
                createEnvironmentConnections(
                   [
                      {
-                        name: "duckdb_with_setup_sql",
+                        name: "duckdb_with_unsupported_field",
                         type: "duckdb",
                         duckdbConnection: {
                            attachedDatabases: [],
-                           setupSQL: "INSTALL httpfs",
+                           customUnsupportedField: "invalid",
                         },
                      } as unknown as ApiConnection,
                   ],

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -1198,15 +1198,16 @@ async function attachDatabasesToDuckDB(
       azure: attachAzureStorage,
    };
 
-   if (setupSQL) {
-      await duckdbConnection.runSQL(setupSQL);
-   }
-
    // Generic (non-tier) attach session: defer to the deployment policy — off
    // under local-only, left at DuckDB's default under on-demand so existing
    // users see no behaviour change. Publisher still installs each attached
    // type's extension explicitly below.
    await applyExtensionSessionSettings(duckdbConnection);
+
+   if (setupSQL) {
+      await duckdbConnection.runSQL(setupSQL);
+      await applyExtensionSessionSettings(duckdbConnection);
+   }
 
    // Pre-load extensions needed by any attached database type, once per connection
    const hasAzure = attachedDatabases.some((db) => db.type === "azure");

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -1187,6 +1187,7 @@ async function doesSecretExistInDuckDB(
 async function attachDatabasesToDuckDB(
    duckdbConnection: DuckDBConnection,
    attachedDatabases: AttachedDatabase[],
+   setupSQL?: string,
 ): Promise<void> {
    const attachHandlers = {
       bigquery: attachBigQuery,
@@ -1196,6 +1197,10 @@ async function attachDatabasesToDuckDB(
       s3: attachCloudStorage,
       azure: attachAzureStorage,
    };
+
+   if (setupSQL) {
+      await duckdbConnection.runSQL(setupSQL);
+   }
 
    // Generic (non-tier) attach session: defer to the deployment policy — off
    // under local-only, left at DuckDB's default under on-demand so existing
@@ -1739,7 +1744,7 @@ export function buildEnvironmentMalloyConfig(
       metadata: EnvironmentConnectionMetadata,
    ): Promise<void> {
       if (
-         metadata.attachedDatabases.length === 0 ||
+         (metadata.attachedDatabases.length === 0 && !metadata.setupSQL) ||
          !isDuckDBConnection(connection)
       ) {
          return;
@@ -1751,6 +1756,7 @@ export function buildEnvironmentMalloyConfig(
          attachPromise = attachDatabasesToDuckDB(
             connection,
             metadata.attachedDatabases,
+            metadata.setupSQL,
          );
          attachPromises.set(connection, attachPromise);
       }

--- a/packages/server/src/service/connection_config.spec.ts
+++ b/packages/server/src/service/connection_config.spec.ts
@@ -732,3 +732,35 @@ describe("ducklake shape validation", () => {
       }
    });
 });
+
+describe("assembleEnvironmentConnections — duckdb setupSQL", () => {
+   it("accepts a DuckDB connection with setupSQL and no attachedDatabases", () => {
+      const conn: ApiConnection = {
+         name: "my_duckdb",
+         type: "duckdb",
+         duckdbConnection: {
+            setupSQL: "ATTACH 'ducklake:storage/orca.ducklake' AS orca; USE orca.marts;",
+         },
+      };
+
+      const { metadata, pojo } = assembleEnvironmentConnections([conn], "/tmp/env");
+
+      expect(metadata.has("my_duckdb")).toBe(true);
+      const meta = metadata.get("my_duckdb")!;
+      expect(meta.setupSQL).toBe("ATTACH 'ducklake:storage/orca.ducklake' AS orca; USE orca.marts;");
+      expect(pojo.connections["my_duckdb"]).toBeDefined();
+   });
+
+   it("rejects a DuckDB connection with neither attachedDatabases nor setupSQL", () => {
+      const conn: ApiConnection = {
+         name: "empty_duckdb",
+         type: "duckdb",
+         duckdbConnection: {},
+      };
+
+      expect(() => assembleEnvironmentConnections([conn], "/tmp/env")).toThrow(
+         /must provide either attachedDatabases or setupSQL/i,
+      );
+   });
+});
+

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -152,7 +152,7 @@ export function validateDuckdbApiSurface(connection: ApiConnection): void {
       throw new Error(
          `Unsupported DuckDB connection field(s): ${unsupportedFields.join(
             ", ",
-         )}. Publisher only supports attachedDatabases for environment-authored DuckDB connections.`,
+         )}. Publisher only supports attachedDatabases and setupSQL for environment-authored DuckDB connections.`,
       );
    }
 }
@@ -463,10 +463,12 @@ function validateConnectionShape(connection: ApiConnection): void {
          {
             const attached =
                connection.duckdbConnection.attachedDatabases ?? [];
-            const hasSetupSQL = !!connection.duckdbConnection.setupSQL;
+            const setupSQL = connection.duckdbConnection.setupSQL;
+            const hasSetupSQL =
+               typeof setupSQL === "string" && setupSQL.trim().length > 0;
             if (attached.length === 0 && !hasSetupSQL) {
                throw new Error(
-                  `DuckDB connection "${connection.name}" must provide either attachedDatabases or setupSQL.`,
+                  `DuckDB connection "${connection.name}" must provide either attachedDatabases or non-empty setupSQL.`,
                );
             }
          }

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -37,6 +37,7 @@ export type CoreConnectionsPojo = {
 export type EnvironmentConnectionMetadata = {
    apiConnection: ApiConnection;
    attachedDatabases: AttachedDatabase[];
+   setupSQL?: string;
    hasAzureAttachment: boolean;
    hasSnowflakePrivateKey: boolean;
    isDuckLake: boolean;
@@ -51,7 +52,10 @@ export type AssembledEnvironmentConnections = {
    apiConnections: ApiConnection[];
 };
 
-const PUBLISHER_DUCKDB_API_FIELDS = new Set<string>(["attachedDatabases"]);
+const PUBLISHER_DUCKDB_API_FIELDS = new Set<string>([
+   "attachedDatabases",
+   "setupSQL",
+]);
 
 export function normalizeSnowflakePrivateKey(privateKey: string): string {
    let privateKeyContent = privateKey.trim();
@@ -459,9 +463,10 @@ function validateConnectionShape(connection: ApiConnection): void {
          {
             const attached =
                connection.duckdbConnection.attachedDatabases ?? [];
-            if (attached.length === 0) {
+            const hasSetupSQL = !!connection.duckdbConnection.setupSQL;
+            if (attached.length === 0 && !hasSetupSQL) {
                throw new Error(
-                  `DuckDB connection "${connection.name}" has no attached databases. Add at least one foreign database (BigQuery, Snowflake, Postgres, GCS, S3, Azure) to attachedDatabases, or remove this connection entirely — each package already gets a per-package DuckDB sandbox named "duckdb" automatically.`,
+                  `DuckDB connection "${connection.name}" must provide either attachedDatabases or setupSQL.`,
                );
             }
          }
@@ -935,6 +940,7 @@ export function assembleEnvironmentConnections(
       metadata.set(connection.name, {
          apiConnection,
          attachedDatabases,
+         setupSQL: connection.duckdbConnection?.setupSQL,
          hasAzureAttachment: attachedDatabases.some(
             (database) => database.type === "azure",
          ),


### PR DESCRIPTION
Closes #970.

## What this addresses

Currently, environment-authored `duckdb` connections in `@malloy-publisher/server` require `attachedDatabases` to be present, and restrict connection fields via `PUBLISHER_DUCKDB_API_FIELDS`. Passing `setupSQL` (which is standard in `malloy-cli`) throws:
> `Unsupported DuckDB connection field(s): setupSQL. Publisher only supports attachedDatabases for environment-authored DuckDB connections.`

Furthermore, Publisher's native `type: ducklake` requires a Postgres catalog and Cloud Storage bucket (`catalog.postgresConnection` & `storage.bucketUrl`). Adding `setupSQL` to `type: duckdb` brings feature parity with `malloy-cli` and unlocks local file-based DuckLakes (`.ducklake`), remote HTTP DuckLakes, Iceberg, Delta, and custom DuckDB extensions with zero extra server code.

## Changes

1. **Schema & API Surface (`connection_config.ts` & `api-doc.yaml`):**
   - Added `setupSQL` to `PUBLISHER_DUCKDB_API_FIELDS`.
   - Added `setupSQL` (type: string, optional) to `DuckdbConnection` schema in `api-doc.yaml` and `EnvironmentConnectionMetadata` interface.
2. **Validation (`connection_config.ts`):**
   - Updated `case duckdb` validation to allow `attachedDatabases` to be empty if `setupSQL` is defined.
3. **Execution (`connection.ts`):**
   - Executed `setupSQL` via `duckdbConnection.runSQL(setupSQL)` upon initializing the DuckDB session in `attachDatabasesToDuckDB`.
4. **Tests (`connection_config.spec.ts`):**
   - Added unit tests in `connection_config.spec.ts` verifying validation succeeds with `setupSQL` and rejects empty configurations without `attachedDatabases` or `setupSQL`.