### PR TITLE
fix(server)!: key the incremental ledger on the table, not the package

### DIFF
--- a/packages/server/src/service/incremental_apply.spec.ts
+++ b/packages/server/src/service/incremental_apply.spec.ts
@@ -623,6 +623,7 @@ describe("deltaStatements: merge", () => {
 const LINEAGE = {
    physicalTableName: "analytics.daily",
    connectionName: "wh",
+   sourceEntityId: "sid",
    watermarkName: "order_date",
    watermarkType: "date",
    mergeKeys: [] as string[],
@@ -665,6 +666,19 @@ describe("ledgerLineageMismatch", () => {
             "analytics.other",
          ) as unknown as string,
       });
+   });
+
+   it("rejects a boundary measured over different build SQL", () => {
+      // Load-bearing since the ledger stopped being keyed on the content address:
+      // a standalone publisher's table names carry no content token, so an edited
+      // model keeps its table name and the read HITS. Without this check the
+      // delta would be applied to a table its own definition no longer describes.
+      const mismatch = ledgerLineageMismatch(
+         { ...LEDGER, sourceEntityId: "sid-before-the-edit" },
+         LINEAGE,
+      );
+      expect(mismatch?.reasonCode).toBe("lineage_changed");
+      expect(mismatch?.reason).toContain("content address");
    });
 
    it("rejects a boundary advanced on another connection", () => {

--- a/packages/server/src/service/incremental_apply.ts
+++ b/packages/server/src/service/incremental_apply.ts
@@ -791,14 +791,28 @@ export async function applyDeltaScript(
 
 /**
  * Everything the ledger has to agree with before a delta may run: which table,
- * on which connection, advanced by which declaration. A change to any of them
- * means the recorded boundary describes a different table or a different meaning
- * of "covered", so it cannot be built on.
+ * on which connection, computed from which SQL, advanced by which declaration. A
+ * change to any of them means the recorded boundary describes a different table or
+ * a different meaning of "covered", so it cannot be built on.
  */
 export interface IncrementalLineage {
-   /** Logical (unquoted) physical table name, as the manifest records it. */
+   /**
+    * Logical (unquoted) physical table name, as the manifest records it. With
+    * `connectionName`, the ledger row's key.
+    */
    physicalTableName: string;
    connectionName: string;
+   /**
+    * The source's CONTENT address — a fingerprint of the build SQL, not the
+    * caller-assigned `BuildInstruction.sourceEntityId`. Compared rather than keyed
+    * on, and the comparison is what guarantees a boundary is never read against SQL
+    * other than the SQL it was computed from: an edited source seeds instead of
+    * deltaing onto a table its definition no longer describes. That used to be the
+    * ledger's key and so was true for free; now it is checked, because a table's
+    * name does not have to change when its definition does (a standalone
+    * publisher's names carry no content token).
+    */
+   sourceEntityId: string;
    watermarkName: string;
    /** The watermark's Malloy type (`date`, `timestamp`, `number`, `string`). */
    watermarkType: string;
@@ -842,6 +856,18 @@ export function ledgerLineageMismatch(
    }
    const changed = (reason: string) =>
       ({ reasonCode: "lineage_changed", reason }) as const;
+   // Checked before the individual declarations because it subsumes them: a
+   // different content address means different build SQL, and the boundary was
+   // measured over rows that SQL may no longer produce. The declaration checks
+   // below catch the narrower case of a model edit that moves `watermark=` or
+   // `merge_key=` — those do NOT move the address (proven in
+   // incremental_compiler_contract.spec.ts), which is why both layers exist.
+   if (entry.sourceEntityId !== lineage.sourceEntityId) {
+      return changed(
+         `the source's content address changed, so the recorded boundary was ` +
+            `measured over different SQL than this refresh would apply a delta to`,
+      );
+   }
    if (entry.connectionName !== lineage.connectionName) {
       return changed(
          `the recorded boundary was advanced on connection ` +

--- a/packages/server/src/service/incremental_build.spec.ts
+++ b/packages/server/src/service/incremental_build.spec.ts
@@ -43,6 +43,7 @@ function lineage(
       dialect: overrides.dialect ?? "postgres",
       physicalTableName: "orders_v1",
       connectionName: "wh",
+      sourceEntityId: "addr-1",
       isStorageBuild: overrides.isStorageBuild ?? false,
    });
 }
@@ -63,6 +64,7 @@ describe("incrementalLineage", () => {
       ).toEqual({
          physicalTableName: "orders_v1",
          connectionName: "wh",
+         sourceEntityId: "addr-1",
          watermarkName: "order_date",
          watermarkType: "date",
          mergeKeys: ["order_id", "region"],

--- a/packages/server/src/service/incremental_build.ts
+++ b/packages/server/src/service/incremental_build.ts
@@ -32,20 +32,27 @@ import type { IncrementalDeclaration } from "./incremental_declaration";
  * testable against fakes and keeps the build loop free of ledger bookkeeping.
  */
 
-/** The ledger surface a build needs; a narrowing of ResourceRepository. */
+/**
+ * The ledger surface a build needs; a narrowing of ResourceRepository.
+ *
+ * Keyed on (environment, connection, physical table): a boundary is a fact about a
+ * TABLE, so every accessor here is addressed the way the lineage already is. The
+ * three functions below therefore never need a source address to find a row —
+ * they pass `lineage`, which carries both halves of the table key.
+ */
 export interface IncrementalLedgerStore {
    getIncrementalLedgerEntry(
       environmentId: string,
-      packageName: string,
-      sourceEntityId: string,
+      connectionName: string,
+      physicalTableName: string,
    ): Promise<IncrementalLedgerEntry | null>;
    upsertIncrementalLedgerEntry(
       entry: Omit<IncrementalLedgerEntry, "createdAt" | "advancedAt">,
    ): Promise<IncrementalLedgerEntry>;
    deleteIncrementalLedgerEntry(
       environmentId: string,
-      packageName: string,
-      sourceEntityId: string,
+      connectionName: string,
+      physicalTableName: string,
    ): Promise<void>;
 }
 
@@ -84,6 +91,8 @@ export function incrementalLineage(params: {
    dialect: string;
    physicalTableName: string;
    connectionName: string;
+   /** The source's content address — see IncrementalLineage.sourceEntityId. */
+   sourceEntityId: string;
    isStorageBuild: boolean;
 }): IncrementalLineage | undefined {
    const d = params.declaration;
@@ -111,6 +120,7 @@ export function incrementalLineage(params: {
    return {
       physicalTableName: params.physicalTableName,
       connectionName: params.connectionName,
+      sourceEntityId: params.sourceEntityId,
       watermarkName: watermark.name,
       watermarkType: watermark.malloyType,
       mergeKeys,
@@ -130,7 +140,6 @@ export async function planSourceRefresh(params: {
    context: IncrementalRunContext;
    lineage: IncrementalLineage;
    persistSource: PersistSource;
-   sourceEntityId: string;
    quotedTablePath: string;
    /**
     * The build's own SQL for this source — `PersistSource.getSQL()` resolved
@@ -163,8 +172,8 @@ export async function planSourceRefresh(params: {
    try {
       ledgerEntry = await context.ledger.getIncrementalLedgerEntry(
          context.environmentId,
-         context.packageName,
-         params.sourceEntityId,
+         lineage.connectionName,
+         lineage.physicalTableName,
       );
    } catch (err) {
       return {
@@ -212,7 +221,6 @@ export async function planSourceRefresh(params: {
 export async function advanceLedger(params: {
    context: IncrementalRunContext;
    lineage: IncrementalLineage;
-   sourceEntityId: string;
    coveredThrough: WatermarkBound;
 }): Promise<void> {
    const { context, lineage } = params;
@@ -220,7 +228,7 @@ export async function advanceLedger(params: {
       await context.ledger.upsertIncrementalLedgerEntry({
          environmentId: context.environmentId,
          packageName: context.packageName,
-         sourceEntityId: params.sourceEntityId,
+         sourceEntityId: lineage.sourceEntityId,
          coveredThroughValue: params.coveredThrough.value,
          coveredThroughType: params.coveredThrough.malloyType,
          watermarkDimension: lineage.watermarkName,
@@ -233,7 +241,8 @@ export async function advanceLedger(params: {
    } catch (err) {
       logger.warn("Failed to advance the covered_through boundary", {
          packageName: context.packageName,
-         sourceEntityId: params.sourceEntityId,
+         physicalTableName: lineage.physicalTableName,
+         sourceEntityId: lineage.sourceEntityId,
          error: errMessage(err),
       });
    }
@@ -247,18 +256,18 @@ export async function advanceLedger(params: {
  */
 export async function resetLedger(
    context: IncrementalRunContext,
-   sourceEntityId: string,
+   lineage: IncrementalLineage,
 ): Promise<void> {
    try {
       await context.ledger.deleteIncrementalLedgerEntry(
          context.environmentId,
-         context.packageName,
-         sourceEntityId,
+         lineage.connectionName,
+         lineage.physicalTableName,
       );
    } catch (err) {
       logger.warn("Failed to clear the covered_through boundary", {
          packageName: context.packageName,
-         sourceEntityId,
+         physicalTableName: lineage.physicalTableName,
          error: errMessage(err),
       });
    }
@@ -275,7 +284,6 @@ export async function resetLedger(
 export async function advanceLedgerAfterSeed(params: {
    context: IncrementalRunContext;
    lineage: IncrementalLineage;
-   sourceEntityId: string;
    quotedTablePath: string;
    runner: SqlRunner;
    dialect: string;
@@ -294,7 +302,7 @@ export async function advanceLedgerAfterSeed(params: {
                "the next refresh will rebuild again",
             {
                packageName: params.context.packageName,
-               sourceEntityId: params.sourceEntityId,
+               physicalTableName: params.lineage.physicalTableName,
                error: boundary.error,
             },
          );
@@ -304,7 +312,6 @@ export async function advanceLedgerAfterSeed(params: {
    await advanceLedger({
       context: params.context,
       lineage: params.lineage,
-      sourceEntityId: params.sourceEntityId,
       coveredThrough: boundary.bound,
    });
    return boundary.bound;

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -902,6 +902,7 @@ export class MaterializationService {
                   dialect: persistSource.dialectName,
                   physicalTableName: logicalName,
                   connectionName: persistSource.connectionName,
+                  sourceEntityId,
                   isStorageBuild: destination !== undefined,
                }) !== undefined;
 
@@ -1693,12 +1694,14 @@ export class MaterializationService {
       // Present only when the run resolved at least one incremental declaration;
       // absent leaves this method exactly the full-rebuild path it was.
       incremental?: IncrementalRunContext,
-      // The source's content address, which is what the covered_through ledger is
-      // keyed by — NOT `instruction.sourceEntityId`, which is caller-assigned and
-      // opaque (see the index comment in executeInstructedBuild). Keying on
-      // content is what guarantees a boundary is never read against SQL other
-      // than the SQL it was computed from: different SQL is a different key, so a
-      // changed source seeds instead of deltaing onto a stale table.
+      // The source's content address — NOT `instruction.sourceEntityId`, which is
+      // caller-assigned and opaque (see the index comment in
+      // executeInstructedBuild). Recorded on the covered_through ledger and
+      // COMPARED on every read, which is what guarantees a boundary is never read
+      // against SQL other than the SQL it was computed from: different SQL is a
+      // mismatch, so a changed source seeds instead of deltaing onto a stale table.
+      // (It used to be part of the ledger's key, which gave the same guarantee for
+      // free but made a boundary un-findable across a package's versions.)
       contentSourceEntityId?: string,
    ): Promise<ManifestEntry> {
       const sourceEntityId = instruction.sourceEntityId;
@@ -1800,6 +1803,7 @@ export class MaterializationService {
                  dialect,
                  physicalTableName,
                  connectionName: persistSource.connectionName,
+                 sourceEntityId: contentSourceEntityId,
                  isStorageBuild,
               })
             : undefined;
@@ -1810,7 +1814,6 @@ export class MaterializationService {
             ? {
                  context: incremental,
                  lineage,
-                 ledgerKey: contentSourceEntityId,
               }
             : undefined;
       if (incrementalRefresh) {
@@ -1844,7 +1847,7 @@ export class MaterializationService {
       if (incrementalRefresh) {
          await resetLedger(
             incrementalRefresh.context,
-            incrementalRefresh.ledgerKey,
+            incrementalRefresh.lineage,
          );
       }
 
@@ -1906,7 +1909,6 @@ export class MaterializationService {
          ? await advanceLedgerAfterSeed({
               context: incrementalRefresh.context,
               lineage: incrementalRefresh.lineage,
-              sourceEntityId: incrementalRefresh.ledgerKey,
               quotedTablePath: quotedPhysical,
               dialect,
               runner: (sql) => connection.runSQL(sql, runOptions),
@@ -1944,8 +1946,6 @@ export class MaterializationService {
       lineage: IncrementalLineage;
       persistSource: PersistSource;
       instruction: BuildInstruction;
-      /** The source's content address: the covered_through ledger's key. */
-      ledgerKey: string;
       connection: MalloyConnection;
       buildSQL: string;
       quotedTablePath: string;
@@ -1962,7 +1962,6 @@ export class MaterializationService {
          context,
          lineage,
          persistSource,
-         sourceEntityId: params.ledgerKey,
          quotedTablePath: params.quotedTablePath,
          // The CTAS's own SQL, manifest-resolved. The delta filters this exact
          // string, so it computes what a rebuild would — see deltaSelect.
@@ -1991,7 +1990,6 @@ export class MaterializationService {
          await advanceLedger({
             context,
             lineage,
-            sourceEntityId: params.ledgerKey,
             coveredThrough: step.coveredThrough,
          });
          const durationMs = Math.round(performance.now() - startTime);

--- a/packages/server/src/storage/DatabaseInterface.ts
+++ b/packages/server/src/storage/DatabaseInterface.ts
@@ -101,16 +101,16 @@ export interface ResourceRepository {
    // Incremental ledger
    getIncrementalLedgerEntry(
       environmentId: string,
-      packageName: string,
-      sourceEntityId: string,
+      connectionName: string,
+      physicalTableName: string,
    ): Promise<IncrementalLedgerEntry | null>;
    upsertIncrementalLedgerEntry(
       entry: Omit<IncrementalLedgerEntry, "createdAt" | "advancedAt">,
    ): Promise<IncrementalLedgerEntry>;
    deleteIncrementalLedgerEntry(
       environmentId: string,
-      packageName: string,
-      sourceEntityId: string,
+      connectionName: string,
+      physicalTableName: string,
    ): Promise<void>;
 }
 
@@ -205,8 +205,15 @@ export interface Materialization {
  */
 export interface IncrementalLedgerEntry {
    environmentId: string;
+   /** Whoever last advanced this boundary. Recorded, not part of the key. */
    packageName: string;
-   /** The source's content address; the lineage this boundary belongs to. */
+   /**
+    * The source's content address, as of the build that last advanced this
+    * boundary. Recorded, not part of the key — and therefore COMPARED on read
+    * (see ledgerLineageMismatch), because a table whose definition changed keeps
+    * its name in a standalone publisher and a delta must not be applied across
+    * that change.
+    */
    sourceEntityId: string;
    /**
     * Canonical scalar text of the boundary (ISO-8601 for temporal types,
@@ -222,7 +229,12 @@ export interface IncrementalLedgerEntry {
    /** The `merge_key=` dimensions, in declared order; empty for range replace. */
    mergeKeyDimensions: string[];
    derivedStrategy: IncrementalStrategy;
-   /** Lineage identity, so a boundary is never read against another table. */
+   /**
+    * The table the boundary is a fact about. With `environmentId` and
+    * `connectionName` this is the row's KEY, which is what makes a boundary
+    * survive a package being presented under a different (version-qualified)
+    * name between refreshes.
+    */
    physicalTableName: string;
    connectionName: string;
    /** Audit: which run last advanced this boundary, and when. */

--- a/packages/server/src/storage/duckdb/DuckDBRepository.ts
+++ b/packages/server/src/storage/duckdb/DuckDBRepository.ts
@@ -253,13 +253,13 @@ export class DuckDBRepository implements ResourceRepository {
 
    async getIncrementalLedgerEntry(
       environmentId: string,
-      packageName: string,
-      sourceEntityId: string,
+      connectionName: string,
+      physicalTableName: string,
    ): Promise<IncrementalLedgerEntry | null> {
       return this.incrementalLedgerRepo.get(
          environmentId,
-         packageName,
-         sourceEntityId,
+         connectionName,
+         physicalTableName,
       );
    }
 
@@ -271,13 +271,13 @@ export class DuckDBRepository implements ResourceRepository {
 
    async deleteIncrementalLedgerEntry(
       environmentId: string,
-      packageName: string,
-      sourceEntityId: string,
+      connectionName: string,
+      physicalTableName: string,
    ): Promise<void> {
       return this.incrementalLedgerRepo.deleteEntry(
          environmentId,
-         packageName,
-         sourceEntityId,
+         connectionName,
+         physicalTableName,
       );
    }
 }

--- a/packages/server/src/storage/duckdb/IncrementalLedgerRepository.spec.ts
+++ b/packages/server/src/storage/duckdb/IncrementalLedgerRepository.spec.ts
@@ -14,6 +14,8 @@ describe("IncrementalLedgerRepository", () => {
    const ENV = "env-1";
    const PKG = "pkg-a";
    const SOURCE = "sha-daily-revenue";
+   const CONN = "warehouse";
+   const TABLE = "analytics.daily_revenue";
    const dbs: DuckDBConnection[] = [];
 
    afterEach(async () => {
@@ -43,16 +45,16 @@ describe("IncrementalLedgerRepository", () => {
          watermarkDimension: "order_date",
          mergeKeyDimensions: [],
          derivedStrategy: "range_replace",
-         physicalTableName: "analytics.daily_revenue",
-         connectionName: "warehouse",
+         physicalTableName: TABLE,
+         connectionName: CONN,
          advancedByMaterializationId: "run-1",
          ...overrides,
       };
    }
 
-   it("returns null for a lineage with no boundary yet (which means SEED)", async () => {
+   it("returns null for a table with no boundary yet (which means SEED)", async () => {
       const { repo } = await freshRepo();
-      expect(await repo.get(ENV, PKG, SOURCE)).toBeNull();
+      expect(await repo.get(ENV, CONN, TABLE)).toBeNull();
    });
 
    it("round-trips a boundary, its declarations and its lineage identity", async () => {
@@ -67,18 +69,18 @@ describe("IncrementalLedgerRepository", () => {
       expect(written.mergeKeyDimensions).toEqual(["order_id", "region"]);
       expect(written.derivedStrategy).toBe("merge");
 
-      const read = await repo.get(ENV, PKG, SOURCE);
+      const read = await repo.get(ENV, CONN, TABLE);
       expect(read).not.toBeNull();
       expect(read!.watermarkDimension).toBe("order_date");
       expect(read!.mergeKeyDimensions).toEqual(["order_id", "region"]);
-      expect(read!.physicalTableName).toBe("analytics.daily_revenue");
-      expect(read!.connectionName).toBe("warehouse");
+      expect(read!.sourceEntityId).toBe(SOURCE);
+      expect(read!.packageName).toBe(PKG);
       expect(read!.advancedByMaterializationId).toBe("run-1");
       expect(read!.advancedAt).toBeInstanceOf(Date);
       expect(read!.createdAt).toBeInstanceOf(Date);
    });
 
-   it("advances in place: one row per lineage, never a second boundary", async () => {
+   it("advances in place: one row per table, never a second boundary", async () => {
       // The property that makes a retried advance a no-op instead of ambiguity.
       const { repo, db } = await freshRepo();
       await repo.upsert(entry());
@@ -93,9 +95,34 @@ describe("IncrementalLedgerRepository", () => {
          "SELECT count(*) AS n FROM incremental_ledger",
       );
       expect(Number(count[0].n)).toBe(1);
-      const read = await repo.get(ENV, PKG, SOURCE);
+      const read = await repo.get(ENV, CONN, TABLE);
       expect(read!.coveredThroughValue).toBe("2024-07-01");
       expect(read!.advancedByMaterializationId).toBe("run-2");
+   });
+
+   it("keeps ONE boundary for a table refreshed under a second package name", async () => {
+      // The reason the key is the table. An orchestrated host that serves several
+      // versions of one package presents a version-qualified package name
+      // (Credible sends `<package>|<versionId>`), and fires a shared table's
+      // refresh through whichever version materialized most recently — so the
+      // name changes on the first refresh after every publish while the table
+      // stays exactly the same. Keyed on the package, that read missed and the
+      // source re-seeded in full every publish; keyed on the table it advances.
+      const { repo, db } = await freshRepo();
+      await repo.upsert(entry({ packageName: "orders|v1" }));
+      await repo.upsert(
+         entry({ packageName: "orders|v2", coveredThroughValue: "2024-07-01" }),
+      );
+
+      const count = await db.all<{ n: unknown }>(
+         "SELECT count(*) AS n FROM incremental_ledger",
+      );
+      expect(Number(count[0].n)).toBe(1);
+      const read = await repo.get(ENV, CONN, TABLE);
+      expect(read!.coveredThroughValue).toBe("2024-07-01");
+      // The tag names the last writer, which is the honest answer for a table
+      // several versions refresh in turn.
+      expect(read!.packageName).toBe("orders|v2");
    });
 
    it("keeps created_at across an advance while advanced_at moves", async () => {
@@ -111,36 +138,40 @@ describe("IncrementalLedgerRepository", () => {
       );
    });
 
-   it("keys by (environment, package, source): neighbours never collide", async () => {
-      // A BuildID carries no environment input, so two environments can address
-      // the same source identically. Their boundaries must not be the same row.
+   it("keys by (environment, connection, table): neighbours never collide", async () => {
+      // A physical name is only unique WITHIN a connection, and nothing about a
+      // table's identity carries an environment — so all three are needed for two
+      // boundaries that describe different tables to be different rows.
       const { repo } = await freshRepo();
       await repo.upsert(entry({ coveredThroughValue: "2024-06-01" }));
       await repo.upsert(
          entry({ environmentId: "env-2", coveredThroughValue: "2024-01-01" }),
       );
       await repo.upsert(
-         entry({ packageName: "pkg-b", coveredThroughValue: "2024-02-01" }),
+         entry({
+            connectionName: "other-wh",
+            coveredThroughValue: "2024-02-01",
+         }),
       );
       await repo.upsert(
          entry({
-            sourceEntityId: "sha-other",
+            physicalTableName: "analytics.other",
             coveredThroughValue: "2024-03-01",
          }),
       );
 
-      expect((await repo.get(ENV, PKG, SOURCE))!.coveredThroughValue).toBe(
+      expect((await repo.get(ENV, CONN, TABLE))!.coveredThroughValue).toBe(
          "2024-06-01",
       );
-      expect((await repo.get("env-2", PKG, SOURCE))!.coveredThroughValue).toBe(
+      expect((await repo.get("env-2", CONN, TABLE))!.coveredThroughValue).toBe(
          "2024-01-01",
       );
-      expect((await repo.get(ENV, "pkg-b", SOURCE))!.coveredThroughValue).toBe(
-         "2024-02-01",
-      );
-      expect((await repo.get(ENV, PKG, "sha-other"))!.coveredThroughValue).toBe(
-         "2024-03-01",
-      );
+      expect(
+         (await repo.get(ENV, "other-wh", TABLE))!.coveredThroughValue,
+      ).toBe("2024-02-01");
+      expect(
+         (await repo.get(ENV, CONN, "analytics.other"))!.coveredThroughValue,
+      ).toBe("2024-03-01");
    });
 
    it("preserves a numeric and a string boundary as text, unrounded", async () => {
@@ -151,7 +182,7 @@ describe("IncrementalLedgerRepository", () => {
             coveredThroughValue: "9007199254740993",
          }),
       );
-      expect((await repo.get(ENV, PKG, SOURCE))!.coveredThroughValue).toBe(
+      expect((await repo.get(ENV, CONN, TABLE))!.coveredThroughValue).toBe(
          "9007199254740993",
       );
 
@@ -161,53 +192,143 @@ describe("IncrementalLedgerRepository", () => {
             coveredThroughValue: "us-east-1'; DROP TABLE x",
          }),
       );
-      expect((await repo.get(ENV, PKG, SOURCE))!.coveredThroughValue).toBe(
+      expect((await repo.get(ENV, CONN, TABLE))!.coveredThroughValue).toBe(
          "us-east-1'; DROP TABLE x",
       );
    });
 
-   it("deletes one lineage's boundary, so the next run re-seeds it", async () => {
+   it("deletes one table's boundary, so the next run re-seeds it", async () => {
       const { repo } = await freshRepo();
       await repo.upsert(entry());
-      await repo.upsert(entry({ sourceEntityId: "sha-other" }));
+      await repo.upsert(entry({ physicalTableName: "analytics.other" }));
 
-      await repo.deleteEntry(ENV, PKG, SOURCE);
+      await repo.deleteEntry(ENV, CONN, TABLE);
 
-      expect(await repo.get(ENV, PKG, SOURCE)).toBeNull();
-      expect(await repo.get(ENV, PKG, "sha-other")).not.toBeNull();
+      expect(await repo.get(ENV, CONN, TABLE)).toBeNull();
+      expect(await repo.get(ENV, CONN, "analytics.other")).not.toBeNull();
    });
 
    it("cascades by package and by environment", async () => {
+      // Distinct tables per row, since the package name no longer separates them.
       const { repo } = await freshRepo();
       await repo.upsert(entry());
-      await repo.upsert(entry({ packageName: "pkg-b" }));
+      await repo.upsert(
+         entry({ packageName: "pkg-b", physicalTableName: "analytics.b" }),
+      );
       await repo.upsert(entry({ environmentId: "env-2" }));
 
       await repo.deleteByPackage(ENV, PKG);
-      expect(await repo.get(ENV, PKG, SOURCE)).toBeNull();
-      expect(await repo.get(ENV, "pkg-b", SOURCE)).not.toBeNull();
+      expect(await repo.get(ENV, CONN, TABLE)).toBeNull();
+      expect(await repo.get(ENV, CONN, "analytics.b")).not.toBeNull();
 
       await repo.deleteByEnvironmentId(ENV);
-      expect(await repo.get(ENV, "pkg-b", SOURCE)).toBeNull();
-      expect(await repo.get("env-2", PKG, SOURCE)).not.toBeNull();
+      expect(await repo.get(ENV, CONN, "analytics.b")).toBeNull();
+      expect(await repo.get("env-2", CONN, TABLE)).not.toBeNull();
+   });
+
+   describe("re-keying an existing database", () => {
+      // The schema pass runs on every boot, so both halves matter: it has to
+      // replace a table still keyed on the package, and it must not touch one
+      // already keyed on the table — otherwise every restart would silently
+      // discard every boundary and re-seed every incremental source.
+      const LEGACY_DDL = `
+         CREATE TABLE incremental_ledger (
+           environment_id VARCHAR NOT NULL,
+           package_name VARCHAR NOT NULL,
+           source_entity_id VARCHAR NOT NULL,
+           covered_through_value VARCHAR NOT NULL,
+           covered_through_type VARCHAR NOT NULL,
+           watermark_dimension VARCHAR NOT NULL,
+           merge_key_dimensions JSON NOT NULL,
+           derived_strategy VARCHAR NOT NULL,
+           physical_table_name VARCHAR NOT NULL,
+           connection_name VARCHAR NOT NULL,
+           advanced_by_materialization_id VARCHAR,
+           advanced_at TIMESTAMP NOT NULL,
+           created_at TIMESTAMP NOT NULL,
+           PRIMARY KEY (environment_id, package_name, source_entity_id)
+         )`;
+
+      /**
+       * Seeded with a raw INSERT because `upsert` CANNOT write here: its
+       * ON CONFLICT names the new key, and DuckDB rejects a conflict target that
+       * no constraint covers. Which is the point — the drop is REQUIRED, not
+       * housekeeping. Left in place, a legacy table would fail every advance (a
+       * swallowed warning), and every incremental source would seed forever.
+       */
+      async function insertLegacyRow(
+         db: DuckDBConnection,
+         packageName: string,
+      ): Promise<void> {
+         const now = new Date().toISOString();
+         await db.run(
+            `INSERT INTO incremental_ledger VALUES
+              (?, ?, ?, '2024-06-01', 'date', 'order_date', '[]',
+               'range_replace', ?, ?, 'run-1', ?, ?)`,
+            [ENV, packageName, SOURCE, TABLE, CONN, now, now],
+         );
+      }
+
+      it("replaces a package-keyed ledger, and the new key then holds", async () => {
+         const { repo, db } = await freshRepo();
+         await db.run("DROP TABLE incremental_ledger");
+         await db.run(LEGACY_DDL);
+         // Two rows for ONE table, which is exactly what the old key permitted
+         // and what made a shared table re-seed after every publish.
+         await insertLegacyRow(db, "orders|v1");
+         await insertLegacyRow(db, "orders|v2");
+         expect(
+            Number(
+               (
+                  await db.all<{ n: unknown }>(
+                     "SELECT count(*) AS n FROM incremental_ledger",
+                  )
+               )[0].n,
+            ),
+         ).toBe(2);
+
+         await initializeSchema(db);
+
+         // Dropped, not migrated: the boundary is a cache whose miss path is a
+         // seed, so each source rebuilds once and then advances by delta.
+         expect(await repo.get(ENV, CONN, TABLE)).toBeNull();
+         await repo.upsert(entry({ packageName: "orders|v1" }));
+         await repo.upsert(entry({ packageName: "orders|v2" }));
+         expect(
+            Number(
+               (
+                  await db.all<{ n: unknown }>(
+                     "SELECT count(*) AS n FROM incremental_ledger",
+                  )
+               )[0].n,
+            ),
+         ).toBe(1);
+      });
+
+      it("leaves a table-keyed ledger and its boundaries alone", async () => {
+         const { repo, db } = await freshRepo();
+         await repo.upsert(entry({ coveredThroughValue: "2024-07-01" }));
+
+         await initializeSchema(db);
+
+         expect((await repo.get(ENV, CONN, TABLE))?.coveredThroughValue).toBe(
+            "2024-07-01",
+         );
+      });
    });
 
    it("reads an unparseable merge-key list as empty, which forces a re-seed", async () => {
       // Degrading to [] reads as "range replace", which MISMATCHES any merge
       // declaration — the direction that re-seeds rather than merging under keys
       // we could not confirm.
-      const db = new DuckDBConnection(":memory:");
-      dbs.push(db);
-      await db.initialize();
-      await initializeSchema(db);
-      const repo = new IncrementalLedgerRepository(db);
+      const { repo, db } = await freshRepo();
       await repo.upsert(entry({ mergeKeyDimensions: ["order_id"] }));
       await db.run(
          `UPDATE incremental_ledger SET merge_key_dimensions = '"not-a-list"'
-           WHERE source_entity_id = ?`,
-         [SOURCE],
+           WHERE physical_table_name = ?`,
+         [TABLE],
       );
-      expect((await repo.get(ENV, PKG, SOURCE))!.mergeKeyDimensions).toEqual(
+      expect((await repo.get(ENV, CONN, TABLE))!.mergeKeyDimensions).toEqual(
          [],
       );
    });

--- a/packages/server/src/storage/duckdb/IncrementalLedgerRepository.ts
+++ b/packages/server/src/storage/duckdb/IncrementalLedgerRepository.ts
@@ -7,9 +7,13 @@ import { DuckDBConnection } from "./DuckDBConnection";
 /**
  * DuckDB-backed store for the incremental `covered_through` boundaries.
  *
- * One row per (environment, package, sourceEntityId): the exclusive upper end of
- * the watermark range that source's serving table is known to contain, plus the
- * declarations it was computed under and the lineage it belongs to.
+ * One row per (environment, connection, physical table): the exclusive upper end
+ * of the watermark range that table is known to contain, plus the declarations it
+ * was computed under and the source address it was computed for.
+ *
+ * Keyed on the table because that is what the boundary is a fact about. The source
+ * address and the package name are recorded but NOT keys — see the schema comment
+ * for why keying on them broke a table shared across package versions.
  *
  * Deliberately has NO locking of its own. The single writer is already
  * guaranteed one level up, by the `active_key` unique index on
@@ -26,21 +30,26 @@ export class IncrementalLedgerRepository {
 
    async get(
       environmentId: string,
-      packageName: string,
-      sourceEntityId: string,
+      connectionName: string,
+      physicalTableName: string,
    ): Promise<IncrementalLedgerEntry | null> {
       const row = await this.db.get<Record<string, unknown>>(
          `SELECT * FROM incremental_ledger
-           WHERE environment_id = ? AND package_name = ? AND source_entity_id = ?`,
-         [environmentId, packageName, sourceEntityId],
+           WHERE environment_id = ? AND connection_name = ?
+             AND physical_table_name = ?`,
+         [environmentId, connectionName, physicalTableName],
       );
       return row ? mapRow(row) : null;
    }
 
    /**
-    * Record a boundary, replacing whatever this lineage had before. `created_at`
-    * survives a replace (it dates the lineage's first seed, which is the useful
+    * Record a boundary, replacing whatever this table had before. `created_at`
+    * survives a replace (it dates the table's first seed, which is the useful
     * thing to know), while `advanced_at` moves with every write.
+    *
+    * `package_name` and `source_entity_id` are overwritten with the writer's, so
+    * the row always names whoever last advanced it — which is the honest answer
+    * for a table that several versions of a package refresh in turn.
     */
    async upsert(
       entry: Omit<IncrementalLedgerEntry, "createdAt" | "advancedAt">,
@@ -54,14 +63,15 @@ export class IncrementalLedgerRepository {
              physical_table_name, connection_name,
              advanced_by_materialization_id, advanced_at, created_at
           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-          ON CONFLICT (environment_id, package_name, source_entity_id) DO UPDATE SET
+          ON CONFLICT (environment_id, connection_name, physical_table_name)
+          DO UPDATE SET
+             package_name = EXCLUDED.package_name,
+             source_entity_id = EXCLUDED.source_entity_id,
              covered_through_value = EXCLUDED.covered_through_value,
              covered_through_type = EXCLUDED.covered_through_type,
              watermark_dimension = EXCLUDED.watermark_dimension,
              merge_key_dimensions = EXCLUDED.merge_key_dimensions,
              derived_strategy = EXCLUDED.derived_strategy,
-             physical_table_name = EXCLUDED.physical_table_name,
-             connection_name = EXCLUDED.connection_name,
              advanced_by_materialization_id = EXCLUDED.advanced_by_materialization_id,
              advanced_at = EXCLUDED.advanced_at
           RETURNING *`,
@@ -85,19 +95,20 @@ export class IncrementalLedgerRepository {
    }
 
    /**
-    * Forget a lineage's boundary. Used when a forced full rebuild replaces the
+    * Forget a table's boundary. Used when a forced full rebuild replaces the
     * table's contents wholesale: the old boundary describes data that no longer
     * exists, and leaving it would let the next delta start mid-table.
     */
    async deleteEntry(
       environmentId: string,
-      packageName: string,
-      sourceEntityId: string,
+      connectionName: string,
+      physicalTableName: string,
    ): Promise<void> {
       await this.db.run(
          `DELETE FROM incremental_ledger
-           WHERE environment_id = ? AND package_name = ? AND source_entity_id = ?`,
-         [environmentId, packageName, sourceEntityId],
+           WHERE environment_id = ? AND connection_name = ?
+             AND physical_table_name = ?`,
+         [environmentId, connectionName, physicalTableName],
       );
    }
 
@@ -108,6 +119,13 @@ export class IncrementalLedgerRepository {
       );
    }
 
+   /**
+    * Forget every boundary tagged with a package, for when that package is
+    * deleted. Best-effort by nature now that the package is not part of the key:
+    * the tag names whoever last advanced a row, so a table shared across versions
+    * of a package keeps its boundary if a different version wrote it last. That
+    * costs at most one seed, and only if the table survives its package.
+    */
    async deleteByPackage(
       environmentId: string,
       packageName: string,

--- a/packages/server/src/storage/duckdb/schema.ts
+++ b/packages/server/src/storage/duckdb/schema.ts
@@ -24,6 +24,11 @@ export async function initializeSchema(
       await dropLegacyProjectSchema(db);
       logger.info("Creating database schema for the first time...");
    }
+   // Re-keying `incremental_ledger` has to happen on an ALREADY-initialized
+   // database — that is the only case where the old key is on disk — so it runs
+   // outside the branch above rather than beside the legacy-projects drop.
+   await dropPackageKeyedIncrementalLedger(db);
+
    // Always fall through to the CREATE TABLE IF NOT EXISTS pass below.
    // The statements are idempotent and let an already-initialized DB pick
    // up new tables added in later builds (e.g., the `themes` table for
@@ -126,19 +131,36 @@ export async function initializeSchema(
 
    // Incremental ledger.
    //
-   // One row per persisted source lineage that refreshes incrementally, holding
-   // the durable `covered_through` boundary: the exclusive upper end of the
-   // watermark range the serving table is known to contain. A delta run reads it
-   // as the range's start, and advances it only after the DML commits, which is
-   // what makes a crash between the two a repeat rather than a gap.
+   // One row per TABLE that refreshes incrementally, holding the durable
+   // `covered_through` boundary: the exclusive upper end of the watermark range
+   // that table is known to contain. A delta run reads it as the range's start,
+   // and advances it only after the DML commits, which is what makes a crash
+   // between the two a repeat rather than a gap.
    //
-   // The declaration columns are not bookkeeping. Changing `watermark=` or
-   // `merge_key=` changes the DML WITHOUT moving the source's content address
-   // (proven in incremental_compiler_contract.spec.ts), so the address alone
-   // cannot tell a delta that the rules changed under it. Recording what the
-   // boundary was computed under lets the build path detect the mismatch and
-   // re-seed instead of applying a delta whose semantics no longer match the
-   // table.
+   // Keyed on (environment, connection, physical table) because that is what the
+   // boundary is a fact ABOUT. It was keyed on (environment, package, source
+   // address) and that was wrong in a way only an orchestrated host could see: a
+   // host that serves several versions of one package presents a version-
+   // qualified package name (Credible sends `<package>|<versionId>`, which is how
+   // one worker holds several versions at once), so a table shared across those
+   // versions got a fresh ledger row on the first refresh after every publish. No
+   // row means no boundary, and no boundary means a full re-seed — of a table
+   // whose whole purpose is not being rebuilt. Worse, the re-seed lands on the
+   // serving table's own name, so it goes DROP + RENAME over a live table instead
+   // of the atomic cutover a fresh generation gets.
+   //
+   // The declaration columns — the watermark, the merge keys, the strategy, and
+   // the source's content address — are not bookkeeping. Each is recorded so the
+   // read can REFUSE (ledgerLineageMismatch): a change to any of them means the
+   // boundary was measured under rules that no longer apply, so the build path
+   // re-seeds rather than applying a delta whose semantics no longer match the
+   // table. The address needs comparing because it stopped being the key, and a
+   // table's name need not change when its definition does — a standalone
+   // publisher's names are `#@ persist name=` or the source name, with no content
+   // token. The watermark and merge keys need comparing because changing them
+   // changes the DML WITHOUT moving the address at all (proven in
+   // incremental_compiler_contract.spec.ts), so not even the address would be
+   // sufficient on its own.
    //
    // No claim/lease column: the single writer is already guaranteed by the
    // `active_key` unique index on `materializations` (at most one active run per
@@ -159,7 +181,7 @@ export async function initializeSchema(
       advanced_by_materialization_id VARCHAR,
       advanced_at TIMESTAMP NOT NULL,
       created_at TIMESTAMP NOT NULL,
-      PRIMARY KEY (environment_id, package_name, source_entity_id)
+      PRIMARY KEY (environment_id, connection_name, physical_table_name)
     )
   `);
 
@@ -200,9 +222,53 @@ export async function initializeSchema(
    await db.run(
       "CREATE UNIQUE INDEX IF NOT EXISTS idx_materializations_active_key ON materializations(active_key)",
    );
+   // Not a key prefix any more, and so load-bearing rather than merely helpful:
+   // deleting a package's rows is now a scan of a non-key column.
    await db.run(
       "CREATE INDEX IF NOT EXISTS idx_incremental_ledger_environment_package ON incremental_ledger(environment_id, package_name)",
    );
+}
+
+/**
+ * Drop an `incremental_ledger` still keyed on (environment, package, source
+ * address), so the pass above recreates it keyed on the table.
+ *
+ * DuckDB cannot re-key a table in place and this schema has no migration
+ * framework, so the choice is drop-and-recreate or leave the old key on disk
+ * silently. Dropping is safe here in a way it would not be for any other table:
+ * the ledger is a CACHE of a boundary the publisher can always re-derive, and its
+ * miss path is a seed — the same fallback every unprovable fact takes. Losing it
+ * costs one full rebuild per incremental source, which is exactly what the old key
+ * was already costing on every publish.
+ */
+async function dropPackageKeyedIncrementalLedger(
+   db: DuckDBConnection,
+): Promise<void> {
+   const present = await db.all<{ name: string }>(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='incremental_ledger'",
+   );
+   if (!present || present.length === 0) {
+      return;
+   }
+   // `pk` is true for every column of a composite primary key, so the old key is
+   // identifiable by package_name being part of it. Reading the key rather than a
+   // schema version means this is self-limiting: once no database has the old key,
+   // it never fires again.
+   const columns = await db.all<{ name: string; pk: boolean }>(
+      "PRAGMA table_info('incremental_ledger')",
+   );
+   const keyedOnPackage = columns.some(
+      (column) => column.name === "package_name" && Boolean(column.pk),
+   );
+   if (!keyedOnPackage) {
+      return;
+   }
+   logger.info(
+      "Re-keying the incremental ledger onto (environment, connection, table); " +
+         "recorded covered_through boundaries are discarded, so each incremental " +
+         "source rebuilds in full once and then resumes advancing by delta",
+   );
+   await db.run("DROP TABLE IF EXISTS incremental_ledger");
 }
 
 /**


### PR DESCRIPTION
A `covered_through` boundary is a fact about a **table**, but it was keyed on
`(environment_id, package_name, source_entity_id)` — and a package name is not stable across an
orchestrated host's versions of one package.

## What was wrong

Credible presents a version-qualified package name (`<package>|<versionId>`, which is how one worker
holds several versions of a package at once), and fires a shared table's refresh through whichever
version materialized most recently. A publish makes the new version the most recent one, so the first
refresh after **every publish** arrived under a `package_name` the ledger had never seen: no row, no
boundary, `mode: "seed"`. A full recompute, on a source whose entire purpose is not being rebuilt.

Correctness was never at stake — a seed is always right — but two things beyond the cost:

- **That seed was not a cutover.** It lands on the instructed name, which for an in-place refresh IS
  the live serving table, so its CTAS → `DROP` → `RENAME` left readers seeing the table missing for
  the width of those two DDL statements. The one place a refresh was not atomic.
- The host records `delta_applied` either way, since the wire does not report which of seed/delta ran.

## The change

`PRIMARY KEY (environment_id, connection_name, physical_table_name)`. Version-independent by
construction, and truer on its own terms: two packages materializing different tables keep separate
rows, one table refreshed through three versions of its package keeps one. `package_name` and
`source_entity_id` stay on the row as attributes naming whoever last advanced it.

## The part worth reviewing

Taking the content address out of the key takes a guarantee with it. The old key made *"different
build SQL is a different row"* free, and a standalone publisher's physical names carry no content
token — they are `#@ persist name=` or the source name — so an edited model keeps its table name and
the read now **hits**. A model edit that adds a `where:` moves neither the output columns nor the
`watermark=`/`merge_key=` declarations the read already compared, so nothing else would have caught
it: a delta applied under a definition the existing rows do not match.

So the address joins `ledgerLineageMismatch` alongside the watermark, merge keys and strategy —
recorded on write, compared on read, and a change re-seeds. Same protection, relocated from the key to
a check, which is where the other declarations already had to live anyway (changing `watermark=` does
not move the address at all).

## Re-keying an existing database

No migration, and the drop is **not optional**. The ledger is a cache of a boundary the publisher can
always re-derive and its miss path is a seed, so `initializeSchema` detects a table still keyed on the
package (`PRAGMA table_info`, checking whether `package_name` is part of the primary key) and drops it
so the ordinary `CREATE TABLE IF NOT EXISTS` pass recreates it. Self-limiting — it reads the key
rather than a schema version, so once no database carries the old key it never fires again.

Left in place, a legacy table would be worse than untidy: the new upsert's `ON CONFLICT` names a
constraint the old table lacks, so every advance would fail (a swallowed warning) and every
incremental source would seed forever. Cost of the drop is one full rebuild per incremental source —
the same cost the bug was already charging on every publish.

## Tests

- `IncrementalLedgerRepository.spec.ts`: one boundary survives across `orders|v1` → `orders|v2` (the
  regression); the new key's neighbour separation across environment, connection and table; and both
  halves of the re-key at boot — a package-keyed table is replaced, and a table-keyed one is left
  alone with its boundaries intact. That last one matters most, since the schema pass runs on every
  boot and getting it wrong would discard every boundary on every restart.
- `incremental_apply.spec.ts`: a boundary measured over different build SQL is refused.

Typecheck and lint clean; 182 unit tests and 48 materialization integration tests pass. The 3
`concurrent_package` integration failures on this tree are pre-existing (confirmed on an unmodified
checkout).
