### PR TITLE
fix(server): read notes as well as blockNotes when resolving a source-level #(authorize) gate

### DIFF
--- a/packages/server/src/service/annotations.ts
+++ b/packages/server/src/service/annotations.ts
@@ -149,17 +149,27 @@ export function annotationTexts(
 
 /**
  * The annotation texts declared directly on ONE node of an `AnnotationsDef`
- * chain — not its `inherits` ancestors. Malloy files a source-level
- * annotation under `blockNotes` for `#(tag)\nsource: name is ...` but under
- * `notes` for every other source-level placement — the multi-definition block
- * form (`source:\n  #(tag)\n  name is ...`) and either side of the `is`
- * (`source: name is\n  #(tag)\n  base`, malloy's `getIsNotes`). Same
- * declaration slot, different key depending only on which syntax the author
- * used (confirmed by compiling each form and inspecting the resulting
- * `SourceDef.annotations`).
- * A caller walking `inherits` by hand to find the nearest declaring level —
- * rather than flattening the whole chain via {@link annotationTexts} — needs
- * this at each link so a block-form declaration is not silently skipped.
+ * chain — not its `inherits` ancestors.
+ *
+ * A source-level annotation lands under one of two keys, decided purely by
+ * which syntax the author used:
+ *
+ *     blockNotes    #(tag)                 statement form
+ *                   source: name is ...
+ *
+ *     notes         source:                multi-definition block form
+ *                     #(tag)
+ *                     name is ...
+ *
+ *     notes         source: name is        after `is` (malloy's getIsNotes)
+ *                     #(tag)
+ *                     base
+ *
+ * It is the same declaration slot in all three — confirmed by compiling each
+ * form and inspecting the resulting `SourceDef.annotations`. So a caller that
+ * walks `inherits` by hand for the nearest declaring level, rather than
+ * flattening the whole chain via {@link annotationTexts}, has to read both keys
+ * at each link, or it silently skips the latter two forms.
  */
 export function ownLevelNoteTexts(
    annote: AnnotationsDef | undefined,

--- a/packages/server/src/service/annotations.ts
+++ b/packages/server/src/service/annotations.ts
@@ -151,3 +151,23 @@ export function annotationTexts(
    const texts = new Annotations(annote).texts();
    return texts.length > 0 ? texts : undefined;
 }
+
+/**
+ * The annotation texts declared directly on ONE node of an `AnnotationsDef`
+ * chain — not its `inherits` ancestors. Malloy files a source-level
+ * annotation under `blockNotes` for `#(tag)\nsource: name is ...` but under
+ * `notes` for the multi-definition block form (`source:\n  #(tag)\n  name is
+ * ...`): same declaration slot, different key depending only on which of the
+ * two syntaxes the author used (confirmed by compiling both against a
+ * `duckdb.sql` source and inspecting the resulting `SourceDef.annotations`).
+ * A caller walking `inherits` by hand to find the nearest declaring level —
+ * rather than flattening the whole chain via {@link annotationTexts} — needs
+ * this at each link so a block-form declaration is not silently skipped.
+ */
+export function ownLevelNoteTexts(
+   annote: AnnotationsDef | undefined,
+): string[] {
+   return [...(annote?.blockNotes ?? []), ...(annote?.notes ?? [])].map(
+      (note) => note.text,
+   );
+}

--- a/packages/server/src/service/annotations.ts
+++ b/packages/server/src/service/annotations.ts
@@ -128,12 +128,7 @@ export function ownModelNotes(modelDef: ModelDef): string[] {
       // Ancestral-first, matching `Annotations.texts()`, so a later cell's tag
       // wins over an earlier one the way a later line does within a file.
       for (const dep of entry.inheritsFrom) visit(dep);
-      for (const note of [
-         ...(entry.ownNotes.blockNotes ?? []),
-         ...(entry.ownNotes.notes ?? []),
-      ]) {
-         texts.push(note.text);
-      }
+      texts.push(...ownLevelNoteTexts(entry.ownNotes));
    };
    visit(modelDef.modelID);
    return texts;
@@ -156,10 +151,12 @@ export function annotationTexts(
  * The annotation texts declared directly on ONE node of an `AnnotationsDef`
  * chain — not its `inherits` ancestors. Malloy files a source-level
  * annotation under `blockNotes` for `#(tag)\nsource: name is ...` but under
- * `notes` for the multi-definition block form (`source:\n  #(tag)\n  name is
- * ...`): same declaration slot, different key depending only on which of the
- * two syntaxes the author used (confirmed by compiling both against a
- * `duckdb.sql` source and inspecting the resulting `SourceDef.annotations`).
+ * `notes` for every other source-level placement — the multi-definition block
+ * form (`source:\n  #(tag)\n  name is ...`) and either side of the `is`
+ * (`source: name is\n  #(tag)\n  base`, malloy's `getIsNotes`). Same
+ * declaration slot, different key depending only on which syntax the author
+ * used (confirmed by compiling each form and inspecting the resulting
+ * `SourceDef.annotations`).
  * A caller walking `inherits` by hand to find the nearest declaring level —
  * rather than flattening the whole chain via {@link annotationTexts} — needs
  * this at each link so a block-form declaration is not silently skipped.

--- a/packages/server/src/service/authorize_integration.spec.ts
+++ b/packages/server/src/service/authorize_integration.spec.ts
@@ -2842,6 +2842,11 @@ source:
       );
       expect(sourceNamed(model, "bf_open")?.authorize).toBeUndefined();
       expect(model.getAuthorize("bf_open")).toEqual([]);
+      // Positive half of the control: the gate has to have landed on the item
+      // it precedes. Without this, an off-by-one that attributed a block item's
+      // note to the PREVIOUS definition would still satisfy the assertions
+      // above while leaving nothing gated at all.
+      expect(model.getAuthorize("bf_sibling_locked")).toEqual(["false"]);
       const { result } = await runGated(
          "block_sibling.malloy",
          "run: bf_open -> { aggregate: c }",
@@ -2909,11 +2914,14 @@ source: bf_ext is bf_base extend {}
       ).rejects.toBeInstanceOf(AccessDeniedError);
    });
 
-   it("carries a block-form base's gate to an extension resolved via the source registry", async () => {
-      // The third read site: `resolveDeclaredSource` follows `sourceRegistry`
-      // when no `inherits` link survives (a `join_one`/`join_many` case, or a
-      // rename). Exercised here via a query-source derived from a block-form
-      // locked base, matching the existing derivation-enforcement coverage.
+   it("carries a block-form base's gate through a query-source derivation", async () => {
+      // `collectEntryPointGates` resolves a `query_source`'s base through
+      // `query.structRef`, so the gate has to be readable off the BASE's own
+      // block-form notes. (This does not reach `ancestorGateExprs`'s
+      // `resolveDeclaredSource` branch — that one is only entered when no
+      // `inherits` link survives, and no fixture here produces a declared
+      // source that both carries notes and is reached that way, so the
+      // sourceRegistry read stays defensive rather than covered.)
       await writeModel(
          "block_registry.malloy",
          `source:
@@ -2933,5 +2941,100 @@ source: bf_reg_derived is bf_reg_base -> { select: id, secret }
             {},
          ),
       ).rejects.toBeInstanceOf(AccessDeniedError);
+   });
+
+   it("evaluates a block-form gate that references a given", async () => {
+      // Every other test here uses a constant gate, which never reaches
+      // `bindProbeGivens`/`validateAuthorizeProbes` with a real `$NAME`. The
+      // realistic block-form gate does, so pin both directions of the probe.
+      await writeModel(
+         "block_given.malloy",
+         `##! experimental.givens
+
+given:
+  ROLE :: string
+
+source:
+  #(authorize) "$ROLE = 'analyst'"
+  bf_given is duckdb.table('customers') extend { measure: c is count() }
+`,
+      );
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "block_given.malloy",
+         getConnections(),
+      );
+      expect(model.getAuthorize("bf_given")).toEqual(["$ROLE = 'analyst'"]);
+      const { result } = await runGated(
+         "block_given.malloy",
+         "run: bf_given -> { aggregate: c }",
+         { ROLE: "analyst" },
+      );
+      expect(result.data).toBeDefined();
+      await expect(
+         runGated("block_given.malloy", "run: bf_given -> { aggregate: c }", {
+            ROLE: "intern",
+         }),
+      ).rejects.toBeInstanceOf(AccessDeniedError);
+   });
+
+   it("gates a source whose #(authorize) sits after the `is`", async () => {
+      // The third producer of source-level `notes`: malloy's `getIsNotes`
+      // collects annotations on either side of the `is`, so this placement was
+      // dropped by the `blockNotes`-only read exactly like the block form.
+      await writeModel(
+         "block_afteris.malloy",
+         `source: bf_afteris is
+  #(authorize) "false"
+  duckdb.table('customers') extend { measure: c is count() }
+`,
+      );
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "block_afteris.malloy",
+         getConnections(),
+      );
+      expect(model.getAuthorize("bf_afteris")).toEqual(["false"]);
+      await expect(
+         runGated(
+            "block_afteris.malloy",
+            "run: bf_afteris -> { aggregate: c }",
+            {},
+         ),
+      ).rejects.toBeInstanceOf(AccessDeniedError);
+   });
+
+   it("fails model load for a block-form gate naming an undeclared given", async () => {
+      // The `source_extraction.ts` half of the read, isolated. `ownAuthorizeSources`
+      // is the ONLY consumer of the extractor's own-gate answer that survives the
+      // Model constructor (which overwrites `sources[].authorize` from the
+      // enforcement walk in model.ts), so this is what pins the reporting half:
+      // with a `blockNotes`-only extractor the bad gate is invisible at load and
+      // the model compiles clean.
+      await writeModel(
+         "block_validate.malloy",
+         `##! experimental.givens
+
+given:
+  ROLE :: string
+
+source:
+  #(authorize) "$NO_SUCH_GIVEN = 'x'"
+  bf_validate is duckdb.table('customers') extend { measure: c is count() }
+`,
+      );
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "block_validate.malloy",
+         getConnections(),
+      );
+      const err = model.getNotebookError();
+      expect(err).toBeDefined();
+      expect(err?.message).toContain(
+         'Invalid #(authorize) annotation on source "bf_validate"',
+      );
    });
 });

--- a/packages/server/src/service/authorize_integration.spec.ts
+++ b/packages/server/src/service/authorize_integration.spec.ts
@@ -2768,3 +2768,170 @@ source: fl_tagged is fl_locked extend {}
       }
    });
 });
+
+// A gate written above a standalone `source:` lands in `annotations.blockNotes`.
+// The SAME gate written inside a multi-definition `source:` block
+// (`source:\n  #(authorize)\n  name is ...`) lands in `annotations.notes`
+// instead — same declaration slot, different key depending only on which
+// syntax the author used (confirmed by compiling both and inspecting the
+// resulting SourceDef). Reading `blockNotes` only reported the block form as
+// ungated and served every query against it — a real access-control bypass an
+// author could not detect from Publisher's own introspection response.
+describe("a gate declared in a multi-definition source: block is not silently dropped", () => {
+   it("gates a source declared with its own #(authorize) inside a source: block", async () => {
+      await writeModel(
+         "block.malloy",
+         `source:
+  #(authorize) "false"
+  bf_locked is duckdb.table('customers') extend { measure: c is count() }
+`,
+      );
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "block.malloy",
+         getConnections(),
+      );
+      expect(sourceNamed(model, "bf_locked")?.authorize).toEqual(["false"]);
+      expect(model.getAuthorize("bf_locked")).toEqual(["false"]);
+      await expect(
+         runGated("block.malloy", "run: bf_locked -> { aggregate: c }", {}),
+      ).rejects.toBeInstanceOf(AccessDeniedError);
+   });
+
+   it("still gates the line-above form the same block-form model also uses", async () => {
+      // Guards against a fix that special-cases the block form and stops
+      // reading `blockNotes` — both forms must keep working side by side.
+      await writeModel(
+         "block_mixed.malloy",
+         `#(authorize) "false"
+source: bf_above is duckdb.table('customers') extend { measure: c is count() }
+
+source:
+  #(authorize) "false"
+  bf_block is duckdb.table('customers') extend { measure: c is count() }
+`,
+      );
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "block_mixed.malloy",
+         getConnections(),
+      );
+      expect(model.getAuthorize("bf_above")).toEqual(["false"]);
+      expect(model.getAuthorize("bf_block")).toEqual(["false"]);
+   });
+
+   it("does not over-gate a sibling in the same block that declares no annotation", async () => {
+      // The narrowest-safe-reading control: `notes` only ever carries the
+      // annotation directly above ONE block item, never a sibling's, so an
+      // undecorated definition in the same block must stay unrestricted.
+      await writeModel(
+         "block_sibling.malloy",
+         `source:
+  bf_open is duckdb.table('customers') extend { measure: c is count() }
+  #(authorize) "false"
+  bf_sibling_locked is duckdb.table('customers') extend { measure: c is count() }
+`,
+      );
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "block_sibling.malloy",
+         getConnections(),
+      );
+      expect(sourceNamed(model, "bf_open")?.authorize).toBeUndefined();
+      expect(model.getAuthorize("bf_open")).toEqual([]);
+      const { result } = await runGated(
+         "block_sibling.malloy",
+         "run: bf_open -> { aggregate: c }",
+         {},
+      );
+      expect(result.data).toBeDefined();
+   });
+
+   it("does not over-gate a field/view-level annotation that merely mentions authorize-shaped text", async () => {
+      // `notes`/`blockNotes` are populated only by SOURCE-level (block-item)
+      // annotations. A dimension- or view-level annotation never lands on the
+      // source struct's own annotations at all, so it cannot be mistaken for a
+      // source gate by the wider read.
+      await writeModel(
+         "block_field_level.malloy",
+         `source: bf_field is duckdb.table('customers') extend {
+  #(authorize) "false"
+  dimension: region_copy is region
+  measure: c is count()
+}
+`,
+      );
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "block_field_level.malloy",
+         getConnections(),
+      );
+      expect(model.getAuthorize("bf_field")).toEqual([]);
+      const { result } = await runGated(
+         "block_field_level.malloy",
+         "run: bf_field -> { aggregate: c }",
+         {},
+      );
+      expect(result.data).toBeDefined();
+   });
+
+   it("carries a block-form base's gate to an extension through annotations.inherits", async () => {
+      // The base's gate is filed under `annotations.inherits.notes` once the
+      // extension adds its own (unrelated) annotation — the same demotion
+      // `ancestorGateExprs` already follows for the line-above form.
+      await writeModel(
+         "block_inherit.malloy",
+         `source:
+  #(authorize) "false"
+  bf_base is duckdb.table('customers') extend { measure: c is count() }
+
+# bar_chart
+source: bf_ext is bf_base extend {}
+`,
+      );
+      const model = await Model.create(
+         "test-pkg",
+         TEST_PKG_DIR,
+         "block_inherit.malloy",
+         getConnections(),
+      );
+      expect(model.getAuthorize("bf_ext")).toEqual(["false"]);
+      await expect(
+         runGated(
+            "block_inherit.malloy",
+            "run: bf_ext -> { aggregate: c }",
+            {},
+         ),
+      ).rejects.toBeInstanceOf(AccessDeniedError);
+   });
+
+   it("carries a block-form base's gate to an extension resolved via the source registry", async () => {
+      // The third read site: `resolveDeclaredSource` follows `sourceRegistry`
+      // when no `inherits` link survives (a `join_one`/`join_many` case, or a
+      // rename). Exercised here via a query-source derived from a block-form
+      // locked base, matching the existing derivation-enforcement coverage.
+      await writeModel(
+         "block_registry.malloy",
+         `source:
+  #(authorize) "false"
+  bf_reg_base is duckdb.table('customers') extend {
+    measure: c is count()
+    dimension: secret is name
+  }
+
+source: bf_reg_derived is bf_reg_base -> { select: id, secret }
+`,
+      );
+      await expect(
+         runGated(
+            "block_registry.malloy",
+            "run: bf_reg_derived -> { select: id, secret }",
+            {},
+         ),
+      ).rejects.toBeInstanceOf(AccessDeniedError);
+   });
+});

--- a/packages/server/src/service/materialization_eligibility.ts
+++ b/packages/server/src/service/materialization_eligibility.ts
@@ -300,12 +300,10 @@ function walkForAuthorize(
 
    const record = node as Record<string, unknown>;
 
-   // Annotation notes live under `blockNotes` (the `#(tag)\nsource: x is ...`
-   // statement form, and a model's `##`) or `notes` (the same source-level slot
-   // for the multi-definition `source:` block form, and after-`is` placement),
-   // as either bare strings or `{ text }` objects. Both keys are read: `notes`
-   // is NOT model/file-only, and treating it that way is what let a block-form
-   // `#(authorize)` be dropped elsewhere.
+   // Annotation notes live under `blockNotes` or `notes` — both are per-item
+   // slots at the same level, keyed by the author's syntax rather than by scope
+   // (see `ownLevelNoteTexts`), so both have to be read. Each entry is either a
+   // bare string or a `{ text }` object.
    for (const key of ["blockNotes", "notes"]) {
       const arr = record[key];
       if (!Array.isArray(arr)) continue;

--- a/packages/server/src/service/materialization_eligibility.ts
+++ b/packages/server/src/service/materialization_eligibility.ts
@@ -300,8 +300,12 @@ function walkForAuthorize(
 
    const record = node as Record<string, unknown>;
 
-   // Annotation notes live under `blockNotes` (source/statement) or `notes`
-   // (model/file), as either bare strings or `{ text }` objects.
+   // Annotation notes live under `blockNotes` (the `#(tag)\nsource: x is ...`
+   // statement form, and a model's `##`) or `notes` (the same source-level slot
+   // for the multi-definition `source:` block form, and after-`is` placement),
+   // as either bare strings or `{ text }` objects. Both keys are read: `notes`
+   // is NOT model/file-only, and treating it that way is what let a block-form
+   // `#(authorize)` be dropped elsewhere.
    for (const key of ["blockNotes", "notes"]) {
       const arr = record[key];
       if (!Array.isArray(arr)) continue;

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -874,10 +874,8 @@ export class Model {
       struct: SourceDef,
       modelDef?: ModelDef,
    ): { exprs: string[]; fromAncestor: boolean; ambientPrefix: number } {
-      // `blockNotes` covers `#(tag)\nsource: name is ...`; the multi-definition
-      // `source:` block form files the same declaration under `notes` instead
-      // (see {@link ownLevelNoteTexts}) — reading only the former let a
-      // block-form `#(authorize)` compile and report as an ungated source.
+      // Both note keys: which one a gate lands in is decided by the author's
+      // syntax, not by scope. See {@link ownLevelNoteTexts}.
       const ownNotes = ownLevelNoteTexts(struct.annotations);
       try {
          const own = collectAuthorizeExprs(ownNotes);
@@ -915,10 +913,8 @@ export class Model {
     * render tag or doc comment, whoever wrote it. Both links are followed here,
     * nearest first, and the first ancestor that declares a gate wins.
     *
-    * Each level is read with {@link ownLevelNoteTexts}, not `blockNotes`
-    * alone: a base declared with the multi-definition `source:` block form
-    * files its gate under `notes` instead, and `blockNotes`-only would lose
-    * that gate the moment it moves onto `annotations.inherits`.
+    * Each level is read with {@link ownLevelNoteTexts} rather than `blockNotes`,
+    * so a base whose gate landed under `notes` is still found on every link.
     *
     * "Own wins over ancestor" is what keeps the documented locked-base +
     * curated-extension idiom working (an extension declaring its own gate

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -71,7 +71,11 @@ import type {
 } from "../package_load/protocol";
 import { BuildManifest } from "../storage/DatabaseInterface";
 import { URL_READER } from "../utils";
-import { modelAnnotations, ownModelNotes } from "./annotations";
+import {
+   modelAnnotations,
+   ownLevelNoteTexts,
+   ownModelNotes,
+} from "./annotations";
 import {
    assertNoCallerAuthorizeAnnotation,
    collectAuthorizeExprs,
@@ -870,9 +874,11 @@ export class Model {
       struct: SourceDef,
       modelDef?: ModelDef,
    ): { exprs: string[]; fromAncestor: boolean; ambientPrefix: number } {
-      const ownNotes = (struct.annotations?.blockNotes ?? []).map(
-         (note) => note.text,
-      );
+      // `blockNotes` covers `#(tag)\nsource: name is ...`; the multi-definition
+      // `source:` block form files the same declaration under `notes` instead
+      // (see {@link ownLevelNoteTexts}) — reading only the former let a
+      // block-form `#(authorize)` compile and report as an ungated source.
+      const ownNotes = ownLevelNoteTexts(struct.annotations);
       try {
          const own = collectAuthorizeExprs(ownNotes);
          if (own.length > 0) {
@@ -909,6 +915,11 @@ export class Model {
     * render tag or doc comment, whoever wrote it. Both links are followed here,
     * nearest first, and the first ancestor that declares a gate wins.
     *
+    * Each level is read with {@link ownLevelNoteTexts}, not `blockNotes`
+    * alone: a base declared with the multi-definition `source:` block form
+    * files its gate under `notes` instead, and `blockNotes`-only would lose
+    * that gate the moment it moves onto `annotations.inherits`.
+    *
     * "Own wins over ancestor" is what keeps the documented locked-base +
     * curated-extension idiom working (an extension declaring its own gate
     * replaces the base's). That is only safe because the declaration is the
@@ -932,9 +943,7 @@ export class Model {
          inherited && depth < ANCESTOR_WALK_MAX_DEPTH;
          depth++
       ) {
-         const exprs = collectAuthorizeExprs(
-            (inherited.blockNotes ?? []).map((note) => note.text),
-         );
+         const exprs = collectAuthorizeExprs(ownLevelNoteTexts(inherited));
          if (exprs.length > 0) return exprs;
          inherited = inherited.inherits;
       }
@@ -951,9 +960,7 @@ export class Model {
       if (declared.kind === "unresolvable") return ["false"];
       if (declared.kind === "none" || seen.has(declared.source)) return [];
       const exprs = collectAuthorizeExprs(
-         (declared.source.annotations?.blockNotes ?? []).map(
-            (note) => note.text,
-         ),
+         ownLevelNoteTexts(declared.source.annotations),
       );
       return exprs.length > 0
          ? exprs

--- a/packages/server/src/service/source_extraction.ts
+++ b/packages/server/src/service/source_extraction.ts
@@ -124,9 +124,11 @@ export interface ExtractedQuery {
  * files its declarations under `notes` instead of `blockNotes` — same slot,
  * different key depending only on which syntax the author used. The authorize
  * reads below use {@link ownLevelNoteTexts}, which covers both. The `#(filter)`
- * walk deliberately still reads `blockNotes` only: it has the same gap, but
- * `#(filter)` is deprecated, so closing it would newly enforce a `required`
- * filter that a live model has been running without.
+ * walk deliberately still reads `blockNotes` only: it has the same live gap —
+ * a block-form `#(filter) ... required` is dropped, and `buildFilterClause`
+ * then never raises the "required filter not provided" error the author asked
+ * for — but closing it would start rejecting requests against models that have
+ * been serving them, so it is left for a change that can carry that break.
  *
  * Two lists come out of this, and the distinction is load-bearing:
  *  - `authorize` is the EFFECTIVE gate (file-level `##(authorize)` from

--- a/packages/server/src/service/source_extraction.ts
+++ b/packages/server/src/service/source_extraction.ts
@@ -119,16 +119,16 @@ export interface ExtractedQuery {
  * walked, nearest declaration wins, matching `Model.gateExprsForOwnAnnotations`.
  * Joins are a separate concern and are not gated.
  *
- * `blockNotes` alone is also not sufficient WITHIN one level: the
- * multi-definition `source:` block form (`source:\n  #(tag)\n  name is ...`)
- * files its declarations under `notes` instead of `blockNotes` — same slot,
- * different key depending only on which syntax the author used. The authorize
- * reads below use {@link ownLevelNoteTexts}, which covers both. The `#(filter)`
- * walk deliberately still reads `blockNotes` only: it has the same live gap —
- * a block-form `#(filter) ... required` is dropped, and `buildFilterClause`
- * then never raises the "required filter not provided" error the author asked
- * for — but closing it would start rejecting requests against models that have
- * been serving them, so it is left for a change that can carry that break.
+ * `blockNotes` alone is also not sufficient WITHIN one level, because which
+ * note key a declaration lands in is decided by the author's syntax. The
+ * authorize reads below therefore go through {@link ownLevelNoteTexts}, which
+ * covers both keys.
+ *
+ * The `#(filter)` walk deliberately still reads `blockNotes` only. It has the
+ * same live gap: a block-form `#(filter) ... required` is dropped, so
+ * `buildFilterClause` never raises the "required filter not provided" error the
+ * author asked for. Closing it would start rejecting requests that live models
+ * have been serving, so it is left for a change that can carry that break.
  *
  * Two lists come out of this, and the distinction is load-bearing:
  *  - `authorize` is the EFFECTIVE gate (file-level `##(authorize)` from

--- a/packages/server/src/service/source_extraction.ts
+++ b/packages/server/src/service/source_extraction.ts
@@ -22,7 +22,11 @@ import {
    StructDef,
    TurtleDef,
 } from "@malloydata/malloy";
-import { annotationTexts, modelAnnotations } from "./annotations";
+import {
+   annotationTexts,
+   modelAnnotations,
+   ownLevelNoteTexts,
+} from "./annotations";
 import { collectAuthorizeExprs, type AuthorizeMap } from "./authorize";
 import { parseFilters, type FilterDefinition } from "./filter";
 
@@ -115,6 +119,15 @@ export interface ExtractedQuery {
  * walked, nearest declaration wins, matching `Model.gateExprsForOwnAnnotations`.
  * Joins are a separate concern and are not gated.
  *
+ * `blockNotes` alone is also not sufficient WITHIN one level: the
+ * multi-definition `source:` block form (`source:\n  #(tag)\n  name is ...`)
+ * files its declarations under `notes` instead of `blockNotes` — same slot,
+ * different key depending only on which syntax the author used. The authorize
+ * reads below use {@link ownLevelNoteTexts}, which covers both. The `#(filter)`
+ * walk deliberately still reads `blockNotes` only: it has the same gap, but
+ * `#(filter)` is deprecated, so closing it would newly enforce a `required`
+ * filter that a live model has been running without.
+ *
  * Two lists come out of this, and the distinction is load-bearing:
  *  - `authorize` is the EFFECTIVE gate (file-level `##(authorize)` from
  *    `modelDef.annotations.notes`, then own-or-inherited), evaluated as one OR
@@ -198,9 +211,7 @@ export function extractSourcesFromModelDef(
          // gates and source gates form one OR disjunction. A malformed
          // annotation propagates (model fails to load) rather than silently
          // dropping the gate — see the file-level note above.
-         const ownNotes = (struct.annotations?.blockNotes ?? []).map(
-            (note) => note.text,
-         );
+         const ownNotes = ownLevelNoteTexts(struct.annotations);
          const ownGates = collectAuthorizeExprs(ownNotes);
          let inheritedGates: string[] = [];
          if (ownGates.length === 0) {
@@ -209,9 +220,7 @@ export function extractSourcesFromModelDef(
                cur;
                cur = cur.inherits
             ) {
-               const exprs = collectAuthorizeExprs(
-                  (cur.blockNotes ?? []).map((note) => note.text),
-               );
+               const exprs = collectAuthorizeExprs(ownLevelNoteTexts(cur));
                if (exprs.length > 0) {
                   inheritedGates = exprs;
                   break;


### PR DESCRIPTION
## The bug

Malloy files a source-level annotation under `annotations.blockNotes` for `#(tag)\nsource: name is ...`, but under `annotations.notes` for the multi-definition block form. Gate resolution read `blockNotes` only, so a gate written the second way was silently dropped:

```malloy
#(authorize) "false"
source: gated_lineabove is duckdb.sql("select 'CA' as state") extend {
  view: v is { group_by: state }
}

source:
  #(authorize) "false"
  gated_blockform is duckdb.sql("select 'NY' as state") extend {
    view: v is { group_by: state }
  }
```

Against `0.0.237`, same gate, differing only in placement:

| Source | `GET .../models/{path}` | `POST .../query` |
| --- | --- | --- |
| `gated_lineabove` | `authorize: ['false']` | **403** Access denied |
| `gated_blockform` | `authorize: None` | **200 — rows served** |

`#(authorize) "false"` granted access. The author's only feedback is that the query works, which reads as "my gate allows this caller" rather than "my gate was discarded".

It is the same declaration slot, keyed differently purely by syntax — confirmed by compiling both forms and inspecting the resulting `SourceDef.annotations`, not inferred. Malloy binds the annotation to that source and propagates it through `extend` onto `annotations.inherits.notes`, exactly as a line-above gate propagates via `inherits.blockNotes`.

## Scope: five sites, both halves of the feature

- **`model.ts`** (enforcement) — `gateExprsForOwnAnnotations`; and both reads in `ancestorGateExprs` (each `inherits` link, and the `sourceRegistry`-resolved declared source).
- **`source_extraction.ts`** (reporting) — `extractSourcesFromModelDef`'s own-gate read and inherited-chain loop, which feed `getSources()` and therefore the reported `sources[].authorize`.

The two halves broke independently. That is why the source both *reported* ungated and *served* rows, and why fixing either alone would leave half the bug — notably, a consumer that trusts the reported gate set would still inherit it.

`ownLevelNoteTexts(annote)` in `annotations.ts` is now the single place that reads `[...blockNotes, ...notes]` at one `AnnotationsDef` node. Deliberately not `annotationTexts`, which flattens the whole `inherits` chain — authorize needs nearest-declaring-level-wins.

## Over-gating was checked before widening the read

Widening a read that decides access can fail just as silently in the opposite direction, so each form was compiled and its landing place recorded first:

| Form | Lands in |
| --- | --- |
| line-above standalone `source:` | `blockNotes` |
| block form, gate on the item | `notes` |
| gate after the `is` (`source: x is\n#(tag)\nbase`) | `notes` |
| block form, gate on item 1 of 2 — item 2 | `annotations` **undefined** (no leak) |
| field-level (`dimension:`) annotation | struct `annotations` **undefined** (no leak) |
| view-level annotation | struct `annotations` **undefined** (no leak) |
| block-form base, extended | `inherits.notes` |
| line-above base, extended | `inherits.blockNotes` |

A source struct's `notes` — and each link of its `inherits` chain — is populated only by a source-level annotation attached to that one item. Never a field/view-level annotation, never a sibling definition in the same block. So reading both keys cannot invent a gate nobody wrote; it only stops dropping one that was written. No ordering or location discriminator was needed. Three of the new tests pin that direction explicitly.

Incidentally, the comment at `materialization_eligibility.ts:303` (which already reads both) undersells this: `notes` is not model/file-only — it is the same per-item slot as `blockNotes`, chosen by syntax rather than by scope.

## `#(filter)` deliberately left alone

The `#(filter)` walk in the same function has the identical gap: a block-form `#(filter) ... required` is dropped, so `buildFilterClause` never raises the "required filter not provided" error the author asked for. Left unfixed and noted in a comment, because closing it would start rejecting requests that live models have been serving. Happy to include it if you'd rather take that break here.

## Tests

`bun test src` from `packages/server` → **2064 pass / 0 fail**, with 9 new cases in `authorize_integration.spec.ts`. (Worth noting for anyone reproducing: run it from `packages/server`, not the repo root. Two `package.spec.ts` cases copy a fixture via the relative path `tests/fixtures/xlsx/database.xlsx` and fail on cwd alone from the root, and a root-level run also picks up pre-existing `packages/cli` failures — a missing generated `../api/generated` plus four `consoleLogSpy` assertions. None are in files this branch touches.)

Worth flagging how weak the first pass at these was. The `source_extraction.ts` half of the fix — two of the five sites — initially had **no coverage at all**: reverting both left the suite at exactly the 2061/0 the first revision of this PR quoted. `sources[].authorize` assertions cannot catch it, because the `Model` constructor overwrites that field from `entryPointGatesBySource` (the `model.ts` path), masking whatever the extractor returned. The isolating case is `fails model load for a block-form gate naming an undeclared given`, which reaches the extractor through `ownAuthorizeSources` → `validateAuthorizeProbes` and fails if either extractor site is reverted.

Two other corrections from that pass:

- One test was labelled as covering the `sourceRegistry`-resolved read. It does not reach `resolveDeclaredSource`; the denial comes from the `query_source` derivation branch. Across this spec that function only ever resolves to an annotation-less copy, so **that fifth site is fixed but unverified** — changed for consistency, not because a test pins it.
- The over-gating control asserted only its negative half, so it would have passed against a model with no gate at all. It now asserts the positive side too. A block-form gate that references a *given* is also covered now; every earlier case used a constant, which short-circuits the probe path authors actually hit.

`eslint` and `prettier` clean. `tsc --noEmit` reports 6 errors, all pre-existing and confirmed identical on `main` via stash.

## One thing to decide

This changes behaviour for models that currently load and serve, in two ways:

1. **A well-formed block-form gate starts being enforced** — queries that succeed today will 403. That is the point (the author wrote a gate and meant it), but anyone unknowingly serving data through one loses access on upgrade.
2. **A malformed block-form gate now fails the whole model load**, not just the queries against that source. Authorize parse failures deliberately propagate rather than being swallowed, so a block-form `#(authorize)` that was previously ignored — including one naming a given that does not exist — now takes down every source in that file, ungated ones included.

The second has the wider blast radius and is the one a release note most needs to say out loud.

On disclosure: I held this back initially as a possible security report, then concluded the affected syntax is obscure enough (I found no documented `source:` block example in the Malloy docs) that a normal public PR is the more useful artifact. Say the word if you'd rather handle it privately instead.
