### PR TITLE
fix(server): list schemas and load packages for database-less Snowflake connections

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -4141,25 +4141,30 @@ components:
           type: string
           description: Snowflake username for authentication
         password:
-          type: string
+          type: ["string", "null"]
           description: Snowflake password for authentication
         privateKey:
           type: string
           description: Snowflake private key for authentication
         privateKeyPass:
-          type: string
+          type: ["string", "null"]
           description: Passphrase for the Snowflake private key
         warehouse:
           type: string
           description: Snowflake warehouse name
         database:
-          type: string
-          description: Snowflake database name
+          type: ["string", "null"]
+          description:
+            Snowflake database name. Omitted or null connects with no current
+            database, so names must be fully qualified as
+            DATABASE.SCHEMA.TABLE and schema discovery spans the account.
         schema:
-          type: string
-          description: Snowflake schema name
+          type: ["string", "null"]
+          description:
+            Snowflake schema name. Sets the session default schema; it does not
+            restrict which schemas are discoverable.
         role:
-          type: string
+          type: ["string", "null"]
           description: Snowflake role name
         responseTimeoutMilliseconds:
           type: integer

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -4161,8 +4161,9 @@ components:
         schema:
           type: ["string", "null"]
           description:
-            Snowflake schema name. Sets the session default schema; it does not
-            restrict which schemas are discoverable.
+            Snowflake schema name. Sets the session default schema and forms part
+            of the connection's identity, so it determines what a materialization
+            build runs as. It does not restrict which schemas are discoverable.
         role:
           type: ["string", "null"]
           description: Snowflake role name

--- a/packages/server/src/service/connection.spec.ts
+++ b/packages/server/src/service/connection.spec.ts
@@ -1839,6 +1839,67 @@ describe("connection integration tests", () => {
             }
          });
 
+         it("should drop explicitly-null Snowflake options from private-key connOptions", async () => {
+            // This is the path that actually throws. A key-pair connection
+            // bypasses the core connection registry (which strips nulls itself)
+            // and is built directly by buildSnowflakePrivateKeyConnection, where
+            // cloneApiConnection's shallow spread leaves nulls intact. A
+            // surviving null reaches SnowflakeConnection.getDigest(), whose
+            // makeDigest reads `.length` off each part and special-cases only
+            // `undefined` -- so the digest throws, and because it is taken by the
+            // package-load worker's metadata RPC, the symptom is a whole package
+            // failing to load rather than a connection error.
+            //
+            // The fixture above omits these fields, making them `undefined`,
+            // which never reproduced the bug. They must be explicitly null here.
+            const { malloyConnections, releaseConnections } =
+               await createEnvironmentConnections(
+                  [
+                     {
+                        name: "sf_private_key_nulls",
+                        type: "snowflake",
+                        snowflakeConnection: {
+                           account: "test-account",
+                           username: "test-user",
+                           privateKey:
+                              "-----BEGIN PRIVATE KEY-----MIIB-----END PRIVATE KEY-----",
+                           warehouse: "test-warehouse",
+                           database: null,
+                           schema: null,
+                           role: null,
+                           password: null,
+                           privateKeyPass: null,
+                        },
+                     },
+                  ],
+                  testEnvironmentPath,
+               );
+
+            try {
+               const connection = malloyConnections.get(
+                  "sf_private_key_nulls",
+               ) as unknown as {
+                  connOptions: Record<string, unknown>;
+                  getDigest: () => string;
+               };
+               // Absent, not null: `null` is what breaks the digest.
+               for (const field of [
+                  "database",
+                  "schema",
+                  "role",
+                  "password",
+                  "privateKeyPass",
+               ]) {
+                  expect(connection.connOptions[field]).toBeUndefined();
+               }
+               // The real oracle: the digest is what threw, so compute it.
+               expect(() => connection.getDigest()).not.toThrow();
+               expect(typeof connection.getDigest()).toBe("string");
+            } finally {
+               await releaseConnections();
+            }
+         });
+
          it("should translate Trino Peaka credentials to core extraCredential", () => {
             const assembled = assembleEnvironmentConnections(
                [

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -1476,10 +1476,25 @@ function entryToDuckDBOptions(
    return { ...removeUndefined(rest), name };
 }
 
+/**
+ * Drop keys whose value is absent, treating `null` as absent alongside
+ * `undefined`.
+ *
+ * `null` matters as much as `undefined` here: an optional field omitted from
+ * JSON config arrives as `null`, and the values this builds land in a Malloy
+ * connection whose `getDigest()` feeds them to `makeDigest`, which reads
+ * `.length` off each part and special-cases `undefined` alone. A surviving
+ * `null` therefore throws "null is not an object (evaluating 'p.length')" on
+ * the first digest. That digest is taken by the package-load worker's
+ * connection-metadata RPC, so the symptom is not a connection error but the
+ * whole package failing to load with "import reference failure" on the source
+ * line -- while the same model compiles cleanly through /compile, which runs on
+ * the main thread and never takes a digest.
+ */
 function removeUndefined<T extends object>(value: T): Partial<T> {
    return Object.fromEntries(
       Object.entries(value).filter(
-         ([, fieldValue]) => fieldValue !== undefined,
+         ([, fieldValue]) => fieldValue !== undefined && fieldValue !== null,
       ),
    ) as Partial<T>;
 }

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -1536,12 +1536,14 @@ function entryToDuckDBOptions(
  * line -- while the same model compiles cleanly through /compile, which runs on
  * the main thread and never takes a digest.
  */
-function removeUndefined<T extends object>(value: T): Partial<T> {
+function removeUndefined<T extends object>(
+   value: T,
+): { [K in keyof T]?: Exclude<T[K], null> } {
    return Object.fromEntries(
       Object.entries(value).filter(
          ([, fieldValue]) => fieldValue !== undefined && fieldValue !== null,
       ),
-   ) as Partial<T>;
+   ) as { [K in keyof T]?: Exclude<T[K], null> };
 }
 
 function buildSnowflakePrivateKeyConnection(

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -1525,16 +1525,31 @@ function entryToDuckDBOptions(
  * Drop keys whose value is absent, treating `null` as absent alongside
  * `undefined`.
  *
- * `null` matters as much as `undefined` here: an optional field omitted from
- * JSON config arrives as `null`, and the values this builds land in a Malloy
+ * This is the null guard for the connectors Publisher builds ITSELF, outside
+ * Malloy's connection lookup. Core strips nulls on its own registry path, so
+ * anything assembled into the Malloy config pojo is already covered; the two
+ * callers here are not. `buildSnowflakePrivateKeyConnection` bypasses the
+ * registry entirely, and reads through `cloneApiConnection`, whose shallow
+ * spread leaves an explicit `null` intact.
+ *
+ * `null` matters as much as `undefined` because the values this builds land in a
  * connection whose `getDigest()` feeds them to `makeDigest`, which reads
  * `.length` off each part and special-cases `undefined` alone. A surviving
- * `null` therefore throws "null is not an object (evaluating 'p.length')" on
- * the first digest. That digest is taken by the package-load worker's
- * connection-metadata RPC, so the symptom is not a connection error but the
- * whole package failing to load with "import reference failure" on the source
- * line -- while the same model compiles cleanly through /compile, which runs on
- * the main thread and never takes a digest.
+ * `null` therefore throws "null is not an object (evaluating 'p.length')" on the
+ * first digest. That digest is taken by the package-load worker's
+ * connection-metadata RPC, so the symptom is not a connection error but the whole
+ * package failing to load with "import reference failure" on the source line --
+ * while the same model compiles cleanly through /compile, which runs on the main
+ * thread and never takes a digest.
+ *
+ * A field omitted from config arrives as `undefined` and was always fine. The
+ * `null` has a producer: an explicit `"database": null` in publisher.config.json,
+ * or a client that serializes unset optionals as null over POST /connections.
+ * Once stored it is durable, because ConnectionRepository round-trips through
+ * JSON.stringify/parse, which drops `undefined` but preserves `null`.
+ *
+ * Stripping is identity-preserving: an explicit null and an omitted field
+ * produce the same digest, so no content-addressed id splits across the fix.
  */
 function removeUndefined<T extends object>(
    value: T,

--- a/packages/server/src/service/connection_config.spec.ts
+++ b/packages/server/src/service/connection_config.spec.ts
@@ -128,6 +128,67 @@ describe("assembleEnvironmentConnections — databricks", () => {
    });
 });
 
+describe("assembleEnvironmentConnections — snowflake", () => {
+   // An optional field omitted from JSON config arrives as `null`, not
+   // `undefined`. Malloy's makeDigest reads `.length` off every part and
+   // special-cases `undefined` alone, so a surviving `null` throws when a
+   // digest is taken -- which happens on the package-load worker's
+   // connection-metadata RPC, surfacing as the whole package failing to load
+   // with "import reference failure" rather than as a connection error.
+   const nullableFields = ["database", "schema", "role"] as const;
+
+   function snowflakeConnection(
+      overrides: Record<string, unknown>,
+   ): ApiConnection {
+      return {
+         name: "sf",
+         type: "snowflake",
+         snowflakeConnection: {
+            account: "acct",
+            username: "user",
+            password: "pw",
+            warehouse: "wh",
+            ...overrides,
+         },
+      } as ApiConnection;
+   }
+
+   for (const field of nullableFields) {
+      it(`omits a null ${field} from the core entry`, () => {
+         const { pojo } = assembleEnvironmentConnections([
+            snowflakeConnection({ [field]: null }),
+         ]);
+
+         const entry = pojo.connections["sf"] as Record<string, unknown>;
+         // Explicitly not null: `undefined` is what the digest tolerates.
+         expect(entry[field]).toBeUndefined();
+         expect(entry[field]).not.toBeNull();
+      });
+   }
+
+   it("preserves a configured database", () => {
+      const { pojo } = assembleEnvironmentConnections([
+         snowflakeConnection({ database: "MYDB", schema: "MYSCHEMA" }),
+      ]);
+
+      const entry = pojo.connections["sf"] as Record<string, unknown>;
+      expect(entry.database).toBe("MYDB");
+      expect(entry.schema).toBe("MYSCHEMA");
+   });
+
+   it("carries no null through to any core-entry value", () => {
+      const { pojo } = assembleEnvironmentConnections([
+         snowflakeConnection({ database: null, schema: null, role: null }),
+      ]);
+
+      const entry = pojo.connections["sf"] as Record<string, unknown>;
+      const nulls = Object.entries(entry)
+         .filter(([, value]) => value === null)
+         .map(([key]) => key);
+      expect(nulls).toEqual([]);
+   });
+});
+
 describe("normalizeSnowflakePrivateKey", () => {
    const { privateKey: pkcs8Pem } = generateKeyPairSync("rsa", {
       modulusLength: 2048,

--- a/packages/server/src/service/connection_config.spec.ts
+++ b/packages/server/src/service/connection_config.spec.ts
@@ -129,12 +129,17 @@ describe("assembleEnvironmentConnections — databricks", () => {
 });
 
 describe("assembleEnvironmentConnections — snowflake", () => {
-   // An optional field omitted from JSON config arrives as `null`, not
-   // `undefined`. Malloy's makeDigest reads `.length` off every part and
-   // special-cases `undefined` alone, so a surviving `null` throws when a
-   // digest is taken -- which happens on the package-load worker's
-   // connection-metadata RPC, surfacing as the whole package failing to load
-   // with "import reference failure" rather than as a connection error.
+   // An EXPLICIT null in config (or a client serializing an unset optional as
+   // null) survives to the connector; an omitted field arrives as `undefined`
+   // and was always fine. Malloy's makeDigest reads `.length` off every part and
+   // special-cases `undefined` alone, so a surviving `null` throws when a digest
+   // is taken -- which happens on the package-load worker's connection-metadata
+   // RPC, surfacing as the whole package failing to load with "import reference
+   // failure" rather than as a connection error.
+   //
+   // These assertions cover the pojo path, which Malloy's own lookup also
+   // guards. The key-pair path that actually reproduced the bug is pinned in
+   // connection.spec.ts.
    const nullableFields = ["database", "schema", "role"] as const;
 
    function snowflakeConnection(

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -53,6 +53,20 @@ export type AssembledEnvironmentConnections = {
 
 const PUBLISHER_DUCKDB_API_FIELDS = new Set<string>(["attachedDatabases"]);
 
+/**
+ * Collapse `null` to `undefined` for an optional connection field.
+ *
+ * JSON config distinguishes "absent" from "explicitly null", but the Malloy
+ * config layer treats only `undefined` as absent -- `makeDigest` reads
+ * `.length` off every part it is given and special-cases `undefined` alone, so
+ * a `null` throws rather than hashing as empty. Callers that spread through
+ * `removeUndefined` are not protected either: it filters `undefined`, so a
+ * `null` survives it.
+ */
+function nullToUndefined<T>(value: T | null | undefined): T | undefined {
+   return value ?? undefined;
+}
+
 export function normalizeSnowflakePrivateKey(privateKey: string): string {
    let privateKeyContent = privateKey.trim();
 
@@ -1004,17 +1018,35 @@ export function assembleEnvironmentConnections(
                is: "snowflake",
                account: connection.snowflakeConnection?.account,
                username: connection.snowflakeConnection?.username,
-               password: connection.snowflakeConnection?.password,
+               password: nullToUndefined(
+                  connection.snowflakeConnection?.password,
+               ),
                privateKey: connection.snowflakeConnection?.privateKey
                   ? normalizeSnowflakePrivateKey(
                        connection.snowflakeConnection.privateKey,
                     )
                   : undefined,
-               privateKeyPass: connection.snowflakeConnection?.privateKeyPass,
+               privateKeyPass: nullToUndefined(
+                  connection.snowflakeConnection?.privateKeyPass,
+               ),
                warehouse: connection.snowflakeConnection?.warehouse,
-               database: connection.snowflakeConnection?.database,
-               schema: connection.snowflakeConnection?.schema,
-               role: connection.snowflakeConnection?.role,
+               // An omitted optional field arrives as `null` from JSON config,
+               // never as `undefined`. Malloy's `makeDigest` maps over these
+               // values reading `.length`, and it special-cases `undefined`
+               // only, so a `null` here throws
+               // "null is not an object (evaluating 'p.length')" the first time
+               // a digest is taken. That happens on the package-load worker's
+               // connection-metadata RPC, so the failure does not surface as a
+               // connection error: the whole package fails to load with
+               // "import reference failure" on the source line, while the same
+               // model compiles fine through /compile (main thread, no digest).
+               // Normalize at this boundary so `null` never enters the Malloy
+               // config, rather than at each consumer.
+               database: nullToUndefined(
+                  connection.snowflakeConnection?.database,
+               ),
+               schema: nullToUndefined(connection.snowflakeConnection?.schema),
+               role: nullToUndefined(connection.snowflakeConnection?.role),
                timeoutMs:
                   connection.snowflakeConnection?.responseTimeoutMilliseconds,
                // Pool sizing is server-owned policy (matches the values

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -1030,18 +1030,20 @@ export function assembleEnvironmentConnections(
                   connection.snowflakeConnection?.privateKeyPass,
                ),
                warehouse: connection.snowflakeConnection?.warehouse,
-               // An omitted optional field arrives as `null` from JSON config,
-               // never as `undefined`. Malloy's `makeDigest` maps over these
-               // values reading `.length`, and it special-cases `undefined`
-               // only, so a `null` here throws
-               // "null is not an object (evaluating 'p.length')" the first time
-               // a digest is taken. That happens on the package-load worker's
-               // connection-metadata RPC, so the failure does not surface as a
-               // connection error: the whole package fails to load with
-               // "import reference failure" on the source line, while the same
-               // model compiles fine through /compile (main thread, no digest).
-               // Normalize at this boundary so `null` never enters the Malloy
-               // config, rather than at each consumer.
+               // An EXPLICIT `"database": null` in config (or a client that
+               // serializes unset optionals as null) survives to here; an omitted
+               // field arrives as `undefined` and was always fine. Malloy's
+               // `makeDigest` reads `.length` off each part and special-cases
+               // `undefined` only, so a surviving `null` throws
+               // "null is not an object (evaluating 'p.length')" on the first
+               // digest.
+               //
+               // Defense in depth rather than the load-bearing fix: Malloy's own
+               // connection lookup already drops nulls before building a
+               // connector, so this pojo path is covered upstream today. The fix
+               // that matters is `removeUndefined` in connection.ts, on the
+               // key-pair path that bypasses that lookup. Kept because the Malloy
+               // dependency is a caret range and core's guard is not a contract.
                database: nullToUndefined(
                   connection.snowflakeConnection?.database,
                ),

--- a/packages/server/src/service/connection_federation.spec.ts
+++ b/packages/server/src/service/connection_federation.spec.ts
@@ -102,6 +102,29 @@ describe("federateSourceForPassthrough", () => {
       expect(secret).not.toContain("\n   PASSWORD '");
    });
 
+   it("snowflake: omits DATABASE from the secret when the connection has none", async () => {
+      // A database-less connection is now loadable and queryable, so it can also
+      // reach a `storage=` build. The secret simply carries no DATABASE, which
+      // means the passthrough session has no current database and any SQL run
+      // through it must name tables in full. Pinned so the emitted secret is a
+      // deliberate shape rather than an accident of the conditional spread: an
+      // empty `DATABASE ''` line would be worse than its absence, since the
+      // extension would take it as a real (empty) database name.
+      const { conn, sql } = stubbedConnection();
+      await federateSourceForPassthrough(conn, "snowflake", {
+         name: "src_sf_nodb",
+         snowflakeConnection: {
+            account: "acct",
+            username: "user",
+            password: "pwd",
+            warehouse: "WH",
+         } as components["schemas"]["SnowflakeConnection"],
+      });
+      const secret = sql.find((s) => s.includes("CREATE OR REPLACE SECRET"))!;
+      expect(secret).not.toContain("DATABASE");
+      expect(secret).toContain("WAREHOUSE 'WH'");
+   });
+
    it("snowflake: normalizes a single-line private key, as the live path does", async () => {
       // The shape that matters. A multi-line PEM is already valid, so a test
       // using one passes whether or not the key is normalized. A SINGLE-LINE key

--- a/packages/server/src/service/db_utils.spec.ts
+++ b/packages/server/src/service/db_utils.spec.ts
@@ -581,6 +581,132 @@ describe("getSchemasForConnection", () => {
    });
 
    describe("snowflake", () => {
+      function snowflakeConn(
+         database?: string,
+         schema?: string,
+      ): ApiConnection {
+         return {
+            name: "test",
+            type: "snowflake",
+            snowflakeConnection: {
+               account: "acct",
+               username: "user",
+               password: "pw",
+               warehouse: "wh",
+               database,
+               schema,
+            },
+         };
+      }
+
+      it("scopes the query to the configured database", async () => {
+         const rows = [
+            {
+               CATALOG_NAME: "MYDB",
+               SCHEMA_NAME: "TEST_SCHEMA",
+               SCHEMA_OWNER: "SYSADMIN",
+            },
+         ];
+         const m = mockConnection(rows);
+         const schemas = await getSchemasForConnection(
+            snowflakeConn("MYDB", "TEST_SCHEMA"),
+            m.conn,
+         );
+
+         // Qualified, because an unqualified INFORMATION_SCHEMA resolves
+         // against the session's current database.
+         expect(m.lastSQL).toContain("MYDB.INFORMATION_SCHEMA.SCHEMATA");
+         expect(m.lastSQL).toContain("CATALOG_NAME = 'MYDB'");
+         expect(m.lastSQL).toContain("SCHEMA_NAME = 'TEST_SCHEMA'");
+         expect(schemas).toHaveLength(1);
+         expect(schemas[0].name).toBe("MYDB.TEST_SCHEMA");
+         expect(schemas[0].isDefault).toBe(true);
+         expect(schemas[0].isHidden).toBe(false);
+      });
+
+      it("lists schemas across every database when none is configured", async () => {
+         // SHOW output is lower-case, unlike INFORMATION_SCHEMA's.
+         const rows = [
+            { database_name: "DB_B", name: "PUBLIC", owner: "SYSADMIN" },
+            { database_name: "DB_A", name: "SALES", owner: "SYSADMIN" },
+         ];
+         const m = mockConnection(rows);
+         const schemas = await getSchemasForConnection(
+            snowflakeConn(undefined, undefined),
+            m.conn,
+         );
+
+         expect(m.lastSQL).toBe("SHOW SCHEMAS IN ACCOUNT");
+         expect(schemas.map((s) => s.name)).toEqual([
+            "DB_A.SALES",
+            "DB_B.PUBLIC",
+         ]);
+         expect(schemas.every((s) => s.isHidden === false)).toBe(true);
+      });
+
+      it("ignores a configured schema when no database is set", async () => {
+         // The schema is a default for queries, not a filter: honoring it
+         // account-wide would return a same-named schema from every database
+         // and hide the rest.
+         const rows = [
+            { database_name: "DB_A", name: "PUBLIC", owner: "SYSADMIN" },
+            { database_name: "DB_A", name: "OTHER", owner: "SYSADMIN" },
+         ];
+         const m = mockConnection(rows);
+         const schemas = await getSchemasForConnection(
+            snowflakeConn(undefined, "PUBLIC"),
+            m.conn,
+         );
+
+         expect(schemas).toHaveLength(2);
+         // No single schema can be the default without a database to scope it.
+         expect(schemas.every((s) => s.isDefault === false)).toBe(true);
+      });
+
+      it("hides system databases and INFORMATION_SCHEMA account-wide", async () => {
+         const rows = [
+            { database_name: "SNOWFLAKE", name: "ACCOUNT_USAGE", owner: "" },
+            {
+               database_name: "SNOWFLAKE_SAMPLE_DATA",
+               name: "TPCH_SF1",
+               owner: "SYSADMIN",
+            },
+            {
+               database_name: "DB_A",
+               name: "INFORMATION_SCHEMA",
+               owner: "SYSADMIN",
+            },
+            { database_name: "DB_A", name: "SALES", owner: "SYSADMIN" },
+         ];
+         const m = mockConnection(rows);
+         const schemas = await getSchemasForConnection(
+            snowflakeConn(undefined, undefined),
+            m.conn,
+         );
+
+         const visible = schemas.filter((s) => !s.isHidden);
+         expect(visible.map((s) => s.name)).toEqual(["DB_A.SALES"]);
+      });
+
+      it("drops rows that cannot form a DATABASE.SCHEMA name", async () => {
+         // A half-populated row would otherwise yield ".FOO" or "DB.", which
+         // listTablesForSchema parses into a database that does not exist.
+         const rows = [
+            { database_name: "", name: "ORPHAN", owner: "SYSADMIN" },
+            { database_name: "DB_A", name: "", owner: "SYSADMIN" },
+            { database_name: "DB_A", name: "SALES", owner: "SYSADMIN" },
+         ];
+         const m = mockConnection(rows);
+         const schemas = await getSchemasForConnection(
+            snowflakeConn(undefined, undefined),
+            m.conn,
+         );
+
+         expect(schemas.map((s) => s.name)).toEqual(["DB_A.SALES"]);
+      });
+   });
+
+   describe("snowflake", () => {
       it("queries INFORMATION_SCHEMA.SCHEMATA with database filter", async () => {
          const conn: ApiConnection = {
             name: "test",

--- a/packages/server/src/service/db_utils.spec.ts
+++ b/packages/server/src/service/db_utils.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
 
 // Stub the missing optional dependency so db_utils.ts can be imported
 mock.module("@azure/identity", () => ({
@@ -20,6 +20,8 @@ mock.module("@google-cloud/bigquery", () => ({
 }));
 
 import { Connection } from "@malloydata/malloy";
+import { BadRequestError } from "../errors";
+import { logger } from "../logger";
 import { normalizeQueryArray } from "../query_param_utils";
 import {
    extractErrorDataFromError,
@@ -580,7 +582,7 @@ describe("getSchemasForConnection", () => {
       });
    });
 
-   describe("snowflake", () => {
+   describe("snowflake - database-less account listing", () => {
       function snowflakeConn(
          database?: string,
          schema?: string,
@@ -636,12 +638,105 @@ describe("getSchemasForConnection", () => {
             m.conn,
          );
 
-         expect(m.lastSQL).toBe("SHOW SCHEMAS IN ACCOUNT");
+         // The LIMIT is stated rather than left to the server's implicit
+         // default, so that landing on the cap is detectable.
+         expect(m.lastSQL).toBe("SHOW SCHEMAS IN ACCOUNT LIMIT 10000");
          expect(schemas.map((s) => s.name)).toEqual([
             "DB_A.SALES",
             "DB_B.PUBLIC",
          ]);
          expect(schemas.every((s) => s.isHidden === false)).toBe(true);
+      });
+
+      it("warns that the schema list is incomplete when SHOW hits its row cap", async () => {
+         // Passing the LIMIT trades Snowflake's above-10k error for a capped
+         // result, so truncation becomes possible where it previously was not.
+         // Landing on the cap is the only evidence available that schemas are
+         // missing, so silence here would present a partial list as complete.
+         const rows = Array.from({ length: 10_000 }, (_unused, i) => ({
+            database_name: "DB_A",
+            name: `SCHEMA_${i}`,
+            owner: "SYSADMIN",
+         }));
+         const m = mockConnection(rows);
+         const warnSpy = spyOn(logger, "warn");
+         try {
+            await getSchemasForConnection(
+               snowflakeConn(undefined, undefined),
+               m.conn,
+            );
+            const warnings = warnSpy.mock.calls.map((c) => String(c[0]));
+            expect(
+               warnings.some((message) =>
+                  message.includes("hit the SHOW row limit"),
+               ),
+            ).toBe(true);
+         } finally {
+            warnSpy.mockRestore();
+         }
+      });
+
+      it("does not warn when the schema list is below the SHOW row cap", async () => {
+         const rows = [
+            { database_name: "DB_A", name: "PUBLIC", owner: "SYSADMIN" },
+         ];
+         const m = mockConnection(rows);
+         const warnSpy = spyOn(logger, "warn");
+         try {
+            await getSchemasForConnection(
+               snowflakeConn(undefined, undefined),
+               m.conn,
+            );
+            const warnings = warnSpy.mock.calls.map((c) => String(c[0]));
+            expect(
+               warnings.some((message) =>
+                  message.includes("hit the SHOW row limit"),
+               ),
+            ).toBe(false);
+         } finally {
+            warnSpy.mockRestore();
+         }
+      });
+
+      it("surfaces an unusable database name as a bad request, not an internal error", async () => {
+         // A rejected identifier is deterministically invalid, so classifying it
+         // as an internal fault tells the caller to retry a value that can never
+         // succeed. Matches the guard in getSchemasForTrino / Databricks.
+         const m = mockConnection([]);
+         await expect(
+            getSchemasForConnection(
+               snowflakeConn("bad-name", undefined),
+               m.conn,
+            ),
+         ).rejects.toBeInstanceOf(BadRequestError);
+      });
+
+      it("warns rather than silently returning nothing when no row parses", async () => {
+         // A SHOW output whose columns we no longer recognise returns rows and
+         // yields no schemas, which is indistinguishable from an account with no
+         // schemas unless it is reported. This is the collapsed-signal case: the
+         // empty result carries evidence, the silent one does not.
+         const rows = [
+            { unexpected_column: "DB_A", another: "PUBLIC" },
+            { unexpected_column: "DB_B", another: "SALES" },
+         ];
+         const m = mockConnection(rows);
+         const warnSpy = spyOn(logger, "warn");
+         try {
+            const schemas = await getSchemasForConnection(
+               snowflakeConn(undefined, undefined),
+               m.conn,
+            );
+            expect(schemas).toHaveLength(0);
+            const warnings = warnSpy.mock.calls.map((c) => String(c[0]));
+            expect(
+               warnings.some((message) =>
+                  message.includes("missing a database or schema name"),
+               ),
+            ).toBe(true);
+         } finally {
+            warnSpy.mockRestore();
+         }
       });
 
       it("ignores a configured schema when no database is set", async () => {

--- a/packages/server/src/service/db_utils.spec.ts
+++ b/packages/server/src/service/db_utils.spec.ts
@@ -698,6 +698,39 @@ describe("getSchemasForConnection", () => {
          }
       });
 
+      it("shows a shared database's schemas even though SHOW reports no owner", async () => {
+         // SHOW SCHEMAS reports a blank owner for any schema not local to the
+         // account, so every schema of an IMPORTED DATABASE (a Marketplace or
+         // partner share) looks system-owned. Hiding those drops a deliberately
+         // subscribed dataset from the picker.
+         const rows = [
+            { database_name: "SEC_FILINGS", name: "CYBERSYN", owner: "" },
+            { database_name: "SNOWFLAKE", name: "ACCOUNT_USAGE", owner: "" },
+            {
+               database_name: "SEC_FILINGS",
+               name: "INFORMATION_SCHEMA",
+               owner: "",
+            },
+         ];
+         const m = mockConnection(rows);
+         const schemas = await getSchemasForConnection(
+            snowflakeConn(undefined, undefined),
+            m.conn,
+         );
+
+         const visible = schemas.filter((s) => !s.isHidden).map((s) => s.name);
+         expect(visible).toEqual(["SEC_FILINGS.CYBERSYN"]);
+         // The system database and INFORMATION_SCHEMA stay hidden on their own
+         // rules, so dropping the blank-owner test leaks no system noise.
+         expect(
+            schemas.find((s) => s.name === "SNOWFLAKE.ACCOUNT_USAGE")?.isHidden,
+         ).toBe(true);
+         expect(
+            schemas.find((s) => s.name === "SEC_FILINGS.INFORMATION_SCHEMA")
+               ?.isHidden,
+         ).toBe(true);
+      });
+
       it("surfaces an unusable database name as a bad request, not an internal error", async () => {
          // A rejected identifier is deterministically invalid, so classifying it
          // as an internal fault tells the caller to retry a value that can never

--- a/packages/server/src/service/db_utils.ts
+++ b/packages/server/src/service/db_utils.ts
@@ -465,7 +465,21 @@ async function getSchemasForSnowflake(
       return rows.map(({ catalogName, schemaName, owner }) => ({
          name: `${catalogName}.${schemaName}`,
          isHidden:
-            ["SNOWFLAKE", ""].includes(owner) ||
+            owner === "SNOWFLAKE" ||
+            // A BLANK owner counts as system-owned only within a configured
+            // database. Account-wide it does not: SHOW SCHEMAS reports a blank
+            // owner for any schema that is not local to the account, which
+            // includes every schema of an IMPORTED DATABASE -- a Marketplace or
+            // partner share the operator deliberately subscribed to. Treating
+            // those as system schemas drops them from the Connection Explorer
+            // picker by default and tells an agent its tables are elsewhere.
+            //
+            // Nothing is lost by scoping it: account-wide, every other
+            // blank-owner schema is either INFORMATION_SCHEMA (caught by name,
+            // one per database) or inside a Snowflake-managed database (caught
+            // by the set below, which is what actually carries the sample-data
+            // share -- itself blank-owner).
+            (Boolean(database) && owner === "") ||
             schemaName === "INFORMATION_SCHEMA" ||
             // Account-wide listing surfaces Snowflake's own databases, which are
             // noise in a schema picker. They are only reachable in the

--- a/packages/server/src/service/db_utils.ts
+++ b/packages/server/src/service/db_utils.ts
@@ -275,6 +275,105 @@ async function getSchemasForMySQL(
    ];
 }
 
+/**
+ * Snowflake-managed databases, hidden from an account-wide schema listing.
+ *
+ * SNOWFLAKE is the account's metadata share and SNOWFLAKE_SAMPLE_DATA is the
+ * sample share every account gets; neither is user data, and between them they
+ * contribute the large majority of schemas on an otherwise-empty account.
+ */
+const SNOWFLAKE_SYSTEM_DATABASES = new Set([
+   "SNOWFLAKE",
+   "SNOWFLAKE_SAMPLE_DATA",
+]);
+
+/** One schema row, normalized across the two sources that can produce it. */
+interface SnowflakeSchemaRow {
+   catalogName: string;
+   schemaName: string;
+   owner: string;
+}
+
+/**
+ * Schemas within one configured database, via that database's
+ * INFORMATION_SCHEMA. Column names come back upper-case.
+ */
+async function listSnowflakeSchemasInDatabase(
+   connection: ApiConnection,
+   malloyConnection: Connection,
+   database: string,
+   schema: string | undefined,
+): Promise<SnowflakeSchemaRow[]> {
+   const filters = [
+      `CATALOG_NAME = '${sqlLiteral(database, connection.type)}'`,
+   ];
+   if (schema) {
+      filters.push(`SCHEMA_NAME = '${sqlLiteral(schema, connection.type)}'`);
+   }
+   // Identifier position, so this is validated rather than escaped. Previously
+   // spliced bare; a database name is operator-supplied config rather than
+   // caller input, so this is consistency with the Trino/Databricks catalog
+   // handling rather than a new trust boundary.
+   assertSafeSqlIdentifier(database, "database name");
+   const result = await runIntrospectionSQL(
+      malloyConnection,
+      `SELECT CATALOG_NAME, SCHEMA_NAME, SCHEMA_OWNER FROM ${database}.INFORMATION_SCHEMA.SCHEMATA WHERE ${filters.join(
+         " AND ",
+      )} ORDER BY SCHEMA_NAME`,
+   );
+   return standardizeRunSQLResult(result).map((row: unknown) => {
+      const r = row as Record<string, unknown>;
+      return {
+         catalogName: String(r.CATALOG_NAME ?? r.catalog_name ?? ""),
+         schemaName: String(r.SCHEMA_NAME ?? r.schema_name ?? ""),
+         owner: String(r.SCHEMA_OWNER ?? r.schema_owner ?? ""),
+      };
+   });
+}
+
+/**
+ * Every role-visible schema in the account, for a connection with no configured
+ * database.
+ *
+ * SHOW is a metadata command rather than a SELECT, so it needs no current
+ * database. Its output columns are LOWER-case (`database_name`, `name`,
+ * `owner`) where INFORMATION_SCHEMA's are upper-case; reading it with the
+ * upper-case keys yields empty owners, which the caller's `isHidden` rule treats
+ * as a system schema and would hide every row.
+ *
+ * The alternative source, SNOWFLAKE.ACCOUNT_USAGE.SCHEMATA, is rejected on
+ * purpose: it needs elevated grants and lags reality by up to ~2 hours, so a
+ * just-created schema would be missing.
+ */
+async function listSnowflakeSchemasInAccount(
+   malloyConnection: Connection,
+): Promise<SnowflakeSchemaRow[]> {
+   const result = await runIntrospectionSQL(
+      malloyConnection,
+      "SHOW SCHEMAS IN ACCOUNT",
+   );
+   return (
+      standardizeRunSQLResult(result)
+         .map((row: unknown) => {
+            const r = row as Record<string, unknown>;
+            return {
+               catalogName: String(r.database_name ?? r.DATABASE_NAME ?? ""),
+               schemaName: String(r.name ?? r.NAME ?? ""),
+               owner: String(r.owner ?? r.OWNER ?? ""),
+            };
+         })
+         // A row missing either half cannot form a usable DATABASE.SCHEMA name, and
+         // listTablesForSnowflake would mis-parse it. Drop it rather than emit a
+         // name that fails later at the point of use.
+         .filter((r) => r.catalogName && r.schemaName)
+         .sort(
+            (a, b) =>
+               a.catalogName.localeCompare(b.catalogName) ||
+               a.schemaName.localeCompare(b.schemaName),
+         )
+   );
+}
+
 async function getSchemasForSnowflake(
    connection: ApiConnection,
    malloyConnection: Connection,
@@ -286,42 +385,47 @@ async function getSchemasForSnowflake(
       const database = connection.snowflakeConnection.database;
       const schema = connection.snowflakeConnection.schema;
 
-      const filters: string[] = [];
-      if (database) {
-         filters.push(
-            `CATALOG_NAME = '${sqlLiteral(database, connection.type)}'`,
-         );
-      }
-      if (schema) {
-         filters.push(`SCHEMA_NAME = '${sqlLiteral(schema, connection.type)}'`);
-      }
-      const whereClause =
-         filters.length > 0 ? `WHERE ${filters.join(" AND ")}` : "";
+      // INFORMATION_SCHEMA.SCHEMATA is PER-DATABASE in Snowflake, and an
+      // unqualified reference to it resolves against the session's current
+      // database. A connection with no configured database has no current
+      // database, so the unqualified form does not merely return the wrong rows,
+      // it fails outright ("Cannot perform SELECT. This session does not have a
+      // current database"). There is also no qualified form that spans
+      // databases. So the two cases need different instruments:
+      //
+      //   database configured -> <db>.INFORMATION_SCHEMA.SCHEMATA, as before.
+      //   no database         -> SHOW SCHEMAS IN ACCOUNT, which needs no current
+      //                          database and reports every role-visible schema.
+      //
+      // Both branches emit the same `DATABASE.SCHEMA` name, which is the shape
+      // listTablesForSnowflake parses back apart, so the two-part contract holds
+      // either way.
+      const rows = database
+         ? await listSnowflakeSchemasInDatabase(
+              connection,
+              malloyConnection,
+              database,
+              schema,
+           )
+         : await listSnowflakeSchemasInAccount(malloyConnection);
 
-      const result = await runIntrospectionSQL(
-         malloyConnection,
-         `SELECT CATALOG_NAME, SCHEMA_NAME, SCHEMA_OWNER FROM ${database ? `${database}.` : ""}INFORMATION_SCHEMA.SCHEMATA ${whereClause} ORDER BY SCHEMA_NAME`,
-      );
-      const rows = standardizeRunSQLResult(result);
-      return rows.map((row: unknown) => {
-         const typedRow = row as Record<string, unknown>;
-         const catalogName = String(
-            typedRow.CATALOG_NAME ?? typedRow.catalog_name ?? "",
-         );
-         const schemaName = String(
-            typedRow.SCHEMA_NAME ?? typedRow.schema_name ?? "",
-         );
-         const owner = String(
-            typedRow.SCHEMA_OWNER ?? typedRow.schema_owner ?? "",
-         );
-         return {
-            name: `${catalogName}.${schemaName}`,
-            isHidden:
-               ["SNOWFLAKE", ""].includes(owner) ||
-               schemaName === "INFORMATION_SCHEMA",
-            isDefault: schema ? schemaName === schema : false,
-         };
-      });
+      return rows.map(({ catalogName, schemaName, owner }) => ({
+         name: `${catalogName}.${schemaName}`,
+         isHidden:
+            ["SNOWFLAKE", ""].includes(owner) ||
+            schemaName === "INFORMATION_SCHEMA" ||
+            // Account-wide listing surfaces Snowflake's own databases, which are
+            // noise in a schema picker. They are only reachable in the
+            // no-database branch; a connection explicitly pointed at one still
+            // lists it, because there the operator asked for it by name.
+            (!database && SNOWFLAKE_SYSTEM_DATABASES.has(catalogName)),
+         // Scoped to the configured database on purpose. Account-wide, a bare
+         // `schemaName === schema` marks a same-named schema in EVERY database
+         // as the default, so N databases with a `PUBLIC` schema would yield N
+         // defaults. Without a database there is no one default to point at.
+         isDefault:
+            Boolean(database) && Boolean(schema) && schemaName === schema,
+      }));
    } catch (error) {
       logger.error(
          `Error getting schemas for Snowflake connection ${connection.name}`,

--- a/packages/server/src/service/db_utils.ts
+++ b/packages/server/src/service/db_utils.ts
@@ -302,7 +302,9 @@ async function listSnowflakeSchemasInDatabase(
    connection: ApiConnection,
    malloyConnection: Connection,
    database: string,
-   schema: string | undefined,
+   // `null` as well as `undefined`: the API contract declares the optional
+   // Snowflake fields nullable, so an omitted schema arrives as either.
+   schema: string | null | undefined,
 ): Promise<SnowflakeSchemaRow[]> {
    const filters = [
       `CATALOG_NAME = '${sqlLiteral(database, connection.type)}'`,
@@ -332,6 +334,34 @@ async function listSnowflakeSchemasInDatabase(
 }
 
 /**
+ * Snowflake's maximum for the `LIMIT` clause of a SHOW command.
+ *
+ * Stated explicitly rather than omitted, because the two behaviors differ and
+ * only one of them is recoverable. Per Snowflake's SHOW SCHEMAS documentation,
+ * omitting `LIMIT` makes the command ERROR when the result set exceeds ten
+ * thousand rows, which fails the whole listing and returns no schemas at all.
+ * Passing the limit instead caps the result, so a large account still gets a
+ * usable (if partial) list rather than a 500.
+ *
+ * The cap in {@link runIntrospectionSQL} cannot substitute for this. That one is
+ * a driver-side `RunSQLOptions.rowLimit`, which the Snowflake driver applies by
+ * slicing the array it already fetched, so it never reaches the server and never
+ * changes what SHOW itself decides to return or reject.
+ *
+ * Trading the error for a cap makes truncation possible, so the caller warns
+ * when a result lands on the limit: a silently partial schema list is
+ * indistinguishable from a complete one, and a table that exists would simply
+ * never appear.
+ *
+ * 10,000 is Snowflake's own ceiling, not a number chosen here -- `LIMIT 10001`
+ * is rejected -- so this cannot be raised to page further. An account above it
+ * needs a different instrument: SHOW per database, the `FROM '<name>'` cursor
+ * sub-clause, or SNOWFLAKE.ACCOUNT_USAGE.SCHEMATA with its elevated grants and
+ * ~2h lag.
+ */
+const SNOWFLAKE_SHOW_ROW_LIMIT = 10_000;
+
+/**
  * Every role-visible schema in the account, for a connection with no configured
  * database.
  *
@@ -348,29 +378,52 @@ async function listSnowflakeSchemasInDatabase(
 async function listSnowflakeSchemasInAccount(
    malloyConnection: Connection,
 ): Promise<SnowflakeSchemaRow[]> {
+   // The row cap in runIntrospectionSQL cannot cover this: it is passed to the
+   // driver as a RunSQLOptions.rowLimit, which the Snowflake driver applies by
+   // slicing the returned array, so it never reaches the server and never
+   // constrains what SHOW itself decides to return.
    const result = await runIntrospectionSQL(
       malloyConnection,
-      "SHOW SCHEMAS IN ACCOUNT",
+      `SHOW SCHEMAS IN ACCOUNT LIMIT ${SNOWFLAKE_SHOW_ROW_LIMIT}`,
    );
-   return (
-      standardizeRunSQLResult(result)
-         .map((row: unknown) => {
-            const r = row as Record<string, unknown>;
-            return {
-               catalogName: String(r.database_name ?? r.DATABASE_NAME ?? ""),
-               schemaName: String(r.name ?? r.NAME ?? ""),
-               owner: String(r.owner ?? r.OWNER ?? ""),
-            };
-         })
-         // A row missing either half cannot form a usable DATABASE.SCHEMA name, and
-         // listTablesForSnowflake would mis-parse it. Drop it rather than emit a
-         // name that fails later at the point of use.
-         .filter((r) => r.catalogName && r.schemaName)
-         .sort(
-            (a, b) =>
-               a.catalogName.localeCompare(b.catalogName) ||
-               a.schemaName.localeCompare(b.schemaName),
-         )
+   const returnedRows = standardizeRunSQLResult(result);
+   if (returnedRows.length >= SNOWFLAKE_SHOW_ROW_LIMIT) {
+      logger.warn(
+         "Snowflake account-wide schema listing hit the SHOW row limit; the schema list is incomplete and some tables will not be discoverable",
+         {
+            rowLimit: SNOWFLAKE_SHOW_ROW_LIMIT,
+            returnedRows: returnedRows.length,
+         },
+      );
+   }
+   const parsed = returnedRows.map((row: unknown) => {
+      const r = row as Record<string, unknown>;
+      return {
+         catalogName: String(r.database_name ?? r.DATABASE_NAME ?? ""),
+         schemaName: String(r.name ?? r.NAME ?? ""),
+         owner: String(r.owner ?? r.OWNER ?? ""),
+      };
+   });
+   // A row missing either half cannot form a usable DATABASE.SCHEMA name, and
+   // listTablesForSnowflake would mis-parse it. Drop it rather than emit a name
+   // that fails later at the point of use.
+   const usable = parsed.filter((r) => r.catalogName && r.schemaName);
+   if (usable.length < parsed.length) {
+      // Dropping silently would collapse two very different situations into the
+      // same empty list: an account with no schemas, and a SHOW output whose
+      // columns we no longer recognise (a renamed column, or a role that cannot
+      // see them). The second returns rows and still yields nothing, so without
+      // this the endpoint reports "no schemas" for what is really a parse or
+      // permissions failure.
+      logger.warn(
+         "Dropped Snowflake schema rows missing a database or schema name; the schema list is incomplete",
+         { dropped: parsed.length - usable.length, returned: parsed.length },
+      );
+   }
+   return usable.sort(
+      (a, b) =>
+         a.catalogName.localeCompare(b.catalogName) ||
+         a.schemaName.localeCompare(b.schemaName),
    );
 }
 
@@ -427,6 +480,12 @@ async function getSchemasForSnowflake(
             Boolean(database) && Boolean(schema) && schemaName === schema,
       }));
    } catch (error) {
+      // A rejected database name is the config's to fix, not an internal fault.
+      // Flattened into a generic Error it classifies as "unexpected internal
+      // error, retry later", so a caller retries a deterministically-invalid
+      // value forever. Matches getSchemasForTrino, getSchemasForDatabricks and
+      // listTablesForSnowflake, which guard the same way for the same reason.
+      if (error instanceof BadRequestError) throw error;
       logger.error(
          `Error getting schemas for Snowflake connection ${connection.name}`,
          { error },


### PR DESCRIPTION
Snowflake lets a connection omit `database`, resolving names against the session's current database instead. Publisher did not support that: a connection configured without one could not list its schemas, and could not back a source in a published package. Both failures are fixed here.

## Issue 1: listing schemas returned a 500

`getSchemasForSnowflake` built its introspection query as:

```sql
SELECT CATALOG_NAME, SCHEMA_NAME, SCHEMA_OWNER
FROM INFORMATION_SCHEMA.SCHEMATA
```

With no database configured, the `<db>.` prefix was empty and the reference was unqualified. Snowflake resolves an unqualified `INFORMATION_SCHEMA` against the session's current database, and a connection without one has no current database, so the request failed:

```
Cannot perform SELECT. This session does not have a current database.
Call 'USE DATABASE', or use a qualified name.
```

Qualifying the name is not a fix either. `INFORMATION_SCHEMA.SCHEMATA` is per-database in Snowflake, so `MYDB.INFORMATION_SCHEMA.SCHEMATA` returns only `MYDB`'s schemas. No form of that query can span databases.

**Fix.** The two cases now use different instruments. A connection with a configured database keeps the existing per-database query, byte for byte. A connection without one uses `SHOW SCHEMAS IN ACCOUNT`, a metadata command that requires no current database and reports every schema the role can see. Both branches emit the same `DATABASE.SCHEMA` name, which `listTablesForSnowflake` already parses back apart, so tables resolve as `DATABASE.SCHEMA.TABLE` either way.

Three details the branch has to get right:

- `SHOW` returns lower-case columns (`database_name`, `name`, `owner`) where `INFORMATION_SCHEMA` returns upper-case. Read with the upper-case keys alone, every owner is empty, which the `isHidden` rule treats as a system schema — hiding every row.
- `isDefault` is scoped to the configured database. Applied account-wide, a bare `schemaName === schema` marks a same-named schema in every database as the default.
- A configured `schema` is not applied as a filter when no database is set. It is a session default, not a selector; filtering on it account-wide would return that schema from every database and drop the rest.

## Issue 2: packages naming the connection failed to load

A model whose source named a database-less connection failed to publish:

```
line 8: import reference failure
  | source: overlap_report is snowflake_without_database.table(...)
```

The same source text compiled cleanly through `/compile`, which is what makes this one misleading: the error points at a model line, so it reads as a table-path problem, and the table path was already fully qualified.

The asymmetry is the cause. `/compile` runs on the main thread. Package load runs in the package-load worker pool, and the worker cannot hold native connection handles across the isolate boundary, so it builds a `ProxyConnection` from metadata fetched over RPC. That RPC calls `getDigest()`, and Malloy's `makeDigest` reads `.length` off every part it is given:

```js
parts.map(p => (p === undefined ? '{undefined}' : `${p.length}:${p}`))
```

It special-cases `undefined` only. A field omitted from config arrives as `undefined` and is fine; the `null` has a producer -- an explicit `"database": null` in `publisher.config.json`, or a client that serializes unset optionals as null over `POST /connections`. Once stored it is durable, because `ConnectionRepository` round-trips through `JSON.stringify`/`parse`, which drops `undefined` but preserves `null`. Such a value reached `getDigest()`, which threw `TypeError: null is not an object (evaluating 'p.length')` before any table was touched. The guard that should have removed it filtered on `undefined` alone, so `null` passed through:

```ts
([, fieldValue]) => fieldValue !== undefined,
```

**Fix.** `null` is treated as absent alongside `undefined`, applied to every nullable field (`database`, `schema`, `role`, `password`, `privateKeyPass`) rather than to `database` alone, since each one reaches `makeDigest`.

The load-bearing change is `removeUndefined` in `connection.ts`. That is the **key-pair path**, which bypasses Malloy's connection lookup entirely: `buildSnowflakePrivateKeyConnection` reads through `cloneApiConnection`, a shallow spread that leaves an explicit `null` intact. The `nullToUndefined` helper in `connection_config.ts` covers the config-pojo path, which Malloy's own lookup already guards on the pinned version (`if (value !== undefined && value !== null)` at both lookup sites); it is kept as defense in depth, since the dependency is a caret range and core's guard is not a contract.

The fix is identity-preserving: an explicitly-null field and an omitted one produce the same digest, so no content-addressed id splits across it.

## Verification

Against a live Snowflake account, on a connection with `database` unset:

- Schema listing returns 62 schemas across 10 databases, each named `DATABASE.SCHEMA`.
- Drilling into `ECOMMERCE_SNOWFLAKE.PUBLIC` — a database named nowhere in the connection config — lists its tables as `DATABASE.SCHEMA.TABLE`.
- A package with two sources over that connection publishes, and its queries return 10000 rows, 168063 rows, and a join across both databases in a single query.
- The same schema reached through a database-configured connection and a database-less one returns identical tables, columns, and `tablePath`.

Unit tests cover both fixes and were checked by reverting each fix in turn: dropping the database qualifier from the emitted schema name fails 5 tests, reading `SHOW` output with upper-case keys fails 4, restoring the `undefined`-only filter fails the key-pair digest test, and unscoping the blank-owner rule fails the imported-share test.

### Also addressed in review

- **Blank owner no longer hides shared databases.** `SHOW SCHEMAS` reports a blank `owner` for any schema not local to the account, so every schema of an `IMPORTED DATABASE` (a Marketplace or partner share) looked system-owned and was dropped from the Connection Explorer picker by default. The blank-owner test is now scoped to a configured database. On the verification account this moves 47 hidden to 46, surfacing exactly the share; every other blank-owner row is either `INFORMATION_SCHEMA` (caught by name) or inside a Snowflake-managed database (caught by the system set), so no system noise leaks in.
- **`SHOW SCHEMAS IN ACCOUNT` now passes an explicit `LIMIT 10000`.** Omitting it makes Snowflake error above ten thousand rows, failing the whole listing; passing it caps instead. The driver-side `rowLimit` cannot substitute, since the Snowflake connector applies it by slicing an already-fetched array. Landing on the cap is warned, as is dropping any row that yields no usable `DATABASE.SCHEMA` name.
- **A rejected database name stays a 400.** `assertSafeSqlIdentifier` throws `BadRequestError`, which the surrounding catch was flattening into a generic 500 ("retry later") — the retry-forever shape the sibling Trino and Databricks listings already guard against.
- **`storage=` federation with no database is pinned.** The generated secret carries no `DATABASE` line, so a passthrough session has no current database and its SQL must name tables in full. Asserted in `connection_federation.spec.ts`; the live build path itself is untested.
- **Spec matches the code.** The five optional Snowflake fields the code null-handles are declared nullable in `api-doc.yaml` (3.1 `type: ["string", "null"]`). `account`, `username`, `warehouse` and `privateKey` deliberately stay non-nullable, since validation rejects them absent.

## Known gap

Raw-SQL paths still require a session database or schema. `fetchSelectSchema` and `manifestTemporaryTable` in `@malloydata/db-snowflake` wrap the statement in an unqualified temp object:

```ts
const tempTableName = this.getTempViewName(sqlRef.selectStr);   // bare "tt<hash>"
await this.runSQL(`CREATE OR REPLACE TEMP VIEW ${tempTableName} AS (...)`);
```

Snowflake resolves that bare name against the session, so `/sqlSource`, `/sqlTemporaryTable`, and Malloy `sql()` sources fail with `Cannot perform CREATE TEMPVIEW. This session does not have a current database` (or `...current schema`, when `database` is set and `schema` is empty). Qualifying the statement does not help: the qualified name is inside the `SELECT`, while the unqualified object is the temp view wrapping it.

This is upstream in the driver, not in Publisher, and it is unaffected by this PR. `table()`-based models and `/sqlQuery` do not use that path and work today. The driver already handles the same problem correctly in `probeTableSize`, which qualifies conditionally via `parseSnowflakeTableName`; `getTempViewName` predates that and should follow it.

**Not carried here:** the truncation and dropped-row conditions above are logged server-side but not surfaced to the caller, so an agent asking `malloy_searchDatabaseSchema` what schemas exist sees a clean list. That tool already builds a `warnings` array, but the schema listing has no warning channel of its own (`getSchemasForConnection` returns `ApiSchema[]`), so plumbing them through means a contract change this PR otherwise does not make. Left as a follow-up.
