### PR TITLE
feat(server): tag a storage= build's warehouse read, and report what it cost

### DIFF
--- a/.github/workflows/connection-integration-tests.yml
+++ b/.github/workflows/connection-integration-tests.yml
@@ -6,12 +6,20 @@ on:
     paths:
       - "packages/server/src/service/connection.ts"
       - "packages/server/src/service/connection.spec.ts"
+      - "packages/server/src/service/materialization_build_session.ts"
+      - "packages/server/src/service/build_read_cost.ts"
+      - "packages/server/src/service/build_query_tag.ts"
+      - "packages/server/src/service/storage_build_bigquery.integration.spec.ts"
       - ".github/workflows/connection-integration-tests.yml"
   pull_request:
     branches: [main]
     paths:
       - "packages/server/src/service/connection.ts"
       - "packages/server/src/service/connection.spec.ts"
+      - "packages/server/src/service/materialization_build_session.ts"
+      - "packages/server/src/service/build_read_cost.ts"
+      - "packages/server/src/service/build_query_tag.ts"
+      - "packages/server/src/service/storage_build_bigquery.integration.spec.ts"
       - ".github/workflows/connection-integration-tests.yml"
   workflow_dispatch:
 
@@ -127,4 +135,19 @@ jobs:
         run: |
           cd packages/server
           bun test --timeout 100000 src/service/connection.spec.ts
+
+      # The storage= build's warehouse read reaches BigQuery job records the unit
+      # suite cannot: bigquery_execute's returned job id, the child job a
+      # parentJobId listing finds, and the anonymous result table it names. Those
+      # tests drive it through a session that returns the expected shape, so if
+      # any of that moves they all still pass and every real build breaks.
+      #
+      # Uses the public-data SA and a plain local DuckDB destination — no DuckLake
+      # catalog, no Postgres, no object storage. That SA needs
+      # bigquery.readsessions.create: the passthrough streams results over the
+      # Storage Read API on every path, tagged or not.
+      - name: Run storage= build integration tests
+        run: |
+          cd packages/server
+          bun test --timeout 100000 src/service/storage_build_bigquery.integration.spec.ts
 

--- a/.github/workflows/connection-integration-tests.yml
+++ b/.github/workflows/connection-integration-tests.yml
@@ -6,20 +6,12 @@ on:
     paths:
       - "packages/server/src/service/connection.ts"
       - "packages/server/src/service/connection.spec.ts"
-      - "packages/server/src/service/materialization_build_session.ts"
-      - "packages/server/src/service/build_read_cost.ts"
-      - "packages/server/src/service/build_query_tag.ts"
-      - "packages/server/src/service/storage_build_bigquery.integration.spec.ts"
       - ".github/workflows/connection-integration-tests.yml"
   pull_request:
     branches: [main]
     paths:
       - "packages/server/src/service/connection.ts"
       - "packages/server/src/service/connection.spec.ts"
-      - "packages/server/src/service/materialization_build_session.ts"
-      - "packages/server/src/service/build_read_cost.ts"
-      - "packages/server/src/service/build_query_tag.ts"
-      - "packages/server/src/service/storage_build_bigquery.integration.spec.ts"
       - ".github/workflows/connection-integration-tests.yml"
   workflow_dispatch:
 
@@ -136,17 +128,3 @@ jobs:
           cd packages/server
           bun test --timeout 100000 src/service/connection.spec.ts
 
-      # The storage= build's warehouse read reaches BigQuery job records —
-      # bigquery_execute's returned job id, the child job a parentJobId listing
-      # finds, and the anonymous result table it names. The unit suite drives that
-      # through a hand-rolled session that returns the expected shape, so it
-      # proves the logic and nothing about the surface: if any of those move,
-      # every unit test still passes and every real build breaks.
-      #
-      # Uses the public-data SA and a plain local DuckDB destination, so it needs
-      # no DuckLake catalog, no Postgres and no object storage. Skips itself when
-      # the credentials are absent, the same way connection.spec.ts does.
-      - name: Run storage= build integration tests
-        run: |
-          cd packages/server
-          bun test --timeout 100000 src/service/storage_build_bigquery.integration.spec.ts

--- a/.github/workflows/connection-integration-tests.yml
+++ b/.github/workflows/connection-integration-tests.yml
@@ -6,12 +6,20 @@ on:
     paths:
       - "packages/server/src/service/connection.ts"
       - "packages/server/src/service/connection.spec.ts"
+      - "packages/server/src/service/materialization_build_session.ts"
+      - "packages/server/src/service/build_read_cost.ts"
+      - "packages/server/src/service/build_query_tag.ts"
+      - "packages/server/src/service/storage_build_bigquery.integration.spec.ts"
       - ".github/workflows/connection-integration-tests.yml"
   pull_request:
     branches: [main]
     paths:
       - "packages/server/src/service/connection.ts"
       - "packages/server/src/service/connection.spec.ts"
+      - "packages/server/src/service/materialization_build_session.ts"
+      - "packages/server/src/service/build_read_cost.ts"
+      - "packages/server/src/service/build_query_tag.ts"
+      - "packages/server/src/service/storage_build_bigquery.integration.spec.ts"
       - ".github/workflows/connection-integration-tests.yml"
   workflow_dispatch:
 
@@ -127,3 +135,18 @@ jobs:
         run: |
           cd packages/server
           bun test --timeout 100000 src/service/connection.spec.ts
+
+      # The storage= build's warehouse read reaches BigQuery job records —
+      # bigquery_execute's returned job id, the child job a parentJobId listing
+      # finds, and the anonymous result table it names. The unit suite drives that
+      # through a hand-rolled session that returns the expected shape, so it
+      # proves the logic and nothing about the surface: if any of those move,
+      # every unit test still passes and every real build breaks.
+      #
+      # Uses the public-data SA and a plain local DuckDB destination, so it needs
+      # no DuckLake catalog, no Postgres and no object storage. Skips itself when
+      # the credentials are absent, the same way connection.spec.ts does.
+      - name: Run storage= build integration tests
+        run: |
+          cd packages/server
+          bun test --timeout 100000 src/service/storage_build_bigquery.integration.spec.ts

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -5183,17 +5183,25 @@ components:
             reads, so a field carrying one on some paths and the other elsewhere
             would be unsummable across a package's sources.
 
-            **Null is not zero**, and today it is null on more paths than not.
-            Only a COLOCATED build reports a figure, taken from the Malloy
-            connection's own statistics. An incremental delta reports null
-            because its statements do not run through a single call whose result
-            reaches here. A chained `storage=` build reports null because it read
-            its parent's already-materialized table and touched no warehouse at
-            all. A plain `storage=` build reports null because its read goes
-            through DuckDB's query-passthrough, where no Malloy connector is in
-            the call path to report statistics — recovering the figure means
-            reading it back from the warehouse's own accounting, which requires a
-            job identifier the passthrough does not return.
+            **Null is not zero**, and which paths report a figure differs.
+
+            A COLOCATED build reports one, taken from the Malloy connection's own
+            statistics.
+
+            A plain `storage=` build reports one when its warehouse read carried
+            query metadata, and null otherwise. That read goes through DuckDB's
+            query-passthrough rather than a Malloy connector, so the figure is
+            read back from the warehouse's own accounting afterwards — which needs
+            an identifier for the job, and obtaining one is part of how a TAGGED
+            read is issued. An untagged read is issued the older way, which yields
+            no such identifier, and reports null. A read whose connection cannot
+            reach its own job records also reports null; that case is counted by
+            `publisher_storage_build_attribution_skipped_total`.
+
+            An incremental delta reports null because its statements do not run
+            through a single call whose result reaches here. A chained `storage=`
+            build reports null because it read its parent's already-materialized
+            table and touched no warehouse at all.
         dataAsOf:
           type: string
           format: date-time

--- a/packages/server/src/materialization_metrics.ts
+++ b/packages/server/src/materialization_metrics.ts
@@ -152,6 +152,14 @@ const storageBuildFailureCounter = lazyCounter(
    "storage= build failures (federation/passthrough/attach/CTAS), distinct from " +
       "in-warehouse build failures. Label: destination (connection name).",
 );
+const attributionSkippedCounter = lazyCounter(
+   "publisher_storage_build_attribution_skipped_total",
+   "storage= builds whose warehouse read went out UNATTRIBUTED while tagging was " +
+      "on. Label: reason ('job_listing_unavailable'). The read still ran and the " +
+      "build still succeeded — what was lost is the label in the customer's own " +
+      "query history, and the cost on this side. Without this an operator who " +
+      "turns tagging on and sees nothing has a single log line to go on.",
+);
 const eligibilityRefusedCounter = lazyCounter(
    "publisher_materialization_eligibility_refused_total",
    "storage= materialization-eligibility refusals. Label: reason " +
@@ -299,6 +307,17 @@ export function recordDropTables(
  */
 export function recordStorageBuildFailure(destination: string): void {
    storageBuildFailureCounter().add(1, { destination });
+}
+
+/**
+ * Record a build that ran its warehouse read WITHOUT attribution, despite tagging
+ * being on. Not a failure — the build succeeded and the rows are correct — which
+ * is exactly why it needs a counter: nothing else about the run looks wrong.
+ */
+export function recordAttributionSkipped(
+   reason: "job_listing_unavailable",
+): void {
+   attributionSkippedCounter().add(1, { reason });
 }
 
 /**

--- a/packages/server/src/service/build_query_tag.spec.ts
+++ b/packages/server/src/service/build_query_tag.spec.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+   bigQueryQueryLabelValue,
+   snowflakeQueryTagValue,
+   snowflakeSetQueryTagSQL,
+} from "./build_query_tag";
+
+describe("snowflakeQueryTagValue", () => {
+   it("renders the bag as JSON so the properties stay queryable", () => {
+      expect(
+         snowflakeQueryTagValue({ team: "finance", cred_org: "acme" }),
+      ).toBe('{"team":"finance","cred_org":"acme"}');
+   });
+
+   it("preserves case", () => {
+      // QUERY_HISTORY is read by humans and by joins against other systems'
+      // identifiers; folding case here would silently rename both.
+      expect(snowflakeQueryTagValue({ Team: "Finance" })).toBe(
+         '{"Team":"Finance"}',
+      );
+   });
+
+   it("has no tag for an empty or absent bag", () => {
+      expect(snowflakeQueryTagValue({})).toBeUndefined();
+      expect(snowflakeQueryTagValue(undefined)).toBeUndefined();
+   });
+
+   it("drops an over-long tag rather than truncating it into invalid JSON", () => {
+      // Truncated JSON is unparseable, and a consumer cannot tell that from a
+      // bug. Absent reads as absent.
+      const huge = { k: "x".repeat(2100) };
+      expect(snowflakeQueryTagValue(huge)).toBeUndefined();
+   });
+});
+
+describe("snowflakeSetQueryTagSQL", () => {
+   it("tags the session, through the passthrough, carrying the secret", () => {
+      const sql = snowflakeSetQueryTagSQL({ team: "finance" }, "sf_secret");
+      expect(sql).toStartWith("SELECT * FROM snowflake_query(");
+      expect(sql).toContain("ALTER SESSION SET QUERY_TAG");
+      expect(sql).toContain("'sf_secret'");
+   });
+
+   it("emits nothing when there is nothing to tag", () => {
+      expect(snowflakeSetQueryTagSQL({}, "s")).toBeUndefined();
+      expect(snowflakeSetQueryTagSQL(undefined, "s")).toBeUndefined();
+   });
+
+   it("escapes a backslash for BOTH nesting levels, so the stored tag still parses", () => {
+      // The failure this pins is silent and not a syntax error. A property value
+      // may contain a backslash (the contract admits printable ASCII except `"`),
+      // JSON renders it `\\`, and Snowflake treats backslash as an escape inside
+      // a single-quoted literal. Doubling quotes only would deliver `\` where the
+      // JSON needed `\\`: the statement succeeds, and the tag it stores is
+      // unparseable in QUERY_HISTORY.
+      const sql = snowflakeSetQueryTagSQL({ path: "c:\\src" }, "s")!;
+
+      // Recover the Snowflake-level statement, then what Snowflake reads from it.
+      const snowflakeSees = unwrapDuckDBLiteral(sql);
+      const tag = snowflakeReadsLiteral(
+         snowflakeSees.slice(snowflakeSees.indexOf("'")),
+      );
+
+      expect(JSON.parse(tag)).toEqual({ path: "c:\\src" });
+   });
+
+   it("escapes a quote in a value without terminating the literal early", () => {
+      const sql = snowflakeSetQueryTagSQL({ team: "o'brien" }, "s")!;
+      const snowflakeSees = unwrapDuckDBLiteral(sql);
+      const tag = snowflakeReadsLiteral(
+         snowflakeSees.slice(snowflakeSees.indexOf("'")),
+      );
+      expect(JSON.parse(tag)).toEqual({ team: "o'brien" });
+   });
+});
+
+describe("bigQueryQueryLabelValue", () => {
+   it("renders key:value pairs joined by commas", () => {
+      expect(
+         bigQueryQueryLabelValue({ cred_run: "abc", cred_class: "ops" }),
+      ).toBe("cred_run:abc,cred_class:ops");
+   });
+
+   it("lowercases and substitutes anything outside BigQuery's grammar", () => {
+      expect(bigQueryQueryLabelValue({ Team: "Acme Corp" })).toBe(
+         "team:acme_corp",
+      );
+   });
+
+   it("removes the separators a value could otherwise inject", () => {
+      // `,` and `:` are outside [a-z0-9_-], so the join cannot be confused by a
+      // property value. This is what makes the joined form safe by construction
+      // rather than by the caller being careful.
+      expect(bigQueryQueryLabelValue({ k: "a,b:c" })).toBe("k:a_b_c");
+   });
+
+   it("removes quote and backslash, so the value cannot disturb its SQL literal", () => {
+      expect(bigQueryQueryLabelValue({ k: "o'brien\\x" })).toBe("k:o_brien_x");
+   });
+
+   it("drops a key that cannot start with a lowercase letter", () => {
+      // BigQuery rejects it outright, so sending it would fail the whole job.
+      expect(bigQueryQueryLabelValue({ "1st": "x", ok: "y" })).toBe("ok:y");
+   });
+
+   it("has no label when every key was dropped, rather than an empty string", () => {
+      expect(bigQueryQueryLabelValue({ "1st": "x" })).toBeUndefined();
+      expect(bigQueryQueryLabelValue({})).toBeUndefined();
+      expect(bigQueryQueryLabelValue(undefined)).toBeUndefined();
+   });
+
+   it("truncates to BigQuery's 63-character ceiling", () => {
+      expect(bigQueryQueryLabelValue({ k: "x".repeat(80) })).toBe(
+         `k:${"x".repeat(63)}`,
+      );
+   });
+});
+
+/** Undo one DuckDB string literal (quote-doubling only — no backslash escape). */
+function unwrapDuckDBLiteral(sql: string): string {
+   const start = sql.indexOf("'");
+   const body = sql.slice(start + 1);
+   return body.slice(0, body.lastIndexOf("', '")).replace(/''/g, "'");
+}
+
+/** What Snowflake reads from a single-quoted literal: `''` -> `'`, `\X` -> `X`. */
+function snowflakeReadsLiteral(literal: string): string {
+   let out = "";
+   let i = 1;
+   while (i < literal.length) {
+      if (literal[i] === "\\") {
+         out += literal[i + 1];
+         i += 2;
+         continue;
+      }
+      if (literal[i] === "'" && literal[i + 1] === "'") {
+         out += "'";
+         i += 2;
+         continue;
+      }
+      if (literal[i] === "'") return out;
+      out += literal[i++];
+   }
+   return out;
+}

--- a/packages/server/src/service/build_query_tag.spec.ts
+++ b/packages/server/src/service/build_query_tag.spec.ts
@@ -99,6 +99,15 @@ describe("bigQueryQueryLabelValue", () => {
       expect(bigQueryQueryLabelValue({ k: "o'brien\\x" })).toBe("k:o_brien_x");
    });
 
+   it("dedupes keys that collide once sanitized, rather than failing the build", () => {
+      // Property names are validated case-PRESERVING, so `Team` and `team` are
+      // two legal properties that both render as `team`. BigQuery refuses a label
+      // list with a duplicate key outright — verified against a live project:
+      // "Invalid query label list 'team:a,team:b'. Duplicate..." — which fails the
+      // script and kills the build. Last wins.
+      expect(bigQueryQueryLabelValue({ Team: "a", team: "b" })).toBe("team:b");
+   });
+
    it("drops a key that cannot start with a lowercase letter", () => {
       // BigQuery rejects it outright, so sending it would fail the whole job.
       expect(bigQueryQueryLabelValue({ "1st": "x", ok: "y" })).toBe("ok:y");

--- a/packages/server/src/service/build_query_tag.ts
+++ b/packages/server/src/service/build_query_tag.ts
@@ -113,11 +113,18 @@ export function bigQueryQueryLabelValue(
    metadata: QueryMetadata | undefined,
 ): string | undefined {
    if (metadata === undefined) return undefined;
-   const pairs: string[] = [];
+   // Keyed rather than appended, because sanitizing can collide two properties
+   // onto one label key and BigQuery REFUSES a list containing a duplicate: the
+   // statement errors, the script fails, and the build dies. The bag admits that
+   // collision legally — property names are validated case-PRESERVING, so `Team`
+   // and `team` are two properties that both render as `team`. Last wins, which
+   // is the shape every other drop in this rendering already takes.
+   const rendered = new Map<string, string>();
    for (const [key, value] of Object.entries(metadata)) {
       const sanitizedKey = sanitizeBigQueryKey(key);
       if (sanitizedKey === undefined) continue;
-      pairs.push(`${sanitizedKey}:${sanitizeBigQueryValue(value)}`);
+      rendered.set(sanitizedKey, sanitizeBigQueryValue(value));
    }
-   return pairs.length > 0 ? pairs.join(",") : undefined;
+   if (rendered.size === 0) return undefined;
+   return [...rendered].map(([key, value]) => `${key}:${value}`).join(",");
 }

--- a/packages/server/src/service/build_query_tag.ts
+++ b/packages/server/src/service/build_query_tag.ts
@@ -1,0 +1,123 @@
+import { sqlLiteral } from "./db_utils";
+import type { QueryMetadata } from "./query_metadata";
+
+/**
+ * Render a build's query-metadata bag into each warehouse's own tagging grammar,
+ * for the `storage=` build path.
+ *
+ * The Malloy connectors render this bag for every query they issue, but a
+ * `storage=` build reads through DuckDB's native query-passthrough, so no
+ * connector is in the call path. These functions are the passthrough's
+ * equivalent, deliberately matching what the connectors emit so one deployment's
+ * query history reads the same whichever path produced the statement.
+ *
+ * Neither connector exports its renderer — `@malloydata/db-snowflake` exports
+ * `SnowflakeConnection` and `buildPoolOptions`, `@malloydata/db-bigquery` exports
+ * `BigQueryConnection` — and reaching into either package's `dist/` is not a
+ * dependency this repo takes anywhere else. So the grammars are reimplemented
+ * here, and pinned by tests that state the grammar rather than compare against
+ * an import that cannot be made.
+ *
+ * Pinned to @malloydata/malloy 0.0.427.
+ */
+
+/**
+ * Snowflake's `QUERY_TAG` ceiling. The bag arrives already bounded to this on
+ * its serialized size ({@link ./query_metadata}'s own budget, which sheds whole
+ * properties to fit), so this is a backstop rather than a working limit.
+ */
+const MAX_QUERY_TAG_LENGTH = 2000;
+
+/** BigQuery label keys and values are at most 63 characters. */
+const BQ_MAX_LEN = 63;
+
+/**
+ * The bag as a Snowflake `QUERY_TAG` value: JSON, so the properties stay
+ * queryable in `QUERY_HISTORY` / `QUERY_ATTRIBUTION_HISTORY` rather than
+ * arriving as one opaque string. Case is preserved.
+ *
+ * Undefined for an empty bag, and undefined rather than TRUNCATED for an
+ * over-long one: slicing JSON produces a tag that no consumer can parse, which
+ * is indistinguishable from a bug at the point someone tries to read it. An
+ * absent tag at least reads as absent. (db-snowflake slices; it can afford to,
+ * because the bag it receives was bounded upstream by the same budget that
+ * bounds this one.)
+ */
+export function snowflakeQueryTagValue(
+   metadata: QueryMetadata | undefined,
+): string | undefined {
+   if (metadata === undefined || Object.keys(metadata).length === 0) {
+      return undefined;
+   }
+   const tag = JSON.stringify(metadata);
+   return tag.length > MAX_QUERY_TAG_LENGTH ? undefined : tag;
+}
+
+/**
+ * The statement that tags every subsequent read on this build's Snowflake
+ * session, or undefined when there is nothing to tag.
+ *
+ * Session-scoped rather than per-statement because the passthrough exposes no
+ * per-call parameter map: `snowflake_query()` takes SQL and a secret and nothing
+ * else. The passthrough reuses ONE session across calls, which is what makes a
+ * session-level tag reach the build's read at all.
+ *
+ * <b>Escaped with {@link sqlLiteral} for the snowflake dialect, not by doubling
+ * quotes.</b> A property value may contain a backslash — the contract admits
+ * printable ASCII except `"` — and JSON renders one as `\\`. Snowflake treats
+ * backslash as an escape inside a single-quoted literal, so quote-doubling alone
+ * delivers `\` where the JSON needed `\\`, and the stored tag no longer parses:
+ * unqueryable in `QUERY_HISTORY`, which is the entire purpose of tagging, and
+ * silent because the statement itself succeeds.
+ */
+export function snowflakeSetQueryTagSQL(
+   metadata: QueryMetadata | undefined,
+   secretName: string,
+): string | undefined {
+   const tag = snowflakeQueryTagValue(metadata);
+   if (tag === undefined) return undefined;
+   const inner = `ALTER SESSION SET QUERY_TAG = '${sqlLiteral(tag, "snowflake")}'`;
+   // The outer literal is parsed by DuckDB, which has no backslash escape, so
+   // the passthrough's own quote-doubling is the correct level here.
+   return `SELECT * FROM snowflake_query('${inner.replace(/'/g, "''")}', '${secretName.replace(/'/g, "''")}')`;
+}
+
+/** BigQuery's label grammar: lowercase, `[a-z0-9_-]`, at most 63 characters. */
+function sanitizeBigQueryValue(value: string): string {
+   return value
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]/g, "_")
+      .slice(0, BQ_MAX_LEN);
+}
+
+/** A key that cannot be made to start with a lowercase letter is dropped. */
+function sanitizeBigQueryKey(key: string): string | undefined {
+   const sanitized = sanitizeBigQueryValue(key);
+   return /^[a-z]/.test(sanitized) ? sanitized : undefined;
+}
+
+/**
+ * The bag as a value for BigQuery's `@@query_label` system variable:
+ * `key:value` pairs joined by commas, which is the form that variable takes.
+ * The job's `configuration.labels` then carries them as a map.
+ *
+ * The separators need no escaping, which is a property of the grammar rather
+ * than luck: `,` and `:` are both outside `[a-z0-9_-]`, so sanitizing every key
+ * and value removes any that a property could have contributed. The same
+ * substitution removes `'` and `\`, so this value cannot disturb the SQL literal
+ * it is embedded in either.
+ *
+ * Undefined when the bag is empty, or when every key was dropped as unusable.
+ */
+export function bigQueryQueryLabelValue(
+   metadata: QueryMetadata | undefined,
+): string | undefined {
+   if (metadata === undefined) return undefined;
+   const pairs: string[] = [];
+   for (const [key, value] of Object.entries(metadata)) {
+      const sanitizedKey = sanitizeBigQueryKey(key);
+      if (sanitizedKey === undefined) continue;
+      pairs.push(`${sanitizedKey}:${sanitizeBigQueryValue(value)}`);
+   }
+   return pairs.length > 0 ? pairs.join(",") : undefined;
+}

--- a/packages/server/src/service/build_read_cost.spec.ts
+++ b/packages/server/src/service/build_read_cost.spec.ts
@@ -90,6 +90,21 @@ describe("snowflakeCostSQL", () => {
       );
    });
 
+   it("takes the fallback for a name Snowflake would reject unquoted", () => {
+      // An unquoted Snowflake identifier must START with a letter or underscore,
+      // so a leading digit or `$` is exactly the quote-needing name the fallback
+      // exists for — emitted bare it would fail to compile.
+      for (const rejected of ["1db", "$db", "9"]) {
+         expect(snowflakeCostSQL("{}", rejected)).toContain(
+            "FROM TABLE(SNOWFLAKE.INFORMATION_SCHEMA",
+         );
+      }
+      // A leading underscore is legal, and is not pushed to the fallback.
+      expect(snowflakeCostSQL("{}", "_db")).toContain(
+         "FROM TABLE(_db.INFORMATION_SCHEMA",
+      );
+   });
+
    it("takes the fallback rather than interpolating a name that needs quoting", () => {
       // A correct answer rather than a degraded one — the fallback returns the
       // same rows — and it keeps a configured value out of identifier position.

--- a/packages/server/src/service/build_read_cost.spec.ts
+++ b/packages/server/src/service/build_read_cost.spec.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+   bigQueryReadCost,
+   pickSnowflakeReadRow,
+   snowflakeCostSQL,
+   snowflakeReadCost,
+} from "./build_read_cost";
+
+describe("bigQueryReadCost", () => {
+   it("keeps billed and scanned as separate numbers", () => {
+      // BigQuery rounds up to a 10MB floor, so a small read bills an order of
+      // magnitude above what it scanned. Measured live: 5,114,816 -> 10,485,760.
+      const cost = bigQueryReadCost(
+         {
+            bytes_processed: "5114816",
+            bytes_billed: "10485760",
+            total_slot_time_ms: 26,
+            cache_hit: "false",
+         },
+         "script_job_x_0",
+         "job_parent",
+      );
+      expect(cost.bytesScanned).toBe(5114816);
+      expect(cost.bytesBilled).toBe(10485760);
+      expect(cost.cacheHit).toBe(false);
+   });
+
+   it("carries the parent, which is the id the child can be found BY", () => {
+      const cost = bigQueryReadCost({}, "child", "parent");
+      expect(cost.jobId).toBe("child");
+      expect(cost.parentJobId).toBe("parent");
+   });
+});
+
+describe("snowflakeCostSQL", () => {
+   it("scopes by tag rather than by LAST_QUERY_ID", () => {
+      // The session is not exclusively the build's: the ADBC driver issues its own
+      // connection probes, and measured live LAST_QUERY_ID() after a build-shaped
+      // read returned a probe rather than the read.
+      const sql = snowflakeCostSQL('{"cred_run":"r1"}');
+      expect(sql).toContain("QUERY_TAG =");
+      expect(sql).not.toContain("LAST_QUERY_ID");
+   });
+
+   it("excludes its own shape, which carries the same tag", () => {
+      expect(snowflakeCostSQL("{}")).toContain(
+         "QUERY_TEXT NOT LIKE '%INFORMATION_SCHEMA.QUERY_HISTORY%'",
+      );
+   });
+
+   it("escapes a backslash in the tag, or it matches NOTHING", () => {
+      // The tag is JSON, so a value containing a backslash arrives doubled.
+      // Snowflake consumes one as an escape, so quote-doubling alone compares
+      // against a string that cannot equal the stored tag — measured live, it
+      // matched zero rows and reported no cost rather than an error.
+      const tag = JSON.stringify({ cred_org: "o'brien\\co" });
+      const sql = snowflakeCostSQL(tag);
+      // Computed rather than hand-written: the levels are exactly what is easy to
+      // get wrong, so spelling them out in a literal would test the spelling.
+      const snowflakeEscaped = tag.replace(/\\/g, "\\\\").replace(/'/g, "''");
+      expect(sql).toContain(`QUERY_TAG = '${snowflakeEscaped}'`);
+      // And specifically NOT the quote-only form, which matched zero rows live.
+      expect(sql).not.toContain(`QUERY_TAG = '${tag.replace(/'/g, "''")}'`);
+   });
+
+   it("reads the low-latency history view, not the lagging one", () => {
+      // ACCOUNT_USAGE lags by up to three hours, so it cannot answer a question
+      // asked immediately after a build.
+      const sql = snowflakeCostSQL("{}");
+      expect(sql).toContain("INFORMATION_SCHEMA.QUERY_HISTORY");
+      expect(sql).not.toContain("ACCOUNT_USAGE");
+   });
+});
+
+describe("pickSnowflakeReadRow", () => {
+   const read = {
+      query_text: "SELECT a FROM t",
+      rows_produced: 4321,
+      bytes_scanned: 900,
+   };
+   const probe = { query_text: "SELECT 1", rows_produced: 0, bytes_scanned: 0 };
+
+   it("picks the build's read out of the driver's probes", () => {
+      // Measured live: one build-shaped read left the read plus two `SELECT 1`
+      // connection probes under the same tag.
+      expect(
+         pickSnowflakeReadRow([probe, read, probe], "SELECT a FROM t"),
+      ).toBe(read);
+   });
+
+   it("tolerates surrounding whitespace on either side", () => {
+      expect(
+         pickSnowflakeReadRow([{ query_text: " SELECT a " }], "SELECT a"),
+      ).toEqual({ query_text: " SELECT a " });
+   });
+
+   it("reports nothing when the read is not among them", () => {
+      expect(
+         pickSnowflakeReadRow([probe, probe], "SELECT a FROM t"),
+      ).toBeNull();
+   });
+
+   it("reports nothing rather than guessing between duplicates", () => {
+      expect(
+         pickSnowflakeReadRow([read, { ...read }], "SELECT a FROM t"),
+      ).toBeNull();
+   });
+
+   it("reads a row whose columns came back UPPERCASE", () => {
+      // What Snowflake returns if the quoted aliases are ever lost.
+      expect(
+         pickSnowflakeReadRow([{ QUERY_TEXT: "SELECT a" }], "SELECT a"),
+      ).toEqual({ QUERY_TEXT: "SELECT a" });
+   });
+});
+
+describe("snowflakeReadCost", () => {
+   it("reports scanned bytes and execution time, and no billed or slot figure", () => {
+      // Snowflake bills warehouse-seconds, so there is no per-query billed
+      // quantity, and EXECUTION_TIME is wall clock — a different thing from
+      // BigQuery's aggregate slot time. Neither is invented.
+      const cost = snowflakeReadCost({
+         job_id: "01b2-c3",
+         bytes_scanned: 4_500_000,
+         execution_time_ms: 812,
+         rows_produced: 66,
+      });
+      expect(cost).toEqual({
+         engine: "snowflake",
+         jobId: "01b2-c3",
+         parentJobId: null,
+         bytesScanned: 4_500_000,
+         bytesBilled: null,
+         slotTimeMs: null,
+         executionTimeMs: 812,
+         cacheHit: false,
+      });
+   });
+
+   it("leaves cacheHit null rather than false when an input is missing", () => {
+      const cost = snowflakeReadCost({
+         job_id: "q",
+         bytes_scanned: null,
+         rows_produced: 66,
+      });
+      expect(cost.cacheHit).toBeNull();
+   });
+
+   it("over-reports a cache hit for anything that produces rows without scanning", () => {
+      // Documented rather than fixed: measured live, a GENERATOR returning 50,000
+      // rows reports BYTES_SCANNED 0 and is indistinguishable from a cached read.
+      // A build's read scans real tables, so the shape barely arises there.
+      const cost = snowflakeReadCost({
+         job_id: "q",
+         bytes_scanned: 0,
+         rows_produced: 50_000,
+      });
+      expect(cost.cacheHit).toBe(true);
+   });
+});

--- a/packages/server/src/service/build_read_cost.spec.ts
+++ b/packages/server/src/service/build_read_cost.spec.ts
@@ -64,6 +64,40 @@ describe("snowflakeCostSQL", () => {
       expect(sql).not.toContain(`QUERY_TAG = '${tag.replace(/'/g, "''")}'`);
    });
 
+   it("resolves INFORMATION_SCHEMA against the connection's own database", () => {
+      expect(snowflakeCostSQL("{}", "MYDB")).toContain(
+         "FROM TABLE(MYDB.INFORMATION_SCHEMA.QUERY_HISTORY_BY_SESSION(",
+      );
+   });
+
+   it("emits that database BARE, so it resolves the way the session did", () => {
+      // Quoting would make it case-EXACT, while the connection parameter that put
+      // the session on this database resolves case-insensitively. Verified live: a
+      // connection configured with a lower-cased name qualifies and returns the
+      // read; quoted, it would name a database that does not exist.
+      const sql = snowflakeCostSQL("{}", "mydb");
+      expect(sql).toContain("FROM TABLE(mydb.INFORMATION_SCHEMA");
+      expect(sql).not.toContain('"mydb"');
+   });
+
+   it("falls back to the shared database when the connection has none", () => {
+      // Snowflake supports a database-less connection, and INFORMATION_SCHEMA is
+      // per-database: unqualified, it resolves against a current database that
+      // such a session does not have. Verified live — the unqualified form raises
+      // 002004 (42601) there, and SNOWFLAKE.INFORMATION_SCHEMA answers normally.
+      expect(snowflakeCostSQL("{}", undefined)).toContain(
+         "FROM TABLE(SNOWFLAKE.INFORMATION_SCHEMA",
+      );
+   });
+
+   it("takes the fallback rather than interpolating a name that needs quoting", () => {
+      // A correct answer rather than a degraded one — the fallback returns the
+      // same rows — and it keeps a configured value out of identifier position.
+      expect(snowflakeCostSQL("{}", 'we"ird db')).toContain(
+         "FROM TABLE(SNOWFLAKE.INFORMATION_SCHEMA",
+      );
+   });
+
    it("reads the low-latency history view, not the lagging one", () => {
       // ACCOUNT_USAGE lags by up to three hours, so it cannot answer a question
       // asked immediately after a build.

--- a/packages/server/src/service/build_read_cost.ts
+++ b/packages/server/src/service/build_read_cost.ts
@@ -1,0 +1,159 @@
+/**
+ * What a `storage=` build's warehouse read cost, as the warehouse accounts for it.
+ *
+ * Every field is nullable and per-engine, deliberately rather than by omission:
+ * the warehouses do not measure the same things, and flattening them into a
+ * shared shape would invent equivalences that do not exist. There is no
+ * cross-engine "cost" number here — BigQuery bills bytes, Snowflake bills
+ * warehouse-seconds — so a caller comparing two engines must compare like for
+ * like or not at all.
+ */
+export interface BuildReadCost {
+   engine: "bigquery" | "snowflake";
+   /** The warehouse's own id for the job that ran the read and carries these numbers. */
+   jobId: string | null;
+   /**
+    * The job to look {@link jobId} up BY, on an engine where it is not findable
+    * on its own. BigQuery runs a labelled read as a script, and a script's child
+    * job is absent from the default `bigquery_jobs()` listing — so the child id
+    * alone resolves to nothing, and this is the id an operator needs. Null where
+    * `jobId` is directly findable, which is every other case.
+    */
+   parentJobId: string | null;
+   /** Bytes the query read. BigQuery `totalBytesProcessed`; Snowflake `BYTES_SCANNED`. */
+   bytesScanned: number | null;
+   /**
+    * Bytes the query is BILLED for, which is not the same number: BigQuery
+    * rounds up to a 10MB minimum per query, so a small read bills an order of
+    * magnitude above what it scanned, and refreshes are mostly small reads.
+    * BigQuery only — Snowflake has no per-query billed quantity at all.
+    */
+   bytesBilled: number | null;
+   /**
+    * BigQuery slot-milliseconds: aggregate parallel compute, so it is NOT wall
+    * clock and routinely exceeds the query's duration. Null on Snowflake, whose
+    * compute is billed per warehouse-second regardless of what runs on it.
+    * Deliberately not merged with Snowflake's execution time, which measures
+    * something else.
+    */
+   slotTimeMs: number | null;
+   /** Snowflake wall-clock execution ms. Null on BigQuery, where slotTimeMs is the meaningful number. */
+   executionTimeMs: number | null;
+   /**
+    * The warehouse answered from cache, so this read was free. On a BUILD that is
+    * a finding rather than a curiosity: the cache is invalidated when the
+    * underlying tables change, so a cached build means the source data had not
+    * moved and the rebuild did no useful work.
+    */
+   cacheHit: boolean | null;
+}
+
+/**
+ * The cost columns to select from a BigQuery job record, for the query that is
+ * already locating the read's result table. Sharing that one call is what keeps
+ * cost off any separate lookup: a script's child job is not in the default
+ * `bigquery_jobs()` listing and can only be reached through its parent, so a
+ * later lookup keyed on the child's id finds nothing at all.
+ */
+export const BIGQUERY_COST_COLUMNS = `
+   total_slot_time_ms,
+   json_extract_string(statistics, '$.query.totalBytesProcessed') AS bytes_processed,
+   json_extract_string(statistics, '$.query.totalBytesBilled')    AS bytes_billed,
+   json_extract_string(statistics, '$.query.cacheHit')            AS cache_hit`;
+
+/** Read {@link BIGQUERY_COST_COLUMNS} off a job row. */
+export function bigQueryReadCost(
+   row: Record<string, unknown>,
+   jobId: string | null,
+   parentJobId: string | null,
+): BuildReadCost {
+   return {
+      engine: "bigquery",
+      jobId,
+      parentJobId,
+      bytesScanned: num(row.bytes_processed),
+      bytesBilled: num(row.bytes_billed),
+      slotTimeMs: num(row.total_slot_time_ms),
+      executionTimeMs: null,
+      cacheHit: bool(row.cache_hit),
+   };
+}
+
+/**
+ * Snowflake's query history for ONE query, keyed on its id.
+ *
+ * `INFORMATION_SCHEMA.QUERY_HISTORY` rather than `ACCOUNT_USAGE.QUERY_HISTORY`:
+ * the latter lags by up to three hours and needs elevated grants, so it cannot
+ * answer a question asked immediately after a build. The one used here carries no
+ * such lag — measured against a live account, a query appears in it immediately.
+ *
+ * The key is the id the session just reported, so this statement embeds no query
+ * text and needs no time window, candidate cap, or ambiguity rule. Aliases are
+ * QUOTED because Snowflake folds a bare alias to uppercase, which would make
+ * every field below read undefined while a row still came back.
+ */
+export function snowflakeCostSQL(queryId: string): string {
+   return `
+      SELECT QUERY_ID       AS "job_id",
+             BYTES_SCANNED  AS "bytes_scanned",
+             EXECUTION_TIME AS "execution_time_ms",
+             ROWS_PRODUCED  AS "rows_produced"
+      FROM TABLE(INFORMATION_SCHEMA.QUERY_HISTORY())
+      WHERE QUERY_ID = '${queryId.replace(/'/g, "''")}'`;
+}
+
+/** Read {@link snowflakeCostSQL}'s row. */
+export function snowflakeReadCost(row: Record<string, unknown>): BuildReadCost {
+   const scanned = num(col(row, "bytes_scanned"));
+   const produced = num(col(row, "rows_produced"));
+   return {
+      engine: "snowflake",
+      jobId: str(col(row, "job_id")),
+      // QUERY_HISTORY is keyed on the query id directly; there is no parent.
+      parentJobId: null,
+      bytesScanned: scanned,
+      bytesBilled: null,
+      slotTimeMs: null,
+      executionTimeMs: num(col(row, "execution_time_ms")),
+      // Inferred, not reported: Snowflake exposes no cache-hit column, and a
+      // served-from-cache query is recognisable by having scanned nothing while
+      // still producing rows. Left null rather than a guessed `false` when either
+      // input is missing, so an absent column never reads as "not cached".
+      cacheHit:
+         scanned === null || produced === null
+            ? null
+            : scanned === 0 && produced > 0,
+   };
+}
+
+/**
+ * Read a column case-insensitively. The quoted aliases are what make the keys
+ * lowercase; this is a second line of defence, so a transport that ever folds
+ * case again produces a wrong-looking number rather than a silent null.
+ */
+function col(row: Record<string, unknown>, key: string): unknown {
+   if (key in row) return row[key];
+   const upper = key.toUpperCase();
+   if (upper in row) return row[upper];
+   const hit = Object.keys(row).find((k) => k.toLowerCase() === key);
+   return hit === undefined ? undefined : row[hit];
+}
+
+function num(value: unknown): number | null {
+   if (value === null || value === undefined) return null;
+   const n = typeof value === "bigint" ? Number(value) : Number(value);
+   return Number.isFinite(n) ? n : null;
+}
+
+function str(value: unknown): string | null {
+   return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function bool(value: unknown): boolean | null {
+   if (typeof value === "boolean") return value;
+   if (typeof value === "string") {
+      if (value === "true") return true;
+      if (value === "false") return false;
+   }
+   return null;
+}

--- a/packages/server/src/service/build_read_cost.ts
+++ b/packages/server/src/service/build_read_cost.ts
@@ -1,6 +1,13 @@
 import { sqlLiteral } from "./db_utils";
 
 /**
+ * How much of the build session's history to admit before filtering. Generous
+ * against a session that runs a handful of statements, and set EXPLICITLY because
+ * the default is 100 and applies before the `WHERE` — see {@link snowflakeCostSQL}.
+ */
+const SNOWFLAKE_HISTORY_LIMIT = 10_000;
+
+/**
  * What a `storage=` build's warehouse read cost, as the warehouse accounts for it.
  *
  * Every field is nullable and per-engine, deliberately rather than by omission:
@@ -92,8 +99,19 @@ export function bigQueryReadCost(
  * Keyed on the TAG, not on `LAST_QUERY_ID()`. The passthrough's session is not
  * exclusively ours: the ADBC driver issues its own `SELECT 1` connection probes
  * around each call, and measured against a live account `LAST_QUERY_ID()` after a
- * build-shaped read returned a probe, not the read. A tag scopes to this build's
- * session, and {@link pickSnowflakeReadRow} then picks the read out of it.
+ * build-shaped read returned a probe, not the read. {@link pickSnowflakeReadRow}
+ * then picks the read out of what this returns.
+ *
+ * <b>`_BY_SESSION`, with an explicit `RESULT_LIMIT`, and both matter.</b> These
+ * table functions cap their output BEFORE the `WHERE` runs, so a predicate can
+ * only filter rows the cap already admitted — no key, however unique, reaches
+ * past it. Measured against a live account: with the read pushed beyond the
+ * default 100, the plain account-wide form matched ZERO rows while the same
+ * predicate at `RESULT_LIMIT => 10000` matched one. `_BY_SESSION` narrows the
+ * candidates to this build's own session, and the explicit limit means that
+ * narrowing is what bounds the set rather than a default that happens to be
+ * larger than a build — the session form carries the same 100 default, and was
+ * also empty in that measurement.
  *
  * The accounting query itself carries the same tag, so it excludes its own shape.
  * Aliases are QUOTED because Snowflake folds a bare alias to uppercase, which
@@ -113,7 +131,8 @@ export function snowflakeCostSQL(queryTag: string): string {
              BYTES_SCANNED  AS "bytes_scanned",
              EXECUTION_TIME AS "execution_time_ms",
              ROWS_PRODUCED  AS "rows_produced"
-      FROM TABLE(INFORMATION_SCHEMA.QUERY_HISTORY())
+      FROM TABLE(INFORMATION_SCHEMA.QUERY_HISTORY_BY_SESSION(
+                 RESULT_LIMIT => ${SNOWFLAKE_HISTORY_LIMIT}))
       WHERE QUERY_TAG = '${sqlLiteral(queryTag, "snowflake")}'
         AND EXECUTION_STATUS = 'SUCCESS'
         AND QUERY_TEXT NOT LIKE '%INFORMATION_SCHEMA.QUERY_HISTORY%'`;

--- a/packages/server/src/service/build_read_cost.ts
+++ b/packages/server/src/service/build_read_cost.ts
@@ -89,6 +89,30 @@ export function bigQueryReadCost(
 }
 
 /**
+ * The database to resolve `INFORMATION_SCHEMA` against.
+ *
+ * Emitted BARE rather than quoted, and only when it is a plain identifier.
+ * Quoting would make it case-exact, while the connection parameter that put the
+ * session on this database resolves case-insensitively — so a connection
+ * configured `mydb` against a stored `MYDB` would qualify to a database that does
+ * not exist. Bare resolution matches how the session got here.
+ *
+ * A name needing quotes takes the shared-database fallback instead of being
+ * interpolated raw. That is a correct answer rather than a degraded one — the
+ * fallback is measured to return the same rows — and it keeps a configured value
+ * out of identifier position.
+ */
+function snowflakeDatabaseQualifier(
+   database: string | null | undefined,
+): string {
+   // typeof, not a truthiness check: the API models an unset database as either
+   // null or undefined, and an empty string is not a database either.
+   return typeof database === "string" && /^[A-Za-z0-9_$]+$/.test(database)
+      ? database
+      : "SNOWFLAKE";
+}
+
+/**
  * The queries this build's session ran, found by the tag the build set on it.
  *
  * `INFORMATION_SCHEMA.QUERY_HISTORY` rather than `ACCOUNT_USAGE.QUERY_HISTORY`:
@@ -138,30 +162,10 @@ export function bigQueryReadCost(
  * The connection's own database is preferred when it has one, so the common shape
  * keeps resolving exactly where it did before.
  */
-/**
- * The database to resolve `INFORMATION_SCHEMA` against.
- *
- * Emitted BARE rather than quoted, and only when it is a plain identifier.
- * Quoting would make it case-exact, while the connection parameter that put the
- * session on this database resolves case-insensitively — so a connection
- * configured `mydb` against a stored `MYDB` would qualify to a database that does
- * not exist. Bare resolution matches how the session got here.
- *
- * A name needing quotes takes the shared-database fallback instead of being
- * interpolated raw. That is a correct answer rather than a degraded one — the
- * fallback is measured to return the same rows — and it keeps a configured value
- * out of identifier position.
- */
-function snowflakeDatabaseQualifier(database: string | undefined): string {
-   return database !== undefined && /^[A-Za-z0-9_$]+$/.test(database)
-      ? database
-      : "SNOWFLAKE";
-}
-
 export function snowflakeCostSQL(
    queryTag: string,
    /** The connection's configured database, absent for a database-less one. */
-   database?: string,
+   database?: string | null,
 ): string {
    const qualifier = `${snowflakeDatabaseQualifier(database)}.INFORMATION_SCHEMA`;
    return `

--- a/packages/server/src/service/build_read_cost.ts
+++ b/packages/server/src/service/build_read_cost.ts
@@ -1,3 +1,5 @@
+import { sqlLiteral } from "./db_utils";
+
 /**
  * What a `storage=` build's warehouse read cost, as the warehouse accounts for it.
  *
@@ -80,26 +82,65 @@ export function bigQueryReadCost(
 }
 
 /**
- * Snowflake's query history for ONE query, keyed on its id.
+ * The queries this build's session ran, found by the tag the build set on it.
  *
  * `INFORMATION_SCHEMA.QUERY_HISTORY` rather than `ACCOUNT_USAGE.QUERY_HISTORY`:
  * the latter lags by up to three hours and needs elevated grants, so it cannot
  * answer a question asked immediately after a build. The one used here carries no
  * such lag — measured against a live account, a query appears in it immediately.
  *
- * The key is the id the session just reported, so this statement embeds no query
- * text and needs no time window, candidate cap, or ambiguity rule. Aliases are
- * QUOTED because Snowflake folds a bare alias to uppercase, which would make
- * every field below read undefined while a row still came back.
+ * Keyed on the TAG, not on `LAST_QUERY_ID()`. The passthrough's session is not
+ * exclusively ours: the ADBC driver issues its own `SELECT 1` connection probes
+ * around each call, and measured against a live account `LAST_QUERY_ID()` after a
+ * build-shaped read returned a probe, not the read. A tag scopes to this build's
+ * session, and {@link pickSnowflakeReadRow} then picks the read out of it.
+ *
+ * The accounting query itself carries the same tag, so it excludes its own shape.
+ * Aliases are QUOTED because Snowflake folds a bare alias to uppercase, which
+ * would make every field below read undefined while a row still came back.
+ *
+ * The tag is escaped with {@link sqlLiteral}, not by doubling quotes. It is JSON,
+ * so a property value containing a backslash arrives here doubled — and Snowflake
+ * consumes one as an escape, leaving a comparison value that cannot equal the tag
+ * actually stored. Measured against a live account: quote-doubling here matched
+ * ZERO rows for a tag carrying a backslash, and reported no cost rather than an
+ * error.
  */
-export function snowflakeCostSQL(queryId: string): string {
+export function snowflakeCostSQL(queryTag: string): string {
    return `
       SELECT QUERY_ID       AS "job_id",
+             QUERY_TEXT     AS "query_text",
              BYTES_SCANNED  AS "bytes_scanned",
              EXECUTION_TIME AS "execution_time_ms",
              ROWS_PRODUCED  AS "rows_produced"
       FROM TABLE(INFORMATION_SCHEMA.QUERY_HISTORY())
-      WHERE QUERY_ID = '${queryId.replace(/'/g, "''")}'`;
+      WHERE QUERY_TAG = '${sqlLiteral(queryTag, "snowflake")}'
+        AND EXECUTION_STATUS = 'SUCCESS'
+        AND QUERY_TEXT NOT LIKE '%INFORMATION_SCHEMA.QUERY_HISTORY%'`;
+}
+
+/**
+ * Pick the build's own read out of the queries that carried its tag.
+ *
+ * Measured against a live account, one build-shaped read left FOUR tagged
+ * queries: the read, two driver probes, and the accounting query.
+ *
+ * The read is identified by comparing text HERE rather than in the statement
+ * sent to the warehouse, and that distinction is the point: the compiled SQL is
+ * never embedded in a warehouse query, so there is nothing to escape and no
+ * dialect whose literal grammar it could break. The tag has already reduced the
+ * candidates to this one build's session.
+ *
+ * Returns null on anything other than exactly one match rather than guessing.
+ */
+export function pickSnowflakeReadRow(
+   rows: Record<string, unknown>[],
+   buildSQL: string,
+): Record<string, unknown> | null {
+   const matches = rows.filter(
+      (row) => str(col(row, "query_text"))?.trim() === buildSQL.trim(),
+   );
+   return matches.length === 1 ? matches[0] : null;
 }
 
 /** Read {@link snowflakeCostSQL}'s row. */

--- a/packages/server/src/service/build_read_cost.ts
+++ b/packages/server/src/service/build_read_cost.ts
@@ -105,9 +105,14 @@ export function bigQueryReadCost(
 function snowflakeDatabaseQualifier(
    database: string | null | undefined,
 ): string {
+   // Must START with a letter or underscore, which is Snowflake's own rule for an
+   // unquoted identifier: a leading digit or `$` is precisely the quote-needing
+   // name this is meant to hand to the fallback rather than emit bare.
+   //
    // typeof, not a truthiness check: the API models an unset database as either
    // null or undefined, and an empty string is not a database either.
-   return typeof database === "string" && /^[A-Za-z0-9_$]+$/.test(database)
+   return typeof database === "string" &&
+      /^[A-Za-z_][A-Za-z0-9_$]*$/.test(database)
       ? database
       : "SNOWFLAKE";
 }

--- a/packages/server/src/service/build_read_cost.ts
+++ b/packages/server/src/service/build_read_cost.ts
@@ -123,15 +123,54 @@ export function bigQueryReadCost(
  * actually stored. Measured against a live account: quote-doubling here matched
  * ZERO rows for a tag carrying a backslash, and reported no cost rather than an
  * error.
+ *
+ * <b>A connection may have no database, and then the name has to be qualified.</b>
+ * `INFORMATION_SCHEMA` is per-database and an unqualified reference resolves
+ * against the session's CURRENT database — which a database-less connection does
+ * not have, so the statement fails to compile rather than returning nothing.
+ * Measured against a live account: the unqualified form raises `002004 (42601)`
+ * on such a connection while `SNOWFLAKE.INFORMATION_SCHEMA` answers normally, and
+ * answers identically on a connection that does have one. The `SNOWFLAKE` shared
+ * database exists on every account, which is what makes it usable as the fallback
+ * qualifier; a role that cannot read it loses the cost and nothing else, since
+ * the caller treats a failed lookup as no cost.
+ *
+ * The connection's own database is preferred when it has one, so the common shape
+ * keeps resolving exactly where it did before.
  */
-export function snowflakeCostSQL(queryTag: string): string {
+/**
+ * The database to resolve `INFORMATION_SCHEMA` against.
+ *
+ * Emitted BARE rather than quoted, and only when it is a plain identifier.
+ * Quoting would make it case-exact, while the connection parameter that put the
+ * session on this database resolves case-insensitively — so a connection
+ * configured `mydb` against a stored `MYDB` would qualify to a database that does
+ * not exist. Bare resolution matches how the session got here.
+ *
+ * A name needing quotes takes the shared-database fallback instead of being
+ * interpolated raw. That is a correct answer rather than a degraded one — the
+ * fallback is measured to return the same rows — and it keeps a configured value
+ * out of identifier position.
+ */
+function snowflakeDatabaseQualifier(database: string | undefined): string {
+   return database !== undefined && /^[A-Za-z0-9_$]+$/.test(database)
+      ? database
+      : "SNOWFLAKE";
+}
+
+export function snowflakeCostSQL(
+   queryTag: string,
+   /** The connection's configured database, absent for a database-less one. */
+   database?: string,
+): string {
+   const qualifier = `${snowflakeDatabaseQualifier(database)}.INFORMATION_SCHEMA`;
    return `
       SELECT QUERY_ID       AS "job_id",
              QUERY_TEXT     AS "query_text",
              BYTES_SCANNED  AS "bytes_scanned",
              EXECUTION_TIME AS "execution_time_ms",
              ROWS_PRODUCED  AS "rows_produced"
-      FROM TABLE(INFORMATION_SCHEMA.QUERY_HISTORY_BY_SESSION(
+      FROM TABLE(${qualifier}.QUERY_HISTORY_BY_SESSION(
                  RESULT_LIMIT => ${SNOWFLAKE_HISTORY_LIMIT}))
       WHERE QUERY_TAG = '${sqlLiteral(queryTag, "snowflake")}'
         AND EXECUTION_STATUS = 'SUCCESS'

--- a/packages/server/src/service/build_read_cost.ts
+++ b/packages/server/src/service/build_read_cost.ts
@@ -119,6 +119,12 @@ export function snowflakeReadCost(row: Record<string, unknown>): BuildReadCost {
       // served-from-cache query is recognisable by having scanned nothing while
       // still producing rows. Left null rather than a guessed `false` when either
       // input is missing, so an absent column never reads as "not cached".
+      //
+      // It OVER-reports: anything producing rows without reading a table looks
+      // identical. Measured against a live account, a GENERATOR returning 50,000
+      // rows reports BYTES_SCANNED 0 and reads here as a cache hit. A build's read
+      // scans real tables, so the shape barely arises on this path — but this is a
+      // hint, not a fact, and nothing should bill against it.
       cacheHit:
          scanned === null || produced === null
             ? null

--- a/packages/server/src/service/materialization_build_session.ts
+++ b/packages/server/src/service/materialization_build_session.ts
@@ -137,6 +137,46 @@ async function tagSnowflakeSession(
 }
 
 /**
+ * Can this connection reach the job records the split depends on?
+ *
+ * The split locates its result table by listing the executed script's child job,
+ * which is an API surface the direct `bigquery_query()` path never touches — so
+ * turning attribution on would otherwise add a permission requirement to builds
+ * that previously needed none, and discover it only AFTER a read had been billed.
+ * This asks the question with a one-row listing, before anything runs.
+ *
+ * <b>A false answer costs attribution, not the build.</b> That is the invariant
+ * this whole path is meant to keep, and it is the reason the check exists rather
+ * than a try/catch further down: once the read has run, falling back is no longer
+ * free — the rows live only in a table this cannot find, so the alternative to
+ * failing would be paying for the read a second time.
+ *
+ * Not cached: it is one listing per build against an API the build is about to
+ * use anyway, and caching it would have to key on the connection's credentials
+ * and survive their rotation.
+ */
+async function canSplitBigQueryRead(
+   session: DuckDBConnection,
+   handle: string,
+): Promise<boolean> {
+   try {
+      await session.runSQL(
+         `SELECT job_id FROM bigquery_jobs('${escapeSQL(handle)}', maxResults := 1)`,
+      );
+      return true;
+   } catch (error) {
+      logger.warn(
+         "Cannot list BigQuery jobs for this connection, so this build's " +
+            "warehouse read will not be labelled or costed",
+         {
+            error: error instanceof Error ? error.message : String(error),
+         },
+      );
+      return false;
+   }
+}
+
+/**
  * What the CTAS reads from, and the warehouse's own id for the read when the
  * shape of that read yielded one.
  *
@@ -199,7 +239,12 @@ export async function issuePassthroughRead(
       sourceType === "bigquery"
          ? bigQueryQueryLabelValue(queryMetadata)
          : undefined;
-   if (label === undefined) {
+   // Asked BEFORE anything runs, so an unusable split costs a probe rather than a
+   // build. Past this point the read has been issued and billed, and there is no
+   // longer a cheap way back: without the job record the result table cannot be
+   // located, so the rows cannot be captured at all and re-issuing them through
+   // the direct shape would bill the same read twice.
+   if (label === undefined || !(await canSplitBigQueryRead(session, handle))) {
       return {
          selectSQL: wrapPassthrough(sourceType, handle, buildSQL),
          jobId: null,

--- a/packages/server/src/service/materialization_build_session.ts
+++ b/packages/server/src/service/materialization_build_session.ts
@@ -14,6 +14,8 @@ import { logger } from "../logger";
 import { errMessage } from "../utils";
 import { quoteIdentifier, quoteManifestTablePath } from "./quoting";
 import { projectToPublicColumns } from "./build_plan";
+import { snowflakeSetQueryTagSQL } from "./build_query_tag";
+import type { QueryMetadata } from "./query_metadata";
 import {
    attachDuckLakeReadWrite,
    escapeSQL,
@@ -86,6 +88,39 @@ export function wrapPassthrough(
             `Unsupported passthrough source type: ${String(exhaustive)}`,
          );
       }
+   }
+}
+
+/**
+ * Tag every subsequent read on a Snowflake build session with this build's
+ * query metadata.
+ *
+ * Snowflake only, and by capability rather than preference: the passthrough
+ * reuses ONE session across `snowflake_query()` calls, so a session-level
+ * `QUERY_TAG` reaches the read that follows. BigQuery has no equivalent —
+ * `bigquery_query()` accepts no labels parameter and cannot run the script that
+ * would set one — so its labelling is part of how the read itself is issued.
+ * Postgres has no per-statement tag to set.
+ *
+ * <b>Best-effort.</b> A build that produces correct rows must not fail because
+ * the warehouse refused a tag; the cost is attribution for this one build, which
+ * the log line makes diagnosable.
+ */
+async function tagSnowflakeSession(
+   session: DuckDBConnection,
+   sourceType: FederatedSourceType,
+   handle: string,
+   queryMetadata: QueryMetadata | undefined,
+): Promise<void> {
+   if (sourceType !== "snowflake") return;
+   const sql = snowflakeSetQueryTagSQL(queryMetadata, handle);
+   if (sql === undefined) return;
+   try {
+      await session.runSQL(sql);
+   } catch (error) {
+      logger.warn("Could not tag the Snowflake build session", {
+         error: error instanceof Error ? error.message : String(error),
+      });
    }
 }
 
@@ -229,6 +264,17 @@ export async function buildSourceIntoStorage(params: {
    /** Logical, unquoted physical table path (may carry a container path). */
    physicalTableName: string;
    environmentPath: string;
+   /**
+    * Per-query metadata for the warehouse read, already resolved through the
+    * same layering the colocated path uses.
+    *
+    * It has to be applied HERE rather than by a Malloy connector, which is the
+    * whole reason this parameter exists: the read runs inside DuckDB's native
+    * query-passthrough, so no connector is in the call path to render the bag
+    * onto the statement. Without this, a `storage=` build is the one kind of
+    * warehouse work the deployment cannot attribute.
+    */
+   queryMetadata?: QueryMetadata;
 }): Promise<StorageBuildResult> {
    const {
       destinationName,
@@ -237,6 +283,7 @@ export async function buildSourceIntoStorage(params: {
       buildSQL,
       physicalTableName,
       environmentPath,
+      queryMetadata,
    } = params;
 
    assertSupportedDestination(destinationName, destinationConnection);
@@ -271,6 +318,13 @@ export async function buildSourceIntoStorage(params: {
          session,
          sourceType,
          sourceFederationConfig(sourceConnection),
+      );
+
+      await tagSnowflakeSession(
+         session,
+         sourceType,
+         federated.handle,
+         queryMetadata,
       );
 
       // The CTAS target MUST be qualified with the destination catalog (the

--- a/packages/server/src/service/materialization_build_session.ts
+++ b/packages/server/src/service/materialization_build_session.ts
@@ -14,7 +14,15 @@ import { logger } from "../logger";
 import { errMessage } from "../utils";
 import { quoteIdentifier, quoteManifestTablePath } from "./quoting";
 import { projectToPublicColumns } from "./build_plan";
-import { snowflakeSetQueryTagSQL } from "./build_query_tag";
+import {
+   bigQueryQueryLabelValue,
+   snowflakeSetQueryTagSQL,
+} from "./build_query_tag";
+import {
+   BIGQUERY_COST_COLUMNS,
+   bigQueryReadCost,
+   type BuildReadCost,
+} from "./build_read_cost";
 import type { QueryMetadata } from "./query_metadata";
 import {
    attachDuckLakeReadWrite,
@@ -122,6 +130,145 @@ async function tagSnowflakeSession(
          error: error instanceof Error ? error.message : String(error),
       });
    }
+}
+
+/**
+ * What the CTAS reads from, and the warehouse's own id for the read when the
+ * shape of that read yielded one.
+ *
+ * `jobId` is what makes a build's cost recoverable by an EXACT key rather than by
+ * matching recorded query text, so it is carried out of here even though the
+ * build itself does not need it.
+ */
+export interface PassthroughRead {
+   /** The SELECT the CTAS wraps. */
+   selectSQL: string;
+   /** The warehouse's id for the read, null when this shape does not produce one. */
+   jobId: string | null;
+   /**
+    * What the read cost, when the shape that issued it also reported it.
+    *
+    * Read from the SAME job record that located the result table rather than by a
+    * later lookup, because a later lookup is not available: a script's child job
+    * is absent from the default `bigquery_jobs()` listing and reachable only
+    * through its parent, so its id resolves to nothing on its own.
+    */
+   cost: BuildReadCost | null;
+}
+
+/**
+ * Issue the source-warehouse read for a `storage=` build and return what the
+ * CTAS should select from.
+ *
+ * Two shapes, and which one runs is decided by whether there is a BigQuery label
+ * to apply:
+ *
+ * <ul>
+ *   <li><b>Direct</b> — `wrapPassthrough`'s single rows-returning call. Every
+ *       engine, and BigQuery too when there is nothing to label. Returns no job
+ *       id: no passthrough hands one back for a call that returns rows.
+ *   <li><b>Split (BigQuery, labelled)</b> — `bigquery_execute` runs the SELECT
+ *       inside a script that sets `@@query_label` first, then the anonymous result
+ *       table that job wrote is read with `bigquery_scan`. `bigquery_query()`
+ *       cannot serve this: it takes no labels parameter, and it cannot run a
+ *       script (a script returns no result schema), so labelling BigQuery is not
+ *       available without splitting the read.
+ * </ul>
+ *
+ * <b>The split is not a second scan.</b> Reading the anonymous result table goes
+ * through the Storage Read API and creates no new QUERY job — measured by
+ * diffing the project's QUERY job ids across the read. `bigquery_query()` is
+ * almost certainly doing the same two steps internally.
+ *
+ * Gating on the label rather than on the engine keeps the unlabelled path
+ * byte-identical to what it was, so the blast radius of the split is exactly the
+ * set of builds that asked to be attributed.
+ */
+export async function issuePassthroughRead(
+   session: DuckDBConnection,
+   sourceType: FederatedSourceType,
+   handle: string,
+   buildSQL: string,
+   queryMetadata: QueryMetadata | undefined,
+): Promise<PassthroughRead> {
+   const label =
+      sourceType === "bigquery"
+         ? bigQueryQueryLabelValue(queryMetadata)
+         : undefined;
+   if (label === undefined) {
+      return {
+         selectSQL: wrapPassthrough(sourceType, handle, buildSQL),
+         jobId: null,
+         cost: null,
+      };
+   }
+
+   // The label is set by a statement of its own, so the script has two: BigQuery
+   // creates a parent job for the script and one child per statement, and it is
+   // the CHILD that ran the SELECT which carries both the label and the cost.
+   const script = `SET @@query_label = "${label}";\n${buildSQL};`;
+   const executed = await session.runSQL(
+      `SELECT * FROM bigquery_execute('${escapeSQL(handle)}', '${escapeSQL(script)}')`,
+   );
+   const parentJobId = firstColumn(executed, "job_id");
+   if (parentJobId === null) {
+      throw new Error(
+         "bigquery_execute returned no job_id for the build's read, so its " +
+            "result table cannot be located",
+      );
+   }
+
+   // The destination table is read from the job record rather than constructed:
+   // it is an anonymous table whose name BigQuery chooses.
+   const child = await session.runSQL(`
+      SELECT job_id,
+             json_extract_string(configuration, '$.query.destinationTable.projectId') AS project,
+             json_extract_string(configuration, '$.query.destinationTable.datasetId') AS dataset,
+             json_extract_string(configuration, '$.query.destinationTable.tableId')   AS table,
+             ${BIGQUERY_COST_COLUMNS}
+      FROM (SELECT * FROM bigquery_jobs('${escapeSQL(handle)}',
+                                        parentJobId := '${escapeSQL(parentJobId)}')
+            WHERE job_type = 'QUERY')`);
+   const rows = resultRows(child);
+   const located = rows.find((r) => str(r.dataset) && str(r.table));
+   if (located === undefined) {
+      // The read HAS run and been paid for at this point. Re-issuing it through
+      // the direct shape would run and bill it a second time, so this fails
+      // instead: a retry is the operator's decision, not a silent double charge.
+      throw new Error(
+         `The build's BigQuery read (job ${parentJobId}) left no locatable ` +
+            `result table, so its rows cannot be captured`,
+      );
+   }
+
+   const path = [
+      str(located.project) ?? handle,
+      str(located.dataset),
+      str(located.table),
+   ].join(".");
+   const jobId = str(located.job_id);
+   return {
+      selectSQL: `SELECT * FROM bigquery_scan('${escapeSQL(path)}')`,
+      jobId,
+      cost: bigQueryReadCost(located, jobId, parentJobId),
+   };
+}
+
+/** Rows from a `runSQL` result, which is either the array itself or wraps one. */
+function resultRows(result: unknown): Record<string, unknown>[] {
+   if (Array.isArray(result)) return result as Record<string, unknown>[];
+   const rows = (result as { rows?: unknown })?.rows;
+   return Array.isArray(rows) ? (rows as Record<string, unknown>[]) : [];
+}
+
+/** One named column from the first row, or null when it is absent or empty. */
+function firstColumn(result: unknown, column: string): string | null {
+   const rows = resultRows(result);
+   return rows.length > 0 ? str(rows[0][column]) : null;
+}
+
+function str(value: unknown): string | null {
+   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
 /** Narrow a connection's declared type to a supported passthrough source type. */
@@ -235,6 +382,12 @@ export interface StorageBuildResult {
    storageDestinationName: string;
    /** Authoritative DuckDB column schema, captured post-build via DESCRIBE. */
    schema: WireColumn[];
+   /**
+    * What the source warehouse charged for the read, when the read's shape
+    * reported it. Null is never "free" — see {@link PassthroughRead.cost} for
+    * which shapes report and which do not.
+    */
+   readCost: BuildReadCost | null;
 }
 
 /**
@@ -345,18 +498,28 @@ export async function buildSourceIntoStorage(params: {
          `${destinationName}.${physicalTableName}`,
          "duckdb",
       );
-      const passthrough = wrapPassthrough(
+      const read = await issuePassthroughRead(
+         session,
          sourceType,
          federated.handle,
          buildSQL,
+         queryMetadata,
       );
 
       // Capture the authoritative schema from the freshly-built table — the
       // serve transform declares exactly this, and the compiler does not
       // type-check a virtual source's declared columns.
-      const schema = await createTableAndDescribe(session, target, passthrough);
+      const schema = await createTableAndDescribe(
+         session,
+         target,
+         read.selectSQL,
+      );
 
-      return { storageDestinationName: destinationName, schema };
+      return {
+         storageDestinationName: destinationName,
+         schema,
+         readCost: read.cost,
+      };
    } finally {
       // Dispose closes the private instance (releasing every secret + attach —
       // nothing federated or read-write survives the build) and removes its
@@ -499,6 +662,11 @@ export async function buildDownstreamIntoStorage(params: {
       return {
          storageDestinationName: destinationName,
          schema,
+         // A chained build reads its parent's already-materialized table out of
+         // the destination store, so it touches no source warehouse and there is
+         // nothing to account for. Null here means "did not spend", which is the
+         // one place in this file where it does.
+         readCost: null,
       };
    } finally {
       await dispose();

--- a/packages/server/src/service/materialization_build_session.ts
+++ b/packages/server/src/service/materialization_build_session.ts
@@ -27,6 +27,7 @@ import {
    snowflakeReadCost,
    type BuildReadCost,
 } from "./build_read_cost";
+import { recordAttributionSkipped } from "../materialization_metrics";
 import type { QueryMetadata } from "./query_metadata";
 import {
    attachDuckLakeReadWrite,
@@ -172,8 +173,77 @@ async function canSplitBigQueryRead(
             error: error instanceof Error ? error.message : String(error),
          },
       );
+      recordAttributionSkipped("job_listing_unavailable");
       return false;
    }
+}
+
+/**
+ * A build failed AFTER its warehouse read had run and been billed.
+ *
+ * The distinction is the whole point of the type: everything else this path
+ * throws happens before anything is charged, and can be retried for the price of
+ * a retry. This cannot — the read is paid for, and its rows live in an anonymous
+ * table the build could not locate, so retrying pays for the same read twice.
+ * A caller with a retry policy should treat it as a decision for an operator
+ * rather than something to re-drive automatically.
+ *
+ * It is not degradable to "no cost". Without the job record there is no result
+ * table, so there are no rows to capture — the failure is the build's, not the
+ * telemetry's, which is why this path throws where the Snowflake one returns null.
+ */
+export class BilledReadNotCapturedError extends Error {
+   constructor(message: string) {
+      super(message);
+      this.name = "BilledReadNotCapturedError";
+   }
+}
+
+/** How many times to re-ask for the job record before giving up on the build. */
+const BIGQUERY_LOOKUP_ATTEMPTS = 3;
+const BIGQUERY_LOOKUP_BACKOFF_MS = 250;
+
+/**
+ * Re-ask for the job record a few times before failing a build whose read has
+ * already been billed.
+ *
+ * The capability probe establishes that this connection CAN list jobs, so a
+ * failure here is a transient — a 5xx, a quota trip, a credential rotated between
+ * the probe and now — rather than a standing permission answer. Those are worth a
+ * retry precisely because the alternative is so expensive: the read is paid for
+ * and cannot be re-issued for free.
+ *
+ * Bounded and short. This runs while the build session still holds federated
+ * credentials, and a warehouse that is genuinely down should surface as a failed
+ * build rather than a long stall.
+ */
+async function withBigQueryLookupRetry<T>(work: () => Promise<T>): Promise<T> {
+   let lastError: unknown;
+   for (let attempt = 1; attempt <= BIGQUERY_LOOKUP_ATTEMPTS; attempt++) {
+      try {
+         return await work();
+      } catch (error) {
+         lastError = error;
+         if (attempt < BIGQUERY_LOOKUP_ATTEMPTS) {
+            logger.warn(
+               "Could not read the BigQuery job record for a build's read; retrying",
+               {
+                  attempt,
+                  of: BIGQUERY_LOOKUP_ATTEMPTS,
+                  error: error instanceof Error ? error.message : String(error),
+               },
+            );
+            await new Promise((resolve) =>
+               setTimeout(resolve, BIGQUERY_LOOKUP_BACKOFF_MS * attempt),
+            );
+         }
+      }
+   }
+   throw new BilledReadNotCapturedError(
+      `Could not read the BigQuery job record for a build's read after ` +
+         `${BIGQUERY_LOOKUP_ATTEMPTS} attempts, so its rows cannot be captured: ` +
+         `${lastError instanceof Error ? lastError.message : String(lastError)}`,
+   );
 }
 
 /**
@@ -261,7 +331,7 @@ export async function issuePassthroughRead(
    );
    const parentJobId = firstColumn(executed, "job_id");
    if (parentJobId === null) {
-      throw new Error(
+      throw new BilledReadNotCapturedError(
          "bigquery_execute returned no job_id for the build's read, so its " +
             "result table cannot be located",
       );
@@ -269,7 +339,15 @@ export async function issuePassthroughRead(
 
    // The destination table is read from the job record rather than constructed:
    // it is an anonymous table whose name BigQuery chooses.
-   const child = await session.runSQL(`
+   //
+   // Ordered NEWEST first because the script has more than one statement and
+   // nothing documents the order a `parentJobId` listing returns them in. Taking
+   // the newest with a destination table takes the SELECT, which is the last
+   // statement and the one whose rows this is after. (Measured, `SET
+   // @@query_label` produces no such child — but that is behaviour, not a
+   // guarantee, and this costs nothing to pin.)
+   const child = await withBigQueryLookupRetry(() =>
+      session.runSQL(`
       SELECT job_id,
              json_extract_string(configuration, '$.query.destinationTable.projectId') AS project,
              json_extract_string(configuration, '$.query.destinationTable.datasetId') AS dataset,
@@ -277,14 +355,13 @@ export async function issuePassthroughRead(
              ${BIGQUERY_COST_COLUMNS}
       FROM (SELECT * FROM bigquery_jobs('${escapeSQL(handle)}',
                                         parentJobId := '${escapeSQL(parentJobId)}')
-            WHERE job_type = 'QUERY')`);
+            WHERE job_type = 'QUERY')
+      ORDER BY creation_time DESC`),
+   );
    const rows = resultRows(child);
    const located = rows.find((r) => str(r.dataset) && str(r.table));
    if (located === undefined) {
-      // The read HAS run and been paid for at this point. Re-issuing it through
-      // the direct shape would run and bill it a second time, so this fails
-      // instead: a retry is the operator's decision, not a silent double charge.
-      throw new Error(
+      throw new BilledReadNotCapturedError(
          `The build's BigQuery read (job ${parentJobId}) left no locatable ` +
             `result table, so its rows cannot be captured`,
       );

--- a/packages/server/src/service/materialization_build_session.ts
+++ b/packages/server/src/service/materialization_build_session.ts
@@ -328,7 +328,7 @@ async function snowflakeReadCostAfterBuild(
     * Snowflake supports that shape, and `INFORMATION_SCHEMA` is per-database, so
     * the lookup has to be told where to resolve it — see {@link snowflakeCostSQL}.
     */
-   database: string | undefined,
+   database: string | null | undefined,
 ): Promise<BuildReadCost | null> {
    if (sourceType !== "snowflake") return null;
    // Untagged there is nothing to scope the history by — and nothing asked to be

--- a/packages/server/src/service/materialization_build_session.ts
+++ b/packages/server/src/service/materialization_build_session.ts
@@ -21,6 +21,8 @@ import {
 import {
    BIGQUERY_COST_COLUMNS,
    bigQueryReadCost,
+   snowflakeCostSQL,
+   snowflakeReadCost,
    type BuildReadCost,
 } from "./build_read_cost";
 import type { QueryMetadata } from "./query_metadata";
@@ -252,6 +254,49 @@ export async function issuePassthroughRead(
       jobId,
       cost: bigQueryReadCost(located, jobId, parentJobId),
    };
+}
+
+/**
+ * Ask Snowflake what the build's read just cost, keyed on the id of the query it
+ * ran.
+ *
+ * Runs AFTER the read, which is what `LAST_QUERY_ID()` needs and why this is not
+ * part of issuing the read: the passthrough reuses one session, so the id it
+ * reports is the read's. That makes the key EXACT — this statement embeds no
+ * query text, and needs no time window, candidate cap or ambiguity rule.
+ *
+ * <b>Best-effort.</b> The rows are already built and captured, so a lookup that
+ * fails costs a number, never the build.
+ */
+async function snowflakeReadCostAfterBuild(
+   session: DuckDBConnection,
+   sourceType: FederatedSourceType,
+   handle: string,
+): Promise<BuildReadCost | null> {
+   if (sourceType !== "snowflake") return null;
+   try {
+      const idResult = await session.runSQL(
+         passthroughSnowflake(`SELECT LAST_QUERY_ID() AS "query_id"`, handle),
+      );
+      const queryId = firstColumn(idResult, "query_id");
+      if (queryId === null) return null;
+
+      const costResult = await session.runSQL(
+         passthroughSnowflake(snowflakeCostSQL(queryId), handle),
+      );
+      const row = resultRows(costResult)[0];
+      return row === undefined ? null : snowflakeReadCost(row);
+   } catch (error) {
+      logger.warn("Could not read back what the Snowflake build read cost", {
+         error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+   }
+}
+
+/** Snowflake-dialect SQL sent through the passthrough, which is the only route to it. */
+function passthroughSnowflake(innerSQL: string, handle: string): string {
+   return `SELECT * FROM snowflake_query('${escapeSQL(innerSQL)}', '${escapeSQL(handle)}')`;
 }
 
 /** Rows from a `runSQL` result, which is either the array itself or wraps one. */
@@ -518,7 +563,17 @@ export async function buildSourceIntoStorage(params: {
       return {
          storageDestinationName: destinationName,
          schema,
-         readCost: read.cost,
+         // BigQuery reported its cost while issuing the read, because the shape
+         // that carries the label also returns the job. Snowflake's read is
+         // unchanged, so it can only be asked once the read has run — which is
+         // here, while the session still holds the credentials.
+         readCost:
+            read.cost ??
+            (await snowflakeReadCostAfterBuild(
+               session,
+               sourceType,
+               federated.handle,
+            )),
       };
    } finally {
       // Dispose closes the private instance (releasing every secret + attach —

--- a/packages/server/src/service/materialization_build_session.ts
+++ b/packages/server/src/service/materialization_build_session.ts
@@ -16,11 +16,13 @@ import { quoteIdentifier, quoteManifestTablePath } from "./quoting";
 import { projectToPublicColumns } from "./build_plan";
 import {
    bigQueryQueryLabelValue,
+   snowflakeQueryTagValue,
    snowflakeSetQueryTagSQL,
 } from "./build_query_tag";
 import {
    BIGQUERY_COST_COLUMNS,
    bigQueryReadCost,
+   pickSnowflakeReadRow,
    snowflakeCostSQL,
    snowflakeReadCost,
    type BuildReadCost,
@@ -257,13 +259,15 @@ export async function issuePassthroughRead(
 }
 
 /**
- * Ask Snowflake what the build's read just cost, keyed on the id of the query it
- * ran.
+ * Ask Snowflake what the build's read just cost, scoped by the tag the build set
+ * on its session.
  *
- * Runs AFTER the read, which is what `LAST_QUERY_ID()` needs and why this is not
- * part of issuing the read: the passthrough reuses one session, so the id it
- * reports is the read's. That makes the key EXACT — this statement embeds no
- * query text, and needs no time window, candidate cap or ambiguity rule.
+ * Runs AFTER the read, because the history has to contain it. Scoped by the TAG
+ * rather than `LAST_QUERY_ID()`: the session is not exclusively this build's, as
+ * the ADBC driver issues `SELECT 1` connection probes around each passthrough
+ * call — measured against a live account, `LAST_QUERY_ID()` after a build-shaped
+ * read returned a probe rather than the read, which would have reported a probe's
+ * zero cost for every Snowflake build.
  *
  * <b>Best-effort.</b> The rows are already built and captured, so a lookup that
  * fails costs a number, never the build.
@@ -272,20 +276,20 @@ async function snowflakeReadCostAfterBuild(
    session: DuckDBConnection,
    sourceType: FederatedSourceType,
    handle: string,
+   buildSQL: string,
+   queryMetadata: QueryMetadata | undefined,
 ): Promise<BuildReadCost | null> {
    if (sourceType !== "snowflake") return null;
+   // Untagged there is nothing to scope the history by — and nothing asked to be
+   // attributed in the first place.
+   const tag = snowflakeQueryTagValue(queryMetadata);
+   if (tag === undefined) return null;
    try {
-      const idResult = await session.runSQL(
-         passthroughSnowflake(`SELECT LAST_QUERY_ID() AS "query_id"`, handle),
-      );
-      const queryId = firstColumn(idResult, "query_id");
-      if (queryId === null) return null;
-
       const costResult = await session.runSQL(
-         passthroughSnowflake(snowflakeCostSQL(queryId), handle),
+         passthroughSnowflake(snowflakeCostSQL(tag), handle),
       );
-      const row = resultRows(costResult)[0];
-      return row === undefined ? null : snowflakeReadCost(row);
+      const row = pickSnowflakeReadRow(resultRows(costResult), buildSQL);
+      return row === null ? null : snowflakeReadCost(row);
    } catch (error) {
       logger.warn("Could not read back what the Snowflake build read cost", {
          error: error instanceof Error ? error.message : String(error),
@@ -573,6 +577,8 @@ export async function buildSourceIntoStorage(params: {
                session,
                sourceType,
                federated.handle,
+               buildSQL,
+               queryMetadata,
             )),
       };
    } finally {

--- a/packages/server/src/service/materialization_build_session.ts
+++ b/packages/server/src/service/materialization_build_session.ts
@@ -323,6 +323,12 @@ async function snowflakeReadCostAfterBuild(
    handle: string,
    buildSQL: string,
    queryMetadata: QueryMetadata | undefined,
+   /**
+    * The source connection's configured database, absent when it has none.
+    * Snowflake supports that shape, and `INFORMATION_SCHEMA` is per-database, so
+    * the lookup has to be told where to resolve it — see {@link snowflakeCostSQL}.
+    */
+   database: string | undefined,
 ): Promise<BuildReadCost | null> {
    if (sourceType !== "snowflake") return null;
    // Untagged there is nothing to scope the history by — and nothing asked to be
@@ -331,7 +337,7 @@ async function snowflakeReadCostAfterBuild(
    if (tag === undefined) return null;
    try {
       const costResult = await session.runSQL(
-         passthroughSnowflake(snowflakeCostSQL(tag), handle),
+         passthroughSnowflake(snowflakeCostSQL(tag, database), handle),
       );
       const row = pickSnowflakeReadRow(resultRows(costResult), buildSQL);
       return row === null ? null : snowflakeReadCost(row);
@@ -624,6 +630,7 @@ export async function buildSourceIntoStorage(params: {
                federated.handle,
                buildSQL,
                queryMetadata,
+               sourceConnection.snowflakeConnection?.database,
             )),
       };
    } finally {

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -2447,6 +2447,12 @@ export class MaterializationService {
             storageDestinationName: result.storageDestinationName,
             columns: result.schema.length,
             durationMs,
+            // The whole cost, not just the one field the manifest carries. These
+            // are the numbers that answer a cost question and the ids that let a
+            // human reach the job in the warehouse's own console — the manifest
+            // has room for neither. Null says the read's shape reported nothing,
+            // which is not the same as free: see BuildReadCost.
+            readCost: result.readCost,
          },
       );
 

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -2461,13 +2461,17 @@ export class MaterializationService {
          realization: instruction.realization,
          rowCount: null,
          buildDurationMs: durationMs,
-         // The warehouse read happens inside DuckDB's query-passthrough, so the
-         // Malloy connector that supplies this on the colocated path is not in
-         // the call path and there is no per-query statistic to carry. Reading it
-         // back from the warehouse's own accounting requires an identifier for
-         // the job, which the passthrough does not return for a rows-returning
-         // call; obtaining one restructures how the build issues its read.
-         queryCostBytes: null,
+         // SCANNED, matching the colocated path above, which fills this from the
+         // connector's runStats -- and that is totalBytesProcessed, i.e. scanned.
+         // Reporting billed here would put two different quantities in one field,
+         // differing by up to BigQuery's 10MB floor, and anyone summing it across
+         // a package's sources would add them together.
+         //
+         // Null when the read's shape reported nothing: a rows-returning
+         // passthrough call hands back no job to account for. Today that means a
+         // build whose metadata bag was empty, since it is the label that makes
+         // BigQuery's read a form that reports.
+         queryCostBytes: result.readCost?.bytesScanned ?? null,
       };
    }
 

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -1904,6 +1904,22 @@ export class MaterializationService {
          connectionDigests,
       });
 
+      // Every statement of this source's build carries the same metadata, so the
+      // warehouse's query history shows the staging CTAS, the drop and the rename
+      // as one attributable unit of work.
+      //
+      // Resolved before the storage branch below so BOTH build paths carry the
+      // same bag, layered the same way. A `storage=` build reads through DuckDB's
+      // query-passthrough rather than a Malloy connection, so it applies these
+      // itself instead of handing them to `runSQL` — but what it applies has to be
+      // the same properties, or one deployment's query history attributes the two
+      // paths differently.
+      const runOptions = this.buildRunSQLOptions(
+         persistSource,
+         environment,
+         buildMetadata,
+      );
+
       // `storage=` build: materialize into a DuckDB/DuckLake destination via a
       // build-scoped session (never on the source or serve connection). Diverges
       // fully from the in-warehouse CTAS below — different engine, credential
@@ -1940,17 +1956,9 @@ export class MaterializationService {
             publicBuildSQL,
             builtEntries,
             dependsOnStorageUpstream,
+            runOptions.queryMetadata,
          );
       }
-
-      // Every statement of this source's build carries the same metadata, so the
-      // warehouse's query history shows the staging CTAS, the drop and the rename
-      // as one attributable unit of work.
-      const runOptions = this.buildRunSQLOptions(
-         persistSource,
-         environment,
-         buildMetadata,
-      );
 
       // Incremental refresh: a source that declares `refresh="incremental"` and a
       // usable watermark can advance its serving table by a bounded delta instead
@@ -2237,6 +2245,12 @@ export class MaterializationService {
       buildSQL: string,
       builtEntries: Record<string, ManifestEntry>,
       dependsOnStorageUpstream: boolean,
+      /**
+       * Applied to the warehouse read by the passthrough itself — see
+       * {@link buildSourceIntoStorage}. Resolved by the caller through the same
+       * layering the colocated path uses.
+       */
+      queryMetadata?: QueryMetadata,
    ): Promise<ManifestEntry> {
       const sourceEntityId = instruction.sourceEntityId;
       const physicalTableName = instruction.physicalTableName;
@@ -2336,6 +2350,7 @@ export class MaterializationService {
                buildSQL,
                physicalTableName,
                environmentPath: environment.getEnvironmentPath(),
+               queryMetadata,
             });
          } catch (err) {
             // Redaction: a failed federation / passthrough / attach

--- a/packages/server/src/service/passthrough_read.spec.ts
+++ b/packages/server/src/service/passthrough_read.spec.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "bun:test";
+
+import { issuePassthroughRead } from "./materialization_build_session";
+
+/** A build session that records what it was asked to run and replays canned rows. */
+function fakeSession(replies: Record<string, unknown>[][] = []) {
+   const issued: string[] = [];
+   let next = 0;
+   const session = {
+      runSQL: async (sql: string) => {
+         issued.push(sql);
+         return { rows: replies[next++] ?? [] };
+      },
+   };
+   return { session: session as never, issued };
+}
+
+const BQ_CHILD = [
+   {
+      job_id: "script_job_abc_0",
+      project: "proj",
+      dataset: "_anon_ds",
+      table: "anon_tbl",
+      bytes_processed: "5114816",
+      bytes_billed: "10485760",
+      total_slot_time_ms: 26,
+      cache_hit: "false",
+   },
+];
+
+describe("issuePassthroughRead — direct shape", () => {
+   it("leaves an UNLABELLED BigQuery read exactly as it was", async () => {
+      // The split is gated on there being a label, so a deployment that is not
+      // tagging keeps byte-for-byte the read it had before.
+      const { session, issued } = fakeSession();
+      const read = await issuePassthroughRead(
+         session,
+         "bigquery",
+         "proj",
+         "SELECT 1",
+         undefined,
+      );
+      expect(read.selectSQL).toBe(
+         "SELECT * FROM bigquery_query('proj', 'SELECT 1')",
+      );
+      expect(read.jobId).toBeNull();
+      expect(read.cost).toBeNull();
+      // Nothing was executed to produce it.
+      expect(issued).toEqual([]);
+   });
+
+   it("leaves Snowflake unsplit even WITH metadata", async () => {
+      // Snowflake carries its tag on the session, so its read never changes
+      // shape; splitting it would buy nothing.
+      const { session, issued } = fakeSession();
+      const read = await issuePassthroughRead(
+         session,
+         "snowflake",
+         "sf_secret",
+         "SELECT 1",
+         { cred_run: "r1" },
+      );
+      expect(read.selectSQL).toStartWith("SELECT * FROM snowflake_query(");
+      expect(read.jobId).toBeNull();
+      expect(issued).toEqual([]);
+   });
+
+   it("leaves Postgres unsplit, having no per-statement tag", async () => {
+      const { session } = fakeSession();
+      const read = await issuePassthroughRead(
+         session,
+         "postgres",
+         "pg",
+         "SELECT 1",
+         { cred_run: "r1" },
+      );
+      expect(read.selectSQL).toStartWith("SELECT * FROM postgres_query(");
+   });
+
+   it("stays direct when every property was unusable as a BigQuery key", async () => {
+      // A bag that renders to no label leaves nothing to split FOR.
+      const { session, issued } = fakeSession();
+      const read = await issuePassthroughRead(
+         session,
+         "bigquery",
+         "proj",
+         "SELECT 1",
+         { "1st": "x" },
+      );
+      expect(read.selectSQL).toStartWith("SELECT * FROM bigquery_query(");
+      expect(issued).toEqual([]);
+   });
+});
+
+describe("issuePassthroughRead — BigQuery split", () => {
+   it("runs the SELECT inside a labelled script, then scans its result table", async () => {
+      const { session, issued } = fakeSession([
+         [{ job_id: "job_parent" }],
+         BQ_CHILD,
+      ]);
+      const read = await issuePassthroughRead(
+         session,
+         "bigquery",
+         "proj",
+         "SELECT a FROM t",
+         { cred_run: "run_1", cred_class: "ops" },
+      );
+
+      expect(issued[0]).toContain("bigquery_execute('proj'");
+      expect(issued[0]).toContain(
+         'SET @@query_label = \"cred_run:run_1,cred_class:ops\"',
+      );
+      // The SELECT rides in the same script, which is the only way the label
+      // applies to the job that runs it.
+      expect(issued[0]).toContain("SELECT a FROM t");
+      // The child is reached through its parent — it is not in the default listing.
+      expect(issued[1]).toContain("parentJobId := 'job_parent'");
+      expect(read.selectSQL).toBe(
+         "SELECT * FROM bigquery_scan('proj._anon_ds.anon_tbl')",
+      );
+   });
+
+   it("reports the cost from the same call that located the table", async () => {
+      const { session } = fakeSession([[{ job_id: "job_parent" }], BQ_CHILD]);
+      const read = await issuePassthroughRead(
+         session,
+         "bigquery",
+         "proj",
+         "SELECT a FROM t",
+         { cred_run: "run_1" },
+      );
+      expect(read.cost).toEqual({
+         engine: "bigquery",
+         jobId: "script_job_abc_0",
+         parentJobId: "job_parent",
+         bytesScanned: 5114816,
+         bytesBilled: 10485760,
+         slotTimeMs: 26,
+         executionTimeMs: null,
+         cacheHit: false,
+      });
+   });
+
+   it("keeps billed and scanned apart", async () => {
+      // BigQuery's 10MB floor bills a small read well above what it scanned, and
+      // refreshes are mostly small reads, so collapsing the two would understate
+      // every one of them.
+      const { session } = fakeSession([[{ job_id: "p" }], BQ_CHILD]);
+      const read = await issuePassthroughRead(
+         session,
+         "bigquery",
+         "proj",
+         "SELECT 1",
+         { cred_run: "r" },
+      );
+      expect(read.cost?.bytesScanned).toBe(5114816);
+      expect(read.cost?.bytesBilled).toBe(10485760);
+   });
+
+   it("carries the PARENT id, without which the cost job cannot be looked up", async () => {
+      // Measured against a live project: the child of a script is absent from the
+      // default bigquery_jobs() listing, so its id alone resolves to nothing.
+      const { session } = fakeSession([[{ job_id: "job_parent" }], BQ_CHILD]);
+      const read = await issuePassthroughRead(
+         session,
+         "bigquery",
+         "proj",
+         "SELECT 1",
+         { cred_run: "r" },
+      );
+      expect(read.cost?.parentJobId).toBe("job_parent");
+   });
+
+   it("fails rather than re-running a read that already happened", async () => {
+      // The query HAS run and been billed by this point. Falling back to the
+      // direct shape would run and bill it a second time; a retry is the
+      // operator's decision, not a silent double charge.
+      const { session } = fakeSession([[{ job_id: "job_parent" }], []]);
+      await expect(
+         issuePassthroughRead(session, "bigquery", "proj", "SELECT 1", {
+            cred_run: "r",
+         }),
+      ).rejects.toThrow(/no locatable result table/);
+   });
+
+   it("fails loudly when the execute reports no job at all", async () => {
+      const { session } = fakeSession([[]]);
+      await expect(
+         issuePassthroughRead(session, "bigquery", "proj", "SELECT 1", {
+            cred_run: "r",
+         }),
+      ).rejects.toThrow(/no job_id/);
+   });
+
+   it("escapes the build SQL into the script it embeds", async () => {
+      const { session, issued } = fakeSession([
+         [{ job_id: "job_parent" }],
+         BQ_CHILD,
+      ]);
+      await issuePassthroughRead(
+         session,
+         "bigquery",
+         "proj",
+         "SELECT 'it''s' AS x",
+         { cred_run: "r" },
+      );
+      // Doubled once for the DuckDB literal the script rides in. DuckDB has no
+      // backslash escape, so a backslash in the compiled SQL passes through to
+      // BigQuery unchanged — which is what BigQuery's own literal grammar needs.
+      expect(issued[0]).toContain("SELECT ''it''''s'' AS x");
+   });
+});

--- a/packages/server/src/service/passthrough_read.spec.ts
+++ b/packages/server/src/service/passthrough_read.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 
-import { issuePassthroughRead } from "./materialization_build_session";
+import {
+   BilledReadNotCapturedError,
+   issuePassthroughRead,
+} from "./materialization_build_session";
 
 /** A build session that records what it was asked to run and replays canned rows. */
 function fakeSession(replies: Record<string, unknown>[][] = []) {
@@ -238,6 +241,87 @@ describe("issuePassthroughRead — BigQuery split", () => {
          { cred_run: "r" },
       );
       expect(read.cost?.parentJobId).toBe("job_parent");
+   });
+
+   it("asks for the NEWEST child first, so the SELECT wins over any sibling", async () => {
+      // The script has more than one statement and nothing documents the order a
+      // parentJobId listing returns them in. Newest-first takes the last
+      // statement, which is the SELECT whose rows this is after.
+      const { session, issued } = fakeSession([
+         PROBE_OK,
+         [{ job_id: "job_parent" }],
+         BQ_CHILD,
+      ]);
+      await issuePassthroughRead(session, "bigquery", "proj", "SELECT 1", {
+         cred_run: "r",
+      });
+      expect(issued[2]).toContain("ORDER BY creation_time DESC");
+   });
+
+   it("picks the first child carrying a result table, given that ordering", async () => {
+      const { session } = fakeSession([
+         PROBE_OK,
+         [{ job_id: "job_parent" }],
+         // A sibling with no destination table must not be selected over the read.
+         [{ job_id: "sibling", dataset: null, table: null }, ...BQ_CHILD],
+      ]);
+      const read = await issuePassthroughRead(
+         session,
+         "bigquery",
+         "proj",
+         "SELECT 1",
+         { cred_run: "r" },
+      );
+      expect(read.selectSQL).toContain("proj._anon_ds.anon_tbl");
+      expect(read.jobId).toBe("script_job_abc_0");
+   });
+
+   it("retries a failing job lookup before failing a build already billed for", async () => {
+      // The probe established that this connection CAN list, so a failure here is
+      // transient — and the alternative is expensive, because the read is paid for
+      // and cannot be re-issued for free.
+      let calls = 0;
+      const session = {
+         runSQL: async (sql: string) => {
+            if (!sql.includes("parentJobId")) {
+               return {
+                  rows: sql.includes("bigquery_execute")
+                     ? [{ job_id: "job_parent" }]
+                     : [{ job_id: "any" }],
+               };
+            }
+            calls++;
+            if (calls < 3) throw new Error("503 backend error");
+            return { rows: BQ_CHILD };
+         },
+      } as never;
+      const read = await issuePassthroughRead(
+         session,
+         "bigquery",
+         "proj",
+         "SELECT 1",
+         { cred_run: "r" },
+      );
+      expect(calls).toBe(3);
+      expect(read.cost?.bytesScanned).toBe(5114816);
+   });
+
+   it("marks a post-read failure as one a retry would pay for twice", async () => {
+      // Distinguishable so a retry policy can tell "already billed" from "safe to
+      // retry" — the read has run either way.
+      const { session } = fakeSession([
+         PROBE_OK,
+         [{ job_id: "job_parent" }],
+         [],
+      ]);
+      const error = await issuePassthroughRead(
+         session,
+         "bigquery",
+         "proj",
+         "SELECT 1",
+         { cred_run: "r" },
+      ).catch((e: Error) => e);
+      expect(error).toBeInstanceOf(BilledReadNotCapturedError);
    });
 
    it("fails rather than re-running a read that already happened", async () => {

--- a/packages/server/src/service/passthrough_read.spec.ts
+++ b/packages/server/src/service/passthrough_read.spec.ts
@@ -15,6 +15,9 @@ function fakeSession(replies: Record<string, unknown>[][] = []) {
    return { session: session as never, issued };
 }
 
+/** The capability probe's reply — a listing that succeeds. */
+const PROBE_OK = [{ job_id: "any" }];
+
 const BQ_CHILD = [
    {
       job_id: "script_job_abc_0",
@@ -92,9 +95,67 @@ describe("issuePassthroughRead — direct shape", () => {
    });
 });
 
+describe("issuePassthroughRead — the split's capability probe", () => {
+   /** A session whose FIRST statement throws — i.e. job listing is unavailable. */
+   function sessionWithoutJobListing() {
+      const issued: string[] = [];
+      const session = {
+         runSQL: async (sql: string) => {
+            issued.push(sql);
+            if (sql.includes("bigquery_jobs")) {
+               throw new Error("Access Denied: bigquery.jobs.list");
+            }
+            return { rows: [] };
+         },
+      };
+      return { session: session as never, issued };
+   }
+
+   it("falls back to the direct shape rather than failing the build", async () => {
+      // Turning attribution on must not add a permission requirement that breaks
+      // builds. The cost of not having it is attribution, not the build.
+      const { session } = sessionWithoutJobListing();
+      const read = await issuePassthroughRead(
+         session,
+         "bigquery",
+         "proj",
+         "SELECT a FROM t",
+         { cred_run: "r1" },
+      );
+      expect(read.selectSQL).toStartWith("SELECT * FROM bigquery_query(");
+      expect(read.cost).toBeNull();
+   });
+
+   it("asks BEFORE issuing the read, so a fallback costs nothing already billed", async () => {
+      // Past the read there is no cheap way back: the rows live only in a table
+      // this cannot locate, so falling back would mean paying for the read twice.
+      const { session, issued } = sessionWithoutJobListing();
+      await issuePassthroughRead(session, "bigquery", "proj", "SELECT a", {
+         cred_run: "r1",
+      });
+      expect(issued).toHaveLength(1);
+      expect(issued[0]).toContain("bigquery_jobs");
+      expect(issued.some((s) => s.includes("bigquery_execute"))).toBe(false);
+   });
+
+   it("does not probe at all when there is no label to carry", async () => {
+      // No label, no split, nothing to ask about.
+      const { session, issued } = sessionWithoutJobListing();
+      await issuePassthroughRead(
+         session,
+         "bigquery",
+         "proj",
+         "SELECT a",
+         undefined,
+      );
+      expect(issued).toEqual([]);
+   });
+});
+
 describe("issuePassthroughRead — BigQuery split", () => {
    it("runs the SELECT inside a labelled script, then scans its result table", async () => {
       const { session, issued } = fakeSession([
+         PROBE_OK,
          [{ job_id: "job_parent" }],
          BQ_CHILD,
       ]);
@@ -106,22 +167,26 @@ describe("issuePassthroughRead — BigQuery split", () => {
          { cred_run: "run_1", cred_class: "ops" },
       );
 
-      expect(issued[0]).toContain("bigquery_execute('proj'");
-      expect(issued[0]).toContain(
+      expect(issued[1]).toContain("bigquery_execute('proj'");
+      expect(issued[1]).toContain(
          'SET @@query_label = "cred_run:run_1,cred_class:ops"',
       );
       // The SELECT rides in the same script, which is the only way the label
       // applies to the job that runs it.
-      expect(issued[0]).toContain("SELECT a FROM t");
+      expect(issued[1]).toContain("SELECT a FROM t");
       // The child is reached through its parent — it is not in the default listing.
-      expect(issued[1]).toContain("parentJobId := 'job_parent'");
+      expect(issued[2]).toContain("parentJobId := 'job_parent'");
       expect(read.selectSQL).toBe(
          "SELECT * FROM bigquery_scan('proj._anon_ds.anon_tbl')",
       );
    });
 
    it("reports the cost from the same call that located the table", async () => {
-      const { session } = fakeSession([[{ job_id: "job_parent" }], BQ_CHILD]);
+      const { session } = fakeSession([
+         PROBE_OK,
+         [{ job_id: "job_parent" }],
+         BQ_CHILD,
+      ]);
       const read = await issuePassthroughRead(
          session,
          "bigquery",
@@ -145,7 +210,7 @@ describe("issuePassthroughRead — BigQuery split", () => {
       // BigQuery's 10MB floor bills a small read well above what it scanned, and
       // refreshes are mostly small reads, so collapsing the two would understate
       // every one of them.
-      const { session } = fakeSession([[{ job_id: "p" }], BQ_CHILD]);
+      const { session } = fakeSession([PROBE_OK, [{ job_id: "p" }], BQ_CHILD]);
       const read = await issuePassthroughRead(
          session,
          "bigquery",
@@ -160,7 +225,11 @@ describe("issuePassthroughRead — BigQuery split", () => {
    it("carries the PARENT id, without which the cost job cannot be looked up", async () => {
       // Measured against a live project: the child of a script is absent from the
       // default bigquery_jobs() listing, so its id alone resolves to nothing.
-      const { session } = fakeSession([[{ job_id: "job_parent" }], BQ_CHILD]);
+      const { session } = fakeSession([
+         PROBE_OK,
+         [{ job_id: "job_parent" }],
+         BQ_CHILD,
+      ]);
       const read = await issuePassthroughRead(
          session,
          "bigquery",
@@ -175,7 +244,11 @@ describe("issuePassthroughRead — BigQuery split", () => {
       // The query HAS run and been billed by this point. Falling back to the
       // direct shape would run and bill it a second time; a retry is the
       // operator's decision, not a silent double charge.
-      const { session } = fakeSession([[{ job_id: "job_parent" }], []]);
+      const { session } = fakeSession([
+         PROBE_OK,
+         [{ job_id: "job_parent" }],
+         [],
+      ]);
       await expect(
          issuePassthroughRead(session, "bigquery", "proj", "SELECT 1", {
             cred_run: "r",
@@ -184,7 +257,7 @@ describe("issuePassthroughRead — BigQuery split", () => {
    });
 
    it("fails loudly when the execute reports no job at all", async () => {
-      const { session } = fakeSession([[]]);
+      const { session } = fakeSession([PROBE_OK, []]);
       await expect(
          issuePassthroughRead(session, "bigquery", "proj", "SELECT 1", {
             cred_run: "r",
@@ -194,6 +267,7 @@ describe("issuePassthroughRead — BigQuery split", () => {
 
    it("escapes the build SQL into the script it embeds", async () => {
       const { session, issued } = fakeSession([
+         PROBE_OK,
          [{ job_id: "job_parent" }],
          BQ_CHILD,
       ]);
@@ -207,6 +281,6 @@ describe("issuePassthroughRead — BigQuery split", () => {
       // Doubled once for the DuckDB literal the script rides in. DuckDB has no
       // backslash escape, so a backslash in the compiled SQL passes through to
       // BigQuery unchanged — which is what BigQuery's own literal grammar needs.
-      expect(issued[0]).toContain("SELECT ''it''''s'' AS x");
+      expect(issued[1]).toContain("SELECT ''it''''s'' AS x");
    });
 });

--- a/packages/server/src/service/passthrough_read.spec.ts
+++ b/packages/server/src/service/passthrough_read.spec.ts
@@ -108,7 +108,7 @@ describe("issuePassthroughRead — BigQuery split", () => {
 
       expect(issued[0]).toContain("bigquery_execute('proj'");
       expect(issued[0]).toContain(
-         'SET @@query_label = \"cred_run:run_1,cred_class:ops\"',
+         'SET @@query_label = "cred_run:run_1,cred_class:ops"',
       );
       // The SELECT rides in the same script, which is the only way the label
       // applies to the job that runs it.

--- a/packages/server/src/service/storage_build_bigquery.integration.spec.ts
+++ b/packages/server/src/service/storage_build_bigquery.integration.spec.ts
@@ -24,25 +24,22 @@ import { MaterializationService } from "./materialization_service";
  * needs no DuckLake catalog, no Postgres and no object storage — only a BigQuery
  * credential.
  *
- * <b>Not yet wired into `connection-integration-tests.yml`, for one reason:</b>
- * the repository's public-data service account lacks
- * `bigquery.readsessions.create`, and every path here needs it. That is not a
- * property of the split — the untagged case below uses `bigquery_query()`, the
- * shape `storage=` builds have always used, and it fails the same way:
+ * <b>The service account needs `bigquery.readsessions.create`</b>, and that is a
+ * requirement of the passthrough rather than of anything here: it streams its
+ * results over the Storage Read API on every path. The untagged case below is the
+ * evidence — it uses `bigquery_query()`, the shape `storage=` builds have always
+ * used, and without that permission it fails identically to the tagged one:
  *
  *     the user does not have 'bigquery.readsessions.create' permission
  *
- * The passthrough reads its results over the Storage Read API, so
- * `roles/bigquery.readSessionUser` (or an equivalent grant) is a standing
- * requirement for materializing ANY BigQuery source into a storage destination,
- * independent of tagging. Granting it to that service account is all this needs;
- * adding the file to the workflow's path filter and a step that runs it is then a
- * two-line change.
+ * So `roles/bigquery.readSessionUser` (or equivalent) is a standing requirement
+ * for materializing ANY BigQuery source into a storage destination, independent
+ * of tagging. Worth knowing before reading a failure here as a defect in the
+ * split.
  *
- * Until then it runs wherever the credentials do exist — set
- * `BIGQUERY_PUBLIC_DATA_CREDENTIALS` to a key file and
- * `BIGQUERY_PUBLIC_DATA_PROJECT_ID` to its project. Absent those it skips, so it
- * costs a developer without credentials nothing.
+ * Locally, set `BIGQUERY_PUBLIC_DATA_CREDENTIALS` to a key file and
+ * `BIGQUERY_PUBLIC_DATA_PROJECT_ID` to its project. Absent those this skips, so
+ * it costs a developer without credentials nothing.
  */
 const hasPublicDataBigQueryCredentials = () =>
    !!(

--- a/packages/server/src/service/storage_build_bigquery.integration.spec.ts
+++ b/packages/server/src/service/storage_build_bigquery.integration.spec.ts
@@ -20,9 +20,29 @@ import { MaterializationService } from "./materialization_service";
  * one of those tests still passes and every real build breaks.
  *
  * Reuses the public-data service account and the credential-gating shape of
- * `connection.spec.ts`, and runs in the same workflow. The destination is a plain
- * local DuckDB file, so this needs no DuckLake catalog, no Postgres and no object
- * storage — only a BigQuery credential.
+ * `connection.spec.ts`. The destination is a plain local DuckDB file, so this
+ * needs no DuckLake catalog, no Postgres and no object storage — only a BigQuery
+ * credential.
+ *
+ * <b>Not yet wired into `connection-integration-tests.yml`, for one reason:</b>
+ * the repository's public-data service account lacks
+ * `bigquery.readsessions.create`, and every path here needs it. That is not a
+ * property of the split — the untagged case below uses `bigquery_query()`, the
+ * shape `storage=` builds have always used, and it fails the same way:
+ *
+ *     the user does not have 'bigquery.readsessions.create' permission
+ *
+ * The passthrough reads its results over the Storage Read API, so
+ * `roles/bigquery.readSessionUser` (or an equivalent grant) is a standing
+ * requirement for materializing ANY BigQuery source into a storage destination,
+ * independent of tagging. Granting it to that service account is all this needs;
+ * adding the file to the workflow's path filter and a step that runs it is then a
+ * two-line change.
+ *
+ * Until then it runs wherever the credentials do exist — set
+ * `BIGQUERY_PUBLIC_DATA_CREDENTIALS` to a key file and
+ * `BIGQUERY_PUBLIC_DATA_PROJECT_ID` to its project. Absent those it skips, so it
+ * costs a developer without credentials nothing.
  */
 const hasPublicDataBigQueryCredentials = () =>
    !!(

--- a/packages/server/src/service/storage_build_bigquery.integration.spec.ts
+++ b/packages/server/src/service/storage_build_bigquery.integration.spec.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "fs/promises";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { DuckDBConnection } from "@malloydata/db-duckdb";
+import { storageDestinationRoot } from "./connection_config";
+import { buildSourceIntoStorage } from "./materialization_build_session";
+import { MaterializationService } from "./materialization_service";
+
+/**
+ * The `storage=` build's warehouse read, against a REAL BigQuery project.
+ *
+ * What this covers that the unit tests cannot: the unit suite drives
+ * {@link buildSourceIntoStorage} through a hand-rolled session that returns
+ * exactly the shape the code expects, so it proves the logic and nothing about
+ * the surface. If `bigquery_jobs()`'s columns move, or `bigquery_execute` stops
+ * returning `job_id`, or the anonymous result table stops being reachable, every
+ * one of those tests still passes and every real build breaks.
+ *
+ * Reuses the public-data service account and the credential-gating shape of
+ * `connection.spec.ts`, and runs in the same workflow. The destination is a plain
+ * local DuckDB file, so this needs no DuckLake catalog, no Postgres and no object
+ * storage — only a BigQuery credential.
+ */
+const hasPublicDataBigQueryCredentials = () =>
+   !!(
+      process.env.BIGQUERY_PUBLIC_DATA_CREDENTIALS &&
+      process.env.BIGQUERY_PUBLIC_DATA_PROJECT_ID
+   );
+
+const SKIP_MESSAGE =
+   "Skipping: BIGQUERY_PUBLIC_DATA_CREDENTIALS / BIGQUERY_PUBLIC_DATA_PROJECT_ID not configured";
+
+/** A read of a real table, with a unique predicate so BigQuery cannot serve it from cache. */
+const buildSQLFor = (nonce: string) =>
+   `SELECT word AS who, word_count AS n ` +
+   `FROM \`bigquery-public-data.samples.shakespeare\` ` +
+   `WHERE word_count > 3 AND corpus != 'nonce_${nonce}' LIMIT 12`;
+
+async function runBuild(
+   nonce: string,
+   queryMetadata: Record<string, string> | undefined,
+) {
+   const serviceAccountKeyJson = await fs.readFile(
+      process.env.BIGQUERY_PUBLIC_DATA_CREDENTIALS!,
+      "utf-8",
+   );
+   const environmentPath = mkdtempSync(
+      path.join(os.tmpdir(), `storage-build-${nonce}-`),
+   );
+   const physicalTableName = `orders_${nonce}`;
+   const result = await buildSourceIntoStorage({
+      destinationName: "lake",
+      destinationConnection: { name: "lake", type: "duckdb" } as never,
+      sourceConnection: {
+         name: "bq_src",
+         type: "bigquery",
+         bigqueryConnection: {
+            serviceAccountKeyJson,
+            defaultProjectId: process.env.BIGQUERY_PUBLIC_DATA_PROJECT_ID!,
+         },
+      } as never,
+      buildSQL: buildSQLFor(nonce),
+      physicalTableName,
+      environmentPath,
+      queryMetadata,
+   });
+   return { result, environmentPath, physicalTableName };
+}
+
+/** Rows the build actually landed in the destination file. */
+async function rowsInDestination(
+   environmentPath: string,
+   physicalTableName: string,
+): Promise<number> {
+   const session = new DuckDBConnection("verify", ":memory:");
+   try {
+      await session.runSQL(
+         `ATTACH '${path.join(storageDestinationRoot(environmentPath), "lake.duckdb")}' AS lake (READ_ONLY)`,
+      );
+      const raw = await session.runSQL(
+         `SELECT count(*) AS n FROM lake."${physicalTableName}"`,
+      );
+      const rows = (
+         Array.isArray(raw) ? raw : ((raw as { rows?: unknown[] }).rows ?? [])
+      ) as Record<string, unknown>[];
+      return Number(rows[0]?.n);
+   } finally {
+      await session.close();
+   }
+}
+
+describe("storage= build against live BigQuery", () => {
+   it("labels the read, captures its rows, and reports what it cost", async () => {
+      if (!hasPublicDataBigQueryCredentials()) {
+         console.log(SKIP_MESSAGE);
+         return;
+      }
+      const nonce = `lbl${Date.now()}`;
+      const { result, environmentPath, physicalTableName } = await runBuild(
+         nonce,
+         { cred_run: nonce, cred_org: "acme_corp", cred_class: "ops" },
+      );
+
+      // The rows are the point: a cost figure from a build that captured
+      // nothing would be worse than no figure.
+      expect(await rowsInDestination(environmentPath, physicalTableName)).toBe(
+         12,
+      );
+      expect(result.schema.map((c) => c.name)).toEqual(["who", "n"]);
+
+      // The split ran, which is the only way a label reaches the job.
+      const cost = result.readCost;
+      expect(cost).not.toBeNull();
+      expect(cost!.engine).toBe("bigquery");
+      expect(cost!.jobId).toBeTruthy();
+      // The child job is not in the default listing, so the parent is what an
+      // operator needs to reach it.
+      expect(cost!.parentJobId).toBeTruthy();
+
+      // Real figures off the real job record — this is the surface a fake
+      // session cannot exercise.
+      expect(cost!.bytesScanned).toBeGreaterThan(0);
+      expect(cost!.bytesBilled).toBeGreaterThan(0);
+      // BigQuery's 10MB-per-query floor: a small read bills above what it
+      // scanned, which is why these are separate fields.
+      expect(cost!.bytesBilled).toBeGreaterThanOrEqual(cost!.bytesScanned!);
+      expect(cost!.cacheHit).toBe(false);
+   }, 120_000);
+
+   it("puts SCANNED bytes on the manifest entry, never billed", async () => {
+      // The one field the manifest carries, pinned against the one that would
+      // look plausible in its place. Worth doing here rather than over a fake:
+      // these two numbers only diverge against a real warehouse — the 10MB floor
+      // is what makes billed exceed scanned — so a stub would have to assert the
+      // difference it invented.
+      if (!hasPublicDataBigQueryCredentials()) {
+         console.log(SKIP_MESSAGE);
+         return;
+      }
+      const nonce = `mft${Date.now()}`;
+      const serviceAccountKeyJson = await fs.readFile(
+         process.env.BIGQUERY_PUBLIC_DATA_CREDENTIALS!,
+         "utf-8",
+      );
+      const environmentPath = mkdtempSync(
+         path.join(os.tmpdir(), `storage-manifest-${nonce}-`),
+      );
+      const sourceConnection = {
+         name: "bq_src",
+         type: "bigquery",
+         bigqueryConnection: {
+            serviceAccountKeyJson,
+            defaultProjectId: process.env.BIGQUERY_PUBLIC_DATA_PROJECT_ID!,
+         },
+      };
+      const service = Object.create(MaterializationService.prototype) as Record<
+         string,
+         (...a: unknown[]) => Promise<Record<string, unknown>>
+      >;
+      const entry = await service.buildOneSourceIntoStorage(
+         { name: "orders", connectionName: "bq_src" },
+         {
+            sourceEntityId: `sid-${nonce}`,
+            physicalTableName: `orders_${nonce}`,
+            destination: "lake",
+         },
+         { strict: false, update: () => {} },
+         {
+            getApiConnection: () => sourceConnection,
+            getStorageDestination: () => ({ name: "lake", type: "duckdb" }),
+            getEnvironmentPath: () => environmentPath,
+         },
+         buildSQLFor(nonce),
+         {},
+         false,
+         { cred_run: nonce, cred_class: "ops" },
+      );
+
+      const billed = 10_485_760;
+      expect(entry.queryCostBytes).toBeGreaterThan(0);
+      // Scanned and billed genuinely differ on this read, so this distinguishes.
+      expect(entry.queryCostBytes).toBeLessThan(billed);
+      expect(entry.queryCostBytes).not.toBe(billed);
+   }, 120_000);
+
+   it("leaves an untagged read in the shape it had before, and reports no cost", async () => {
+      if (!hasPublicDataBigQueryCredentials()) {
+         console.log(SKIP_MESSAGE);
+         return;
+      }
+      const nonce = `pln${Date.now()}`;
+      const { result, environmentPath, physicalTableName } = await runBuild(
+         nonce,
+         undefined,
+      );
+
+      // Same rows by the older path — the split is not load-bearing for data.
+      expect(await rowsInDestination(environmentPath, physicalTableName)).toBe(
+         12,
+      );
+      // No label to carry means no split, and a rows-returning passthrough
+      // call hands back no job to account for.
+      expect(result.readCost).toBeNull();
+   }, 120_000);
+});


### PR DESCRIPTION
A `storage=` build reads its source warehouse through DuckDB's native query-passthrough, so no Malloy connector is in the call path to render the query-metadata bag onto the statement. Every such build has therefore reached the warehouse **untagged** — the one kind of work a deployment cannot attribute, and invisible in `INFORMATION_SCHEMA.JOBS.labels` / `QUERY_HISTORY.query_tag`.

The tag machinery already exists; the build path routes around it. This closes that, and the same change makes the read's cost recoverable.

## What changed

The bag is resolved **before** the storage branch, through the same layering the colocated path uses (connection default < model < enforced < run context), so both paths attribute identically. It is then applied by the passthrough itself.

| | how it is tagged | how its cost is keyed |
|---|---|---|
| **Snowflake** | session `QUERY_TAG`; the read is unchanged | the tag, over the session's own history |
| **BigQuery** | `@@query_label`, which requires splitting the read | the job the split returns |
| **Postgres** | no per-statement tag exists | — |
| **chained `storage=`** | reads the parent's stored table; touches no warehouse | n/a — null means "did not spend" |

`ManifestEntry.queryCostBytes` is now populated for `storage=` builds, which #992 deliberately left null. The **whole** `BuildReadCost` — billed bytes, slot or execution time, the cache flag, and the warehouse's own job ids — goes onto the build's existing log line, since the manifest has room for one figure and those exist to answer questions it cannot.

## Why BigQuery's read had to be split

Not a workaround — the split *is* the labelling mechanism. `bigquery_query()` cannot carry a label by any route:

```
bigquery_query(..., labels|job_labels|query_label|query_labels|label := ...)
  → Binder Error: Invalid named parameter          (all five)
bigquery_query('SET @@query_label = "..."; SELECT ...')
  → Binder Error: Query response does not contain a result schema
```

So a labelled read runs as `bigquery_execute` over a two-statement script, and the anonymous result table that job wrote is then read with `bigquery_scan`.

**The split is not a second scan.** Reading the anonymous table goes through the Storage Read API and creates no new QUERY job — measured by diffing the project's QUERY job ids across the read, with the window capped well above the count so it could not saturate.

**Two gates, and the second one matters more.** There must be a label to carry, *and* the connection must be able to reach the job records the split depends on — asked once, with a one-row listing, **before anything is issued**. Past that point the read has been billed and there is no cheap way back: the rows live only in a table the build can no longer locate, so the alternative to failing would be paying for the read twice. A connection that cannot list gets the unlabelled read it had before, and loses attribution rather than its build.

## Cost, without matching query text

Both engines are keyed exactly, and **no compiled SQL is embedded in any statement sent to a warehouse**.

- **BigQuery** — the job record that locates the result table already carries the cost, so it comes back on that same call. A second lookup is not available anyway: a script's child job is absent from the default `bigquery_jobs()` listing and reachable only through its parent, so the child id alone resolves to nothing. The parent is carried for that reason.
- **Snowflake** — scoped to the build's own session and filtered by the tag, then the read is picked out of that set **in code** rather than in the statement, so the compiled SQL never becomes data inside a warehouse-parsed literal.

## Verified against live warehouses

Exercising the shipped functions, not a copy of the SQL they build.

| | |
|---|---|
| label lands on the BigQuery job | ✅ `{"cred_run":"run_abc123","cred_class":"ops","cred_org":"acme_corp"}` |
| value canonicalized to BQ's grammar | ✅ `Acme Corp` → `acme_corp` |
| cost returned with the read | ✅ **5,114,816 scanned / 10,485,760 billed**, 26ms slot, not cached |
| `bigquery_scan` adds a QUERY job | ❌ none |
| unlabelled BigQuery read | ✅ unchanged, no job id, nothing executed to produce it |
| BigQuery refuses a duplicate label key | ✅ `Invalid query label list 'team:a,team:b'. Duplicate…` |
| Snowflake tag stored and re-parsed | ✅ round-trips as valid JSON with `'` **and** `\` in one value |
| Snowflake read picked out of the session | ✅ from the read plus two driver probes |
| Snowflake cost, database-backed connection | ✅ cost returned |
| Snowflake cost, database-LESS connection | ✅ cost returned (qualified — see below) |

The scanned/billed pair is the 10MB-per-query floor in the wild: 2.05× on a single small read, and refreshes are mostly small reads.

## Notes for review

**Neither connector exports its metadata renderer.** `@malloydata/db-snowflake` exports `SnowflakeConnection` and `buildPoolOptions`; `@malloydata/db-bigquery` exports `BigQueryConnection`. `snowflakeQueryTag` lives in `dist/snowflake_executor` and `toBigQueryLabels` is module-private, and reaching into either package's `dist/` is not a dependency this repo takes anywhere else. Both grammars are reimplemented in `build_query_tag.ts` and pinned by tests that state the grammar. Exporting them upstream would let both copies go.

**Two Snowflake escaping faults, both found live, both fixed with the repo's dialect-aware `sqlLiteral`.** Neither was a syntax error; both failed silently.

- The tag is JSON, and a property value may contain a backslash (the contract admits printable ASCII except `"`). Quote-doubling alone delivered `\` where the JSON needed `\\`, storing a tag that **succeeds and then does not parse** in `QUERY_HISTORY` — precisely the thing tagging exists for.
- The same value inside the lookup's `QUERY_TAG =` comparison matched **zero rows**, reporting no cost rather than an error.

**These history table functions cap their output BEFORE the `WHERE` runs.** So a predicate can only filter rows the cap already admitted, and no key — however unique — reaches past it. Measured: with the read pushed beyond the default 100, the account-wide form matched zero rows while the same predicate at `RESULT_LIMIT => 10000` matched one. The lookup is `_BY_SESSION` **with an explicit limit**, and both halves are load-bearing — the session form carries the same default and was also empty in that measurement.

**`LAST_QUERY_ID()` is not usable here**, which is why the Snowflake key is the tag. The passthrough's session is not exclusively the build's: the ADBC driver issues its own `SELECT 1` connection probes around each call, and measured live, `LAST_QUERY_ID()` after a build-shaped read returned a probe. Keyed on it, every Snowflake build would have reported a probe's zero cost.

**A database-less Snowflake connection needed the name qualified.** `INFORMATION_SCHEMA` is per-database and an unqualified reference resolves against the session's *current* database, which such a connection does not have — measured, the unqualified form raises `002004 (42601)` there. It now uses the connection's own database when it has one, and the `SNOWFLAKE` shared database when it does not. The name is emitted **bare** rather than quoted, because quoting makes it case-exact while the connection parameter that put the session there resolves case-insensitively; a name that would need quotes takes the fallback instead of being interpolated raw.

**A legal bag could kill a BigQuery build.** Property names are validated case-*preserving*, so `Team` and `team` are two properties that both render to one label key, and BigQuery refuses a list containing a duplicate. Rendered through a map now, last wins — metered like the other drops this rendering makes.

**The Snowflake cache-hit flag over-reports** and is documented as a hint rather than a fact. Snowflake exposes no cache-hit column, so it is inferred from scanning nothing while producing rows — and a `GENERATOR` returning 50,000 rows is indistinguishable from a cached read. A build's read scans real tables, so the shape barely arises on this path.

**Verifying the Snowflake path locally needs the ADBC driver**, which only the Docker image carries (#995). On macOS the published `.dylib` must additionally be renamed to `libadbc_driver_snowflake.so` — the extension hardcodes that filename in its search even on Darwin, and reports the right directory with the wrong name.

**Tests:** run the way CI runs them — `test:unit` **2404 pass / 0 fail**, `test:integration --max-workers=1` **250 pass / 0 fail**, `typecheck` and `lint` clean across all packages. Note that reproducing CI's typecheck locally needs `generate-api-types` and `build:sdk` first; without them the generated `api.ts` and the SDK go stale and produce errors that are not in the tree.
