### PR TITLE
fix(server): add columns to a publisher.db that predates them

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,13 +26,17 @@ An existing `publisher.db` has always picked up a new **table** added by a later
 
 ### What changed
 
-- **Schema init now reconciles columns.** After the `CREATE TABLE` pass, the declared shape is compared against what is on disk and anything declared-but-absent is added. Only nullable columns, and only additions.
-- **What it cannot fix, it now says at boot.** A type change, or a missing `NOT NULL` column, is logged as a warning naming the column, instead of surfacing later as a binder error on an unrelated request. This is the part that keeps earning its keep after this particular column is behind us.
+- **Schema init now reconciles columns.** After the `CREATE TABLE` pass, the declared shape is compared against what is on disk and anything declared-but-absent is added. Additions only, and only for columns carrying no constraint. A declared `DEFAULT` **is** carried across and backfills existing rows.
+- **What it cannot fix, it now says at boot.** A constrained column that cannot be added, or a column already present whose type, nullability or default has changed, is logged as a warning naming the column, instead of surfacing later as a binder error on an unrelated request. This is the part that keeps earning its keep after this particular column is behind us.
 - **Nothing is ever dropped.** Columns and tables an older store has and this build no longer declares are left in place and reported at debug level. `materializations.build_plan` (added and removed within four days in June 2026) and the `build_manifests` table are both inert relics of this kind; removing them is a decision for an operator, not something an upgrade should do quietly.
 
-### Why only additive
+### What is and is not carried across
 
-`ALTER TABLE ... ADD COLUMN` in DuckDB rejects a column carrying any constraint, `NOT NULL` included, with or without a `DEFAULT`. So the safe subset is not a policy this code chose — it is the boundary the engine enforces. A future column outside it needs a hand-written step, and the boot warning is what tells you the day one appears.
+`ALTER TABLE ... ADD COLUMN` in DuckDB rejects a column carrying any constraint — `NOT NULL`, `PRIMARY KEY`, `UNIQUE`, `CHECK`, `FOREIGN KEY` — with or without a `DEFAULT`. A bare `DEFAULT` is accepted. So the safe subset is not a policy this code chose; it is the boundary the engine enforces.
+
+Constraints are read from `duckdb_constraints()` rather than inferred from nullability, which matters more than it sounds: a `UNIQUE` or `CHECK` column reports as _nullable_, so screening on nullability alone would add it as a bare column and leave the store holding the right column under the wrong rules — two servers on the same build enforcing differently depending on how their store was created. Such a column is refused and named in the warning instead.
+
+A future column outside the safe subset needs a hand-written step, and the boot warning is what tells you the day one appears.
 
 There is still no schema-version marker, and none is needed: the comparison is against the database itself. The expected shape is not written down twice either — it is read back from a scratch in-memory database the same DDL has just been run against, so the `CREATE TABLE` statements remain the single declaration of the schema.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,6 +38,12 @@ Constraints are read from `duckdb_constraints()` rather than inferred from nulla
 
 A future column outside the safe subset needs a hand-written step, and the boot warning is what tells you the day one appears.
 
+Constraints are also now compared on columns both sides already have, and reported the same way. A constraint added to an existing table's DDL is as invisible to `CREATE TABLE IF NOT EXISTS` as a column is, and the consequence is quieter: the older store keeps accepting rows a fresh one rejects, with nothing failing to say so.
+
+### On a large store
+
+Adding a column without a default is a catalog operation, not a data rewrite — on a 5M-row, 205MB `materializations` table it took 17ms and grew the file by 0.1%. Adding one **with** a `DEFAULT` backfills every existing row, so that path is a real write: ~81ms on the same table, with a longer checkpoint. Both are trivial against a boot that compiles packages, and both happen before the server accepts traffic, but only the first is free.
+
 There is still no schema-version marker, and none is needed: the comparison is against the database itself. The expected shape is not written down twice either — it is read back from a scratch in-memory database the same DDL has just been run against, so the `CREATE TABLE` statements remain the single declaration of the schema.
 
 ### Why it took an upgrade to find

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,7 +27,7 @@ An existing `publisher.db` has always picked up a new **table** added by a later
 ### What changed
 
 - **Schema init now reconciles columns.** After the `CREATE TABLE` pass, the declared shape is compared against what is on disk and anything declared-but-absent is added. Additions only, and only for columns carrying no constraint. A declared `DEFAULT` **is** carried across and backfills existing rows.
-- **What it cannot fix, it now says at boot.** A constrained column that cannot be added, or a column already present whose type, nullability or default has changed, is logged as a warning naming the column, instead of surfacing later as a binder error on an unrelated request. This is the part that keeps earning its keep after this particular column is behind us.
+- **What it cannot fix, it now says at boot.** A constrained column that cannot be added, or a column already present whose type, nullability, default or constraints have changed, is logged as a warning naming the column, instead of surfacing later as a binder error on an unrelated request. This is the part that keeps earning its keep after this particular column is behind us.
 - **Nothing is ever dropped.** Columns and tables an older store has and this build no longer declares are left in place and reported at debug level. `materializations.build_plan` (added and removed within four days in June 2026) and the `build_manifests` table are both inert relics of this kind; removing them is a decision for an operator, not something an upgrade should do quietly.
 
 ### What is and is not carried across
@@ -40,11 +40,11 @@ A future column outside the safe subset needs a hand-written step, and the boot 
 
 Constraints are also now compared on columns both sides already have, and reported the same way. A constraint added to an existing table's DDL is as invisible to `CREATE TABLE IF NOT EXISTS` as a column is, and the consequence is quieter: the older store keeps accepting rows a fresh one rejects, with nothing failing to say so.
 
+There is still no schema-version marker, and none is needed: the comparison is against the database itself. The expected shape is not written down twice either — it is read back from a scratch in-memory database the same DDL has just been run against, so the `CREATE TABLE` statements remain the single declaration of the schema.
+
 ### On a large store
 
 Adding a column without a default is a catalog operation, not a data rewrite — on a 5M-row, 205MB `materializations` table it took 17ms and grew the file by 0.1%. Adding one **with** a `DEFAULT` backfills every existing row, so that path is a real write: ~81ms on the same table, with a longer checkpoint. Both are trivial against a boot that compiles packages, and both happen before the server accepts traffic, but only the first is free.
-
-There is still no schema-version marker, and none is needed: the comparison is against the database itself. The expected shape is not written down twice either — it is read back from a scratch in-memory database the same DDL has just been run against, so the `CREATE TABLE` statements remain the single declaration of the schema.
 
 ### Why it took an upgrade to find
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,30 @@ One behaviour change to know about: `skills-npm.yml` now publishes only from `ma
 
 ---
 
+## [Unreleased] — `publisher.db` picks up new columns on upgrade
+
+An existing `publisher.db` has always picked up a new **table** added by a later build, because `CREATE TABLE IF NOT EXISTS` is idempotent. It never picked up a new **column**: that same statement is a no-op against a table that already exists, however its columns differ. So a store created before a column was introduced never gained it, schema initialization reported success anyway, and the first write naming that column failed at the binder.
+
+**If your `publisher.db` predates 2026-06-19, every `POST .../materializations` has been returning 500** with `Binder Error: Table "materializations" does not have a column with name "manifest"`. That store now repairs itself on the next boot. Materialization is the only thing that was affected; nothing else names the column.
+
+### What changed
+
+- **Schema init now reconciles columns.** After the `CREATE TABLE` pass, the declared shape is compared against what is on disk and anything declared-but-absent is added. Only nullable columns, and only additions.
+- **What it cannot fix, it now says at boot.** A type change, or a missing `NOT NULL` column, is logged as a warning naming the column, instead of surfacing later as a binder error on an unrelated request. This is the part that keeps earning its keep after this particular column is behind us.
+- **Nothing is ever dropped.** Columns and tables an older store has and this build no longer declares are left in place and reported at debug level. `materializations.build_plan` (added and removed within four days in June 2026) and the `build_manifests` table are both inert relics of this kind; removing them is a decision for an operator, not something an upgrade should do quietly.
+
+### Why only additive
+
+`ALTER TABLE ... ADD COLUMN` in DuckDB rejects a column carrying any constraint, `NOT NULL` included, with or without a `DEFAULT`. So the safe subset is not a policy this code chose — it is the boundary the engine enforces. A future column outside it needs a hand-written step, and the boot warning is what tells you the day one appears.
+
+There is still no schema-version marker, and none is needed: the comparison is against the database itself. The expected shape is not written down twice either — it is read back from a scratch in-memory database the same DDL has just been run against, so the `CREATE TABLE` statements remain the single declaration of the schema.
+
+### Why it took an upgrade to find
+
+CI starts from a clean checkout with no `publisher.db`, so the create path always runs with the current DDL and the drift cannot arise. The gap was never a missing assertion — it was that no test had ever booted against a store older than the build. There is one now.
+
+---
+
 ## [Unreleased] — a `storage=` build's warehouse read is now attributable
 
 A `storage=` build reads its source through DuckDB's native query-passthrough, where no Malloy connector is in the call path to apply the query-metadata bag. Every such build therefore reached the warehouse untagged — the one kind of work a deployment could not attribute. It now carries the same bag the colocated path does, resolved through the same layering.

--- a/packages/server/src/storage/duckdb/DuckDBConnection.ts
+++ b/packages/server/src/storage/duckdb/DuckDBConnection.ts
@@ -5,6 +5,7 @@ import {
    type DuckDBValue,
 } from "@duckdb/node-api";
 import * as path from "path";
+import { logger } from "../../logger";
 import { DatabaseConnection } from "../DatabaseInterface";
 
 /**
@@ -56,7 +57,10 @@ export class DuckDBConnection implements DatabaseConnection {
             this.instance.closeSync();
             this.instance = null;
          }
-         console.log("DuckDB connection closed");
+         // Debug, not stdout: the schema reconcile opens and closes a scratch
+         // in-memory database on every boot, and an unconditional "closed" line
+         // during startup reads as the real store going away.
+         logger.debug("DuckDB connection closed");
       } catch (err) {
          const message = err instanceof Error ? err.message : String(err);
          throw new Error(`Failed to close DuckDB connection: ${message}`);

--- a/packages/server/src/storage/duckdb/schema.ts
+++ b/packages/server/src/storage/duckdb/schema.ts
@@ -328,8 +328,16 @@ function columnKey(column: ColumnShape): string {
  *   stand-in would leave the store permanently disagreeing with its own
  *   declaration, so it warns and leaves the write to fail, which is at least
  *   traceable to a named column at boot.
- * - A column already present whose type, nullability or default has changed is
- *   not an ALTER we can infer the intent of.
+ * - A column already present whose type, nullability, default or constraints
+ *   have changed is not an ALTER we can infer the intent of.
+ *
+ *   Where the hand-written step goes when one is needed:
+ *   `dropPackageKeyedIncrementalLedger` below is exactly that shape — a
+ *   targeted pre-pass, keyed off what it finds on disk rather than a version
+ *   marker, running before the CREATE pass so the tables are recreated
+ *   correctly. Copy it rather than rediscovering the pattern; the warning's
+ *   other suggestion, `--init`, is destructive and takes environments,
+ *   packages and materializations with it.
  * - A column or table on disk that this build no longer declares is left alone.
  *   Dropping is a decision, not a reconciliation, and the relics are inert:
  *   `materializations.build_plan` (added and removed within four days in June
@@ -349,12 +357,14 @@ async function reconcileDeclaredColumns(db: DuckDBConnection): Promise<void> {
 
       const declared = await mirror.all<ColumnShape>(COLUMN_SHAPE_QUERY);
       const onDisk = await db.all<ColumnShape>(COLUMN_SHAPE_QUERY);
-      const constraints = await mirror.all<ConstraintRow>(CONSTRAINT_QUERY);
 
       const plan = planColumnReconcile(
          declared,
          onDisk,
-         constrainedColumnsOf(constraints),
+         constrainedColumnsOf(
+            await mirror.all<ConstraintRow>(CONSTRAINT_QUERY),
+         ),
+         constrainedColumnsOf(await db.all<ConstraintRow>(CONSTRAINT_QUERY)),
       );
 
       const added: string[] = [];
@@ -366,7 +376,12 @@ async function reconcileDeclaredColumns(db: DuckDBConnection): Promise<void> {
             await db.run(add.sql);
             added.push(add.description);
          } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
+            // First line only: DuckDBConnection.run appends the whole failing
+            // statement after a newline, which would turn a scannable boot
+            // warning into a multi-line SQL dump.
+            const message = (
+               err instanceof Error ? err.message : String(err)
+            ).split("\n")[0];
             failed.push(`${add.description} (${message})`);
          }
       }
@@ -405,6 +420,15 @@ async function reconcileDeclaredColumns(db: DuckDBConnection): Promise<void> {
    }
 }
 
+/**
+ * The constraint kinds worth comparing between two stores, sorted so the
+ * comparison is order-insensitive. NOT NULL is dropped because `is_nullable`
+ * already carries it, and reporting both would name one difference twice.
+ */
+function enforcedKinds(kinds: string[] | undefined): string[] {
+   return (kinds ?? []).filter((kind) => kind !== "NOT NULL").sort();
+}
+
 /** Every column named by any constraint, mapped to the constraint kinds naming it. */
 export function constrainedColumnsOf(
    constraints: ConstraintRow[],
@@ -438,6 +462,7 @@ export function planColumnReconcile(
    declared: ColumnShape[],
    onDisk: ColumnShape[],
    constrainedColumns: Map<string, string[]>,
+   diskConstrainedColumns: Map<string, string[]>,
 ): {
    adds: Array<{ sql: string; description: string }>;
    needsMigration: string[];
@@ -497,6 +522,20 @@ export function planColumnReconcile(
       ) {
          differences.push(
             `default on disk ${existing.column_default ?? "none"}, declared ${column.column_default ?? "none"}`,
+         );
+      }
+      // A constraint added to a table that already exists is as invisible to
+      // CREATE TABLE IF NOT EXISTS as a column is, and the consequence is worse
+      // than a missing column: the store keeps accepting rows a fresh store
+      // rejects, so two servers on one build enforce different rules with
+      // nothing failing. It has happened here once already — `incremental_ledger`
+      // was re-keyed, and needed the hand-written detector below to catch it.
+      // NOT NULL is excluded because `is_nullable` above says it better.
+      const declaredKinds = enforcedKinds(constrainedColumns.get(key));
+      const diskKinds = enforcedKinds(diskConstrainedColumns.get(key));
+      if (declaredKinds.join(",") !== diskKinds.join(",")) {
+         differences.push(
+            `constraints on disk ${diskKinds.join(" + ") || "none"}, declared ${declaredKinds.join(" + ") || "none"}`,
          );
       }
       if (differences.length > 0) {

--- a/packages/server/src/storage/duckdb/schema.ts
+++ b/packages/server/src/storage/duckdb/schema.ts
@@ -39,9 +39,17 @@ export async function initializeSchema(
    // A CREATE TABLE IF NOT EXISTS is a no-op against an existing table no matter
    // how its COLUMNS differ, so the pass above carries a new table but never a
    // new column. Reconcile those separately, and only where the drift can exist:
-   // a store created by this build (or re-created by --init just above) already
-   // matches the declaration by construction.
-   if (initialized && !force) {
+   // nothing is on disk to have drifted before this build created it.
+   //
+   // `--init` is NOT exempt. It looks like it should be, since dropAllTables
+   // recreates everything from scratch — but that function's table list is a
+   // second, hand-maintained declaration of the table set, exactly the kind of
+   // parallel list this reconcile exists to avoid depending on. A table added to
+   // the DDL and forgotten there survives the drop, no-ops through CREATE TABLE
+   // IF NOT EXISTS, and would keep its drift through the one command the warning
+   // below tells operators to run. On a correctly recreated store the reconcile
+   // finds nothing, so the cost of not exempting it is one in-memory DDL run.
+   if (initialized) {
       await reconcileDeclaredColumns(db);
    }
 
@@ -255,18 +263,36 @@ async function createDeclaredIndexes(db: DuckDBConnection): Promise<void> {
    );
 }
 
-interface ColumnShape {
+export interface ColumnShape {
    table_name: string;
    column_name: string;
    data_type: string;
    is_nullable: boolean;
+   /** SQL expression, as the catalog renders it (e.g. `CAST('t' AS BOOLEAN)`). */
+   column_default: string | null;
 }
 
-/** The shape of a database as the catalog reports it, for both sides of the diff. */
+export interface ConstraintRow {
+   table_name: string;
+   constraint_type: string;
+   constraint_column_names: string[];
+}
+
+// `database_name = current_database()` is load-bearing, not tidiness: filtering
+// on the schema alone also matches DuckDB's own `system.main` catalog (141 of the
+// 146 rows on an empty database) and anything in `temp.main`. Those cancel out
+// across a diff of two DuckDBs, but the keys here are `table.column`, so a
+// same-named table in a second attached database would collide last-wins.
 const COLUMN_SHAPE_QUERY = `
-   SELECT table_name, column_name, data_type, is_nullable
+   SELECT table_name, column_name, data_type, is_nullable, column_default
    FROM duckdb_columns()
-   WHERE schema_name = 'main'
+   WHERE schema_name = 'main' AND database_name = current_database()
+`;
+
+const CONSTRAINT_QUERY = `
+   SELECT table_name, constraint_type, constraint_column_names
+   FROM duckdb_constraints()
+   WHERE schema_name = 'main' AND database_name = current_database()
 `;
 
 function columnKey(column: ColumnShape): string {
@@ -284,19 +310,26 @@ function columnKey(column: ColumnShape): string {
  * The disk is the other half of the comparison, so no schema-version marker is
  * needed and none is kept.
  *
- * Strictly additive, and only for nullable columns, which is a boundary DuckDB
- * enforces rather than one this code chooses: `ALTER TABLE ... ADD COLUMN`
- * rejects a column carrying any constraint ("Adding columns with constraints not
- * yet supported"), including NOT NULL, with or without a DEFAULT. A bare DEFAULT
- * is accepted and backfills existing rows.
+ * Strictly additive, and only for columns carrying no constraint, which is a
+ * boundary DuckDB enforces rather than one this code chooses: `ALTER TABLE ...
+ * ADD COLUMN` rejects a column carrying any constraint ("Adding columns with
+ * constraints not yet supported") — NOT NULL, PRIMARY KEY, UNIQUE, CHECK and
+ * FOREIGN KEY alike, with or without a DEFAULT. A bare DEFAULT is accepted and
+ * backfills existing rows, so a declared default IS carried across; a constraint
+ * never can be. Constraints are read from `duckdb_constraints()` rather than
+ * inferred from `is_nullable`, because a UNIQUE or CHECK column reports as
+ * nullable and would otherwise be added as a bare column: the store would then
+ * hold the right column under the wrong rules, and two servers on the same build
+ * would enforce differently depending on how their store was created.
  *
  * Everything else the diff finds is reported, not acted on:
  *
- * - A missing NOT NULL column cannot be added at all. Adding it as nullable
- *   would leave the store permanently disagreeing with its own declaration, so
- *   it warns and leaves the write to fail, which is at least traceable to a
- *   named column at boot.
- * - A type change is not an ALTER we can infer the intent of.
+ * - A missing constrained column cannot be added at all. Adding an unconstrained
+ *   stand-in would leave the store permanently disagreeing with its own
+ *   declaration, so it warns and leaves the write to fail, which is at least
+ *   traceable to a named column at boot.
+ * - A column already present whose type, nullability or default has changed is
+ *   not an ALTER we can infer the intent of.
  * - A column or table on disk that this build no longer declares is left alone.
  *   Dropping is a decision, not a reconciliation, and the relics are inert:
  *   `materializations.build_plan` (added and removed within four days in June
@@ -316,53 +349,29 @@ async function reconcileDeclaredColumns(db: DuckDBConnection): Promise<void> {
 
       const declared = await mirror.all<ColumnShape>(COLUMN_SHAPE_QUERY);
       const onDisk = await db.all<ColumnShape>(COLUMN_SHAPE_QUERY);
+      const constraints = await mirror.all<ConstraintRow>(CONSTRAINT_QUERY);
 
-      const declaredTables = new Set(declared.map((c) => c.table_name));
-      const declaredColumns = new Set(declared.map(columnKey));
-      const diskTables = new Set(onDisk.map((c) => c.table_name));
-      const diskColumns = new Map(onDisk.map((c) => [columnKey(c), c]));
+      const plan = planColumnReconcile(
+         declared,
+         onDisk,
+         constrainedColumnsOf(constraints),
+      );
 
       const added: string[] = [];
-      const needsMigration: string[] = [];
-
-      for (const column of declared) {
-         // A table absent from disk was just created by the pass above, at the
-         // declared shape; only tables that predate this build can drift.
-         if (!diskTables.has(column.table_name)) {
-            continue;
-         }
-         const existing = diskColumns.get(columnKey(column));
-         if (!existing) {
-            if (!column.is_nullable) {
-               needsMigration.push(
-                  `${columnKey(column)} (declared NOT NULL; DuckDB cannot add a constrained column)`,
-               );
-               continue;
-            }
-            await db.run(
-               `ALTER TABLE "${column.table_name}" ADD COLUMN IF NOT EXISTS "${column.column_name}" ${column.data_type}`,
-            );
-            added.push(`${columnKey(column)} ${column.data_type}`);
-         } else if (existing.data_type !== column.data_type) {
-            needsMigration.push(
-               `${columnKey(column)} (on disk ${existing.data_type}, declared ${column.data_type})`,
-            );
+      const failed: string[] = [];
+      for (const add of plan.adds) {
+         // Per column, so one column DuckDB refuses cannot abandon the rest of
+         // the reconcile — and so the summary below still reports what did land.
+         try {
+            await db.run(add.sql);
+            added.push(add.description);
+         } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            failed.push(`${add.description} (${message})`);
          }
       }
 
-      const undeclared = [
-         ...onDisk
-            .filter(
-               (c) =>
-                  declaredTables.has(c.table_name) &&
-                  !declaredColumns.has(columnKey(c)),
-            )
-            .map(columnKey),
-         ...[...diskTables]
-            .filter((t) => !declaredTables.has(t))
-            .map((t) => `${t} (whole table)`),
-      ];
-
+      const needsMigration = [...plan.needsMigration, ...failed];
       if (added.length > 0) {
          logger.info(
             `publisher.db: added ${added.length} column(s) this build declares that the store predates: ${added.join(", ")}`,
@@ -375,9 +384,9 @@ async function reconcileDeclaredColumns(db: DuckDBConnection): Promise<void> {
                `the store is migrated by hand or recreated with --init: ${needsMigration.join(", ")}`,
          );
       }
-      if (undeclared.length > 0) {
+      if (plan.undeclared.length > 0) {
          logger.debug(
-            `publisher.db holds ${undeclared.length} column(s)/table(s) this build no longer declares; left in place: ${undeclared.join(", ")}`,
+            `publisher.db holds ${plan.undeclared.length} column(s)/table(s) this build no longer declares; left in place: ${plan.undeclared.join(", ")}`,
          );
       }
    } catch (err) {
@@ -394,6 +403,121 @@ async function reconcileDeclaredColumns(db: DuckDBConnection): Promise<void> {
          // a boot over.
       }
    }
+}
+
+/** Every column named by any constraint, mapped to the constraint kinds naming it. */
+export function constrainedColumnsOf(
+   constraints: ConstraintRow[],
+): Map<string, string[]> {
+   const byColumn = new Map<string, string[]>();
+   for (const constraint of constraints) {
+      for (const column of constraint.constraint_column_names ?? []) {
+         const key = `${constraint.table_name}.${column}`;
+         const kinds = byColumn.get(key) ?? [];
+         if (!kinds.includes(constraint.constraint_type)) {
+            kinds.push(constraint.constraint_type);
+         }
+         byColumn.set(key, kinds);
+      }
+   }
+   return byColumn;
+}
+
+/**
+ * Decide what to do about each difference between the declared shape and the
+ * store, without touching either.
+ *
+ * Split out from the IO so the cases that matter can be tested against synthetic
+ * shapes: today's declared schema has no defaulted or UNIQUE column, so no test
+ * driving the real DDL could reach the branches that handle them, and those are
+ * exactly the branches a future column will land in.
+ *
+ * Exported for tests.
+ */
+export function planColumnReconcile(
+   declared: ColumnShape[],
+   onDisk: ColumnShape[],
+   constrainedColumns: Map<string, string[]>,
+): {
+   adds: Array<{ sql: string; description: string }>;
+   needsMigration: string[];
+   undeclared: string[];
+} {
+   const declaredTables = new Set(declared.map((c) => c.table_name));
+   const declaredColumns = new Set(declared.map(columnKey));
+   const diskTables = new Set(onDisk.map((c) => c.table_name));
+   const diskColumns = new Map(onDisk.map((c) => [columnKey(c), c]));
+
+   const adds: Array<{ sql: string; description: string }> = [];
+   const needsMigration: string[] = [];
+
+   for (const column of declared) {
+      // A table absent from disk was just created by the pass above, at the
+      // declared shape; only tables that predate this build can drift.
+      if (!diskTables.has(column.table_name)) {
+         continue;
+      }
+      const key = columnKey(column);
+      const existing = diskColumns.get(key);
+
+      if (!existing) {
+         const kinds = constrainedColumns.get(key);
+         if (kinds && kinds.length > 0) {
+            needsMigration.push(
+               `${key} (declared ${kinds.join(" + ")}; DuckDB cannot add a constrained column)`,
+            );
+            continue;
+         }
+         const withDefault = column.column_default
+            ? ` DEFAULT ${column.column_default}`
+            : "";
+         adds.push({
+            sql: `ALTER TABLE "${column.table_name}" ADD COLUMN IF NOT EXISTS "${column.column_name}" ${column.data_type}${withDefault}`,
+            description: `${key} ${column.data_type}${withDefault}`,
+         });
+         continue;
+      }
+
+      // Present, but not as declared. Reported per difference rather than as a
+      // bare "differs", because which of the three moved decides what the
+      // hand-written step has to do.
+      const differences: string[] = [];
+      if (existing.data_type !== column.data_type) {
+         differences.push(
+            `type on disk ${existing.data_type}, declared ${column.data_type}`,
+         );
+      }
+      if (existing.is_nullable !== column.is_nullable) {
+         differences.push(
+            `nullability on disk ${existing.is_nullable ? "NULL" : "NOT NULL"}, declared ${column.is_nullable ? "NULL" : "NOT NULL"}`,
+         );
+      }
+      if (
+         (existing.column_default ?? null) !== (column.column_default ?? null)
+      ) {
+         differences.push(
+            `default on disk ${existing.column_default ?? "none"}, declared ${column.column_default ?? "none"}`,
+         );
+      }
+      if (differences.length > 0) {
+         needsMigration.push(`${key} (${differences.join("; ")})`);
+      }
+   }
+
+   const undeclared = [
+      ...onDisk
+         .filter(
+            (c) =>
+               declaredTables.has(c.table_name) &&
+               !declaredColumns.has(columnKey(c)),
+         )
+         .map(columnKey),
+      ...[...diskTables]
+         .filter((t) => !declaredTables.has(t))
+         .map((t) => `${t} (whole table)`),
+   ];
+
+   return { adds, needsMigration, undeclared };
 }
 
 /**

--- a/packages/server/src/storage/duckdb/schema.ts
+++ b/packages/server/src/storage/duckdb/schema.ts
@@ -34,7 +34,31 @@ export async function initializeSchema(
    // up new tables added in later builds (e.g., the `themes` table for
    // the in-app Theme Editor) without forcing operators to run --init
    // and lose their existing environments / packages / materializations.
+   await createDeclaredTables(db);
 
+   // A CREATE TABLE IF NOT EXISTS is a no-op against an existing table no matter
+   // how its COLUMNS differ, so the pass above carries a new table but never a
+   // new column. Reconcile those separately, and only where the drift can exist:
+   // a store created by this build (or re-created by --init just above) already
+   // matches the declaration by construction.
+   if (initialized && !force) {
+      await reconcileDeclaredColumns(db);
+   }
+
+   // After the reconcile, so an index over a newly added column can be created
+   // in the same boot that adds it.
+   await createDeclaredIndexes(db);
+}
+
+/**
+ * The declared schema: every table this build expects `publisher.db` to hold.
+ *
+ * These statements are the single source of truth for the shape of the store —
+ * `reconcileDeclaredColumns` derives the expected columns by running this same
+ * function against a scratch database rather than from a second, hand-maintained
+ * list, so there is no parallel declaration to drift out of sync with the DDL.
+ */
+async function createDeclaredTables(db: DuckDBConnection): Promise<void> {
    // Environments table
    await db.run(`
     CREATE TABLE IF NOT EXISTS environments (
@@ -205,7 +229,9 @@ export async function initializeSchema(
   `);
 
    await createEntityEmbeddingsTable(db);
+}
 
+async function createDeclaredIndexes(db: DuckDBConnection): Promise<void> {
    // Create indexes for better query performance
    await db.run(
       "CREATE INDEX IF NOT EXISTS idx_packages_environment_id ON packages(environment_id)",
@@ -227,6 +253,147 @@ export async function initializeSchema(
    await db.run(
       "CREATE INDEX IF NOT EXISTS idx_incremental_ledger_environment_package ON incremental_ledger(environment_id, package_name)",
    );
+}
+
+interface ColumnShape {
+   table_name: string;
+   column_name: string;
+   data_type: string;
+   is_nullable: boolean;
+}
+
+/** The shape of a database as the catalog reports it, for both sides of the diff. */
+const COLUMN_SHAPE_QUERY = `
+   SELECT table_name, column_name, data_type, is_nullable
+   FROM duckdb_columns()
+   WHERE schema_name = 'main'
+`;
+
+function columnKey(column: ColumnShape): string {
+   return `${column.table_name}.${column.column_name}`;
+}
+
+/**
+ * Add columns this build declares that an existing `publisher.db` does not have.
+ *
+ * The expected shape is not written down anywhere: it is read back out of a
+ * throwaway in-memory database that `createDeclaredTables` has just been run
+ * against. A hand-maintained column list would be a second declaration of the
+ * schema, and a column added to the DDL but forgotten there would reproduce this
+ * bug exactly; executing the DDL makes the statements their own specification.
+ * The disk is the other half of the comparison, so no schema-version marker is
+ * needed and none is kept.
+ *
+ * Strictly additive, and only for nullable columns, which is a boundary DuckDB
+ * enforces rather than one this code chooses: `ALTER TABLE ... ADD COLUMN`
+ * rejects a column carrying any constraint ("Adding columns with constraints not
+ * yet supported"), including NOT NULL, with or without a DEFAULT. A bare DEFAULT
+ * is accepted and backfills existing rows.
+ *
+ * Everything else the diff finds is reported, not acted on:
+ *
+ * - A missing NOT NULL column cannot be added at all. Adding it as nullable
+ *   would leave the store permanently disagreeing with its own declaration, so
+ *   it warns and leaves the write to fail, which is at least traceable to a
+ *   named column at boot.
+ * - A type change is not an ALTER we can infer the intent of.
+ * - A column or table on disk that this build no longer declares is left alone.
+ *   Dropping is a decision, not a reconciliation, and the relics are inert:
+ *   `materializations.build_plan` (added and removed within four days in June
+ *   2026) and the `build_manifests` table both sit on stores in the wild,
+ *   unreferenced by any query.
+ *
+ * A failure here is logged and swallowed. The server can serve an environment it
+ * cannot materialize into, and refusing to boot over that would turn a partial
+ * outage into a total one.
+ */
+async function reconcileDeclaredColumns(db: DuckDBConnection): Promise<void> {
+   let mirror: DuckDBConnection | null = null;
+   try {
+      mirror = new DuckDBConnection(":memory:");
+      await mirror.initialize();
+      await createDeclaredTables(mirror);
+
+      const declared = await mirror.all<ColumnShape>(COLUMN_SHAPE_QUERY);
+      const onDisk = await db.all<ColumnShape>(COLUMN_SHAPE_QUERY);
+
+      const declaredTables = new Set(declared.map((c) => c.table_name));
+      const declaredColumns = new Set(declared.map(columnKey));
+      const diskTables = new Set(onDisk.map((c) => c.table_name));
+      const diskColumns = new Map(onDisk.map((c) => [columnKey(c), c]));
+
+      const added: string[] = [];
+      const needsMigration: string[] = [];
+
+      for (const column of declared) {
+         // A table absent from disk was just created by the pass above, at the
+         // declared shape; only tables that predate this build can drift.
+         if (!diskTables.has(column.table_name)) {
+            continue;
+         }
+         const existing = diskColumns.get(columnKey(column));
+         if (!existing) {
+            if (!column.is_nullable) {
+               needsMigration.push(
+                  `${columnKey(column)} (declared NOT NULL; DuckDB cannot add a constrained column)`,
+               );
+               continue;
+            }
+            await db.run(
+               `ALTER TABLE "${column.table_name}" ADD COLUMN IF NOT EXISTS "${column.column_name}" ${column.data_type}`,
+            );
+            added.push(`${columnKey(column)} ${column.data_type}`);
+         } else if (existing.data_type !== column.data_type) {
+            needsMigration.push(
+               `${columnKey(column)} (on disk ${existing.data_type}, declared ${column.data_type})`,
+            );
+         }
+      }
+
+      const undeclared = [
+         ...onDisk
+            .filter(
+               (c) =>
+                  declaredTables.has(c.table_name) &&
+                  !declaredColumns.has(columnKey(c)),
+            )
+            .map(columnKey),
+         ...[...diskTables]
+            .filter((t) => !declaredTables.has(t))
+            .map((t) => `${t} (whole table)`),
+      ];
+
+      if (added.length > 0) {
+         logger.info(
+            `publisher.db: added ${added.length} column(s) this build declares that the store predates: ${added.join(", ")}`,
+         );
+      }
+      if (needsMigration.length > 0) {
+         logger.warn(
+            "publisher.db does not match the schema this build declares, and the difference " +
+               "cannot be reconciled automatically. Writes naming these columns will fail until " +
+               `the store is migrated by hand or recreated with --init: ${needsMigration.join(", ")}`,
+         );
+      }
+      if (undeclared.length > 0) {
+         logger.debug(
+            `publisher.db holds ${undeclared.length} column(s)/table(s) this build no longer declares; left in place: ${undeclared.join(", ")}`,
+         );
+      }
+   } catch (err) {
+      logger.error(
+         "Failed to reconcile publisher.db against the schema this build declares. " +
+            "The server will continue; if the store predates a column, writes naming it will fail.",
+         err,
+      );
+   } finally {
+      try {
+         await mirror?.close();
+      } catch {
+         // A scratch in-memory database that will not close is not worth failing
+         // a boot over.
+      }
+   }
 }
 
 /**

--- a/packages/server/src/storage/duckdb/schema.ts
+++ b/packages/server/src/storage/duckdb/schema.ts
@@ -496,8 +496,19 @@ export function planColumnReconcile(
          const withDefault = column.column_default
             ? ` DEFAULT ${column.column_default}`
             : "";
+         // Deliberately NOT `IF NOT EXISTS`. The catalog read above is what
+         // establishes the column is absent, so the guard adds no safety — and
+         // on the DuckDB this pins (1.5.0–1.5.3, duckdb/duckdb#23209) `ADD
+         // COLUMN IF NOT EXISTS ... DEFAULT` against a column that DOES exist
+         // re-applies the default to every row instead of doing nothing,
+         // silently destroying the column's data. It hits fixed-width types —
+         // measured here on BOOLEAN and TIMESTAMP, while VARCHAR, INTEGER and
+         // JSON survive — and TIMESTAMP is most of this schema's non-VARCHAR
+         // columns. Without the guard, a disagreement between the plan and the
+         // catalog raises into the per-column catch and is reported, which is
+         // the outcome this whole path is built around.
          adds.push({
-            sql: `ALTER TABLE "${column.table_name}" ADD COLUMN IF NOT EXISTS "${column.column_name}" ${column.data_type}${withDefault}`,
+            sql: `ALTER TABLE "${column.table_name}" ADD COLUMN "${column.column_name}" ${column.data_type}${withDefault}`,
             description: `${key} ${column.data_type}${withDefault}`,
          });
          continue;

--- a/packages/server/tests/unit/duckdb/schema_column_reconcile.test.ts
+++ b/packages/server/tests/unit/duckdb/schema_column_reconcile.test.ts
@@ -6,7 +6,12 @@ import os from "os";
 import path from "path";
 import { DuckDBConnection } from "../../../src/storage/duckdb/DuckDBConnection";
 import { MaterializationRepository } from "../../../src/storage/duckdb/MaterializationRepository";
-import { initializeSchema } from "../../../src/storage/duckdb/schema";
+import {
+   type ColumnShape,
+   constrainedColumnsOf,
+   initializeSchema,
+   planColumnReconcile,
+} from "../../../src/storage/duckdb/schema";
 
 const TEST_DB_DIR = path.join(os.tmpdir(), "duckdb-column-reconcile-tests");
 
@@ -67,6 +72,27 @@ async function columnNames(
    return rows.map((row) => row.column_name);
 }
 
+/**
+ * The full definition of a table's columns, not just their names — type,
+ * nullability and default. Comparing all three is what makes the upgrade
+ * assertions a tripwire: a reconciled store must be indistinguishable from one
+ * this build created, so the day a declared column carries something the ALTER
+ * cannot express, the comparison fails instead of a divergent store shipping.
+ */
+async function fullShape(
+   db: DuckDBConnection,
+   table: string,
+): Promise<unknown[]> {
+   return db.all(
+      `SELECT column_name, data_type, is_nullable, column_default
+       FROM duckdb_columns()
+       WHERE schema_name = 'main' AND database_name = current_database()
+         AND table_name = ?
+       ORDER BY column_name`,
+      [table],
+   );
+}
+
 describe("DuckDB declared-column reconcile", () => {
    beforeEach(async () => {
       await fs.mkdir(TEST_DB_DIR, { recursive: true });
@@ -101,6 +127,16 @@ describe("DuckDB declared-column reconcile", () => {
       expect(created.environmentId).toBe("env-1");
       expect(created.packageName).toBe("pkg-a");
 
+      // The upgraded table is now indistinguishable from a freshly created one,
+      // down to nullability and default — not merely "has a column of that name".
+      const mirror = new DuckDBConnection(":memory:");
+      await mirror.initialize();
+      await initializeSchema(mirror);
+      expect(await fullShape(db, "materializations")).toEqual(
+         await fullShape(mirror, "materializations"),
+      );
+
+      await mirror.close();
       await db.close();
    });
 
@@ -156,6 +192,31 @@ describe("DuckDB declared-column reconcile", () => {
       await db.close();
    });
 
+   it("refuses to add a declared NOT NULL column rather than adding it unconstrained", async () => {
+      const db = new DuckDBConnection(path.join(TEST_DB_DIR, "notnull.duckdb"));
+      await db.initialize();
+      await seedPreManifestSchema(db);
+      // `themes.payload` is declared JSON NOT NULL. A store holding the table
+      // without it cannot be repaired by ALTER, and adding a nullable stand-in
+      // would leave the store disagreeing with its own declaration.
+      await db.run(`
+         CREATE TABLE themes (
+            id VARCHAR PRIMARY KEY,
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP NOT NULL
+         )
+      `);
+
+      await initializeSchema(db);
+
+      expect(await columnNames(db, "themes")).not.toContain("payload");
+      // The reconcile continues past the refusal: the unrelated column it CAN
+      // add still lands in the same boot.
+      expect(await columnNames(db, "materializations")).toContain("manifest");
+
+      await db.close();
+   });
+
    it("is idempotent: a second boot against a reconciled store changes nothing", async () => {
       const db = new DuckDBConnection(
          path.join(TEST_DB_DIR, "idempotent.duckdb"),
@@ -191,5 +252,119 @@ describe("DuckDB declared-column reconcile", () => {
 
       await mirror.close();
       await db.close();
+   });
+});
+
+// Today's declared schema has no defaulted, UNIQUE or CHECK column, so no test
+// driving the real DDL can reach the branches that handle them — and those are
+// precisely the branches the next column added to `schema.ts` will land in.
+// Drive the decision function directly with synthetic shapes instead.
+describe("planColumnReconcile", () => {
+   const col = (
+      table: string,
+      name: string,
+      type: string,
+      overrides: Partial<ColumnShape> = {},
+   ): ColumnShape => ({
+      table_name: table,
+      column_name: name,
+      data_type: type,
+      is_nullable: true,
+      column_default: null,
+      ...overrides,
+   });
+
+   const existingTable = [col("t", "id", "VARCHAR")];
+
+   it("carries a declared DEFAULT onto the added column", () => {
+      const plan = planColumnReconcile(
+         [
+            ...existingTable,
+            col("t", "flag", "BOOLEAN", {
+               column_default: "CAST('t' AS BOOLEAN)",
+            }),
+         ],
+         existingTable,
+         new Map(),
+      );
+      expect(plan.adds).toHaveLength(1);
+      expect(plan.adds[0].sql).toBe(
+         `ALTER TABLE "t" ADD COLUMN IF NOT EXISTS "flag" BOOLEAN DEFAULT CAST('t' AS BOOLEAN)`,
+      );
+      expect(plan.needsMigration).toEqual([]);
+   });
+
+   it("refuses a UNIQUE column, which reports as nullable and would otherwise be added bare", () => {
+      const plan = planColumnReconcile(
+         [...existingTable, col("t", "slug", "VARCHAR")],
+         existingTable,
+         new Map([["t.slug", ["UNIQUE"]]]),
+      );
+      expect(plan.adds).toEqual([]);
+      expect(plan.needsMigration[0]).toContain("t.slug");
+      expect(plan.needsMigration[0]).toContain("UNIQUE");
+   });
+
+   it("reports a nullability or default change on a column already present", () => {
+      const plan = planColumnReconcile(
+         [
+            col("t", "id", "VARCHAR", { is_nullable: false }),
+            col("t", "n", "INTEGER", { column_default: "1" }),
+         ],
+         [col("t", "id", "VARCHAR"), col("t", "n", "INTEGER")],
+         new Map(),
+      );
+      expect(plan.adds).toEqual([]);
+      expect(plan.needsMigration).toHaveLength(2);
+      expect(plan.needsMigration[0]).toContain("nullability");
+      expect(plan.needsMigration[1]).toContain("default");
+   });
+
+   it("never plans anything for a table absent from the store", () => {
+      // Just created at the declared shape by the CREATE TABLE pass.
+      const plan = planColumnReconcile(
+         [col("fresh", "a", "VARCHAR")],
+         [],
+         new Map(),
+      );
+      expect(plan.adds).toEqual([]);
+      expect(plan.needsMigration).toEqual([]);
+   });
+
+   it("reports undeclared columns and tables without planning a drop", () => {
+      const plan = planColumnReconcile(
+         existingTable,
+         [
+            ...existingTable,
+            col("t", "relic", "JSON"),
+            col("gone", "x", "VARCHAR"),
+         ],
+         new Map(),
+      );
+      expect(plan.adds).toEqual([]);
+      expect(plan.undeclared).toEqual(["t.relic", "gone (whole table)"]);
+   });
+
+   it("maps every constraint kind onto the columns it names", () => {
+      const constrained = constrainedColumnsOf([
+         {
+            table_name: "t",
+            constraint_type: "PRIMARY KEY",
+            constraint_column_names: ["a", "b"],
+         },
+         {
+            table_name: "t",
+            constraint_type: "NOT NULL",
+            constraint_column_names: ["a"],
+         },
+         {
+            table_name: "t",
+            constraint_type: "CHECK",
+            constraint_column_names: ["c"],
+         },
+      ]);
+      expect(constrained.get("t.a")).toEqual(["PRIMARY KEY", "NOT NULL"]);
+      expect(constrained.get("t.b")).toEqual(["PRIMARY KEY"]);
+      expect(constrained.get("t.c")).toEqual(["CHECK"]);
    });
 });

--- a/packages/server/tests/unit/duckdb/schema_column_reconcile.test.ts
+++ b/packages/server/tests/unit/duckdb/schema_column_reconcile.test.ts
@@ -316,9 +316,32 @@ describe("planColumnReconcile", () => {
       );
       expect(plan.adds).toHaveLength(1);
       expect(plan.adds[0].sql).toBe(
-         `ALTER TABLE "t" ADD COLUMN IF NOT EXISTS "flag" BOOLEAN DEFAULT CAST('t' AS BOOLEAN)`,
+         `ALTER TABLE "t" ADD COLUMN "flag" BOOLEAN DEFAULT CAST('t' AS BOOLEAN)`,
       );
       expect(plan.needsMigration).toEqual([]);
+   });
+
+   it("never emits IF NOT EXISTS, which DuckDB 1.5.0-1.5.3 turns into a silent overwrite", () => {
+      // duckdb/duckdb#23209: `ADD COLUMN IF NOT EXISTS ... DEFAULT` against a
+      // column that already exists re-applies the default to every row rather
+      // than doing nothing. Reproduced on the pinned engine for BOOLEAN and
+      // TIMESTAMP. The plan's own absence check is the guard, so the clause is
+      // pure downside — pinned here because re-adding it looks like a harmless
+      // safety improvement.
+      const plan = planColumnReconcile(
+         [
+            ...existingTable,
+            col("t", "plain", "VARCHAR"),
+            col("t", "stamped", "TIMESTAMP", { column_default: "now()" }),
+         ],
+         existingTable,
+         new Map(),
+         new Map(),
+      );
+      expect(plan.adds).toHaveLength(2);
+      for (const add of plan.adds) {
+         expect(add.sql).not.toContain("IF NOT EXISTS");
+      }
    });
 
    it("refuses a UNIQUE column, which reports as nullable and would otherwise be added bare", () => {

--- a/packages/server/tests/unit/duckdb/schema_column_reconcile.test.ts
+++ b/packages/server/tests/unit/duckdb/schema_column_reconcile.test.ts
@@ -93,6 +93,25 @@ async function fullShape(
    );
 }
 
+/**
+ * The table's constraints, the half `fullShape` cannot see. A column definition
+ * can match perfectly while the table enforces different rules, which is the
+ * divergence that fails silently rather than loudly.
+ */
+async function tableConstraints(
+   db: DuckDBConnection,
+   table: string,
+): Promise<unknown[]> {
+   return db.all(
+      `SELECT constraint_type, constraint_column_names
+       FROM duckdb_constraints()
+       WHERE schema_name = 'main' AND database_name = current_database()
+         AND table_name = ?
+       ORDER BY constraint_type, constraint_column_names`,
+      [table],
+   );
+}
+
 describe("DuckDB declared-column reconcile", () => {
    beforeEach(async () => {
       await fs.mkdir(TEST_DB_DIR, { recursive: true });
@@ -134,6 +153,9 @@ describe("DuckDB declared-column reconcile", () => {
       await initializeSchema(mirror);
       expect(await fullShape(db, "materializations")).toEqual(
          await fullShape(mirror, "materializations"),
+      );
+      expect(await tableConstraints(db, "materializations")).toEqual(
+         await tableConstraints(mirror, "materializations"),
       );
 
       await mirror.close();
@@ -211,7 +233,11 @@ describe("DuckDB declared-column reconcile", () => {
 
       expect(await columnNames(db, "themes")).not.toContain("payload");
       // The reconcile continues past the refusal: the unrelated column it CAN
-      // add still lands in the same boot.
+      // add still lands in the same boot. Note this exercises the PLANNER's
+      // refusal, not the per-column try/catch around the ALTER — a refused
+      // column never becomes an add, so it never reaches that catch. The catch
+      // is a backstop for DuckDB rejecting an ALTER the screen approved, which
+      // nothing here constructs.
       expect(await columnNames(db, "materializations")).toContain("manifest");
 
       await db.close();
@@ -286,6 +312,7 @@ describe("planColumnReconcile", () => {
          ],
          existingTable,
          new Map(),
+         new Map(),
       );
       expect(plan.adds).toHaveLength(1);
       expect(plan.adds[0].sql).toBe(
@@ -299,6 +326,7 @@ describe("planColumnReconcile", () => {
          [...existingTable, col("t", "slug", "VARCHAR")],
          existingTable,
          new Map([["t.slug", ["UNIQUE"]]]),
+         new Map(),
       );
       expect(plan.adds).toEqual([]);
       expect(plan.needsMigration[0]).toContain("t.slug");
@@ -313,6 +341,7 @@ describe("planColumnReconcile", () => {
          ],
          [col("t", "id", "VARCHAR"), col("t", "n", "INTEGER")],
          new Map(),
+         new Map(),
       );
       expect(plan.adds).toEqual([]);
       expect(plan.needsMigration).toHaveLength(2);
@@ -320,11 +349,39 @@ describe("planColumnReconcile", () => {
       expect(plan.needsMigration[1]).toContain("default");
    });
 
+   it("reports a constraint the store lacks, which no ALTER can add back", () => {
+      // A table-level UNIQUE added to an existing table's DDL: the store keeps
+      // accepting duplicate rows a fresh store would reject, and nothing fails.
+      const plan = planColumnReconcile(
+         existingTable,
+         existingTable,
+         new Map([["t.id", ["PRIMARY KEY", "UNIQUE"]]]),
+         new Map([["t.id", ["PRIMARY KEY"]]]),
+      );
+      expect(plan.adds).toEqual([]);
+      expect(plan.needsMigration).toHaveLength(1);
+      expect(plan.needsMigration[0]).toContain(
+         "constraints on disk PRIMARY KEY",
+      );
+      expect(plan.needsMigration[0]).toContain("declared PRIMARY KEY + UNIQUE");
+   });
+
+   it("does not report NOT NULL twice: nullability covers it, constraints ignore it", () => {
+      const plan = planColumnReconcile(
+         [col("t", "id", "VARCHAR", { is_nullable: false })],
+         [col("t", "id", "VARCHAR", { is_nullable: false })],
+         new Map([["t.id", ["NOT NULL"]]]),
+         new Map(),
+      );
+      expect(plan.needsMigration).toEqual([]);
+   });
+
    it("never plans anything for a table absent from the store", () => {
       // Just created at the declared shape by the CREATE TABLE pass.
       const plan = planColumnReconcile(
          [col("fresh", "a", "VARCHAR")],
          [],
+         new Map(),
          new Map(),
       );
       expect(plan.adds).toEqual([]);
@@ -339,6 +396,7 @@ describe("planColumnReconcile", () => {
             col("t", "relic", "JSON"),
             col("gone", "x", "VARCHAR"),
          ],
+         new Map(),
          new Map(),
       );
       expect(plan.adds).toEqual([]);

--- a/packages/server/tests/unit/duckdb/schema_column_reconcile.test.ts
+++ b/packages/server/tests/unit/duckdb/schema_column_reconcile.test.ts
@@ -1,0 +1,195 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { DuckDBConnection } from "../../../src/storage/duckdb/DuckDBConnection";
+import { MaterializationRepository } from "../../../src/storage/duckdb/MaterializationRepository";
+import { initializeSchema } from "../../../src/storage/duckdb/schema";
+
+const TEST_DB_DIR = path.join(os.tmpdir(), "duckdb-column-reconcile-tests");
+
+// These tests cover the case CI otherwise never reaches: an UPGRADE. Every other
+// suite starts from no `publisher.db` at all, so the CREATE TABLE pass always
+// runs with the current DDL and a column missing from an older store cannot
+// surface. Here the older store is seeded first, on the same connection the
+// assertions run against (see legacy_schema_migration.test.ts for why we do not
+// close and reopen the file mid-test).
+
+/**
+ * The `materializations` shape from before 1673e281 (2026-06-19): no `manifest`
+ * column. Seeded verbatim rather than derived, so it keeps describing the store
+ * that shipped even as the current DDL moves on.
+ */
+async function seedPreManifestSchema(db: DuckDBConnection): Promise<void> {
+   await db.run(`
+      CREATE TABLE environments (
+         id VARCHAR PRIMARY KEY,
+         name VARCHAR NOT NULL UNIQUE,
+         path VARCHAR NOT NULL,
+         description VARCHAR,
+         metadata JSON,
+         created_at TIMESTAMP NOT NULL,
+         updated_at TIMESTAMP NOT NULL
+      )
+   `);
+   await db.run(`
+      CREATE TABLE materializations (
+         id VARCHAR PRIMARY KEY,
+         environment_id VARCHAR NOT NULL,
+         package_name VARCHAR NOT NULL,
+         status VARCHAR NOT NULL,
+         active_key VARCHAR,
+         started_at TIMESTAMP,
+         completed_at TIMESTAMP,
+         error TEXT,
+         metadata JSON,
+         created_at TIMESTAMP NOT NULL,
+         updated_at TIMESTAMP NOT NULL,
+         FOREIGN KEY (environment_id) REFERENCES environments(id)
+      )
+   `);
+   await db.run(
+      `INSERT INTO environments VALUES ('env-1', 'env-one', '/e', NULL, NULL,
+         TIMESTAMP '2026-06-01 00:00:00', TIMESTAMP '2026-06-01 00:00:00')`,
+   );
+}
+
+async function columnNames(
+   db: DuckDBConnection,
+   table: string,
+): Promise<string[]> {
+   const rows = await db.all<{ column_name: string }>(
+      "SELECT column_name FROM duckdb_columns() WHERE schema_name = 'main' AND table_name = ?",
+      [table],
+   );
+   return rows.map((row) => row.column_name);
+}
+
+describe("DuckDB declared-column reconcile", () => {
+   beforeEach(async () => {
+      await fs.mkdir(TEST_DB_DIR, { recursive: true });
+   });
+
+   afterEach(async () => {
+      try {
+         await fs.rm(TEST_DB_DIR, { recursive: true, force: true });
+      } catch {
+         // ignore
+      }
+   });
+
+   it("adds `manifest` to a store that predates it, so creating a materialization works", async () => {
+      const db = new DuckDBConnection(
+         path.join(TEST_DB_DIR, "premanifest.duckdb"),
+      );
+      await db.initialize();
+      await seedPreManifestSchema(db);
+
+      await initializeSchema(db);
+
+      expect(await columnNames(db, "materializations")).toContain("manifest");
+
+      // The exact call that returned 500 on such a store: the repository names
+      // `manifest` in its INSERT, so before the reconcile this threw a binder
+      // error rather than returning a row.
+      const repo = new MaterializationRepository(db);
+      const created = await repo.create("env-1", "pkg-a", "PENDING", {
+         trigger: "manual",
+      });
+      expect(created.environmentId).toBe("env-1");
+      expect(created.packageName).toBe("pkg-a");
+
+      await db.close();
+   });
+
+   it("preserves existing rows, leaving the added column NULL", async () => {
+      const db = new DuckDBConnection(path.join(TEST_DB_DIR, "rows.duckdb"));
+      await db.initialize();
+      await seedPreManifestSchema(db);
+      await db.run(
+         `INSERT INTO materializations (id, environment_id, package_name, status,
+            active_key, metadata, created_at, updated_at)
+          VALUES ('m-old', 'env-1', 'pkg-a', 'MANIFEST_FILE_READY', NULL, NULL,
+            TIMESTAMP '2026-06-02 00:00:00', TIMESTAMP '2026-06-02 00:00:00')`,
+      );
+
+      await initializeSchema(db);
+
+      const rows = await db.all<{ id: string; manifest: unknown }>(
+         "SELECT id, manifest FROM materializations",
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].id).toBe("m-old");
+      expect(rows[0].manifest).toBeNull();
+
+      await db.close();
+   });
+
+   it("leaves columns and tables the current build no longer declares in place", async () => {
+      const db = new DuckDBConnection(path.join(TEST_DB_DIR, "relics.duckdb"));
+      await db.initialize();
+      await seedPreManifestSchema(db);
+      // `build_plan` was added and removed within four days in June 2026, and
+      // `build_manifests` was dropped by the same commit that added `manifest`.
+      // Both are still on stores in the wild; reconciling must not take them.
+      await db.run("ALTER TABLE materializations ADD COLUMN build_plan JSON");
+      await db.run(
+         `CREATE TABLE build_manifests (
+            id VARCHAR PRIMARY KEY,
+            environment_id VARCHAR NOT NULL,
+            created_at TIMESTAMP NOT NULL
+         )`,
+      );
+
+      await initializeSchema(db);
+
+      const columns = await columnNames(db, "materializations");
+      expect(columns).toContain("manifest");
+      expect(columns).toContain("build_plan");
+      const relicTable = await db.all<{ name: string }>(
+         "SELECT name FROM sqlite_master WHERE type='table' AND name='build_manifests'",
+      );
+      expect(relicTable).toHaveLength(1);
+
+      await db.close();
+   });
+
+   it("is idempotent: a second boot against a reconciled store changes nothing", async () => {
+      const db = new DuckDBConnection(
+         path.join(TEST_DB_DIR, "idempotent.duckdb"),
+      );
+      await db.initialize();
+      await seedPreManifestSchema(db);
+
+      await initializeSchema(db);
+      const afterFirst = await columnNames(db, "materializations");
+      await initializeSchema(db);
+      const afterSecond = await columnNames(db, "materializations");
+
+      expect(afterSecond).toEqual(afterFirst);
+
+      await db.close();
+   });
+
+   it("matches a store this build created, so a fresh boot needs no reconcile", async () => {
+      const db = new DuckDBConnection(path.join(TEST_DB_DIR, "fresh.duckdb"));
+      await db.initialize();
+      await initializeSchema(db);
+
+      // Same comparison the reconcile makes, asserted directly: every table the
+      // DDL declares is on disk with exactly the columns declared for it. This
+      // is what makes the reconcile a no-op on a fresh store rather than a
+      // silent source of ALTERs.
+      const mirror = new DuckDBConnection(":memory:");
+      await mirror.initialize();
+      await initializeSchema(mirror);
+      const shapeQuery = `SELECT table_name, column_name, data_type FROM duckdb_columns()
+         WHERE schema_name = 'main' ORDER BY table_name, column_name`;
+      expect(await db.all(shapeQuery)).toEqual(await mirror.all(shapeQuery));
+
+      await mirror.close();
+      await db.close();
+   });
+});


### PR DESCRIPTION
Fixes #998.

`CREATE TABLE IF NOT EXISTS` is idempotent, so an existing `publisher.db` picks up a new **table** added by a later build. It never picks up a new **column**: that same statement is a no-op against a table that already exists, however its columns differ. A store created before a column was introduced therefore never gains it, `initializeSchema` reports success anyway, and the first write naming that column fails at the binder.

There is one such column today, and it breaks materialization outright: a `publisher.db` created before 2026-06-19 returns 500 on every `POST .../materializations` with `Binder Error: Table "materializations" does not have a column with name "manifest"`.

## What this does

Schema init now reconciles columns after the `CREATE TABLE` pass. The expected shape is **not written down a second time** — it is read back out of a throwaway in-memory DuckDB that the same `createDeclaredTables()` has just been run against, then diffed against `duckdb_columns()` on the real store. The `CREATE TABLE` statements stay the single declaration of the schema, so a column added to the DDL but forgotten in a parallel list cannot reproduce this bug. The disk is the other half of the comparison, so no schema-version marker is needed and none is introduced.

It runs on any already-initialized store — nothing is on disk to have drifted before this build created it. **`--init` is deliberately not exempt**, though it looks like it should be: `dropAllTables` recreates everything, but its table list is a second, hand-maintained declaration of the table set, which is exactly the kind of parallel list this reconcile exists to avoid depending on. A table added to the DDL and forgotten there would survive the drop, no-op through `CREATE TABLE IF NOT EXISTS`, and keep its drift through the one command the warning tells operators to run. On a correctly recreated store the reconcile finds nothing, so not exempting it costs one in-memory DDL run.

The `isInitialized()` gate is airtight rather than merely cheap — `environments` is the first table created, so even a store from an interrupted first init trips it and gets reconciled.

**Strictly additive, and only for columns carrying no constraint.** That is a boundary DuckDB enforces, not one this code picked: `ALTER TABLE … ADD COLUMN` rejects a column carrying any constraint — `NOT NULL`, `PRIMARY KEY`, `UNIQUE`, `CHECK`, `FOREIGN KEY` — with or without a `DEFAULT` (`Parser Error: Adding columns with constraints not yet supported`). A bare `DEFAULT` **is** accepted and backfills existing rows, so a declared default is carried across; a constraint never can be.

Constraints come from `duckdb_constraints()` on the mirror rather than from `is_nullable`, which matters more than it sounds: a `UNIQUE` or `CHECK` column reports as *nullable*. Screening on nullability alone would add it to an upgraded store as a bare column — right name, wrong rules — so two servers on the same build would enforce differently depending on how their store was created. That is the same class of bug this PR exists to kill, moved from "column absent" to "column wrong". Such a column is refused and named in the warning instead.

Everything else the diff finds is reported rather than acted on:

- A missing constrained column, or a column already present whose type, nullability, default **or constraints** have changed, warns at boot naming the column. The constraint comparison closes the other half of the divergence above: a `UNIQUE` or `CHECK` added to an existing table's DDL is as invisible to `CREATE TABLE IF NOT EXISTS` as a column is, and it fails more quietly — the older store simply keeps accepting rows a fresh store rejects. It has already happened once here (`incremental_ledger`'s primary key was re-keyed, needing the hand-written `dropPackageKeyedIncrementalLedger` to catch it), which is also where the doc comment now points anyone who has to write such a step. This is what turns a binder error on some later request into a diagnosable line at startup, and it is the part that keeps earning its keep after this particular column is behind us.
- A column or table on disk that this build no longer declares is **left in place** and logged at debug.

## Why nothing is ever dropped

A reconciler symmetrical in both directions would delete data during a routine upgrade. Two relics prove it is not hypothetical:

- **`build_manifests`**, a whole table, added in #666 (2026-04-20) and removed by `1673e281` (2026-06-19) — the same commit that added `manifest`. Every store predating that commit both lacks the column and still carries the table.
- **`materializations.build_plan`**, added by `1673e281` and removed four days later by #844 (`fa820889`, 2026-06-23). Stores created in that window carry a column current code never names.

Both are inert — nothing queries `build_manifests`, and every INSERT names its columns explicitly — and both are cleared by `--init`, which already lists `build_manifests` in `dropAllTables`. Removing them is an operator's decision, not something an upgrade should do quietly. They are the fixture in the "leaves relics in place" test, so the boundary is pinned rather than merely intended.

## Cost on a large store

`ADD COLUMN` of a column **without a default** is a catalog operation, not a data rewrite. Against pre-`manifest` `materializations` tables of realistic width:

| rows | file before | ALTER | + CHECKPOINT | file after |
|---|---|---|---|---|
| 100k | 4.8 MB | 1.1 ms | 2.7 ms | — |
| 1M | 41.5 MB | 4.5 ms | 5.2 ms | 41.8 MB |
| 5M | 204.8 MB | 17.6 ms | 21.5 ms | 205.0 MB |

A 205MB table gained the column in 17.6ms and the file grew 0.1%; row counts were preserved and every existing row read back NULL. It scales with row *count* (~3.5µs/1000 rows, per-row-group metadata), not bytes.

**A column carrying a `DEFAULT` is the exception**, because backfilling existing rows is a real write. Same 5M-row/205MB table: 80.7ms for the ALTER (vs 19.7ms without) and 43.8ms to checkpoint (vs 19.6ms), growing the file 0.8MB instead of 0.2MB. Still a tenth of a second, still before the server accepts traffic — but it is not the free catalog operation the row above describes, and it scales with rows. Only a table actually missing a declared column is touched — `entity_embeddings`, likely the largest by bytes on a real store, is not. Steady state after the one-time fix is the catalog diff alone: 3.7–4.9ms on that 205MB file, flat in row count. All of it is at boot, inside `StorageManager.initialize()`, so it delays readiness rather than blocking queries.

## Why CI never saw it

CI starts from a clean checkout with no `publisher.db`, so the create path always runs with the current DDL and the drift cannot arise. The gap was not a missing assertion — no test had ever booted against a store older than the build. `tests/unit/duckdb/schema_column_reconcile.test.ts` is the first, seeding the pre-`1673e281` shape verbatim so it keeps describing the store that shipped even as the DDL moves on. It covers: the column is added and `MaterializationRepository.create()` (the exact failing call) succeeds, with the upgraded table then compared to a freshly created one across type, nullability, default **and table constraints**, so a future column the ALTER cannot faithfully express turns the test red instead of shipping a divergent store; a declared `NOT NULL` column is refused rather than approximated, while an unrelated addable column still lands in the same boot; existing rows survive with the column NULL; the two relics are left alone; a second boot is a no-op; and a store this build creates already matches the mirror exactly, which is what makes the reconcile a no-op on a fresh store rather than a silent source of ALTERs.

## Verification

Reproduced the failure first, then confirmed the fix on a real server boot rather than only in unit tests — seeded a pre-`manifest` `publisher.db`, started the server, created an environment and package, and issued the call from the issue:

```
info: publisher.db: added 1 column(s) this build declares that the store predates: materializations.manifest JSON
debug: publisher.db holds 1 column(s)/table(s) this build no longer declares; left in place: build_manifests (whole table)
...
POST .../packages/storefront/materializations -> HTTP 201
```

119 tests pass across the duckdb and storage suites; lint, prettier and `tsc` clean.

CI is green on every check, including **Cross Platform Tests on all three platforms**. Windows was the one I considered a genuine risk: these tests open, write and reopen real store files, and `legacy_schema_migration.test.ts` carries a comment about Windows runners failing on a close-and-reopen of the same DuckDB file. Seeding and asserting on a single open connection, the pattern that file established, holds there.

## Two judgment calls worth a reviewer's attention

1. **A missing constrained column warns rather than being approximated by an unconstrained one.** Adding a bare stand-in would make writes succeed but leave the store permanently disagreeing with its own declaration, and the warning would then fire on every boot forever and get tuned out. There are zero such columns today, so this is currently theoretical.
2. **Relics log at `debug`, not `info`.** They are permanent on affected stores, so `info` would be noise on every boot indefinitely. The default `LOG_LEVEL` is `debug`, so they are visible out of the box.

The decision logic is split into a pure `planColumnReconcile()` and unit-tested against synthetic shapes, because today's declared schema has no defaulted, `UNIQUE` or `CHECK` column — so no test driving the real DDL could reach the branches a future column will land in. Those cover the carried `DEFAULT`, the refused `UNIQUE`, constraint drift on a column both sides already have, and that `NOT NULL` is reported once (by nullability) rather than twice.

## Out of scope

Dropping `build_manifests` / `build_plan`, and any non-additive migration machinery. A versioned migration runner was considered and deferred: every store already in the wild has no version marker, so such a scheme would need to infer a baseline from the disk shape first — which is this diff. The boot warning is the trigger for building one, the first time a change lands that this cannot handle.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

