### PR TITLE
fix(server): make the storage= build's coverage real, and its expensive failure distinguishable

### DIFF
--- a/.github/workflows/connection-integration-tests.yml
+++ b/.github/workflows/connection-integration-tests.yml
@@ -10,6 +10,17 @@ on:
       - "packages/server/src/service/build_read_cost.ts"
       - "packages/server/src/service/build_query_tag.ts"
       - "packages/server/src/service/storage_build_bigquery.integration.spec.ts"
+      # Produces the value the manifest assertion pins.
+      - "packages/server/src/service/materialization_service.ts"
+      # The metadata bag's own contract, and the dialect-aware escaper the
+      # Snowflake lookup builds its literal with.
+      - "packages/server/src/service/query_metadata.ts"
+      - "packages/server/src/service/introspection_sql.ts"
+      # The passthrough surfaces this job exists to catch are provided by the
+      # DuckDB extensions, which move with a dependency bump rather than with any
+      # file above.
+      - "packages/server/package.json"
+      - "bun.lock"
       - ".github/workflows/connection-integration-tests.yml"
   pull_request:
     branches: [main]
@@ -20,6 +31,17 @@ on:
       - "packages/server/src/service/build_read_cost.ts"
       - "packages/server/src/service/build_query_tag.ts"
       - "packages/server/src/service/storage_build_bigquery.integration.spec.ts"
+      # Produces the value the manifest assertion pins.
+      - "packages/server/src/service/materialization_service.ts"
+      # The metadata bag's own contract, and the dialect-aware escaper the
+      # Snowflake lookup builds its literal with.
+      - "packages/server/src/service/query_metadata.ts"
+      - "packages/server/src/service/introspection_sql.ts"
+      # The passthrough surfaces this job exists to catch are provided by the
+      # DuckDB extensions, which move with a dependency bump rather than with any
+      # file above.
+      - "packages/server/package.json"
+      - "bun.lock"
       - ".github/workflows/connection-integration-tests.yml"
   workflow_dispatch:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,18 @@ One behaviour change to know about: `skills-npm.yml` now publishes only from `ma
 
 ---
 
+## [Unreleased] — a `storage=` build's warehouse read is now attributable
+
+A `storage=` build reads its source through DuckDB's native query-passthrough, where no Malloy connector is in the call path to apply the query-metadata bag. Every such build therefore reached the warehouse untagged — the one kind of work a deployment could not attribute. It now carries the same bag the colocated path does, resolved through the same layering.
+
+**Snowflake** takes it as a session `QUERY_TAG`; its read is unchanged. **BigQuery** takes it as `@@query_label`, which it cannot do without splitting the read: `bigquery_query()` accepts no labels parameter and cannot run the script that would set one. So a labelled BigQuery read runs as `bigquery_execute` over a two-statement script, and the anonymous result table that job wrote is then read with `bigquery_scan`. Reading that table goes through the Storage Read API and creates no new query job, so the split is not a second scan. **Postgres** has no per-statement tag and is unaffected.
+
+**New operational prerequisite on BigQuery.** A labelled read locates its result table by listing the executed script's child job, an API surface the unsplit read never touched. A connection that cannot list its own jobs keeps the read it had before and loses attribution rather than its build — the fallback is decided by a probe issued _before_ anything runs, and counted by `publisher_storage_build_attribution_skipped_total`. Separately, and independent of tagging, the passthrough streams its results over the Storage Read API on every path: `bigquery.readsessions.create` (`roles/bigquery.readSessionUser`) is a standing requirement for materializing any BigQuery source into a storage destination.
+
+`ManifestEntry.queryCostBytes` is populated for a tagged `storage=` build, and the full per-engine cost — billed bytes, slot or execution time, the cache flag, the warehouse's own job ids — goes to the build's log line.
+
+---
+
 ## [Unreleased] — queries report how they were served, and what they cost
 
 The server measured several things and then discarded them, and the query
@@ -35,9 +47,9 @@ histogram carried two labels that grew without bound. Both are addressed.
 
 **Bytes scanned is not bytes billed.** BigQuery rounds up to a 10MB minimum per query, so a small read bills an order of magnitude above what it scanned — and materialization refreshes are mostly small reads. Every figure reported here is SCANNED. Use it to compare queries against each other; it is not a spend number.
 
-**Null is not zero, and on the build side it is null more often than not.** `ManifestEntry.queryCostBytes` is populated only for a COLOCATED build, from the Malloy connection's own statistics. An incremental delta reports null because its statements do not run through a single call whose result reaches the manifest, and a chained `storage=` build reports null because it read its parent's already-materialized table and touched no warehouse at all.
+**Null is not zero, and on the build side which paths report differs.** `ManifestEntry.queryCostBytes` is populated for a COLOCATED build, from the Malloy connection's own statistics. An incremental delta reports null because its statements do not run through a single call whose result reaches the manifest, and a chained `storage=` build reports null because it read its parent's already-materialized table and touched no warehouse at all.
 
-A plain `storage=` build also reports null, and that one is a gap rather than a property: its read goes through DuckDB's native query-passthrough, where no Malloy connector is in the call path to report statistics. Recovering the figure means reading it back from the warehouse's own accounting, which needs an identifier for the job — and the passthrough does not return one for a rows-returning call. Obtaining that identifier restructures how the build issues its read, so it is deliberately left to the change that does so rather than approximated here.
+A plain `storage=` build reports a figure when its warehouse read carried query metadata, and null otherwise — see the attribution section above for what makes the difference. A Postgres source reports null on every path, since the label that makes a read reportable is BigQuery's.
 
 On the serve side, check `servedFrom` before reading a null as "free": a `storage`-served query touched no warehouse, while a Snowflake or Postgres query touched one and simply reported nothing.
 

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3566,7 +3566,10 @@ components:
         statements a query issues, for the backend's own reporting — cost
         attribution, workload classification, tracing. Each backend applies it
         through a per-query mechanism: Snowflake a per-statement `QUERY_TAG`
-        (the bag as JSON, so its properties are queryable in `QUERY_HISTORY`),
+        (the bag as JSON, so its properties are queryable in `QUERY_HISTORY`) —
+        except on a `storage=` build, whose read goes through DuckDB's
+        query-passthrough and so sets the tag for the SESSION, which means the
+        driver's own connection probes carry the build's bag too,
         BigQuery per-job `labels` (queryable in `INFORMATION_SCHEMA.JOBS`), and
         every other backend a leading SQL comment (`-- team="finance"`, visible
         in query history / `pg_stat_activity`). It never affects results, and it
@@ -5201,7 +5204,11 @@ components:
             An incremental delta reports null because its statements do not run
             through a single call whose result reaches here. A chained `storage=`
             build reports null because it read its parent's already-materialized
-            table and touched no warehouse at all.
+            table and touched no warehouse at all. A POSTGRES source reports null
+            on every path: the label that makes a read reportable is BigQuery's,
+            and Postgres has no per-statement tag to carry one. And a bag whose
+            every property is unusable as a BigQuery label key renders no label,
+            so such a read is issued the untagged way and reports null too.
         dataAsOf:
           type: string
           format: date-time

--- a/docs/query-metadata.md
+++ b/docs/query-metadata.md
@@ -10,28 +10,32 @@ It is observability only. It never affects results, and it is excluded from conn
 
 Each backend gets the bag through a mechanism that attaches **per query**:
 
-| Backend | Mechanism | Where it shows up |
-|---|---|---|
-| Snowflake | per-statement `QUERY_TAG` (the bag as JSON) | `QUERY_HISTORY`, `QUERY_ATTRIBUTION_HISTORY` |
-| BigQuery | per-job `labels` | `INFORMATION_SCHEMA.JOBS` |
+| Backend                                             | Mechanism                                                       | Where it shows up                                           |
+| --------------------------------------------------- | --------------------------------------------------------------- | ----------------------------------------------------------- |
+| Snowflake                                           | per-statement `QUERY_TAG` (the bag as JSON)                     | `QUERY_HISTORY`, `QUERY_ATTRIBUTION_HISTORY`                |
+| BigQuery                                            | per-job `labels`                                                | `INFORMATION_SCHEMA.JOBS`                                   |
 | Trino / Presto, Databricks, Postgres, DuckDB, MySQL | a leading SQL comment — `-- team="finance" class="interactive"` | query history, `pg_stat_activity`, `system.runtime.queries` |
 
 On the comment-carrying backends the bag is part of the statement text, so it shares whatever window that text is stored in: Postgres truncates `pg_stat_activity.query` at `track_activity_query_size` (1024 bytes by default), and a large declared bag can eat enough of it to cut off the SQL itself. Publisher's own context is about 200 characters; a bag near the 20-property cap is not.
 
 Session-scoped mechanisms (Trino client tags, Databricks `SET QUERY_TAGS`, Postgres `application_name`) are deliberately not used: a pooled session serves many queries, so a session-level tag would attribute all of them to whichever one set it last.
 
+**One path is the exception, and it is exempt from that reasoning rather than in spite of it.** A `storage=` build reads its source through DuckDB's native query-passthrough, where no Malloy connector is in the call path to apply a per-statement tag — so the choice there is a session tag or no attribution at all. What makes it safe is that the session is not pooled: each build runs on its own private DuckDB instance, created and disposed for that build, so "whichever one set it last" is always this build. The tag is cleared before the session is released, so a session the driver may hand over pre-tagged cannot leave a stale attribution behind either.
+
+It does not escape the problem entirely, and the residue is worth knowing before reading a bill. The Snowflake driver issues its own connection probes (`SELECT 1`) around each passthrough call, and those run on the tagged session — so they carry the build's bag into `QUERY_HISTORY` alongside the read itself. They scan nothing, so cost grouped by `class` or `run_id` is unaffected; a COUNT of statements grouped the same way reads high.
+
 ## What Publisher adds by itself
 
 Publisher attaches its own context to every statement, so attribution needs no modeling work:
 
-| Property | Meaning |
-|---|---|
-| `class` | `interactive`, `materialize`, `index` or `ops` |
-| `environment`, `package` | where the query came from |
-| `model` | the model a query ran against |
-| `source` | the persist source a build was materializing |
-| `trigger`, `run_id` | what started a build, and which run it belongs to (also the run whose tables a drop is retiring) |
-| `query_id` | identifies this one query; the response hands it back (see below) |
+| Property                 | Meaning                                                                                          |
+| ------------------------ | ------------------------------------------------------------------------------------------------ |
+| `class`                  | `interactive`, `materialize`, `index` or `ops`                                                   |
+| `environment`, `package` | where the query came from                                                                        |
+| `model`                  | the model a query ran against                                                                    |
+| `source`                 | the persist source a build was materializing                                                     |
+| `trigger`, `run_id`      | what started a build, and which run it belongs to (also the run whose tables a drop is retiring) |
+| `query_id`               | identifies this one query; the response hands it back (see below)                                |
 
 Context wins over a declared property of the same name: a caller cannot label its own query as a build, and cannot supply its own `query_id`.
 
@@ -52,11 +56,11 @@ Most specific wins, property by property:
 ```json
 // publisher.json — every statement this package's sources issue
 {
-   "name": "orders",
-   "materialization": {
-      "scope": "version",
-      "queryMetadata": { "team": "finance", "tier": "gold" }
-   }
+  "name": "orders",
+  "materialization": {
+    "scope": "version",
+    "queryMetadata": { "team": "finance", "tier": "gold" }
+  }
 }
 ```
 
@@ -84,9 +88,9 @@ That split is a property of the deployment, not of this code. Publisher's own RE
 ```jsonc
 // connection config
 {
-   "name": "warehouse",
-   "queryMetadata": { "team": "finance" },          // a default; any declaration overrides it
-   "queryMetadataEnforced": { "tenant": "acme" }    // the deployment's; no declaration can
+  "name": "warehouse",
+  "queryMetadata": { "team": "finance" }, // a default; any declaration overrides it
+  "queryMetadataEnforced": { "tenant": "acme" }, // the deployment's; no declaration can
 }
 ```
 

--- a/packages/server/src/materialization_metrics.ts
+++ b/packages/server/src/materialization_metrics.ts
@@ -150,12 +150,18 @@ const storageServeRoutingCounter = lazyCounter(
 const storageBuildFailureCounter = lazyCounter(
    "publisher_storage_build_failures_total",
    "storage= build failures (federation/passthrough/attach/CTAS), distinct from " +
-      "in-warehouse build failures. Label: destination (connection name).",
+      "in-warehouse build failures. Labels: destination (connection name), " +
+      "reason ('build_failed'|'billed_read_not_captured'). The second is the " +
+      "expensive one: the warehouse read ran and was charged, and the rows could " +
+      "not be captured — so a re-drive pays for it again. Worth alerting on " +
+      "separately from a failure that costs only a retry.",
 );
 const attributionSkippedCounter = lazyCounter(
    "publisher_storage_build_attribution_skipped_total",
    "storage= builds whose warehouse read went out UNATTRIBUTED while tagging was " +
-      "on. Label: reason ('job_listing_unavailable'). The read still ran and the " +
+      "on. Label: reason ('job_listing_unavailable'|'tag_failed'|" +
+      "'read_row_not_found'|'read_row_ambiguous'|'cost_query_failed'). " +
+      "The read still ran and the " +
       "build still succeeded — what was lost is the label in the customer's own " +
       "query history, and the cost on this side. Without this an operator who " +
       "turns tagging on and sees nothing has a single log line to go on.",
@@ -305,8 +311,11 @@ export function recordDropTables(
  * counted separately from in-warehouse build failures because the storage path
  * has its own failure modes and destination axis.
  */
-export function recordStorageBuildFailure(destination: string): void {
-   storageBuildFailureCounter().add(1, { destination });
+export function recordStorageBuildFailure(
+   destination: string,
+   reason: "build_failed" | "billed_read_not_captured" = "build_failed",
+): void {
+   storageBuildFailureCounter().add(1, { destination, reason });
 }
 
 /**
@@ -315,7 +324,12 @@ export function recordStorageBuildFailure(destination: string): void {
  * is exactly why it needs a counter: nothing else about the run looks wrong.
  */
 export function recordAttributionSkipped(
-   reason: "job_listing_unavailable",
+   reason:
+      | "job_listing_unavailable"
+      | "tag_failed"
+      | "read_row_not_found"
+      | "read_row_ambiguous"
+      | "cost_query_failed",
 ): void {
    attributionSkippedCounter().add(1, { reason });
 }

--- a/packages/server/src/service/build_read_cost.spec.ts
+++ b/packages/server/src/service/build_read_cost.spec.ts
@@ -43,10 +43,33 @@ describe("snowflakeCostSQL", () => {
       expect(sql).not.toContain("LAST_QUERY_ID");
    });
 
-   it("excludes its own shape, which carries the same tag", () => {
-      expect(snowflakeCostSQL("{}")).toContain(
-         "QUERY_TEXT NOT LIKE '%INFORMATION_SCHEMA.QUERY_HISTORY%'",
-      );
+   it("does NOT filter itself out by text, because it does not need to", () => {
+      // The accounting query carries the same tag as the read it looks for, so a
+      // text filter looks necessary. It is not: pickSnowflakeReadRow requires
+      // exact equality with the build's own SQL, which this statement can never
+      // satisfy. Filtering by text would also have blanked out the source most
+      // likely to care about query cost — one that models query history itself.
+      const sql = snowflakeCostSQL("{}");
+      expect(sql).not.toContain("NOT LIKE");
+
+      // The property that makes it safe, asserted directly.
+      const accountingRow = { query_text: sql, rows_produced: 1 };
+      expect(
+         pickSnowflakeReadRow([accountingRow], "SELECT a FROM t"),
+      ).toBeNull();
+   });
+
+   it("still finds a read whose own SQL queries QUERY_HISTORY", () => {
+      // The false negative the text filter used to create: a legitimate persist
+      // source modelling Snowflake's query history reported null forever.
+      const buildSQL =
+         "SELECT QUERY_ID FROM TABLE(INFORMATION_SCHEMA.QUERY_HISTORY())";
+      const row = {
+         query_text: buildSQL,
+         bytes_scanned: 900,
+         rows_produced: 3,
+      };
+      expect(pickSnowflakeReadRow([row], buildSQL)).toBe(row);
    });
 
    it("escapes a backslash in the tag, or it matches NOTHING", () => {

--- a/packages/server/src/service/build_read_cost.ts
+++ b/packages/server/src/service/build_read_cost.ts
@@ -142,7 +142,13 @@ function snowflakeDatabaseQualifier(
  * larger than a build — the session form carries the same 100 default, and was
  * also empty in that measurement.
  *
- * The accounting query itself carries the same tag, so it excludes its own shape.
+ * The accounting query carries the same tag as the read it is looking for, and is
+ * NOT filtered out by text: {@link pickSnowflakeReadRow} requires exact equality
+ * with the build's own SQL, which this statement can never satisfy, and
+ * EXECUTION_STATUS excludes the in-flight one. A text filter here would have been
+ * redundant with that AND a false negative for the source most likely to care
+ * about query cost — one that models Snowflake's query history itself.
+ *
  * Aliases are QUOTED because Snowflake folds a bare alias to uppercase, which
  * would make every field below read undefined while a row still came back.
  *
@@ -182,8 +188,7 @@ export function snowflakeCostSQL(
       FROM TABLE(${qualifier}.QUERY_HISTORY_BY_SESSION(
                  RESULT_LIMIT => ${SNOWFLAKE_HISTORY_LIMIT}))
       WHERE QUERY_TAG = '${sqlLiteral(queryTag, "snowflake")}'
-        AND EXECUTION_STATUS = 'SUCCESS'
-        AND QUERY_TEXT NOT LIKE '%INFORMATION_SCHEMA.QUERY_HISTORY%'`;
+        AND EXECUTION_STATUS = 'SUCCESS'`;
 }
 
 /**
@@ -255,7 +260,9 @@ function col(row: Record<string, unknown>, key: string): unknown {
 
 function num(value: unknown): number | null {
    if (value === null || value === undefined) return null;
-   const n = typeof value === "bigint" ? Number(value) : Number(value);
+   // Number() handles bigint directly; an explicit branch here read as a
+   // precision guard while doing exactly what the other branch did.
+   const n = Number(value);
    return Number.isFinite(n) ? n : null;
 }
 

--- a/packages/server/src/service/materialization_build_session.ts
+++ b/packages/server/src/service/materialization_build_session.ts
@@ -134,6 +134,9 @@ async function tagSnowflakeSession(
       logger.warn("Could not tag the Snowflake build session", {
          error: error instanceof Error ? error.message : String(error),
       });
+      // Untagged, the read is unattributable in the customer's query history AND
+      // unfindable by the cost lookup, which keys on that same tag.
+      recordAttributionSkipped("tag_failed");
    }
 }
 
@@ -193,8 +196,8 @@ async function canSplitBigQueryRead(
  * telemetry's, which is why this path throws where the Snowflake one returns null.
  */
 export class BilledReadNotCapturedError extends Error {
-   constructor(message: string) {
-      super(message);
+   constructor(message: string, options?: { cause?: unknown }) {
+      super(message, options);
       this.name = "BilledReadNotCapturedError";
    }
 }
@@ -217,7 +220,11 @@ const BIGQUERY_LOOKUP_BACKOFF_MS = 250;
  * credentials, and a warehouse that is genuinely down should surface as a failed
  * build rather than a long stall.
  */
-async function withBigQueryLookupRetry<T>(work: () => Promise<T>): Promise<T> {
+async function withBigQueryLookupRetry<T>(
+   work: () => Promise<T>,
+   /** Named in the terminal error: the only handle on a read that was paid for. */
+   parentJobId: string,
+): Promise<T> {
    let lastError: unknown;
    for (let attempt = 1; attempt <= BIGQUERY_LOOKUP_ATTEMPTS; attempt++) {
       try {
@@ -230,6 +237,7 @@ async function withBigQueryLookupRetry<T>(work: () => Promise<T>): Promise<T> {
                {
                   attempt,
                   of: BIGQUERY_LOOKUP_ATTEMPTS,
+                  parentJobId,
                   error: error instanceof Error ? error.message : String(error),
                },
             );
@@ -239,10 +247,16 @@ async function withBigQueryLookupRetry<T>(work: () => Promise<T>): Promise<T> {
          }
       }
    }
+   // Names the parent job because this is the failure that leaves a read paid for
+   // and uncaptured, and the parent is the only handle on it: a script's child
+   // job is absent from the default listing. Telling an operator a read was
+   // billed without saying which one leaves them nothing to act on.
    throw new BilledReadNotCapturedError(
-      `Could not read the BigQuery job record for a build's read after ` +
-         `${BIGQUERY_LOOKUP_ATTEMPTS} attempts, so its rows cannot be captured: ` +
+      `Could not read the BigQuery job record for a build's read (parent job ` +
+         `${parentJobId}) after ${BIGQUERY_LOOKUP_ATTEMPTS} attempts, so its ` +
+         `rows cannot be captured: ` +
          `${lastError instanceof Error ? lastError.message : String(lastError)}`,
+      { cause: lastError },
    );
 }
 
@@ -346,8 +360,8 @@ export async function issuePassthroughRead(
    // statement and the one whose rows this is after. (Measured, `SET
    // @@query_label` produces no such child — but that is behaviour, not a
    // guarantee, and this costs nothing to pin.)
-   const child = await withBigQueryLookupRetry(() =>
-      session.runSQL(`
+   const located = await withBigQueryLookupRetry(async () => {
+      const child = await session.runSQL(`
       SELECT job_id,
              json_extract_string(configuration, '$.query.destinationTable.projectId') AS project,
              json_extract_string(configuration, '$.query.destinationTable.datasetId') AS dataset,
@@ -356,16 +370,19 @@ export async function issuePassthroughRead(
       FROM (SELECT * FROM bigquery_jobs('${escapeSQL(handle)}',
                                         parentJobId := '${escapeSQL(parentJobId)}')
             WHERE job_type = 'QUERY')
-      ORDER BY creation_time DESC`),
-   );
-   const rows = resultRows(child);
-   const located = rows.find((r) => str(r.dataset) && str(r.table));
-   if (located === undefined) {
-      throw new BilledReadNotCapturedError(
-         `The build's BigQuery read (job ${parentJobId}) left no locatable ` +
-            `result table, so its rows cannot be captured`,
-      );
-   }
+      ORDER BY creation_time DESC`);
+      const row = resultRows(child).find((r) => str(r.dataset) && str(r.table));
+      if (row === undefined) {
+         // Inside the retry on purpose: a listing can answer 200 without having
+         // enumerated the child yet, which is the same transient as a 5xx and is
+         // indistinguishable from it here. Throwing plainly lets the backoff take
+         // it; only the LAST attempt becomes a terminal failure.
+         throw new Error(
+            `no child job with a result table under parent ${parentJobId}`,
+         );
+      }
+      return row;
+   }, parentJobId);
 
    const path = [
       str(located.project) ?? handle,
@@ -416,12 +433,25 @@ async function snowflakeReadCostAfterBuild(
       const costResult = await session.runSQL(
          passthroughSnowflake(snowflakeCostSQL(tag, database), handle),
       );
-      const row = pickSnowflakeReadRow(resultRows(costResult), buildSQL);
-      return row === null ? null : snowflakeReadCost(row);
+      const candidates = resultRows(costResult);
+      const row = pickSnowflakeReadRow(candidates, buildSQL);
+      if (row === null) {
+         // Counted, not just absent. This is the likeliest Snowflake miss —
+         // it turns on QUERY_TEXT matching buildSQL byte for byte after a round
+         // trip through the driver — and without a signal it is invisible.
+         recordAttributionSkipped(
+            candidates.length === 0
+               ? "read_row_not_found"
+               : "read_row_ambiguous",
+         );
+         return null;
+      }
+      return snowflakeReadCost(row);
    } catch (error) {
       logger.warn("Could not read back what the Snowflake build read cost", {
          error: error instanceof Error ? error.message : String(error),
       });
+      recordAttributionSkipped("cost_query_failed");
       return null;
    }
 }
@@ -446,6 +476,37 @@ function firstColumn(result: unknown, column: string): string | null {
 
 function str(value: unknown): string | null {
    return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/**
+ * Clear the session's `QUERY_TAG` before the session is released.
+ *
+ * The build session is private and disposed here, so this is not about leaking a
+ * tag to a later build. It covers the one case the tag statement is allowed to
+ * fail: {@link tagSnowflakeSession} is best-effort, and whether the driver hands
+ * this build a session that was ALREADY tagged is the driver's business rather
+ * than something this can observe. A failed tag on a pre-tagged session would
+ * leave the read attributed to whatever set it last, and wrong attribution is
+ * worse than none — nothing about it looks wrong.
+ *
+ * Best-effort in turn, and last: a build that produced correct rows must not fail
+ * on its own cleanup.
+ */
+async function clearSnowflakeSessionTag(
+   session: DuckDBConnection,
+   sourceType: FederatedSourceType,
+   handle: string | undefined,
+): Promise<void> {
+   if (sourceType !== "snowflake" || handle === undefined) return;
+   try {
+      await session.runSQL(
+         passthroughSnowflake("ALTER SESSION UNSET QUERY_TAG", handle),
+      );
+   } catch (error) {
+      logger.warn("Could not clear the Snowflake build session's query tag", {
+         error: error instanceof Error ? error.message : String(error),
+      });
+   }
 }
 
 /** Narrow a connection's declared type to a supported passthrough source type. */
@@ -626,6 +687,8 @@ export async function buildSourceIntoStorage(params: {
    const { session, dispose } = createIsolatedBuildSession(
       `build_${destinationName}`,
    );
+   // Visible to the finally, which clears the session tag before release.
+   let federatedHandle: string | undefined;
    try {
       await attachDestinationReadWrite(
          session,
@@ -711,6 +774,7 @@ export async function buildSourceIntoStorage(params: {
             )),
       };
    } finally {
+      await clearSnowflakeSessionTag(session, sourceType, federatedHandle);
       // Dispose closes the private instance (releasing every secret + attach —
       // nothing federated or read-write survives the build) and removes its
       // throwaway working directory.

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -77,6 +77,7 @@ import { EnvironmentStore } from "./environment_store";
 import { assertMaterializationEligible } from "./materialization_eligibility";
 import {
    assertStorageServeShapeCompiles,
+   BilledReadNotCapturedError,
    buildDownstreamIntoStorage,
    buildSourceIntoStorage,
    dropStorageTable,
@@ -2366,16 +2367,32 @@ export class MaterializationService {
                sourceConnection,
                destinationConnection,
             );
-            recordStorageBuildFailure(destinationName);
+            // Whether the warehouse read was already BILLED survives the
+            // redaction, because it changes what a caller should do next. This
+            // service's own scheduler advances "regardless of outcome so a
+            // persistent failure retries on the next cron occurrence" and fires
+            // with forceRefresh, which defeats skip-if-unchanged — so a
+            // persistent cause re-runs the same read every occurrence, and on
+            // this branch that means paying for it every occurrence. Rewrapping
+            // as a bare Error made that indistinguishable from an attach
+            // failure, which is free to retry.
+            const alreadyBilled = err instanceof BilledReadNotCapturedError;
+            recordStorageBuildFailure(
+               destinationName,
+               alreadyBilled ? "billed_read_not_captured" : "build_failed",
+            );
             logger.warn("Storage materialization build failed", {
                sourceName: persistSource.name,
                destinationName,
+               alreadyBilled,
                error: safeDetail,
             });
-            throw new Error(
+            const failure =
                `Failed to materialize source '${persistSource.name}' into ` +
-                  `storage destination '${destinationName}': ${safeDetail}`,
-            );
+               `storage destination '${destinationName}': ${safeDetail}`;
+            throw alreadyBilled
+               ? new BilledReadNotCapturedError(failure, { cause: err })
+               : new Error(failure, { cause: err });
          }
       }
 

--- a/packages/server/src/service/passthrough_read.spec.ts
+++ b/packages/server/src/service/passthrough_read.spec.ts
@@ -276,6 +276,56 @@ describe("issuePassthroughRead — BigQuery split", () => {
       expect(read.jobId).toBe("script_job_abc_0");
    });
 
+   it("retries when the listing succeeds but the child is not enumerated yet", async () => {
+      // A 200 with the child missing is the same transient as a 5xx and is
+      // indistinguishable from it here — bigquery_execute returning a job id
+      // proves the script finished, not that the listing has caught up.
+      let calls = 0;
+      const session = {
+         runSQL: async (sql: string) => {
+            if (!sql.includes("parentJobId")) {
+               return {
+                  rows: sql.includes("bigquery_execute")
+                     ? [{ job_id: "job_parent" }]
+                     : [{ job_id: "any" }],
+               };
+            }
+            calls++;
+            // Two empty listings, then the child appears.
+            return { rows: calls < 3 ? [] : BQ_CHILD };
+         },
+      } as never;
+      const read = await issuePassthroughRead(
+         session,
+         "bigquery",
+         "proj",
+         "SELECT 1",
+         { cred_run: "r" },
+      );
+      expect(calls).toBe(3);
+      expect(read.cost?.bytesScanned).toBe(5114816);
+   });
+
+   it("names the parent job when it finally gives up, so the read can be found", async () => {
+      // The one failure documented as the operator's decision. A script's child
+      // job is absent from the default listing, so the parent is the only handle
+      // on a read that was paid for.
+      const { session } = fakeSession([
+         PROBE_OK,
+         [{ job_id: "job_parent" }],
+         [],
+      ]);
+      const error = (await issuePassthroughRead(
+         session,
+         "bigquery",
+         "proj",
+         "SELECT 1",
+         { cred_run: "r" },
+      ).catch((e: Error) => e)) as Error;
+      expect(error).toBeInstanceOf(BilledReadNotCapturedError);
+      expect(error.message).toContain("job_parent");
+   });
+
    it("retries a failing job lookup before failing a build already billed for", async () => {
       // The probe established that this connection CAN list, so a failure here is
       // transient — and the alternative is expensive, because the read is paid for
@@ -327,7 +377,8 @@ describe("issuePassthroughRead — BigQuery split", () => {
    it("fails rather than re-running a read that already happened", async () => {
       // The query HAS run and been billed by this point. Falling back to the
       // direct shape would run and bill it a second time; a retry is the
-      // operator's decision, not a silent double charge.
+      // operator's decision, not a silent double charge. The message is the
+      // retry's terminal one, because an empty listing is now retried first.
       const { session } = fakeSession([
          PROBE_OK,
          [{ job_id: "job_parent" }],
@@ -337,7 +388,7 @@ describe("issuePassthroughRead — BigQuery split", () => {
          issuePassthroughRead(session, "bigquery", "proj", "SELECT 1", {
             cred_run: "r",
          }),
-      ).rejects.toThrow(/no locatable result table/);
+      ).rejects.toThrow(/rows cannot be captured/);
    });
 
    it("fails loudly when the execute reports no job at all", async () => {

--- a/packages/server/src/service/storage_build_bigquery.integration.spec.ts
+++ b/packages/server/src/service/storage_build_bigquery.integration.spec.ts
@@ -38,17 +38,20 @@ import { MaterializationService } from "./materialization_service";
  * split.
  *
  * Locally, set `BIGQUERY_PUBLIC_DATA_CREDENTIALS` to a key file and
- * `BIGQUERY_PUBLIC_DATA_PROJECT_ID` to its project. Absent those this skips, so
- * it costs a developer without credentials nothing.
+ * `BIGQUERY_PUBLIC_DATA_PROJECT_ID` to its project. Absent those this SKIPS —
+ * `describe.skipIf`, not an early `return` from a passing test.
+ *
+ * That distinction is the whole point. This file is under `src/`, so
+ * `test:unit` (`bun test src`) globs it on every PR and on all three platforms,
+ * none of which carry a BigQuery secret. Returning early made those runs report
+ * green tests that had asserted nothing, which is worse than no coverage: it
+ * reads as coverage. A skip reports as a skip.
  */
 const hasPublicDataBigQueryCredentials = () =>
    !!(
       process.env.BIGQUERY_PUBLIC_DATA_CREDENTIALS &&
       process.env.BIGQUERY_PUBLIC_DATA_PROJECT_ID
    );
-
-const SKIP_MESSAGE =
-   "Skipping: BIGQUERY_PUBLIC_DATA_CREDENTIALS / BIGQUERY_PUBLIC_DATA_PROJECT_ID not configured";
 
 /** A read of a real table, with a unique predicate so BigQuery cannot serve it from cache. */
 const buildSQLFor = (nonce: string) =>
@@ -109,117 +112,110 @@ async function rowsInDestination(
    }
 }
 
-describe("storage= build against live BigQuery", () => {
-   it("labels the read, captures its rows, and reports what it cost", async () => {
-      if (!hasPublicDataBigQueryCredentials()) {
-         console.log(SKIP_MESSAGE);
-         return;
-      }
-      const nonce = `lbl${Date.now()}`;
-      const { result, environmentPath, physicalTableName } = await runBuild(
-         nonce,
-         { cred_run: nonce, cred_org: "acme_corp", cred_class: "ops" },
-      );
+describe.skipIf(!hasPublicDataBigQueryCredentials())(
+   "storage= build against live BigQuery",
+   () => {
+      it("labels the read, captures its rows, and reports what it cost", async () => {
+         const nonce = `lbl${Date.now()}`;
+         const { result, environmentPath, physicalTableName } = await runBuild(
+            nonce,
+            { cred_run: nonce, cred_org: "acme_corp", cred_class: "ops" },
+         );
 
-      // The rows are the point: a cost figure from a build that captured
-      // nothing would be worse than no figure.
-      expect(await rowsInDestination(environmentPath, physicalTableName)).toBe(
-         12,
-      );
-      expect(result.schema.map((c) => c.name)).toEqual(["who", "n"]);
+         // The rows are the point: a cost figure from a build that captured
+         // nothing would be worse than no figure.
+         expect(
+            await rowsInDestination(environmentPath, physicalTableName),
+         ).toBe(12);
+         expect(result.schema.map((c) => c.name)).toEqual(["who", "n"]);
 
-      // The split ran, which is the only way a label reaches the job.
-      const cost = result.readCost;
-      expect(cost).not.toBeNull();
-      expect(cost!.engine).toBe("bigquery");
-      expect(cost!.jobId).toBeTruthy();
-      // The child job is not in the default listing, so the parent is what an
-      // operator needs to reach it.
-      expect(cost!.parentJobId).toBeTruthy();
+         // The split ran, which is the only way a label reaches the job.
+         const cost = result.readCost;
+         expect(cost).not.toBeNull();
+         expect(cost!.engine).toBe("bigquery");
+         expect(cost!.jobId).toBeTruthy();
+         // The child job is not in the default listing, so the parent is what an
+         // operator needs to reach it.
+         expect(cost!.parentJobId).toBeTruthy();
 
-      // Real figures off the real job record — this is the surface a fake
-      // session cannot exercise.
-      expect(cost!.bytesScanned).toBeGreaterThan(0);
-      expect(cost!.bytesBilled).toBeGreaterThan(0);
-      // BigQuery's 10MB-per-query floor: a small read bills above what it
-      // scanned, which is why these are separate fields.
-      expect(cost!.bytesBilled).toBeGreaterThanOrEqual(cost!.bytesScanned!);
-      expect(cost!.cacheHit).toBe(false);
-   }, 120_000);
+         // Real figures off the real job record — this is the surface a fake
+         // session cannot exercise.
+         expect(cost!.bytesScanned).toBeGreaterThan(0);
+         expect(cost!.bytesBilled).toBeGreaterThan(0);
+         // BigQuery's 10MB-per-query floor: a small read bills above what it
+         // scanned, which is why these are separate fields.
+         expect(cost!.bytesBilled).toBeGreaterThanOrEqual(cost!.bytesScanned!);
+         expect(cost!.cacheHit).toBe(false);
+      }, 120_000);
 
-   it("puts SCANNED bytes on the manifest entry, never billed", async () => {
-      // The one field the manifest carries, pinned against the one that would
-      // look plausible in its place. Worth doing here rather than over a fake:
-      // these two numbers only diverge against a real warehouse — the 10MB floor
-      // is what makes billed exceed scanned — so a stub would have to assert the
-      // difference it invented.
-      if (!hasPublicDataBigQueryCredentials()) {
-         console.log(SKIP_MESSAGE);
-         return;
-      }
-      const nonce = `mft${Date.now()}`;
-      const serviceAccountKeyJson = await fs.readFile(
-         process.env.BIGQUERY_PUBLIC_DATA_CREDENTIALS!,
-         "utf-8",
-      );
-      const environmentPath = mkdtempSync(
-         path.join(os.tmpdir(), `storage-manifest-${nonce}-`),
-      );
-      const sourceConnection = {
-         name: "bq_src",
-         type: "bigquery",
-         bigqueryConnection: {
-            serviceAccountKeyJson,
-            defaultProjectId: process.env.BIGQUERY_PUBLIC_DATA_PROJECT_ID!,
-         },
-      };
-      const service = Object.create(MaterializationService.prototype) as Record<
-         string,
-         (...a: unknown[]) => Promise<Record<string, unknown>>
-      >;
-      const entry = await service.buildOneSourceIntoStorage(
-         { name: "orders", connectionName: "bq_src" },
-         {
-            sourceEntityId: `sid-${nonce}`,
-            physicalTableName: `orders_${nonce}`,
-            destination: "lake",
-         },
-         { strict: false, update: () => {} },
-         {
-            getApiConnection: () => sourceConnection,
-            getStorageDestination: () => ({ name: "lake", type: "duckdb" }),
-            getEnvironmentPath: () => environmentPath,
-         },
-         buildSQLFor(nonce),
-         {},
-         false,
-         { cred_run: nonce, cred_class: "ops" },
-      );
+      it("puts SCANNED bytes on the manifest entry, never billed", async () => {
+         // The one field the manifest carries, pinned against the one that would
+         // look plausible in its place. Worth doing here rather than over a fake:
+         // these two numbers only diverge against a real warehouse — the 10MB floor
+         // is what makes billed exceed scanned — so a stub would have to assert the
+         // difference it invented.
+         const nonce = `mft${Date.now()}`;
+         const serviceAccountKeyJson = await fs.readFile(
+            process.env.BIGQUERY_PUBLIC_DATA_CREDENTIALS!,
+            "utf-8",
+         );
+         const environmentPath = mkdtempSync(
+            path.join(os.tmpdir(), `storage-manifest-${nonce}-`),
+         );
+         const sourceConnection = {
+            name: "bq_src",
+            type: "bigquery",
+            bigqueryConnection: {
+               serviceAccountKeyJson,
+               defaultProjectId: process.env.BIGQUERY_PUBLIC_DATA_PROJECT_ID!,
+            },
+         };
+         const service = Object.create(
+            MaterializationService.prototype,
+         ) as Record<
+            string,
+            (...a: unknown[]) => Promise<Record<string, unknown>>
+         >;
+         const entry = await service.buildOneSourceIntoStorage(
+            { name: "orders", connectionName: "bq_src" },
+            {
+               sourceEntityId: `sid-${nonce}`,
+               physicalTableName: `orders_${nonce}`,
+               destination: "lake",
+            },
+            { strict: false, update: () => {} },
+            {
+               getApiConnection: () => sourceConnection,
+               getStorageDestination: () => ({ name: "lake", type: "duckdb" }),
+               getEnvironmentPath: () => environmentPath,
+            },
+            buildSQLFor(nonce),
+            {},
+            false,
+            { cred_run: nonce, cred_class: "ops" },
+         );
 
-      const billed = 10_485_760;
-      expect(entry.queryCostBytes).toBeGreaterThan(0);
-      // Scanned and billed genuinely differ on this read, so this distinguishes.
-      expect(entry.queryCostBytes).toBeLessThan(billed);
-      expect(entry.queryCostBytes).not.toBe(billed);
-   }, 120_000);
+         const billed = 10_485_760;
+         expect(entry.queryCostBytes).toBeGreaterThan(0);
+         // Scanned and billed genuinely differ on this read, so this distinguishes.
+         expect(entry.queryCostBytes).toBeLessThan(billed);
+         expect(entry.queryCostBytes).not.toBe(billed);
+      }, 120_000);
 
-   it("leaves an untagged read in the shape it had before, and reports no cost", async () => {
-      if (!hasPublicDataBigQueryCredentials()) {
-         console.log(SKIP_MESSAGE);
-         return;
-      }
-      const nonce = `pln${Date.now()}`;
-      const { result, environmentPath, physicalTableName } = await runBuild(
-         nonce,
-         undefined,
-      );
+      it("leaves an untagged read in the shape it had before, and reports no cost", async () => {
+         const nonce = `pln${Date.now()}`;
+         const { result, environmentPath, physicalTableName } = await runBuild(
+            nonce,
+            undefined,
+         );
 
-      // Same rows by the older path — the split is not load-bearing for data.
-      expect(await rowsInDestination(environmentPath, physicalTableName)).toBe(
-         12,
-      );
-      // No label to carry means no split, and a rows-returning passthrough
-      // call hands back no job to account for.
-      expect(result.readCost).toBeNull();
-   }, 120_000);
-});
+         // Same rows by the older path — the split is not load-bearing for data.
+         expect(
+            await rowsInDestination(environmentPath, physicalTableName),
+         ).toBe(12);
+         // No label to carry means no split, and a rows-returning passthrough
+         // call hands back no job to account for.
+         expect(result.readCost).toBeNull();
+      }, 120_000);
+   },
+);


### PR DESCRIPTION
Follow-ups from review of #999, which merged on auto-merge before these landed. Everything here is a review finding; nothing new is introduced.

## The coverage #999 added was largely notional

**The integration spec passed in CI having asserted nothing.** Its credential gate was an early `return` from a *passing* test, and the file lives under `src/`, which `test:unit` (`bun test src`) globs on every PR and on all three platforms — none of which carry a BigQuery secret. So it reported three green tests that ran no assertions. That is worse than no coverage, because it reads as coverage.

`describe.skipIf` now makes a skip report as a skip:

```
before   3 pass   0 fail      (asserted nothing)
after    0 pass   3 skip      (with credentials: 3 pass / 15 expect() calls)
```

**And the file it defends was not a trigger.** The spec's main assertion pins a value produced at `materialization_service.ts:2480`, and that file was absent from the workflow's `paths:` filter — so the exact edit it guards ran no job containing it. Added, together with `query_metadata.ts`, `introspection_sql.ts`, `package.json` and `bun.lock`: the passthrough surfaces this job exists to catch are provided by DuckDB extensions installed at runtime, so they move with a dependency bump rather than with any source file here.

## The expensive failure was indistinguishable from a cheap one

`BilledReadNotCapturedError` exists so a caller can tell "the read was billed, do not re-drive" from "the attach failed, retry freely". It was erased at its only caller, which caught everything and rethrew a bare `Error` with no `cause`.

**That matters because this service is itself such a caller.** `materialization_scheduler.ts` advances "regardless of outcome so a persistent failure retries on the next cron occurrence" and fires with `forceRefresh: true`, which defeats skip-if-unchanged. A persistent cause therefore re-runs the same read every occurrence — and on this branch, pays for it every occurrence. Exactly the outcome the type was created to prevent.

The type now survives the rethrow, and `publisher_storage_build_failures_total` carries `reason` (`build_failed` | `billed_read_not_captured`) so the two are separable on a dashboard rather than only in prose.

**The retry guarded the wrong shape.** It wrapped `session.runSQL` but not the row-pick, so a listing that answered 200 without the child job enumerated yet failed on the first look with zero attempts — the same transient class the retry exists for, and one `bigquery_execute` returning a job id does not rule out. The row-pick moved inside the retried closure.

**The terminal error now names the parent job.** It is the only handle on a read that was paid for and not captured, since a script's child job is absent from the default listing. Telling an operator a read was billed without saying which one leaves them nothing to act on.

## Attribution gaps beyond the BigQuery one are now counted

`publisher_storage_build_attribution_skipped_total` had one call site and one reason, while five paths produce a null cost. The spec meanwhile told operators the null case "is counted by" it — on a Snowflake deployment it never was.

Now emitted for a refused Snowflake tag, a cost query that fails, and a row-pick that finds nothing (`read_row_not_found`) or too much (`read_row_ambiguous`). The last is the likeliest Snowflake miss — it turns on `QUERY_TEXT` matching the build's SQL byte for byte after a round trip through the driver — and it was previously silent in every channel.

## Two smaller corrections

**Dropped the accounting query's self-exclusion filter.** `QUERY_TEXT NOT LIKE '%INFORMATION_SCHEMA.QUERY_HISTORY%'` was redundant with the exact-equality `pickSnowflakeReadRow` already requires — which that statement can never satisfy — and it blanked out a persist source that models Snowflake's own query history, arguably the customer most interested in query-cost data. The test that asserted the filter now asserts the property that made it unnecessary, plus the false negative it used to create.

**The Snowflake session tag is cleared before release.** The build session is private and disposed, so this is not about leaking to a later build; it covers the case where tagging fails best-effort on a session the driver had already tagged, which would leave the read attributed to whatever set it last. Verified live: the tag reads `""` after.

**`num()`** had `typeof value === "bigint" ? Number(value) : Number(value)` — both branches identical, reading as a precision guard while being none.

## Four documents described behaviour that changed

Three of them ship to users.

- **`QueryMetadata` schema** said Snowflake applies the bag as a per-statement `QUERY_TAG`. On the `storage=` path it is a session tag, and the driver's own connection probes therefore carry the build's bag too.
- **`docs/query-metadata.md`** states as a design rule that session-scoped mechanisms "are deliberately not used". That rule is right; this path is exempt from its reasoning rather than in violation of it, because the session is private per build rather than pooled. Written up as a carve-out, including the residue: probes scan nothing, so cost grouped by `class` or `run_id` is unaffected, but a statement COUNT reads high.
- **`RELEASE_NOTES.md`** still said a plain `storage=` build reports null and that recovering the figure "is deliberately left to the change that does so". This is that change, and line 9 of the same file says every `[Unreleased]` section is copied onto the release page — so the release would have shipped notes contradicting `api-doc.yaml`. Replaced with a section describing what shipped, including the new BigQuery prerequisite.
- **The `queryCostBytes` null list** omitted two cases: a Postgres source, which reports null on every path because the label that makes a read reportable is BigQuery's, and a bag whose every key is unusable as a BigQuery label.

## Verification

Unit **2412 pass / 3 skip / 0 fail**; integration **250 / 0**; the live BigQuery spec **3 pass / 15 expect()** with credentials, `3 skip` without. `typecheck` and `lint` clean across all packages.

Re-checked live on Snowflake after dropping the filter and adding the reset: three candidates under the tag, the read still picked correctly, and the tag cleared after `UNSET`.

## Not included

Two review items are deliberately out of scope here, and one did not reproduce.

- **Redaction of the four new `logger.warn` sites.** They log `error.message` verbatim while the caller wrapping the same function routes it through `redactConnectionSecrets`. Correct as an observation — these helpers never receive the connection objects, so they *cannot* redact — but fixing it means threading connections (or a pre-bound redactor) through the build session, which is a wider change than the rest of this.
- **Snowflake end-to-end coverage.** No secrets are provisioned for it, so it would skip everywhere including CI. Worth doing when they are.
- **`cacheHit` over-reporting on metadata-resolvable aggregates** — measured against a live account and it does not reproduce. `COUNT(*)` and `MIN`/`MAX` report `BYTES_SCANNED = 0` **and `ROWS_PRODUCED = 0`** in `QUERY_HISTORY` (the client still receives its row), so `scanned === 0 && produced > 0` never fires. A `GROUP BY` rollup — the "ordinary materialization" shape — scans normally (119,808 bytes measured) and is not metadata-resolvable at all. The existing `GENERATOR` caveat stands as the accurate one.
