### PR TITLE
docs: stamp the three unreleased notes sections as 0.0.242

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,7 +42,7 @@ A `#@ persist` source can now be materialized into a **storage destination** —
 - **Multi-replica serving via the manifest.** A `storage=` source can be served across a fleet by carrying its serve binding in the same manifest the publisher already fetches from a package's `manifestLocation`: a manifest entry that names a `storageDestinationName` (with the captured `schema` and `sourceName`) binds as a cross-connection serve binding applied to the already-compiled models (no recompile); entries without it remain same-connection `tableName` substitutions (which do recompile). A refresh is the usual manifest-rebind — rewrite the manifest and re-`PATCH` `manifestLocation` — and a storage-only refresh costs no recompile. Entries are keyed by the build's content `sourceEntityId` (= the serve handle), so a freshness refresh keeps the handle and only swaps the table path, while a schema-changing generation gets a new handle. Standalone (no `manifestLocation`), serve bindings are still re-derived per-replica from the local materialization store on package load; run that single-replica. When a `manifestLocation` is set the host is authoritative and the local-store rebind is skipped, so the two binding sources never fight.
 - **Roll back cleanly.** Deleting a package's materializations before rolling back to a publisher version without this tier avoids a wedge: an older build reuses/binds a persisted `storage=` manifest entry as a same-connection table it can't resolve. Building with `storage=` only ever affects deployments that turned the mode on.
 
-## [Unreleased]: one meaning for `givens` across the API
+## [0.0.242]: one meaning for `givens` across the API
 
 `givens` had come to mean four different things: declarations, typed values, string-encoded values, and a bare list of names. It now always means a collection of `Given` declarations, and the other three have names of their own. Renames and spec corrections only; no endpoint changes what it does.
 
@@ -61,7 +61,7 @@ A `#@ persist` source can now be materialized into a **storage destination** —
 - `RawNotebook.path` becomes `RawNotebook.modelPath`. `path` was declared but never populated, so anything reading it was already getting `undefined`; `modelPath` is the value it wanted.
 - A caller that treated a `versionId` request's 500 as a server fault should expect 501.
 
-## [Unreleased] — `PageViewer` is now `DataAppViewer`
+## [0.0.242] — `PageViewer` is now `DataAppViewer`
 
 The SDK component that embeds an in-package HTML data app is renamed, along with the docs page for the built-in web UI. No behavior changes.
 
@@ -78,7 +78,7 @@ The SDK component that embeds an in-package HTML data app is renamed, along with
 
 The REST `/pages` endpoint is untouched by this change and still answers at its existing path. Renaming it to `/data-apps` is a separate, breaking change with its own release note.
 
-## [Unreleased] — Breaking: `/pages` is now `/data-apps`
+## [0.0.242] — Breaking: `/pages` is now `/data-apps`
 
 The endpoint that lists a package's in-package HTML data apps is renamed, along with its schema and the SPA route that opens one. **There is no alias and no deprecation period: a caller still requesting `/pages` stops getting the listing.**
 


### PR DESCRIPTION
### What it does

Stamps the three `[Unreleased]` sections in RELEASE_NOTES.md as `[0.0.242]`. They're on the v0.0.242 release page now, so the file should say so. Header lines only — no prose changed.

### Tested

Docs only, nothing to run. Rendered diff is three header lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)