### PR TITLE
fix(snowflake): make storage= builds from a Snowflake source possible at all

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -349,22 +349,44 @@ jobs:
           #    cannot see it missing -- which is how the image came to ship unable
           #    to run a single Snowflake query.
           #
-          #    Issue a real query against a bogus secret. Offline and
-          #    credential-free it cannot reach Snowflake, so it MUST fail; what is
-          #    checked is which failure. A driver error means the driver is gone.
-          driver_err=$(docker run --rm --network none --entrypoint duckdb \
+          #    4a. Structural: a driver beside EVERY directory holding the
+          #    extension. The Dockerfile places one per directory and asserts that
+          #    at least one exists; "at least one" and "one beside each" diverge if
+          #    a copy fails in a non-final loop iteration, because a pipeline's
+          #    status is its last command's. The explicit zero-match guard matters
+          #    for the same reason: `find | while read` succeeds vacuously when the
+          #    loop body never runs.
+          docker run --rm --entrypoint sh malloy-publisher:smoke-test -c '
+            n=$(find /root/.duckdb/extensions -name snowflake.duckdb_extension -printf "%h\n" | wc -l)
+            [ "$n" -gt 0 ] || { echo "no snowflake.duckdb_extension in the image"; exit 1; }
+            find /root/.duckdb/extensions -name snowflake.duckdb_extension -printf "%h\n" \
+              | while read -r d; do
+                  [ -f "$d/libadbc_driver_snowflake.so" ] || { echo "no driver beside $d"; exit 1; }
+                done' \
+            || { echo "✗ ADBC Snowflake driver not co-located with the extension"; exit 1; }
+          echo "✓ ADBC driver sits beside every snowflake.duckdb_extension"
+
+          #    4b. Functional: the driver actually loads. Presence cannot show that
+          #    -- a wrong-architecture .so is present and undlopenable.
+          #
+          #    Assert what a WORKING driver produces, not the absence of a broken
+          #    one. Offline with a bogus secret the query must fail either way; the
+          #    difference is how far it gets. With the driver loaded, the Go client
+          #    builds a request and the failure names the Snowflake host. Matching
+          #    that positively means a driver that vanishes goes red AND a reworded
+          #    error goes red -- where matching the driver error negatively would
+          #    quietly stop matching and print a tick forever, which is precisely
+          #    the failure this step exists to correct.
+          probe=$(docker run --rm --network none --entrypoint duckdb \
             malloy-publisher:smoke-test -c \
             "LOAD snowflake; CREATE SECRET s (TYPE snowflake, ACCOUNT 'x', USER 'y', PASSWORD 'z');
              SELECT * FROM snowflake_query('SELECT 1','s');" 2>&1 || true)
-          #    Match the ERROR, not the filename: on success the extension logs an
-          #    INFO line carrying the driver's path, which a bare filename grep
-          #    matches too and would fail a perfectly good image.
-          if echo "$driver_err" | grep -q "driver (libadbc_driver_snowflake.so) not found"; then
-            echo "✗ ADBC Snowflake driver missing -- snowflake_query() cannot work"
-            echo "$driver_err"
+          if ! echo "$probe" | grep -q "snowflakecomputing.com"; then
+            echo "✗ snowflake_query() never reached the Snowflake host -- driver did not load"
+            echo "$probe"
             exit 1
           fi
-          echo "✓ snowflake ADBC driver present (a real query fails for other reasons)"
+          echo "✓ ADBC driver loads (a real query reaches the Snowflake host)"
           echo "✓ All baked DuckDB extensions load offline"
       - name: Start container
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -334,16 +334,37 @@ jobs:
             echo "✓ $ext loads offline"
           done
 
-          # 3. The community extensions (bigquery, snowflake) must load offline
-          #    too. snowflake in particular loads via its BUNDLED ADBC driver --
-          #    we removed the external ADBC driver install, so a failure here
-          #    means the extension no longer self-provides the driver.
+          # 3. The community extensions (bigquery, snowflake) must load offline too.
           for ext in bigquery snowflake; do
             docker run --rm --network none --entrypoint duckdb \
               malloy-publisher:smoke-test -c "LOAD $ext;" \
-              || { echo "✗ community extension '$ext' failed to load offline (bundled driver missing?)"; exit 1; }
+              || { echo "✗ community extension '$ext' failed to load offline"; exit 1; }
             echo "✓ $ext loads offline"
           done
+
+          # 4. snowflake does NOT self-provide its ADBC driver, whatever an earlier
+          #    version of this comment asserted. The extension is a wrapper over
+          #    libadbc_driver_snowflake.so, which the image installs separately.
+          #    LOAD succeeds without it and only snowflake_query() fails, so step 3
+          #    cannot see it missing -- which is how the image came to ship unable
+          #    to run a single Snowflake query.
+          #
+          #    Issue a real query against a bogus secret. Offline and
+          #    credential-free it cannot reach Snowflake, so it MUST fail; what is
+          #    checked is which failure. A driver error means the driver is gone.
+          driver_err=$(docker run --rm --network none --entrypoint duckdb \
+            malloy-publisher:smoke-test -c \
+            "LOAD snowflake; CREATE SECRET s (TYPE snowflake, ACCOUNT 'x', USER 'y', PASSWORD 'z');
+             SELECT * FROM snowflake_query('SELECT 1','s');" 2>&1 || true)
+          #    Match the ERROR, not the filename: on success the extension logs an
+          #    INFO line carrying the driver's path, which a bare filename grep
+          #    matches too and would fail a perfectly good image.
+          if echo "$driver_err" | grep -q "driver (libadbc_driver_snowflake.so) not found"; then
+            echo "✗ ADBC Snowflake driver missing -- snowflake_query() cannot work"
+            echo "$driver_err"
+            exit 1
+          fi
+          echo "✓ snowflake ADBC driver present (a real query fails for other reasons)"
           echo "✓ All baked DuckDB extensions load offline"
       - name: Start container
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -366,27 +366,36 @@ jobs:
             || { echo "✗ ADBC Snowflake driver not co-located with the extension"; exit 1; }
           echo "✓ ADBC driver sits beside every snowflake.duckdb_extension"
 
-          #    4b. Functional: the driver actually loads. Presence cannot show that
-          #    -- a wrong-architecture .so is present and undlopenable.
+          #    4b. Functional: the driver actually LOADS. Presence cannot show that
+          #    -- a truncated or wrong-architecture .so sits there and fails to
+          #    dlopen, which 4a reports as perfectly fine.
           #
-          #    Assert what a WORKING driver produces, not the absence of a broken
-          #    one. Offline with a bogus secret the query must fail either way; the
-          #    difference is how far it gets. With the driver loaded, the Go client
-          #    builds a request and the failure names the Snowflake host. Matching
-          #    that positively means a driver that vanishes goes red AND a reworded
-          #    error goes red -- where matching the driver error negatively would
-          #    quietly stop matching and print a tick forever, which is precisely
-          #    the failure this step exists to correct.
-          probe=$(docker run --rm --network none --entrypoint duckdb \
+          #    Asserted by PROGRESS rather than by message. Offline with a bogus
+          #    secret the query fails whatever happens; what differs is how far it
+          #    gets. With the driver loaded it clears ADBC init and enters
+          #    Snowflake's login retry loop, so it is still running when the timeout
+          #    kills it (124). A missing or unloadable driver dies immediately.
+          #
+          #    Two properties follow, both measured against a real image, one with
+          #    the driver deleted and one with it truncated. It cannot rot: no error
+          #    text is matched, so a reworded message cannot quietly stop the check
+          #    from checking -- the failure this step exists to correct. And it
+          #    costs ~10s rather than the ~3.5 MINUTES that letting the login
+          #    retries exhaust takes. That wait is the retry loop itself and is not
+          #    avoidable by pointing the secret at loopback (measured: identical).
+          rc=0
+          docker run --rm --network none --entrypoint bash \
             malloy-publisher:smoke-test -c \
-            "LOAD snowflake; CREATE SECRET s (TYPE snowflake, ACCOUNT 'x', USER 'y', PASSWORD 'z');
-             SELECT * FROM snowflake_query('SELECT 1','s');" 2>&1 || true)
-          if ! echo "$probe" | grep -q "snowflakecomputing.com"; then
-            echo "✗ snowflake_query() never reached the Snowflake host -- driver did not load"
-            echo "$probe"
+            "timeout 10 duckdb -c \"LOAD snowflake;
+               CREATE SECRET s (TYPE snowflake, ACCOUNT 'x', USER 'y', PASSWORD 'z');
+               SELECT * FROM snowflake_query('SELECT 1','s');\" >/dev/null 2>&1" \
+            >/dev/null 2>&1 || rc=$?
+          if [ "$rc" -ne 124 ]; then
+            echo "✗ snowflake_query() died before reaching the network (exit $rc)"
+            echo "  the ADBC driver is missing or failed to load"
             exit 1
           fi
-          echo "✓ ADBC driver loads (a real query reaches the Snowflake host)"
+          echo "✓ ADBC driver loads (a real query reaches Snowflake's login retry)"
           echo "✓ All baked DuckDB extensions load offline"
       - name: Start container
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,30 +18,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # `docker build`, kept in sync by scripts/sync-duckdb-version.js and enforced
 # by the CI consistency check.
 ARG DUCKDB_VERSION=1.5.3
-# The Snowflake extension is a wrapper over the ADBC Snowflake driver, which
-# `INSTALL snowflake FROM community` does NOT bring with it — the extension ships
-# alone and the driver is a separate artifact. Without it the extension installs,
-# LOADs, and answers snowflake_version() perfectly well, and then every
-# snowflake_query() fails at run time with "ADBC Snowflake driver
-# (libadbc_driver_snowflake.so) not found".
-#
-# Pinned and downloaded directly rather than via the upstream installer's
-# `curl … | sh`: a build should not execute a remote script it cannot pin, and
-# the version here is auditable the same way DUCKDB_VERSION is. The driver is
-# published per platform, and this image is built for both amd64 and arm64, so
-# the architecture is resolved rather than assumed.
-#
-# It lands in the extension directory for THIS DuckDB version because that is the
-# first path the extension searches, and it is the same directory the runtime
-# reads its baked extensions from — so the driver travels with them.
-#
-# Its own RUN, with no `|| echo` fallback, so a failed fetch FAILS THE BUILD. The
-# neighbouring step tolerates being offline, and that tolerance is what let this
-# ship broken: an image missing the driver is an image that cannot answer a single
-# Snowflake query, and it should not leave the builder claiming success. The
-# closing `test -f` is the verification — snowflake_version() above cannot serve
-# as one, being a scalar that never touches the driver and passes without it.
-ARG ADBC_SNOWFLAKE_VERSION=1.12.0
 RUN DUCKDB_VERSION=${DUCKDB_VERSION} bash -c "curl -L https://install.duckdb.org | bash" && \
     ln -s /root/.duckdb/cli/${DUCKDB_VERSION}/duckdb /usr/local/bin/duckdb && \
     duckdb -c "INSTALL snowflake FROM community; LOAD snowflake; SELECT snowflake_version();" || \
@@ -49,15 +25,6 @@ RUN DUCKDB_VERSION=${DUCKDB_VERSION} bash -c "curl -L https://install.duckdb.org
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
-
-RUN ADBC_ARCH="$(dpkg --print-architecture)" && \
-    EXT_DIR="/root/.duckdb/extensions/v${DUCKDB_VERSION}/linux_${ADBC_ARCH}" && \
-    mkdir -p "${EXT_DIR}" && \
-    curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors -o /tmp/adbc-snowflake.tar.gz \
-      "https://github.com/adbc-drivers/snowflake/releases/download/go/v${ADBC_SNOWFLAKE_VERSION}/snowflake_linux_${ADBC_ARCH}_v${ADBC_SNOWFLAKE_VERSION}.tar.gz" && \
-    tar -xzf /tmp/adbc-snowflake.tar.gz -C "${EXT_DIR}" libadbc_driver_snowflake.so && \
-    rm -f /tmp/adbc-snowflake.tar.gz && \
-    test -f "${EXT_DIR}/libadbc_driver_snowflake.so"
 
 # Builder stage
 FROM oven/bun:1.3.13-slim AS builder
@@ -138,6 +105,50 @@ RUN --mount=type=cache,target=/root/.bun/install/cache \
 # (the server build) instead of re-running it here. The CLI (base-deps) and
 # runtime engine are pinned to the same DuckDB version, so all agree on one dir.
 COPY --from=builder /root/.duckdb/extensions /root/.duckdb/extensions
+
+# The Snowflake extension is a wrapper over the ADBC Snowflake driver, and
+# `INSTALL snowflake FROM community` does NOT bring it — the extension ships
+# alone, the driver is a separate artifact. Without it the extension installs,
+# LOADs and answers snowflake_version() perfectly well, and then every
+# snowflake_query() fails at run time with "ADBC Snowflake driver
+# (libadbc_driver_snowflake.so) not found".
+#
+# Placed HERE, after the COPY above, rather than earlier: the extension resolves
+# the driver by calling dladdr on ITSELF and looking beside the loaded object, so
+# the driver has to sit next to whichever snowflake.duckdb_extension the runtime
+# actually loads. That directory is discovered rather than reconstructed from a
+# platform string — the CLI (base-deps) and the bake (@duckdb/node-api, in the
+# builder) each write their own, and this is the layer that ships.
+#
+# Downloaded directly rather than through the upstream installer's `curl … | sh`,
+# and checked against the digest GitHub publishes: this is a 16MB native library
+# dlopen'd into the server process, and a version tag is mutable — an asset can
+# be re-uploaded under it. Pin the bytes, not the name.
+#
+# No `|| echo` fallback, unlike the extension install above: a failed fetch FAILS
+# THE BUILD. That tolerance is exactly what let this ship broken. An image without
+# the driver cannot answer a single Snowflake query and must not leave the builder
+# reporting success. The closing `test` is the verification — snowflake_version()
+# cannot serve as one, being a scalar that never touches the driver.
+#
+# When bumping DUCKDB_VERSION, re-check this: the community extension moves with
+# DuckDB and the driver ABI may move with it, and a mismatch surfaces only at
+# query time.
+ARG ADBC_SNOWFLAKE_VERSION=1.12.0
+ARG ADBC_SNOWFLAKE_SHA256_AMD64=9f3b44bd2c5d1a84acd1dadf7b9995e47bad78ca37f799c9e8460ac196fd319c
+ARG ADBC_SNOWFLAKE_SHA256_ARM64=7648311005788d9576ee06ced1efd0f4f5849a5e70ef9946abad08588e312283
+RUN ADBC_ARCH="$(dpkg --print-architecture)" && \
+    if [ "${ADBC_ARCH}" = "amd64" ]; then ADBC_SHA="${ADBC_SNOWFLAKE_SHA256_AMD64}"; \
+    else ADBC_SHA="${ADBC_SNOWFLAKE_SHA256_ARM64}"; fi && \
+    curl -fsSL --retry 8 --retry-delay 3 --retry-max-time 180 --retry-all-errors \
+      -o /tmp/adbc-snowflake.tar.gz \
+      "https://github.com/adbc-drivers/snowflake/releases/download/go/v${ADBC_SNOWFLAKE_VERSION}/snowflake_linux_${ADBC_ARCH}_v${ADBC_SNOWFLAKE_VERSION}.tar.gz" && \
+    echo "${ADBC_SHA}  /tmp/adbc-snowflake.tar.gz" | sha256sum -c - && \
+    tar -xzf /tmp/adbc-snowflake.tar.gz -C /tmp libadbc_driver_snowflake.so && \
+    find /root/.duckdb/extensions -name snowflake.duckdb_extension -printf '%h\n' \
+      | while read -r d; do cp /tmp/libadbc_driver_snowflake.so "$d/"; done && \
+    rm -f /tmp/adbc-snowflake.tar.gz /tmp/libadbc_driver_snowflake.so && \
+    test -n "$(find /root/.duckdb/extensions -name libadbc_driver_snowflake.so -print -quit)"
 
 # Runtime config
 ARG DUCKDB_VERSION=1.5.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,30 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # `docker build`, kept in sync by scripts/sync-duckdb-version.js and enforced
 # by the CI consistency check.
 ARG DUCKDB_VERSION=1.5.3
+# The Snowflake extension is a wrapper over the ADBC Snowflake driver, which
+# `INSTALL snowflake FROM community` does NOT bring with it — the extension ships
+# alone and the driver is a separate artifact. Without it the extension installs,
+# LOADs, and answers snowflake_version() perfectly well, and then every
+# snowflake_query() fails at run time with "ADBC Snowflake driver
+# (libadbc_driver_snowflake.so) not found".
+#
+# Pinned and downloaded directly rather than via the upstream installer's
+# `curl … | sh`: a build should not execute a remote script it cannot pin, and
+# the version here is auditable the same way DUCKDB_VERSION is. The driver is
+# published per platform, and this image is built for both amd64 and arm64, so
+# the architecture is resolved rather than assumed.
+#
+# It lands in the extension directory for THIS DuckDB version because that is the
+# first path the extension searches, and it is the same directory the runtime
+# reads its baked extensions from — so the driver travels with them.
+#
+# Its own RUN, with no `|| echo` fallback, so a failed fetch FAILS THE BUILD. The
+# neighbouring step tolerates being offline, and that tolerance is what let this
+# ship broken: an image missing the driver is an image that cannot answer a single
+# Snowflake query, and it should not leave the builder claiming success. The
+# closing `test -f` is the verification — snowflake_version() above cannot serve
+# as one, being a scalar that never touches the driver and passes without it.
+ARG ADBC_SNOWFLAKE_VERSION=1.12.0
 RUN DUCKDB_VERSION=${DUCKDB_VERSION} bash -c "curl -L https://install.duckdb.org | bash" && \
     ln -s /root/.duckdb/cli/${DUCKDB_VERSION}/duckdb /usr/local/bin/duckdb && \
     duckdb -c "INSTALL snowflake FROM community; LOAD snowflake; SELECT snowflake_version();" || \
@@ -25,6 +49,15 @@ RUN DUCKDB_VERSION=${DUCKDB_VERSION} bash -c "curl -L https://install.duckdb.org
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
+
+RUN ADBC_ARCH="$(dpkg --print-architecture)" && \
+    EXT_DIR="/root/.duckdb/extensions/v${DUCKDB_VERSION}/linux_${ADBC_ARCH}" && \
+    mkdir -p "${EXT_DIR}" && \
+    curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors -o /tmp/adbc-snowflake.tar.gz \
+      "https://github.com/adbc-drivers/snowflake/releases/download/go/v${ADBC_SNOWFLAKE_VERSION}/snowflake_linux_${ADBC_ARCH}_v${ADBC_SNOWFLAKE_VERSION}.tar.gz" && \
+    tar -xzf /tmp/adbc-snowflake.tar.gz -C "${EXT_DIR}" libadbc_driver_snowflake.so && \
+    rm -f /tmp/adbc-snowflake.tar.gz && \
+    test -f "${EXT_DIR}/libadbc_driver_snowflake.so"
 
 # Builder stage
 FROM oven/bun:1.3.13-slim AS builder

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,26 @@ One behaviour change to know about: `skills-npm.yml` now publishes only from `ma
 
 ---
 
+## [Unreleased] — `storage=` builds from a Snowflake source now work
+
+The 0.0.236 notes below list `snowflake_query` among the native query-passthroughs a `storage=` source is materialized through. That was true of the code and never true of the published image: **materializing a Snowflake source into a storage destination has not worked at all.** Two independent faults, both fixed.
+
+### What changed
+
+- **The image now carries the ADBC Snowflake driver.** The Snowflake extension is a wrapper over it, and `INSTALL snowflake FROM community` does not bring it — so every `snowflake_query()` failed at run time with `ADBC Snowflake driver (libadbc_driver_snowflake.so) not found`. It is now fetched at a pinned version, for the image's architecture, into the extension directory the runtime reads.
+- **A key-pair Snowflake connection can be federated.** The passthrough required a password and emitted `PASSWORD`, so a connection authenticating by key pair — which queries fine on the live path — could not be built from at all. Key pair or password is now accepted, with a private-key passphrase when supplied.
+- **`ROLE` and `SCHEMA` travel with the federated connection.** Both are part of what identifies a Malloy connection; without them a build ran under the user's _default_ role while live queries on the same connection used the configured one.
+
+### Why it went unnoticed
+
+Both guards were blind for the same reason. The image build verified Snowflake with `SELECT snowflake_version()` — a scalar that never touches the driver and passes without it — and the offline extension smoke test asserts only that extensions `LOAD`. The driver is a query-time dependency, so nothing that ran at build time could see it missing.
+
+### Operational notes
+
+A failed driver fetch now **fails the image build** rather than warning and continuing. An image without the driver cannot answer a Snowflake query, so it should not leave the builder reporting success — which is how this shipped.
+
+---
+
 ## [0.0.236] — DuckDB/DuckLake materialization tier (`storage=`)
 
 This section describes the tier as it stands at 0.0.236. It first shipped in 0.0.232; the disjoint-set semantics between `storageDestinations` and `connections` landed in 0.0.236.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,7 +30,7 @@ The 0.0.236 notes below list `snowflake_query` among the native query-passthroug
 
 ### Why it went unnoticed
 
-Both guards were blind for the same reason. The image build verified Snowflake with `SELECT snowflake_version()` — a scalar that never touches the driver and passes without it — and the offline extension smoke test asserts only that extensions `LOAD`. The driver is a query-time dependency, so nothing that ran at build time could see it missing.
+Both guards were blind for the same reason. The image build verified Snowflake with `SELECT snowflake_version()` — a scalar that never touches the driver and passes without it — and the offline extension smoke test asserted only that extensions `LOAD`. The driver is a query-time dependency, so nothing that ran at build time could see it missing.
 
 ### Scope, and what is still missing
 
@@ -38,7 +38,7 @@ The driver is installed by the **Docker image**. A local clone or `npx @malloy-p
 
 ### Operational notes
 
-A failed driver fetch now **fails the image build** rather than warning and continuing. An image without the driver cannot answer a Snowflake query, so it should not leave the builder reporting success — which is how this shipped.
+A failed driver fetch now **fails the image build** rather than warning and continuing. An image without the driver cannot answer a Snowflake query, so it should not leave the builder reporting success — which is how this shipped. A release built from an unchecked ref is covered by the same assertion, since it lives in the Dockerfile rather than only in CI.
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,7 +18,7 @@ One behaviour change to know about: `skills-npm.yml` now publishes only from `ma
 
 ---
 
-## [Unreleased] — `storage=` builds from a Snowflake source now work
+## [Unreleased] — `storage=` builds from a Snowflake source now work (Docker image)
 
 The 0.0.236 notes below list `snowflake_query` among the native query-passthroughs a `storage=` source is materialized through. That was true of the code and never true of the published image: **materializing a Snowflake source into a storage destination has not worked at all.** Two independent faults, both fixed.
 
@@ -31,6 +31,10 @@ The 0.0.236 notes below list `snowflake_query` among the native query-passthroug
 ### Why it went unnoticed
 
 Both guards were blind for the same reason. The image build verified Snowflake with `SELECT snowflake_version()` — a scalar that never touches the driver and passes without it — and the offline extension smoke test asserts only that extensions `LOAD`. The driver is a query-time dependency, so nothing that ran at build time could see it missing.
+
+### Scope, and what is still missing
+
+The driver is installed by the **Docker image**. A local clone or `npx @malloy-publisher/server` still has no driver, so `storage=` builds from Snowflake continue to fail there with the same error — installing it is a manual step (`dbc install snowflake`, or the extension's installer script). Closing that properly means the bake step owning the driver alongside the extensions, which is worth doing and is not this change.
 
 ### Operational notes
 

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -925,7 +925,16 @@ async function federateSnowflake(
       account: escapeSQL(sf.account || ""),
       user: escapeSQL(sf.username || ""),
       password: sf.password ? escapeSQL(sf.password) : undefined,
-      privateKey: sf.privateKey ? escapeSQL(sf.privateKey) : undefined,
+      // Normalized rather than passed through. The config federated here is an
+      // UNnormalized clone of the API connection, and the live path normalizes at
+      // its own call site — so this is where the two diverge. A single-line PEM
+      // (no newline after the header) makes Go's pem.Decode return nil, and the
+      // extension wants PKCS#8 where a user may legitimately have pasted PKCS#1.
+      // Without this, a key that queries perfectly well live fails the build:
+      // the same shape of bug this change exists to fix, one layer in.
+      privateKey: sf.privateKey
+         ? escapeSQL(normalizeSnowflakePrivateKey(sf.privateKey))
+         : undefined,
       privateKeyPass: sf.privateKeyPass
          ? escapeSQL(sf.privateKeyPass)
          : undefined,

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -899,15 +899,24 @@ async function federateSnowflake(
          `Snowflake connection configuration missing for: ${config.name}`,
       );
    }
-   const required = {
+   for (const [field, value] of Object.entries({
       account: sf.account,
       username: sf.username,
-      password: sf.password,
-   };
-   for (const [field, value] of Object.entries(required)) {
+   })) {
       if (!value) {
          throw new Error(`Snowflake ${field} is required for: ${config.name}`);
       }
+   }
+   // Key pair OR password, matching what a Snowflake connection may actually be
+   // configured with. Requiring a password made every key-pair connection
+   // unbuildable into a storage destination even though it queries fine live —
+   // and key-pair is where Snowflake is steering programmatic access, so that is
+   // the case that matters most rather than an exotic one.
+   const usesKeyPair = !!sf.privateKey;
+   if (!usesKeyPair && !sf.password) {
+      throw new Error(
+         `Snowflake privateKey or password is required for: ${config.name}`,
+      );
    }
 
    await installAndLoadExtension(connection, "snowflake", true);
@@ -915,21 +924,44 @@ async function federateSnowflake(
    const params = {
       account: escapeSQL(sf.account || ""),
       user: escapeSQL(sf.username || ""),
-      password: escapeSQL(sf.password || ""),
+      password: sf.password ? escapeSQL(sf.password) : undefined,
+      privateKey: sf.privateKey ? escapeSQL(sf.privateKey) : undefined,
+      privateKeyPass: sf.privateKeyPass
+         ? escapeSQL(sf.privateKeyPass)
+         : undefined,
       database: sf.database ? escapeSQL(sf.database) : undefined,
       warehouse: sf.warehouse ? escapeSQL(sf.warehouse) : undefined,
+      schema: sf.schema ? escapeSQL(sf.schema) : undefined,
+      role: sf.role ? escapeSQL(sf.role) : undefined,
    };
    const secretName = sanitizeSecretName(`snowflake_${config.name}`);
-   // DATABASE/WAREHOUSE are optional — emit them only when supplied, so an
-   // absent one doesn't interpolate the literal string 'undefined' into the
+   // Every field below the credential is optional — emit only what was supplied,
+   // so an absent one doesn't interpolate the literal string 'undefined' into the
    // secret (which Snowflake would then try to use as a real db/warehouse name).
+   //
+   // ROLE and SCHEMA are carried for the same reason the credential is: the
+   // Malloy connection folds both into its connection digest, so they are part of
+   // what identifies this connection. Dropping them here would run a build under
+   // the user's DEFAULT role while live queries on the same connection run under
+   // the configured one — a build that fails on permissions the customer thinks
+   // they granted, or worse, one that reads under wider ones.
    const secretLines = [
       `   TYPE snowflake`,
       `   ACCOUNT '${params.account}'`,
       `   USER '${params.user}'`,
-      `   PASSWORD '${params.password}'`,
+      ...(usesKeyPair
+         ? [
+              `   AUTH_TYPE 'key_pair'`,
+              `   PRIVATE_KEY '${params.privateKey}'`,
+              ...(params.privateKeyPass
+                 ? [`   PRIVATE_KEY_PASSPHRASE '${params.privateKeyPass}'`]
+                 : []),
+           ]
+         : [`   PASSWORD '${params.password}'`]),
       ...(params.database ? [`   DATABASE '${params.database}'`] : []),
       ...(params.warehouse ? [`   WAREHOUSE '${params.warehouse}'`] : []),
+      ...(params.schema ? [`   SCHEMA '${params.schema}'`] : []),
+      ...(params.role ? [`   ROLE '${params.role}'`] : []),
    ];
    await connection.runSQL(
       `CREATE OR REPLACE SECRET ${secretName} (\n${secretLines.join(",\n")}\n);`,

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -958,12 +958,16 @@ async function federateSnowflake(
       `   TYPE snowflake`,
       `   ACCOUNT '${params.account}'`,
       `   USER '${params.user}'`,
+      // PRIVATE_KEY_PASSWORD, not the PRIVATE_KEY_PASSPHRASE the extension's docs
+      // show: the latter is carried as a backward-compatible alias onto the
+      // former, and an alias is the thing that gets retired. Both are accepted
+      // today; this is the one the extension actually consumes.
       ...(usesKeyPair
          ? [
               `   AUTH_TYPE 'key_pair'`,
               `   PRIVATE_KEY '${params.privateKey}'`,
               ...(params.privateKeyPass
-                 ? [`   PRIVATE_KEY_PASSPHRASE '${params.privateKeyPass}'`]
+                 ? [`   PRIVATE_KEY_PASSWORD '${params.privateKeyPass}'`]
                  : []),
            ]
          : [`   PASSWORD '${params.password}'`]),

--- a/packages/server/src/service/connection_federation.spec.ts
+++ b/packages/server/src/service/connection_federation.spec.ts
@@ -100,6 +100,33 @@ describe("federateSourceForPassthrough", () => {
       expect(secret).not.toContain("PASSWORD '");
    });
 
+   it("snowflake: normalizes a single-line private key, as the live path does", async () => {
+      // The shape that matters. A multi-line PEM is already valid, so a test
+      // using one passes whether or not the key is normalized. A SINGLE-LINE key
+      // is accepted by the live path (which normalizes at its own call site) and
+      // is what a user pasting from a secret store actually supplies — and left
+      // unreflowed, its header has no trailing newline, which makes Go's
+      // pem.Decode return nil and the build fail on a key that queries fine.
+      const { conn, sql } = stubbedConnection();
+      const body = "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQ".repeat(
+         3,
+      );
+      await federateSourceForPassthrough(conn, "snowflake", {
+         name: "src_sf_oneline",
+         snowflakeConnection: {
+            account: "acct",
+            username: "user",
+            privateKey: `-----BEGIN PRIVATE KEY-----${body}-----END PRIVATE KEY-----`,
+         } as components["schemas"]["SnowflakeConnection"],
+      });
+      const secret = sql.find((s) => s.includes("CREATE OR REPLACE SECRET"))!;
+      // Reflowed: a newline directly after the header rather than base64.
+      expect(secret).toContain("-----BEGIN PRIVATE KEY-----\n");
+      expect(secret).not.toContain(
+         `-----BEGIN PRIVATE KEY-----${body.slice(0, 8)}`,
+      );
+   });
+
    it("snowflake: carries ROLE and SCHEMA so a build matches the live connection", async () => {
       // Both are folded into the Malloy connection's digest, i.e. they are part
       // of what identifies the connection. Dropping them runs the build under the

--- a/packages/server/src/service/connection_federation.spec.ts
+++ b/packages/server/src/service/connection_federation.spec.ts
@@ -74,6 +74,65 @@ describe("federateSourceForPassthrough", () => {
       expect(sql.some((s) => s.includes("ATTACH"))).toBe(false);
    });
 
+   it("snowflake: federates a KEY PAIR connection", async () => {
+      // Requiring a password made every key-pair connection unbuildable into a
+      // storage destination though it queries fine live — and key-pair is where
+      // Snowflake is steering programmatic access.
+      const { conn, sql } = stubbedConnection();
+      const result = await federateSourceForPassthrough(conn, "snowflake", {
+         name: "src_sf_kp",
+         snowflakeConnection: {
+            account: "acct",
+            username: "user",
+            privateKey:
+               "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----",
+            privateKeyPass: "pass'phrase",
+            warehouse: "WH",
+         } as components["schemas"]["SnowflakeConnection"],
+      });
+      expect(result.sourceType).toBe("snowflake");
+      const secret = sql.find((s) => s.includes("CREATE OR REPLACE SECRET"));
+      expect(secret).toContain("AUTH_TYPE 'key_pair'");
+      expect(secret).toContain("PRIVATE KEY-----");
+      expect(secret).toContain("PRIVATE_KEY_PASSPHRASE 'pass''phrase'");
+      // Not even an empty one: a PASSWORD alongside the key pair is what the
+      // extension rejects.
+      expect(secret).not.toContain("PASSWORD '");
+   });
+
+   it("snowflake: carries ROLE and SCHEMA so a build matches the live connection", async () => {
+      // Both are folded into the Malloy connection's digest, i.e. they are part
+      // of what identifies the connection. Dropping them runs the build under the
+      // user's DEFAULT role while live queries use the configured one.
+      const { conn, sql } = stubbedConnection();
+      await federateSourceForPassthrough(conn, "snowflake", {
+         name: "src_sf_role",
+         snowflakeConnection: {
+            account: "acct",
+            username: "user",
+            password: "pw",
+            role: "REPORTING",
+            schema: "ANALYTICS",
+         } as components["schemas"]["SnowflakeConnection"],
+      });
+      const secret = sql.find((s) => s.includes("CREATE OR REPLACE SECRET"));
+      expect(secret).toContain("ROLE 'REPORTING'");
+      expect(secret).toContain("SCHEMA 'ANALYTICS'");
+   });
+
+   it("snowflake: refuses a connection carrying neither credential", async () => {
+      const { conn } = stubbedConnection();
+      await expect(
+         federateSourceForPassthrough(conn, "snowflake", {
+            name: "src_sf_none",
+            snowflakeConnection: {
+               account: "acct",
+               username: "user",
+            } as components["schemas"]["SnowflakeConnection"],
+         }),
+      ).rejects.toThrow(/privateKey or password is required/);
+   });
+
    it("postgres: ATTACHes READ_ONLY and returns the alias as handle", async () => {
       const { conn, sql } = stubbedConnection();
       const result = await federateSourceForPassthrough(conn, "postgres", {

--- a/packages/server/src/service/connection_federation.spec.ts
+++ b/packages/server/src/service/connection_federation.spec.ts
@@ -94,10 +94,12 @@ describe("federateSourceForPassthrough", () => {
       const secret = sql.find((s) => s.includes("CREATE OR REPLACE SECRET"));
       expect(secret).toContain("AUTH_TYPE 'key_pair'");
       expect(secret).toContain("PRIVATE KEY-----");
-      expect(secret).toContain("PRIVATE_KEY_PASSPHRASE 'pass''phrase'");
-      // Not even an empty one: a PASSWORD alongside the key pair is what the
-      // extension rejects.
-      expect(secret).not.toContain("PASSWORD '");
+      expect(secret).toContain("PRIVATE_KEY_PASSWORD 'pass''phrase'");
+      // No BARE password field — not even an empty one, which is what the
+      // extension rejects alongside a key pair. Anchored to the start of the
+      // emitted line: an unanchored "PASSWORD '" also matches inside
+      // PRIVATE_KEY_PASSWORD and would fail on a correct secret.
+      expect(secret).not.toContain("\n   PASSWORD '");
    });
 
    it("snowflake: normalizes a single-line private key, as the live path does", async () => {


### PR DESCRIPTION
A `storage=` build from a Snowflake source cannot work today, for two independent reasons. Both are fixed here, because fixing either alone leaves it broken.

## 1. The image ships without the ADBC Snowflake driver

The Snowflake extension is a wrapper over the ADBC Snowflake driver, and `INSTALL snowflake FROM community` does **not** bring it — the extension ships alone, the driver is a separate artifact.

```
SELECT * FROM snowflake_query('SELECT 1', 'my_secret');
→ ADBC Snowflake driver (libadbc_driver_snowflake.so) not found
```

Reproduced on `linux/amd64` and `linux/arm64`, at DuckDB 1.5.3 (extension v0.1.0) and 1.5.5 (v0.5.2). The newer extension says it outright: *"Install the driver with scripts/install-adbc-driver.sh or `dbc install snowflake`."*

**Why nothing caught it.** Both guards are blind for the same reason: the build's own check is `SELECT snowflake_version()`, a **scalar that never touches the driver** and returns happily without it; CI's offline smoke test asserts each extension **LOADs**, which also passes. The driver is a query-time dependency. A green check that cannot fail is how this shipped.

**The fix** is a pinned, arch-resolved download into the extension directory for the pinned DuckDB version — the first path the extension searches, and the same directory the runtime reads its baked extensions from, so the driver travels with them.

Three deliberate choices:

- **Pinned direct download, not the upstream `curl … | sh`.** A build shouldn't execute a remote script it can't pin, and `ADBC_SNOWFLAKE_VERSION` is auditable the way `DUCKDB_VERSION` already is.
- **Architecture resolved, not assumed** — the image builds for both amd64 and arm64, and the driver is published per platform.
- **Its own `RUN` with no `|| echo` fallback, so a failed fetch fails the build.** While writing this I watched the neighbouring step's offline-tolerance swallow a transient 503 and produce a "successful" build with no driver — the exact bug being fixed, reproduced live. Happy to match the surrounding style if you'd rather, but I'd argue against it. I left that neighbouring step alone to keep the diff honest, though the same argument applies to it.

## 2. Key-pair connections cannot be federated

`federateSnowflake` required a `password` and emitted `PASSWORD '…'`. A connection authenticating by **key pair** — which queries fine on the live path, and which the extension supports via `AUTH_TYPE 'key_pair'` — could not be federated for a passthrough build at all. That is the case that matters rather than an exotic one, given where Snowflake is steering programmatic access.

Now: key pair *or* password, with `PRIVATE_KEY_PASSPHRASE` when supplied.

**`ROLE` and `SCHEMA` travel with it too.** Both are folded into the Malloy connection's digest, i.e. they are part of what identifies the connection. Dropping them ran a build under the user's **default** role while live queries on the same connection used the configured one — a build that fails on permissions the customer believes they granted, or reads under wider ones.

## Verification

Built the image from this branch and ran, inside it, **the secret `federateSourceForPassthrough` itself emits** for a real key-pair connection (generated by calling the function, not hand-copied):

```
SERVER   | ROLE         | WH
10.28.101| ACCOUNTADMIN | COMPUTE_WH
```

`ACCOUNTADMIN` is the *configured* role, which is the ROLE carry working. Before the change, the same query in the same image: `ADBC Snowflake driver … not found`; and before the federation change, a key-pair connection never got that far — it threw `Snowflake password is required`.

Also confirmed: both release assets exist and download (`snowflake_linux_{amd64,arm64}_v1.12.0.tar.gz`); the extension accepts `PRIVATE_KEY_PASSPHRASE`, `ROLE` and `SCHEMA` alongside `AUTH_TYPE 'key_pair'`; and each new test fails with its fix reverted.

Suites: `src/service` + `src/controller` 1611 pass / 0 fail.
