### PR TITLE
fix(materialization): an orchestrated storage build must not redirect a write, or refuse one it can make

### DIFF
--- a/hammer/scenarios/mz-storage/70-strict-upstream-built-here/scenario.md
+++ b/hammer/scenarios/mz-storage/70-strict-upstream-built-here/scenario.md
@@ -1,0 +1,120 @@
+---
+id: strict-upstream-built-here
+tags: orchestration, chained, build-control
+package: sbh
+---
+
+# strictUpstreams: an upstream built in the same call must satisfy the gate
+
+`strictUpstreams` documents two ways an upstream may be satisfied — it fails only
+for an upstream "neither built here nor present in referenceManifest". Every
+other chained scenario covers the second way: the upstream is already built and
+arrives by `reference:` (`reference-manifest-reuse`), from another worker
+(`cross-worker-reference-isolation`), from a refreshed manifest
+(`cross-worker-refreshed-manifest`), or is absent so strict refuses
+(`strict-upstreams-refused`).
+
+This is the FIRST way, and nothing else exercises it: one orchestrated strict
+build whose instruction list holds BOTH the upstream and its dependent. No
+`reference:` is possible or needed — `daily` is not an already-materialized
+artifact to point at, it is a target of this very build. An orchestrator that
+dispatches a package's persist sources together, on the package's first build,
+emits exactly this shape: there is no prior generation to reference, so if
+"built here" does not count, a chained package can never make its first build.
+
+The contrast with `strict-upstreams-refused` is the whole point — same strict
+flag, same chained model, and the ONLY difference is whether `daily` is in the
+instruction list. Absent, strict must refuse. Present, strict must be satisfied.
+
+## Publisher
+
+- PERSIST_STORAGE_MODE: on
+
+## Data orders_pg.sbh_orders
+
+| order_id:int | order_date:date | amount:num |
+| ------------ | --------------- | ---------- |
+| 1            | 2026-01-01      | 100        |
+| 2            | 2026-01-01      | 50         |
+| 3            | 2026-01-02      | 200        |
+
+## Model sbh.malloy
+
+```malloy
+##! experimental.persistence
+
+source: orders is orders_pg.table('public.sbh_orders')
+
+#@ persist name="sbh_daily" storage=lake
+source: daily is orders -> {
+  group_by: order_date
+  aggregate: total_amount is amount.sum()
+}
+
+#@ persist name="sbh_rollup" storage=lake
+source: rollup is daily -> {
+  aggregate: grand_total is total_amount.sum()
+}
+```
+
+## Build (orchestrated, strict, pkg=sbh)
+
+Both sources in one strict instruction list, upstream first. `daily` is built
+here, so `rollup` must resolve it from this build rather than refusing — and
+must not recompute it from raw either, which is what strict exists to forbid.
+
+- daily -> sbh_daily__g1 @ lake
+- rollup -> sbh_rollup__g1 @ lake
+
+## Bind sbh
+
+Distribute the build's manifest so both sources serve from their materialized
+tables.
+
+## Query daily
+
+```malloy
+run: daily -> { select: order_date, total_amount; order_by: order_date asc }
+```
+
+Expect:
+
+| order_date | total_amount |
+| ---------- | ------------ |
+| 2026-01-01 | 150          |
+| 2026-01-02 | 200          |
+
+## Query rollup
+
+The dependent's value proves it read a correct `daily` — whether from the table
+just built or recomputed, the number is the same, so the number alone is not the
+assertion. The assertion is that the build SUCCEEDED at the caller-assigned
+names above, which a strict refusal would have prevented.
+
+```malloy
+run: rollup -> { select: grand_total }
+```
+
+Expect:
+
+| grand_total:num |
+| --------------- |
+| 350             |
+
+## Mutate orders_pg.sbh_orders
+
+| order_id:int | order_date:date | amount:num |
+| ------------ | --------------- | ---------- |
+| 99           | 2026-01-03      | 1000       |
+
+## Query rollup (again)
+
+Stale ⇒ served from the built table, not recomputed live against the mutated
+source. This is what separates "resolved the upstream" from "quietly recomputed
+it": a live recompute would pick the new row up.
+
+Expect:
+
+| grand_total:num |
+| --------------- |
+| 350             |

--- a/hammer/scenarios/mz-storage/71-chained-write-only/scenario.md
+++ b/hammer/scenarios/mz-storage/71-chained-write-only/scenario.md
@@ -1,0 +1,119 @@
+---
+id: chained-write-only
+tags: config, kill-switch, chained
+package: cwo
+---
+
+# `write-only` must not stop a chained pair building, and must serve both live
+
+`mode-matrix` pins what `write-only` means for ONE source: materialize into the
+lake, but do not route reads to the table. `chained-persist` pins that a
+downstream builds by reading its upstream's materialized table. Those two rules
+meet in a case neither covers — every chained scenario runs at `on` — and the
+meeting is not obviously safe: if a downstream builds by READING its upstream,
+and `write-only` is precisely the mode that does not route reads to storage, a
+chained build could plausibly fail in the one mode an operator steps through on
+the way to enabling the tier.
+
+So the rule is that `write-only` governs SERVING, not the build's own upstream
+resolution: both sources still materialize, and both still serve live.
+
+That direction matters. `write-only` is the halfway house of a rollout — turn on
+writing, confirm tables appear, then turn on routing. If a chained package cannot
+be built in that state, the safe rollout order is the one that breaks, and the
+only way through is the riskier jump straight to `on`.
+
+## Publisher
+
+Build into the lake, serve live.
+
+- PERSIST_STORAGE_MODE: write-only
+
+## Data orders_pg.cwo_orders
+
+| order_id:int | order_date:date | amount:num |
+| ------------ | --------------- | ---------- |
+| 1            | 2026-01-01      | 100        |
+| 2            | 2026-01-01      | 50         |
+| 3            | 2026-01-02      | 200        |
+
+## Model cwo.malloy
+
+```malloy
+##! experimental.persistence
+
+source: orders is orders_pg.table('public.cwo_orders')
+
+#@ persist name="cwo_daily" storage=lake
+source: daily is orders -> {
+  group_by: order_date
+  aggregate: total_amount is amount.sum()
+}
+
+#@ persist name="cwo_rollup" storage=lake
+source: rollup is daily -> {
+  aggregate: grand_total is total_amount.sum()
+}
+```
+
+## Publish
+
+Both persist sources materialize. The downstream's upstream resolution must not
+depend on reads being routed — a failure here is the build refusing, not a wrong
+number.
+
+## Query daily
+
+```malloy
+run: daily -> { select: order_date, total_amount; order_by: order_date asc }
+```
+
+Expect:
+
+| order_date | total_amount |
+| ---------- | ------------ |
+| 2026-01-01 | 150          |
+| 2026-01-02 | 200          |
+
+## Query rollup
+
+```malloy
+run: rollup -> { select: grand_total }
+```
+
+Expect:
+
+| grand_total:num |
+| --------------- |
+| 350             |
+
+## Mutate orders_pg.cwo_orders
+
+| order_id:int | order_date:date | amount:num |
+| ------------ | --------------- | ---------- |
+| 99           | 2026-01-03      | 1000       |
+
+## Query daily (again)
+
+`write-only` serves live, so the mutation IS visible — the upstream is not
+routed to its table.
+
+Expect:
+
+| order_date | total_amount |
+| ---------- | ------------ |
+| 2026-01-01 | 150          |
+| 2026-01-02 | 200          |
+| 2026-01-03 | 1000         |
+
+## Query rollup (again)
+
+The downstream serves live too. A stale 350 here would mean the chained source
+routed to storage while its upstream did not — the mode applied inconsistently
+down a chain, which is worse than either mode applied uniformly.
+
+Expect:
+
+| grand_total:num |
+| --------------- |
+| 1350            |

--- a/hammer/scenarios/mz-storage/72-chained-write-only-orchestrated/scenario.md
+++ b/hammer/scenarios/mz-storage/72-chained-write-only-orchestrated/scenario.md
@@ -1,0 +1,118 @@
+---
+id: chained-write-only-orchestrated
+tags: orchestration, chained, kill-switch
+package: cwoo
+---
+
+# `write-only` must govern serving, not whether an orchestrated chained build resolves
+
+`chained-write-only` proves the self-derived publish path builds a chained pair
+at `write-only`. This is the same rule for the ORCHESTRATED path, and the pairing
+is the one an operator actually walks through: a host turns writing on before it
+turns routing on, so the first orchestrated build of a chained package lands in
+exactly this state.
+
+Non-strict on purpose, and paired with `chained-write-only-orchestrated-strict`,
+which is byte-identical but for the flag. Kept as a pair because it is what
+isolates a cause: if the strict twin ever regresses, this one staying green says
+the mode, the chain and the orchestrated path are all still sound and the flag is
+the variable. Collapsing them into one strict scenario would lose that.
+
+So what this pins is narrow and worth pinning on its own: `write-only` governs
+SERVING. It must not change whether an orchestrated build can resolve a chained
+upstream, and it must not leave one source of a chain routed while the other is
+live.
+
+## Publisher
+
+Build into the lake, serve live.
+
+- PERSIST_STORAGE_MODE: write-only
+
+## Data orders_pg.cwoo_orders
+
+| order_id:int | order_date:date | amount:num |
+| ------------ | --------------- | ---------- |
+| 1            | 2026-01-01      | 100        |
+| 2            | 2026-01-01      | 50         |
+| 3            | 2026-01-02      | 200        |
+
+## Model cwoo.malloy
+
+```malloy
+##! experimental.persistence
+
+source: orders is orders_pg.table('public.cwoo_orders')
+
+#@ persist name="cwoo_daily" storage=lake
+source: daily is orders -> {
+  group_by: order_date
+  aggregate: total_amount is amount.sum()
+}
+
+#@ persist name="cwoo_rollup" storage=lake
+source: rollup is daily -> {
+  aggregate: grand_total is total_amount.sum()
+}
+```
+
+## Build (orchestrated, pkg=cwoo)
+
+Both sources at caller-assigned names, into the lake, with routing off.
+
+- daily -> cwoo_daily__g1 @ lake
+- rollup -> cwoo_rollup__g1 @ lake
+
+## Query daily
+
+```malloy
+run: daily -> { select: order_date, total_amount; order_by: order_date asc }
+```
+
+Expect:
+
+| order_date | total_amount |
+| ---------- | ------------ |
+| 2026-01-01 | 150          |
+| 2026-01-02 | 200          |
+
+## Query rollup
+
+```malloy
+run: rollup -> { select: grand_total }
+```
+
+Expect:
+
+| grand_total:num |
+| --------------- |
+| 350             |
+
+## Mutate orders_pg.cwoo_orders
+
+| order_id:int | order_date:date | amount:num |
+| ------------ | --------------- | ---------- |
+| 99           | 2026-01-03      | 1000       |
+
+## Query daily (again)
+
+`write-only` serves live, so the upstream shows the mutation.
+
+Expect:
+
+| order_date | total_amount |
+| ---------- | ------------ |
+| 2026-01-01 | 150          |
+| 2026-01-02 | 200          |
+| 2026-01-03 | 1000         |
+
+## Query rollup (again)
+
+And so does the downstream. A stale 350 here would mean the chain routed
+inconsistently — the dependent reading its table while its upstream read live.
+
+Expect:
+
+| grand_total:num |
+| --------------- |
+| 1350            |

--- a/hammer/scenarios/mz-storage/73-off-must-not-build-into-the-warehouse/scenario.md
+++ b/hammer/scenarios/mz-storage/73-off-must-not-build-into-the-warehouse/scenario.md
@@ -1,0 +1,98 @@
+---
+id: off-must-not-build-into-the-warehouse
+tags: orchestration, kill-switch, security
+package: osw
+---
+
+# `off` must refuse an instructed destination, not redirect the write into the warehouse
+
+`kill-switch-storage-warns` and `mode-matrix` cover what `off` does to SERVING: the
+`storage=` annotation is ignored and the source is served live. Neither builds
+while the switch is down, and that is the gap — because for a BUILD, "ignore the
+annotation" is not a safe default the way it is for a read.
+
+Ignoring `storage=` on a read means serving the same rows from the warehouse they
+already came from. Ignoring it on a write means CREATING A TABLE in the warehouse
+the model said this data may not be written to. `storage=` is a statement about
+where data may NOT go, so a mode that cannot honor it has to decline the write —
+the one outcome it must never produce is the data landing in the source
+warehouse anyway.
+
+The orchestrated path makes this sharp. A host does not merely pass the
+annotation through; it hands the publisher an explicit destination in the
+instruction and a physical name to use. Writing that name somewhere other than
+the instructed destination is not a degraded build, it is a build of a different
+thing, silently — and the host cannot detect it from a success response, because
+the response reports success.
+
+Stepping the mode down is a rollback, so it must stay safe on a loaded package:
+declining is safe, and redirecting the write is not.
+
+## Publisher
+
+Kill switch fully off — destinations cannot be honored.
+
+- PERSIST_STORAGE_MODE: off
+
+## Data orders_pg.osw_orders
+
+| order_id:int | order_date:date | amount:num |
+| ------------ | --------------- | ---------- |
+| 1            | 2026-01-01      | 100        |
+| 2            | 2026-01-01      | 50         |
+| 3            | 2026-01-02      | 200        |
+
+## Model osw.malloy
+
+```malloy
+##! experimental.persistence
+
+source: orders is orders_pg.table('public.osw_orders')
+
+#@ persist name="osw_daily" storage=lake
+source: daily is orders -> {
+  group_by: order_date
+  aggregate: total_amount is amount.sum()
+}
+```
+
+## Build refused (orchestrated, pkg=osw)
+
+The instruction names `lake`. The publisher cannot write there in this mode, so
+the build must fail rather than substitute the connection.
+
+- daily -> osw_daily__g1 @ lake
+
+## SQL the instructed name is absent from the warehouse
+
+The assertion that actually matters, and the one no build-status check can
+stand in for. Whatever the build reported, the instructed physical name must
+not exist in the source warehouse.
+
+```sql
+SELECT count(*)::int AS leaked
+FROM information_schema.tables
+WHERE table_schema = 'public' AND table_name = 'osw_daily__g1';
+```
+
+Expect:
+
+| leaked:int |
+| ---------- |
+| 0          |
+
+## Query daily
+
+The package is unharmed by the refusal — it still serves live, which is what
+`off` means for a read.
+
+```malloy
+run: daily -> { select: order_date, total_amount; order_by: order_date asc }
+```
+
+Expect:
+
+| order_date | total_amount |
+| ---------- | ------------ |
+| 2026-01-01 | 150          |
+| 2026-01-02 | 200          |

--- a/hammer/scenarios/mz-storage/74-chained-write-only-orchestrated-strict/scenario.md
+++ b/hammer/scenarios/mz-storage/74-chained-write-only-orchestrated-strict/scenario.md
@@ -1,0 +1,115 @@
+---
+id: chained-write-only-orchestrated-strict
+tags: orchestration, chained, kill-switch
+package: cwos
+---
+
+# strictUpstreams must not change what an orchestrated chained build can resolve
+
+The discriminating twin of `chained-write-only-orchestrated`: identical model,
+identical instruction list, identical mode. The ONLY difference is
+`strictUpstreams`, and it must not change the outcome here.
+
+That is the whole claim. `strictUpstreams` decides what happens to an upstream
+the build cannot otherwise resolve — it forbids the silent recompute-from-raw
+that `strict-upstreams-refused` pins. It is not supposed to decide whether an
+upstream present in the instruction list can be found. `daily` is built by this
+very call, so there is nothing for strict to forbid: no recompute is needed, and
+the flag should be inert.
+
+Read as a pair, the two scenarios say something neither says alone. Non-strict
+passes, so orchestration, chaining, and `write-only` are each individually fine.
+Strict fails on the same inputs, so the flag is the sole cause — not the mode,
+not the chain, not the orchestrated path.
+
+Kept separate from `strict-upstream-built-here` because the consequence is
+different, not just the mode. That scenario says a chained package cannot make
+its FIRST build. This one says it cannot be built in the state an operator
+deliberately stops at while enabling the tier — writing on, routing still off.
+A fix that only satisfies `on` would leave the safe rollout order broken, and
+this scenario is what would still be red.
+
+## Publisher
+
+Build into the lake, serve live.
+
+- PERSIST_STORAGE_MODE: write-only
+
+## Data orders_pg.cwos_orders
+
+| order_id:int | order_date:date | amount:num |
+| ------------ | --------------- | ---------- |
+| 1            | 2026-01-01      | 100        |
+| 2            | 2026-01-01      | 50         |
+| 3            | 2026-01-02      | 200        |
+
+## Model cwos.malloy
+
+```malloy
+##! experimental.persistence
+
+source: orders is orders_pg.table('public.cwos_orders')
+
+#@ persist name="cwos_daily" storage=lake
+source: daily is orders -> {
+  group_by: order_date
+  aggregate: total_amount is amount.sum()
+}
+
+#@ persist name="cwos_rollup" storage=lake
+source: rollup is daily -> {
+  aggregate: grand_total is total_amount.sum()
+}
+```
+
+## Build (orchestrated, strict, pkg=cwos)
+
+The same two instructions as the non-strict twin, under strict. `daily` is built
+here, so strict has nothing to refuse and the build must succeed at both
+caller-assigned names.
+
+- daily -> cwos_daily__g1 @ lake
+- rollup -> cwos_rollup__g1 @ lake
+
+## Query daily
+
+```malloy
+run: daily -> { select: order_date, total_amount; order_by: order_date asc }
+```
+
+Expect:
+
+| order_date | total_amount |
+| ---------- | ------------ |
+| 2026-01-01 | 150          |
+| 2026-01-02 | 200          |
+
+## Query rollup
+
+```malloy
+run: rollup -> { select: grand_total }
+```
+
+Expect:
+
+| grand_total:num |
+| --------------- |
+| 350             |
+
+## Mutate orders_pg.cwos_orders
+
+| order_id:int | order_date:date | amount:num |
+| ------------ | --------------- | ---------- |
+| 99           | 2026-01-03      | 1000       |
+
+## Query rollup (again)
+
+`write-only` serves live, so the mutation is visible — the same serve behaviour
+the non-strict twin asserts. Pinned here too so a fix cannot turn the build
+green by quietly routing reads that this mode says must stay live.
+
+Expect:
+
+| grand_total:num |
+| --------------- |
+| 1350            |

--- a/hammer/scenarios/mz-storage/75-instruction-order-does-not-change-the-build/scenario.md
+++ b/hammer/scenarios/mz-storage/75-instruction-order-does-not-change-the-build/scenario.md
@@ -1,0 +1,110 @@
+---
+id: instruction-order-does-not-change-the-build
+tags: orchestration, chained, build-control
+package: iob
+---
+
+# The order instructions arrive in must not change what a build produces
+
+`strict-upstream-built-here` lists the upstream before its dependent, which is
+the natural way to write it and therefore the way that hides a bug: if the build
+walked the caller's list, that scenario would pass while a caller who happened to
+list them the other way round got a strict miss on an upstream the same call was
+about to build.
+
+So this is the same build with the instructions REVERSED — `rollup` first,
+`daily` second — and it must behave identically. Order is the caller's
+presentation of a set, not a schedule.
+
+Hosts vary in how they emit instructions — a map iteration, a database ordering,
+a set — and none of them is expressing an intent about sequence. Whatever a build
+does to satisfy dependencies is below the line a host can see, so the only thing
+worth promising at this level is that it does not have to care.
+
+Worth pinning now because it only recently became observable: while a chained
+storage source could not be built under `strictUpstreams` at all, such a build
+failed regardless of order, so nothing could tell a correct ordering apart from
+one that never got far enough to matter.
+
+## Publisher
+
+- PERSIST_STORAGE_MODE: on
+
+## Data orders_pg.iob_orders
+
+| order_id:int | order_date:date | amount:num |
+| ------------ | --------------- | ---------- |
+| 1            | 2026-01-01      | 100        |
+| 2            | 2026-01-01      | 50         |
+| 3            | 2026-01-02      | 200        |
+
+## Model iob.malloy
+
+```malloy
+##! experimental.persistence
+
+source: orders is orders_pg.table('public.iob_orders')
+
+#@ persist name="iob_daily" storage=lake
+source: daily is orders -> {
+  group_by: order_date
+  aggregate: total_amount is amount.sum()
+}
+
+#@ persist name="iob_rollup" storage=lake
+source: rollup is daily -> {
+  aggregate: grand_total is total_amount.sum()
+}
+```
+
+## Build (orchestrated, strict, pkg=iob)
+
+The dependent is listed FIRST. `daily` must still be built before `rollup` reads
+it, which is only true if the build orders by the graph.
+
+- rollup -> iob_rollup__g1 @ lake
+- daily -> iob_daily__g1 @ lake
+
+## Bind iob
+
+## Query daily
+
+```malloy
+run: daily -> { select: order_date, total_amount; order_by: order_date asc }
+```
+
+Expect:
+
+| order_date | total_amount |
+| ---------- | ------------ |
+| 2026-01-01 | 150          |
+| 2026-01-02 | 200          |
+
+## Query rollup
+
+```malloy
+run: rollup -> { select: grand_total }
+```
+
+Expect:
+
+| grand_total:num |
+| --------------- |
+| 350             |
+
+## Mutate orders_pg.iob_orders
+
+| order_id:int | order_date:date | amount:num |
+| ------------ | --------------- | ---------- |
+| 99           | 2026-01-03      | 1000       |
+
+## Query rollup (again)
+
+Stale ⇒ the reversed list still produced a materialized `rollup`, not one
+recomputed live.
+
+Expect:
+
+| grand_total:num |
+| --------------- |
+| 350             |

--- a/packages/server/build.ts
+++ b/packages/server/build.ts
@@ -41,7 +41,28 @@ await build({
    ],
 });
 
-fs.cpSync("../app/dist", "./dist/app", { recursive: true });
+// `dist/app` is what the server actually serves the SPA from at runtime (see
+// ROOT in server.ts) — nothing reads ../app/dist directly. So this copy is
+// load-bearing for the shipped image, not a convenience.
+//
+// The SPA is built by a separate step, which `build:server-only` does not run.
+// That does NOT mean its callers don't need the UI: the Dockerfile builds the
+// app in its own cache layer and then relies on this copy to place it. Absent a
+// bundle we therefore fail loudly by default, so an app build that stops
+// happening breaks the build instead of quietly publishing a UI-less server.
+//
+// SKIP_APP_BUNDLE only declares that absence is acceptable — the harness builds
+// on checkouts with no SPA and drives the REST API. Note the flag does not
+// suppress the copy: `dist` is wiped above, so skipping whenever it was merely
+// requested would strip an already-built SPA out of an existing bundle and leave
+// the next `bun run start` serving a UI that 404s for no visible reason.
+if (process.env.SKIP_APP_BUNDLE === "1" && !fs.existsSync("../app/dist")) {
+   console.log(
+      "SKIP_APP_BUNDLE=1 and ../app/dist is absent: building the server without the app bundle",
+   );
+} else {
+   fs.cpSync("../app/dist", "./dist/app", { recursive: true });
+}
 
 // Copy hand-authored vanilla-JS runtime served at /sdk/publisher.js.
 fs.cpSync("./src/runtime", "./dist/runtime", { recursive: true });

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,7 +24,7 @@
       "test:unit": "bun test --timeout 100000 src",
       "test:integration": "bun test --timeout 200000 tests --max-workers=1",
       "build": "bun generate-api-types && bun build:app && NODE_ENV=production bun run build.ts && bun run bake-duckdb-extensions",
-      "build:server-only": "bun generate-api-types && NODE_ENV=production bun run build.ts && bun run bake-duckdb-extensions",
+      "build:server-only": "bun generate-api-types && NODE_ENV=production SKIP_APP_BUNDLE=1 bun run build.ts && bun run bake-duckdb-extensions",
       "bake-duckdb-extensions": "bun scripts/bake-duckdb-extensions.js",
       "start": "NODE_ENV=production bun run ./dist/server.mjs",
       "start:init": "NODE_ENV=production bun run ./dist/server.mjs --init",

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -1246,8 +1246,7 @@ export class MaterializationService {
                // Enforce the eligibility gate for any storage-targeted build,
                // including orchestrated (host-supplied) instructions — the publisher
                // refuses an ineligible source into the tier itself, not on trust.
-               // Skipped when the mode is off: the kill switch ignores a
-               // host-supplied destination too and does a colocated build.
+               // Skipped when the mode is off: the refusal below owns that case.
                if (
                   orchestratedInstruction?.destination &&
                   getPersistStorageMode() !== "off"
@@ -1266,6 +1265,36 @@ export class MaterializationService {
                   orchestratedInstruction ??
                   bySourceEntityId.get(sourceEntityId);
                if (!instruction) continue;
+
+               // A caller-instructed destination that cannot be honored REFUSES; it
+               // never falls through to a colocated build. Auto-run already applies
+               // this rule, by skipping a `storage=` source while the tier is off
+               // (see deriveSelfInstructions), for the reason given there: a
+               // colocated build CTASes into the source's OWN warehouse, which the
+               // author asked this data not to be written to. An instructed build
+               // needs the rule more, not less — the caller named a destination AND
+               // a physical name, so falling through writes that name into the
+               // warehouse and answers success, and the caller can only detect it by
+               // comparing the echoed destination against the one it sent.
+               //
+               // Refused rather than skipped because the caller asked for a specific
+               // table: silence reads as "built". Stepping the mode down is a
+               // rollback, so it has to stay safe on a loaded package — declining a
+               // write is safe, redirecting one is not. Auto-run cannot reach this:
+               // resolveStorageDestination returns undefined while off, so an
+               // instruction still carrying a destination here is caller-supplied.
+               if (
+                  instruction.destination &&
+                  getPersistStorageMode() === "off"
+               ) {
+                  throw new BadRequestError(
+                     `Source '${persistSource.name}' was instructed to build into ` +
+                        `storage destination '${instruction.destination}', but ` +
+                        `PERSIST_STORAGE_MODE is off, so no destination can be ` +
+                        `written. Refusing rather than building the table into the ` +
+                        `source warehouse instead.`,
+                  );
+               }
 
                // Auto-run already gated pre-getSQL in deriveSelfInstructions;
                // re-assert (idempotent) so no path into a storage build is ungated.
@@ -1547,7 +1576,20 @@ export class MaterializationService {
       // recompute). A stack-on-the-parent build reads the parent's lake table
       // instead, but via a separate DuckDB recompile that does NOT use this
       // warehouse buildSQL — this remains its recompute-from-raw fallback.
-      const buildManifest = manifestExcludingStorage(manifest, builtEntries);
+      //
+      // Which is why a storage build generates it permissively. For that build this
+      // SQL is only the fallback, so refusing to GENERATE it refuses the source
+      // before the parent-reuse attempt below can run: the strict-miss fires on SQL
+      // nothing was going to execute, and a chained storage source becomes
+      // unbuildable under `strictUpstreams` even though reading the parent needs no
+      // recompute at all. Strict is enforced where a recompute would really happen —
+      // buildOneSourceIntoStorage refuses if stacking on the parent proves
+      // impossible. A colocated build keeps strict here: its buildSQL IS what runs,
+      // and it has no parent to stack on.
+      const reducedManifest = manifestExcludingStorage(manifest, builtEntries);
+      const buildManifest = isStorageBuild
+         ? { ...reducedManifest, strict: false }
+         : reducedManifest;
       const buildSQL = persistSource.getSQL({
          buildManifest,
          connectionDigests,


### PR DESCRIPTION
Two ways an orchestrated `storage=` build could go wrong, and six scenarios that hold the rules.

Both were found by pointing an orchestrator at the tier and watching what it actually did, rather than by reading the code — which is why neither showed up in the existing suite.

## An instructed destination that cannot be honored redirected the write

With `PERSIST_STORAGE_MODE=off`, an instructed build fell through to a colocated CTAS: it created the caller's physical name **in the source warehouse** and answered success. A caller could only detect it by comparing the echoed destination against the one it sent — nothing in the response said anything had changed.

`storage=` is a statement about where data may *not* go, so ignoring it on a read is safe (the same rows, from the same warehouse) while ignoring it on a write is not (a new table in the warehouse the author excluded). Auto-run already draws exactly this line, skipping a `storage=` source while the tier is off, and says why. That rule simply never reached the instructed path — which needs it more, not less, because the caller named both a destination and a physical name.

Now refused rather than skipped: the caller asked for a specific table, so silence would read as "built". Stepping the mode down is a rollback, so it has to stay safe on a loaded package — declining a write is safe, redirecting one is not.

## A chained source was unbuildable under `strictUpstreams`

Storage upstreams are excluded from warehouse build SQL because that SQL runs in the source warehouse and cannot reach a lake table. That exclusion is right. But under strict it made *generating* that SQL throw — and for a storage build that SQL is only the recompute-from-raw fallback, since the source is built by reading its parent's lake table, which compiles separately and never uses it.

So strict refused the source before the parent-reuse attempt could run, on SQL nothing was going to execute. A chained package could never make its first build through an orchestrator: on a first build there is no prior generation to reference, so the upstream can only be satisfied by being built in the same call.

A storage build now generates that SQL permissively, and strict is enforced where a recompute would really happen — the refusal already implemented on the chained path. A colocated build keeps strict unchanged: its build SQL *is* what runs, and it has no parent to stack on. `strict-upstreams-refused` still passes, so strict still refuses an upstream that is genuinely absent.

## Scenarios

| scenario | rule |
|---|---|
| `off-must-not-build-into-the-warehouse` | `off` refuses an instructed destination instead of redirecting the write |
| `strict-upstream-built-here` | an upstream built in the same call satisfies `strictUpstreams` |
| `chained-write-only` | `write-only` does not stop a chained pair building, and serves both live |
| `chained-write-only-orchestrated` | the same, orchestrated |
| `chained-write-only-orchestrated-strict` | `strictUpstreams` does not change what an orchestrated chained build resolves |
| `instruction-order-does-not-change-the-build` | instruction order does not change what a build produces |

All six were written first and were red for the right reasons; they are green here without their assertions being weakened.

Two are worth calling out. The `write-only` pair is byte-identical apart from the flag, so if the strict half ever regresses the green half says the mode, the chain and the orchestrated path are all still sound and identifies the flag as the variable. And the ordering scenario reverses the instruction list — build order comes from the dependency graph, but that was only ever exercised with the upstream listed first, and it became load-bearing the moment a chained storage source could be built under strict at all.

`off-must-not-build-into-the-warehouse` asserts against the warehouse directly (`information_schema`), because the bug it guards is one a build-status check cannot see: the build reported `MANIFEST_FILE_READY` while the table sat in the warehouse.

## Also

`build:server-only` failed on a checkout with no SPA bundle, which is what the harness builds on. `SKIP_APP_BUNDLE=1` declares that absence acceptable. The flag does not suppress the copy on its own — `dist` is wiped first, so skipping whenever it was merely requested would strip an already-built SPA out of an existing bundle — and without the flag the copy still fails loudly, so an app build that stops happening breaks the build rather than quietly publishing a UI-less server.

## Verification

- hammer: 71 pass, 3 known-red (all pre-existing and unrelated)
- server unit: 2064 pass, 0 fail
- server integration: 245 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
