### PR TITLE
fix(server): carry author-declared query metadata onto served queries

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3682,12 +3682,16 @@ components:
         `environment`, `package`, `model`, `source`, `trigger`, `run_id`,
         `query_id`, `version`) is applied on top and cannot be overwritten — it
         is what the server is actually doing, and a caller must not be able to
-        relabel it. Those names are also RESERVED against a declaration: a
-        connection, package, model file or source declaring one has it DROPPED
-        rather than attached. Context only overwrites a name it has a value for,
-        and a served query has no `source`, `trigger` or `run_id` — so a declared
-        one would otherwise ride interactive traffic and read, in the backend's
-        own history, exactly like a build. Put no secrets or personal data here: a tag is visible to
+        relabel it. Those names are also RESERVED against a MODEL-SIDE
+        declaration: a package block, a model file or a `#@ persist` annotation
+        declaring one has it DROPPED rather than attached. Context only
+        overwrites a name it has a value for, and a served query has no
+        `source`, `trigger` or `run_id` — so a declared one would otherwise ride
+        interactive traffic and read, in the backend's own history, exactly like
+        a build. A connection default and a per-request bag are not covered: a
+        request setting `queryClass` is a caller describing its own call, while a
+        model-side declaration rides every query against that source, including
+        ones its author never sees. Put no secrets or personal data here: a tag is visible to
         anyone who can read the backend's query history, and on a backend with no
         native tag mechanism it is visible in the statement text.
 

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -1407,10 +1407,19 @@ paths:
         package-level properties. The package must exist and be accessible.
 
         A supplied `materialization` block REPLACES the one on disk, so re-send every
-        field of it you want to keep. Two exceptions, because neither is expressible
-        in the block a caller sends: `scope` (a top-level field) and `queryMetadata`
-        (orthogonal to the schedule and freshness policy this call usually carries) are
-        preserved when omitted. Send `queryMetadata: null` to clear it.
+        field of it you want to keep. Two exceptions are preserved when omitted:
+        `scope`, which is a top-level field and not expressible in the block at all,
+        and `queryMetadata`, which is orthogonal to the schedule and freshness policy
+        this call usually carries — a client setting a schedule has no reason to
+        re-send the package's tags, and dropping them silently untags every statement
+        the package issues.
+
+        `queryMetadata` has two homes: the top-level field, which is canonical, and
+        `materialization.queryMetadata`, which is DEPRECATED and still accepted. The
+        canonical field wins if a request sends both, and both are populated on read.
+        At EITHER home, omitting it preserves the package's tags and so does sending
+        null — a client that serializes unset fields as null must not untag a package
+        by accident. Send an empty object to clear.
       parameters:
         - name: environmentName
           in: path
@@ -2955,6 +2964,32 @@ components:
             URI (gs:// or s3://) of the externally-computed manifest for this package.
             On (re)load the publisher reads it and binds persist references
             (sourceEntityId -> physicalTableName). Null = serve live.
+        queryMetadata:
+          oneOf:
+            - $ref: "#/components/schemas/QueryMetadata"
+            - type: "null"
+          description: |
+            The package-level layer of per-query metadata. Applies to every
+            statement the package's sources issue — a served query as much as a
+            build — and is overridden per property by a model-file, source or
+            per-request declaration.
+
+            **This is the canonical home, here and in `publisher.json`.**
+            `materialization.queryMetadata` is the original one and is
+            DEPRECATED: the properties are not a build setting, so carrying them
+            inside the build-policy block described a scope the feature does not
+            have.
+
+            Both are populated on read and both are accepted on write, so a
+            client can migrate on its own schedule. On write the canonical field
+            wins if a request sends both; in the manifest, the two declaring
+            different bags warns and the root wins, rather than failing the load
+            the way a conflicting `scope` does — a tag is observability only and
+            must never be the reason a package refuses to load.
+
+            Omitting this on a PATCH preserves the package's existing tags, and
+            so does sending null — a client that serializes unset fields as null
+            must not untag a package by accident. Send an empty object to clear.
         materialization:
           oneOf:
             - $ref: "#/components/schemas/PackageMaterializationConfig"
@@ -3084,13 +3119,20 @@ components:
             - $ref: "#/components/schemas/QueryMetadata"
             - type: "null"
           description: >-
-            The manifest's `materialization.queryMetadata` block, verbatim. Null
-            = none declared. The package-level layer of per-query metadata: it
-            applies to every statement the package's sources issue — a build and
-            a served query alike — and a model-file, source or per-request
-            declaration overrides it property by property. Named for
-            materialization historically; it declares what the package's sources
-            ARE, not only how they are built.
+            DEPRECATED home for the package's per-query metadata; read
+            `Package.queryMetadata`, which is canonical. Null = none declared.
+
+            NOT the manifest's `materialization.queryMetadata` verbatim: it is
+            the RESOLVED winner across both manifest homes, and it is synthesized
+            for a package whose manifest has no `materialization` block at all —
+            a package that declares tags the canonical way has no build policy to
+            carry them, and its tags must not be lost for want of one. Both homes
+            are populated on read, so this and `Package.queryMetadata` agree.
+
+            The package-level layer of per-query metadata: it applies to every
+            statement the package's sources issue — a build and a served query
+            alike — and a model-file, source or per-request declaration overrides
+            it property by property.
 
     Freshness:
       type: object
@@ -3676,9 +3718,10 @@ components:
         grammar while other backends keep it.
 
         Layers, most specific wins per property: connection default < package
-        `materialization.queryMetadata` < model-file
-        `## materialization.queryMetadata.*` < `#@ persist queryMetadata.*` <
-        per-request `queryMetadata`. The publisher's own context (`class`,
+        `queryMetadata` < model-file `## queryMetadata.*` < source
+        `#@ queryMetadata.*` < per-request `queryMetadata`. The `materialization.`
+        spellings of the package and model-file layers are deprecated and still
+        read; where a file declares both, the canonical one wins per property. The publisher's own context (`class`,
         `environment`, `package`, `model`, `source`, `trigger`, `run_id`,
         `query_id`, `version`) is applied on top and cannot be overwritten — it
         is what the server is actually doing, and a caller must not be able to
@@ -5001,9 +5044,10 @@ components:
             - type: "null"
           description: >-
             The source's EFFECTIVE per-query metadata after most-specific-wins
-            resolution per property (`#@ persist queryMetadata.*` > model-file
-            `## materialization.queryMetadata.*` > package
-            `materialization.queryMetadata`). Null = declared at no level. The
+            resolution per property (`#@ queryMetadata.*` > model-file
+            `## queryMetadata.*` > package `queryMetadata`; the deprecated
+            `materialization.` spellings of the last two are still read and lose
+            to the canonical ones). Null = declared at no level. The
             publisher attaches it — merged under its own context — to every
             statement it issues while building this source AND to every query
             served from it, and reports it here so a caller can see how the

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3086,9 +3086,11 @@ components:
           description: >-
             The manifest's `materialization.queryMetadata` block, verbatim. Null
             = none declared. The package-level layer of per-query metadata: it
-            applies to every statement the package's sources issue, and a
-            model-file, source or per-request declaration overrides it property
-            by property.
+            applies to every statement the package's sources issue — a build and
+            a served query alike — and a model-file, source or per-request
+            declaration overrides it property by property. Named for
+            materialization historically; it declares what the package's sources
+            ARE, not only how they are built.
 
     Freshness:
       type: object
@@ -3678,9 +3680,14 @@ components:
         `## materialization.queryMetadata.*` < `#@ persist queryMetadata.*` <
         per-request `queryMetadata`. The publisher's own context (`class`,
         `environment`, `package`, `model`, `source`, `trigger`, `run_id`,
-        `query_id`) is applied on top and cannot be overwritten by a declaration
-        — it is what the server is actually doing, and a caller must not be able
-        to relabel it. Put no secrets or personal data here: a tag is visible to
+        `query_id`, `version`) is applied on top and cannot be overwritten — it
+        is what the server is actually doing, and a caller must not be able to
+        relabel it. Those names are also RESERVED against a declaration: a
+        connection, package, model file or source declaring one has it DROPPED
+        rather than attached. Context only overwrites a name it has a value for,
+        and a served query has no `source`, `trigger` or `run_id` — so a declared
+        one would otherwise ride interactive traffic and read, in the backend's
+        own history, exactly like a build. Put no secrets or personal data here: a tag is visible to
         anyone who can read the backend's query history, and on a backend with no
         native tag mechanism it is visible in the statement text.
 
@@ -4994,10 +5001,16 @@ components:
             `## materialization.queryMetadata.*` > package
             `materialization.queryMetadata`). Null = declared at no level. The
             publisher attaches it — merged under its own context — to every
-            statement it issues while building this source, and reports it here so
-            a caller can see how a build will be tagged and tag its own queries
-            the same way. Observability only: excluded from `sourceEntityId`, so
-            editing it never re-addresses the source or orphans its table.
+            statement it issues while building this source AND to every query
+            served from it, and reports it here so a caller can see how the
+            source's traffic will be tagged. Reported as DECLARED, not as
+            attached: a property whose name the server owns (`class`,
+            `environment`, `package`, `model`, `source`, `trigger`, `run_id`,
+            `query_id`, `version`) appears here and is then dropped rather than
+            attached, so copying this bag onto a request verbatim can carry a
+            name the publisher will not accept. Observability only: excluded from
+            `sourceEntityId`, so editing it never re-addresses the source or
+            orphans its table.
         columns:
           type: array
           description: Output schema of the source.

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -5011,10 +5011,13 @@ components:
             attached: a property whose name the server owns (`class`,
             `environment`, `package`, `model`, `source`, `trigger`, `run_id`,
             `query_id`, `version`) appears here and is then dropped rather than
-            attached, so copying this bag onto a request verbatim can carry a
-            name the publisher will not accept. Observability only: excluded from
-            `sourceEntityId`, so editing it never re-addresses the source or
-            orphans its table.
+            attached. Copying this bag onto a request does NOT reproduce that
+            drop: the reservation covers a MODEL-SIDE declaration only, so a
+            `source`, `trigger` or `run_id` sent on a request layer ATTACHES, and
+            the statement then reads, in the backend's own history, exactly like
+            a build of this source. Strip the server-owned names before reusing
+            it. Observability only: excluded from `sourceEntityId`, so editing it
+            never re-addresses the source or orphans its table.
         columns:
           type: array
           description: Output schema of the source.

--- a/docs/materialization.md
+++ b/docs/materialization.md
@@ -213,7 +213,7 @@ The same package definition behaves differently depending on who drives material
 
 ## Attribute a build's cost
 
-`materialization.queryMetadata` (and the per-source `#@ persist queryMetadata.*`) tags every statement a build issues — the staging CTAS, the swap, the rename — so the backend's own reporting can separate build cost from query traffic. Publisher adds `class=materialize` plus the package, source, trigger and run id by itself. See [query-metadata.md](query-metadata.md).
+`materialization.queryMetadata` (and the per-source `#@ persist queryMetadata.*`) tags every statement a build issues — the staging CTAS, the swap, the rename — and every statement a _query_ against the source issues, so the backend's own reporting can attribute both. Separating build cost from query traffic is the context layer's job, not the declaration's: publisher adds `class=materialize` plus the package, source, trigger and run id to a build, and `class=interactive` with none of those to a served query. The block is named for materialization historically; it declares what the source is, not only how it is built. See [query-metadata.md](query-metadata.md).
 
 ## Tune for cost and performance
 

--- a/docs/query-metadata.md
+++ b/docs/query-metadata.md
@@ -52,25 +52,33 @@ Everything except `query_id` is a property of the unit of work rather than of th
 Most specific wins, property by property:
 
 1. **Connection** — `queryMetadata` on the connection config. Use it for what is true of the whole connection.
-2. **Package** — `materialization.queryMetadata` in `publisher.json`.
-3. **Model file** — `## materialization.queryMetadata.<name>="<value>"`.
-4. **Persist source** — `#@ persist queryMetadata.<name>="<value>"`.
+2. **Package** — `queryMetadata` at the root of `publisher.json`.
+3. **Model file** — `## queryMetadata.<name>="<value>"`.
+4. **Source** — `#@ queryMetadata.<name>="<value>"`.
 5. **Request** — `queryMetadata` on a query or SQL request, plus `queryClass` to set `class`.
+
+**Any source can be tagged, not only a persisted one.** `queryMetadata` is a sibling of `persist` in the `#@` namespace rather than a key inside it, so layer 4 applies to a source that is never materialized — its tags ride every query that reads it.
+
+**The `materialization.` spelling is deprecated at layers 2 and 3.** `materialization.queryMetadata` in `publisher.json`, `## materialization.queryMetadata.*` in a model file, and `materialization.queryMetadata` on the package API all still work. None was ever a build-only setting: the properties ride served queries too, so declaring them inside the build-policy block described a scope the feature does not have and sent authors hunting through build settings for a way to label their traffic.
+
+Only the manifest home warns today — that is where the two homes can disagree, and where the warning has something actionable to say. At layer 2 the canonical root wins a conflict and warns, unlike a conflicting `scope`, which fails the load: a tag must never be the reason a package refuses to load. At layer 3 the canonical bare form simply wins per property, silently, and a property only the deprecated form declares still resolves.
+
+The package API carries both homes for as long as the old one is supported: `queryMetadata` on a `Package` is canonical, both are populated on read, both are accepted on write, and the canonical one wins if a request sends both. Omitting it on a PATCH preserves the package's existing tags, and so does sending null — a client that serializes unset fields as null must not untag a package by accident. An empty object clears.
 
 ```json
 // publisher.json — every statement this package's sources issue
 {
   "name": "orders",
+  "queryMetadata": { "team": "finance", "tier": "gold" },
   "materialization": {
-    "scope": "version",
-    "queryMetadata": { "team": "finance", "tier": "gold" }
+    "scope": "version"
   }
 }
 ```
 
 ```malloy
-// model file: a default for every persist source in this file
-## materialization.queryMetadata.surface="marts"
+// model file: a default for every source in this file
+## queryMetadata.surface="marts"
 
 // one source, overriding `tier` and inheriting `team` and `surface`
 #@ persist name="order_rollup" queryMetadata.tier="platinum"

--- a/docs/query-metadata.md
+++ b/docs/query-metadata.md
@@ -39,6 +39,8 @@ Publisher attaches its own context to every statement, so attribution needs no m
 
 Context wins over a declared property of the same name: a caller cannot label its own query as a build, and cannot supply its own `query_id`.
 
+The context names are also **reserved against a declaration**. Context only overwrites a name it has a value for, and a served query has no `source`, `trigger` or `run_id` — so a package, model file or source declaring one would otherwise stamp it on interactive traffic, where it reads in the warehouse's own history exactly like a build. A declared context name is dropped and metered (`reason=reserved_name`) rather than applied.
+
 Everything except `query_id` is a property of the unit of work rather than of the individual call, so a repeated query produces the same values. `query_id` is per call by definition, which on a backend with no native tag mechanism makes the statement text unique and so bypasses an exact-text result cache. That is the deliberate cost of being able to find one query again.
 
 `PUBLISHER_QUERY_METADATA=off`, the default, attaches nothing at all — including caller-supplied properties. Leave it off for a deployment that wants its statements left exactly as Malloy compiles them, or if you would rather have the result cache than the correlation id.
@@ -73,7 +75,9 @@ Most specific wins, property by property:
 source: order_rollup is orders -> { aggregate: revenue is sum(amount) }
 ```
 
-Layers 2–4 describe how a source is **built**. A live query against the model is a different unit of work and does not inherit them — otherwise interactive traffic would be attributed to the build that happens to share the source.
+Layers 2–4 ride **every statement touching the source**, a build and a served query alike. They describe what the source _is_ — whose it is, what it costs, which tier it belongs to — and that is as true of a query reading it as of the build writing it. What distinguishes the two units of work is the context layer: a build carries `class=materialize` with a `source`, `trigger` and `run_id`, and a served query carries `class=interactive` with none of them. Those names are reserved, so no declaration can blur the distinction.
+
+A served query resolves layer 4 from the source it runs against, which the server already resolves for the authorize gate. A statement with no resolvable source — some notebook cells — carries layers 2 and 3 only.
 
 Under pressure — the 20-property cap, or Snowflake's tag limit — properties are given up least-specific-first, so a per-request property outlives a connection-wide one and the server's context outlives both.
 

--- a/docs/query-metadata.md
+++ b/docs/query-metadata.md
@@ -37,9 +37,11 @@ Publisher attaches its own context to every statement, so attribution needs no m
 | `trigger`, `run_id`      | what started a build, and which run it belongs to (also the run whose tables a drop is retiring) |
 | `query_id`               | identifies this one query; the response hands it back (see below)                                |
 
-Context wins over a declared property of the same name: a caller cannot label its own query as a build, and cannot supply its own `query_id`.
+Context wins over a property of the same name: a _declaration_ cannot label the statements it describes as a build, and nothing can supply its own `query_id`.
 
-The context names are also **reserved against a declaration**. Context only overwrites a name it has a value for, and a served query has no `source`, `trigger` or `run_id` — so a package, model file or source declaring one would otherwise stamp it on interactive traffic, where it reads in the warehouse's own history exactly like a build. A declared context name is dropped and metered (`reason=reserved_name`) rather than applied.
+The context names are also **reserved against a model-side declaration** — a package block, a model file or a `#@ persist` annotation. Context only overwrites a name it has a value for, and a served query has no `source`, `trigger` or `run_id`; without the reservation a declaration of one would stamp it on interactive traffic, where it reads in the warehouse's own history exactly like a build. A declared context name is dropped and metered (`reason=reserved_name`) rather than applied, and reported at publish so it arrives as a message rather than a counter tick.
+
+The connection default and the per-request bag are **not** covered, which is deliberate and pre-existing: a request setting `queryClass` is a caller describing its own call, and narrowing either is a compatibility decision of its own. The reservation covers the layer that describes _someone else's_ statements — a model-side declaration rides every query against that source, including queries its author never sees.
 
 Everything except `query_id` is a property of the unit of work rather than of the individual call, so a repeated query produces the same values. `query_id` is per call by definition, which on a backend with no native tag mechanism makes the statement text unique and so bypasses an exact-text result cache. That is the deliberate cost of being able to find one query again.
 

--- a/packages/server/src/controller/model.controller.ts
+++ b/packages/server/src/controller/model.controller.ts
@@ -136,6 +136,10 @@ export class ModelController {
                abortSignal,
                {
                   environment: environmentName,
+                  // The package owns its manifest, so the least-specific
+                  // author-declared layer is read here; the model knows only its
+                  // own file and its package's NAME.
+                  packageMaterialization: p.getMaterializationConfig(),
                   // The environment owns the connection configs, so the default
                   // and enforced layers are read here rather than from the model.
                   connectionMetadata: (connectionName) => {

--- a/packages/server/src/controller/model.controller.ts
+++ b/packages/server/src/controller/model.controller.ts
@@ -139,7 +139,7 @@ export class ModelController {
                   // The package owns its manifest, so the least-specific
                   // author-declared layer is read here; the model knows only its
                   // own file and its package's NAME.
-                  packageMaterialization: p.getMaterializationConfig(),
+                  packageDeclaration: p.getDeclaredQueryMetadata(),
                   // The environment owns the connection configs, so the default
                   // and enforced layers are read here rather than from the model.
                   connectionMetadata: (connectionName) => {

--- a/packages/server/src/controller/query.controller.ts
+++ b/packages/server/src/controller/query.controller.ts
@@ -111,7 +111,7 @@ export class QueryController {
                      // The package owns its manifest, so the least-specific
                      // author-declared layer is read here; the model knows only
                      // its own file and its package's NAME.
-                     packageMaterialization: p.getMaterializationConfig(),
+                     packageDeclaration: p.getDeclaredQueryMetadata(),
                      // The environment owns the connection configs, so the
                      // default and enforced layers are read here rather than
                      // from the model.

--- a/packages/server/src/controller/query.controller.ts
+++ b/packages/server/src/controller/query.controller.ts
@@ -108,6 +108,10 @@ export class QueryController {
                      // Minted here because this is the boundary that returns
                      // it; a path with nowhere to put it does not mint one.
                      correlationId: mintCorrelationId(),
+                     // The package owns its manifest, so the least-specific
+                     // author-declared layer is read here; the model knows only
+                     // its own file and its package's NAME.
+                     packageMaterialization: p.getMaterializationConfig(),
                      // The environment owns the connection configs, so the
                      // default and enforced layers are read here rather than
                      // from the model.

--- a/packages/server/src/mcp/handler_utils.ts
+++ b/packages/server/src/mcp/handler_utils.ts
@@ -23,6 +23,7 @@ import {
 } from "./error_messages";
 import type { Model } from "../service/model";
 import type { Environment } from "../service/environment";
+import type { Package } from "../service/package";
 import { logger } from "../logger";
 
 /**
@@ -174,7 +175,8 @@ export async function getModelForQuery(
    packageName: string,
    modelPath: string,
 ): Promise<
-   { model: Model; environment: Environment } | { error: ErrorDetails }
+   | { model: Model; environment: Environment; pkg: Package }
+   | { error: ErrorDetails }
 > {
    try {
       const environment = await environmentStore.getEnvironment(
@@ -195,7 +197,7 @@ export async function getModelForQuery(
       }
       // Attempt to get the model definition early to catch initial compilation errors
       await model.getModel(); // This might throw ModelCompilationError
-      return { model, environment };
+      return { model, environment, pkg };
    } catch (error) {
       // Handle errors during package/model access or initial compilation
       let errorDetails: ErrorDetails;

--- a/packages/server/src/mcp/tools/execute_query_tool.spec.ts
+++ b/packages/server/src/mcp/tools/execute_query_tool.spec.ts
@@ -53,6 +53,9 @@ function storeWhoseQueryThrows(error: unknown): Partial<EnvironmentStore> {
          ({
             assertCanAdmitQuery: () => undefined,
             getPackage: async () => ({
+               // The tool reads the package manifest for the least-specific
+               // author-declared metadata layer.
+               getMaterializationConfig: () => null,
                getModel: () => ({
                   getModelType: () => "model",
                   getModel: async () => ({}),
@@ -95,6 +98,9 @@ function storeCapturingMetadata(
                return connection;
             },
             getPackage: async () => ({
+               // The tool reads the package manifest for the least-specific
+               // author-declared metadata layer.
+               getMaterializationConfig: () => null,
                getModel: () => ({
                   getModelType: () => "model",
                   getModel: async () => ({}),

--- a/packages/server/src/mcp/tools/execute_query_tool.spec.ts
+++ b/packages/server/src/mcp/tools/execute_query_tool.spec.ts
@@ -53,9 +53,9 @@ function storeWhoseQueryThrows(error: unknown): Partial<EnvironmentStore> {
          ({
             assertCanAdmitQuery: () => undefined,
             getPackage: async () => ({
-               // The tool reads the package manifest for the least-specific
-               // author-declared metadata layer.
-               getMaterializationConfig: () => null,
+               // The tool reads the package's own declared bag as the
+               // least-specific author layer.
+               getDeclaredQueryMetadata: () => null,
                getModel: () => ({
                   getModelType: () => "model",
                   getModel: async () => ({}),
@@ -98,9 +98,9 @@ function storeCapturingMetadata(
                return connection;
             },
             getPackage: async () => ({
-               // The tool reads the package manifest for the least-specific
-               // author-declared metadata layer.
-               getMaterializationConfig: () => null,
+               // The tool reads the package's own declared bag as the
+               // least-specific author layer.
+               getDeclaredQueryMetadata: () => null,
                getModel: () => ({
                   getModelType: () => "model",
                   getModel: async () => ({}),

--- a/packages/server/src/mcp/tools/execute_query_tool.ts
+++ b/packages/server/src/mcp/tools/execute_query_tool.ts
@@ -193,7 +193,7 @@ export function registerExecuteQueryTool(
                // The package owns its manifest, so the least-specific
                // author-declared layer is read here; the model knows only its
                // own file and its package's NAME.
-               packageMaterialization: pkg.getMaterializationConfig(),
+               packageDeclaration: pkg.getDeclaredQueryMetadata(),
                // The environment owns the connection configs, so the default
                // and enforced layers are read here rather than from the model.
                connectionMetadata: (connectionName: string) => {

--- a/packages/server/src/mcp/tools/execute_query_tool.ts
+++ b/packages/server/src/mcp/tools/execute_query_tool.ts
@@ -168,7 +168,7 @@ export function registerExecuteQueryTool(
          }
 
          // --- Execute Query ---
-         const { model, environment } = modelResult;
+         const { model, environment, pkg } = modelResult;
          logger.info(
             `[MCP Tool executeQuery] Model found. Proceeding to execute query.`,
          );
@@ -190,6 +190,10 @@ export function registerExecuteQueryTool(
                environment: environmentName,
                // Minted here because the envelope below returns it.
                correlationId: mintCorrelationId(),
+               // The package owns its manifest, so the least-specific
+               // author-declared layer is read here; the model knows only its
+               // own file and its package's NAME.
+               packageMaterialization: pkg.getMaterializationConfig(),
                // The environment owns the connection configs, so the default
                // and enforced layers are read here rather than from the model.
                connectionMetadata: (connectionName: string) => {

--- a/packages/server/src/package_load/package_load_worker.ts
+++ b/packages/server/src/package_load/package_load_worker.ts
@@ -86,8 +86,10 @@ import { type FilterDefinition } from "../service/filter";
 import {
    PackageMaterializationConfig,
    PackageScope,
-   packageMaterializationWarnings,
+   materializationWithQueryMetadata,
    parsePackageMaterialization,
+   queryMetadataParseWarnings,
+   resolvePackageQueryMetadata,
    resolvePackageScope,
 } from "../service/package_manifest";
 import {
@@ -432,14 +434,29 @@ async function readPackageMetadata(packagePath: string): Promise<{
       manifestLocation?: unknown;
       materialization?: unknown;
       scope?: unknown;
+      queryMetadata?: unknown;
    };
    // Scope has two homes (canonical `materialization.scope`, deprecated root);
    // an invalid value or a conflict between the two throws and fails the load,
    // and the deprecation rides back as a warning.
    const scope = resolvePackageScope(parsed.scope, parsed.materialization);
+   // Query metadata has two homes as well, migrating the other way (canonical
+   // root, deprecated `materialization.queryMetadata`). A conflict warns rather
+   // than throws — see resolvePackageQueryMetadata.
+   const queryMetadata = resolvePackageQueryMetadata(
+      parsed.queryMetadata,
+      parsed.materialization,
+   );
    const manifestWarnings = [
       ...scope.warnings,
-      ...packageMaterializationWarnings(parsed.materialization),
+      ...queryMetadata.warnings,
+      // Report what the WINNING home could not keep. Reading the envelope alone
+      // would say nothing about a malformed property declared at the root, which
+      // is the home authors are being moved to.
+      ...queryMetadataParseWarnings(
+         queryMetadata.queryMetadata,
+         queryMetadata.home,
+      ),
    ];
    return {
       name: parsed.name,
@@ -459,7 +476,10 @@ async function readPackageMetadata(packagePath: string): Promise<{
       // Package-level Malloy Persistence policy; surfaced to the control plane,
       // which owns scheduling. `schedule`/`freshness` are for the control plane;
       // `queryMetadata` is the publisher's own package-level layer.
-      materialization: parsePackageMaterialization(parsed.materialization),
+      materialization: materializationWithQueryMetadata(
+         parsePackageMaterialization(parsed.materialization),
+         queryMetadata.queryMetadata,
+      ),
       // Package-level persist scope mode; defaults to "package".
       scope: scope.scope,
       manifestWarnings:

--- a/packages/server/src/query_metadata_metrics.ts
+++ b/packages/server/src/query_metadata_metrics.ts
@@ -30,7 +30,7 @@ const appliedCounter = lazyCounter(
 );
 const droppedCounter = lazyCounter(
    "publisher_query_metadata_properties_dropped_total",
-   "Metadata properties dropped while resolving a bag. Label: reason ('invalid_name'|'invalid_value'|'property_cap'|'serialized_cap').",
+   "Metadata properties dropped while resolving a bag. Label: reason ('invalid_name'|'invalid_value'|'reserved_name'|'property_cap'|'serialized_cap').",
 );
 
 /** One query's metadata reached the connector. */

--- a/packages/server/src/service/annotations.ts
+++ b/packages/server/src/service/annotations.ts
@@ -48,11 +48,43 @@ export function isReservedRoute(route: string): boolean {
  * `ownNotes`, whose own `inherits` would otherwise leak in. Replace with a
  * direct `import { getModelAnnotations }` once malloy exports it.
  */
+/**
+ * A model file's OWN `##` annotation bundle, ignoring everything it imports.
+ *
+ * The parsed-tag counterpart to {@link ownModelNotes}, which returns note TEXTS
+ * and so cannot feed `parseAsTag` — that needs each note's source location, and
+ * a note without one makes every reader catch and degrade to "no layer". Same
+ * document rule as `ownModelNotes`: a node counts only if it is this document or
+ * one of malloy's synthetic URL-less compiles, so a notebook's per-cell nodes are
+ * in and every real-URL import is out.
+ *
+ * Use this for a tag that describes one document; use {@link modelAnnotations}
+ * only for a policy gate that must survive being imported.
+ */
+export function ownModelAnnotations(modelDef: ModelDef): AnnotationsDef {
+   return foldModelAnnotations(
+      modelDef,
+      (id) => id === modelDef.modelID || id.startsWith("internal://"),
+   );
+}
+
 export function modelAnnotations(modelDef: ModelDef): AnnotationsDef {
+   return foldModelAnnotations(modelDef, () => true);
+}
+
+/**
+ * Shared fold behind {@link modelAnnotations} and {@link ownModelAnnotations} —
+ * the two differ only in which nodes they admit.
+ */
+function foldModelAnnotations(
+   modelDef: ModelDef,
+   admits: (id: string) => boolean,
+): AnnotationsDef {
    const registry = modelDef.modelAnnotations ?? {};
    const visited = new Set<string>();
    const order: string[] = [];
    const visit = (id: string): void => {
+      if (!admits(id)) return;
       if (visited.has(id)) return;
       visited.add(id);
       const entry = registry[id];

--- a/packages/server/src/service/build_plan.spec.ts
+++ b/packages/server/src/service/build_plan.spec.ts
@@ -507,16 +507,25 @@ describe("resolveQueryMetadata", () => {
       });
    });
 
-   it("prefers the model-file envelope over the bare form, per property", () => {
+   it("prefers the CANONICAL model-file form over the deprecated envelope", () => {
+      // Inverted deliberately. The envelope used to win, mirroring freshness —
+      // but freshness migrates the other way (there the envelope is canonical
+      // and the bare form legacy). For query metadata the bare `##
+      // queryMetadata.*` is what an author is now told to write, so the envelope
+      // winning meant the spelling we deprecate silently overrode the one we
+      // recommend, in a file that declares both.
       const source = fakeSource({
          name: "s",
          sourceEntityId: "bid",
          modelQueryMetadata: { tier: "bronze", legacy: "kept" },
-         modelMaterialization: { queryMetadata: { tier: "gold" } },
+         modelMaterialization: { queryMetadata: { tier: "gold", old: "seen" } },
       });
       expect(resolveQueryMetadata(source, null)).toEqual({
-         tier: "gold",
+         tier: "bronze",
          legacy: "kept",
+         // A property only the envelope declares still resolves — the
+         // deprecated home keeps working, it just stops overriding.
+         old: "seen",
       });
    });
 

--- a/packages/server/src/service/build_plan.ts
+++ b/packages/server/src/service/build_plan.ts
@@ -401,7 +401,7 @@ export function resolveQueryMetadata(
    packageMaterialization: WirePackageMaterialization | null | undefined,
 ): QueryMetadata | null {
    return composeDeclaredQueryMetadata({
-      packageMaterialization,
+      packageDeclaration: packageMaterialization?.queryMetadata ?? null,
       modelTag: safeModelTag(source),
       sourceTag: safeSourceTag(source),
    });
@@ -409,9 +409,14 @@ export function resolveQueryMetadata(
 
 /**
  * The author-declared layers of one statement's metadata, composed
- * most-specific-wins PER PROPERTY: source `#@ persist queryMetadata.*` >
- * model-file `## materialization.queryMetadata.*` (bare `## queryMetadata.*`
- * underneath) > package `materialization.queryMetadata`.
+ * most-specific-wins PER PROPERTY: source `#@ queryMetadata.*` > model-file
+ * `## queryMetadata.*` > package `queryMetadata`.
+ *
+ * The package and model-file layers each have a deprecated
+ * `materialization.`-prefixed spelling, still read, sitting UNDERNEATH its
+ * canonical form — so a file declaring both resolves to the canonical one. That
+ * is the OPPOSITE of freshness, where the prefixed spelling IS canonical; the
+ * ordering note in the body is where that trap is spelled out.
  *
  * Takes tags rather than a {@link PersistSource} so the SERVE path can compose
  * the same layers from a loaded model, where no `PersistSource` exists. A
@@ -426,15 +431,29 @@ export function resolveQueryMetadata(
  * "declared nowhere" rather than "declared empty".
  */
 export function composeDeclaredQueryMetadata(layers: {
-   packageMaterialization?: WirePackageMaterialization | null;
+   /**
+    * The package's declared bag — a bag, not the materialization policy that
+    * carries it on the wire. Nothing here needs a schedule or a freshness
+    * window, and threading the policy object through would say this layer is
+    * about materialization when it is not.
+    */
+   packageDeclaration?: QueryMetadata | null;
    modelTag?: ReadableTag;
    sourceTag?: ReadableTag;
 }): QueryMetadata | null {
    // Least specific first, so a more specific layer overwrites property by
    // property.
+   //
+   // `modelTagLayers` yields [envelope, bare], which is most-specific-first for
+   // freshness — there the envelope is the canonical spelling and the bare form
+   // is the legacy one. Query metadata migrates the other way: the bare `##
+   // queryMetadata.*` is canonical and `## materialization.queryMetadata.*` is
+   // deprecated. So the list is consumed as-is rather than reversed, putting the
+   // deprecated spelling underneath. Reversing it let the spelling we tell
+   // authors to stop writing silently override the one we tell them to write.
    const ordered: QueryMetadata[] = [
-      layers.packageMaterialization?.queryMetadata ?? {},
-      ...modelTagLayers(layers.modelTag).map(tagQueryMetadataLayer).reverse(),
+      layers.packageDeclaration ?? {},
+      ...modelTagLayers(layers.modelTag).map(tagQueryMetadataLayer),
       tagQueryMetadataLayer(layers.sourceTag),
    ];
    const resolved: QueryMetadata = Object.assign({}, ...ordered);

--- a/packages/server/src/service/build_plan.ts
+++ b/packages/server/src/service/build_plan.ts
@@ -31,7 +31,7 @@ type WirePersistSourcePlan = components["schemas"]["PersistSourcePlan"];
 type WireColumn = components["schemas"]["Column"];
 type BuildPlan = components["schemas"]["BuildPlan"];
 type WireFreshness = components["schemas"]["Freshness"];
-type WirePackageMaterialization =
+export type WirePackageMaterialization =
    components["schemas"]["PackageMaterializationConfig"];
 type QueryMetadata = components["schemas"]["QueryMetadata"];
 
@@ -50,7 +50,7 @@ interface FreshnessLayer {
  * reads by path, plus the subtree read that a property collection like
  * `queryMetadata { … }` needs.
  */
-interface ReadableTag {
+export interface ReadableTag {
    text(...path: string[]): string | undefined;
    tag(...path: string[]): ReadableTag | undefined;
    entries?(): Iterable<[string, { text(): string | undefined }]>;
@@ -400,16 +400,44 @@ export function resolveQueryMetadata(
    source: PersistSource,
    packageMaterialization: WirePackageMaterialization | null | undefined,
 ): QueryMetadata | null {
+   return composeDeclaredQueryMetadata({
+      packageMaterialization,
+      modelTag: safeModelTag(source),
+      sourceTag: safeSourceTag(source),
+   });
+}
+
+/**
+ * The author-declared layers of one statement's metadata, composed
+ * most-specific-wins PER PROPERTY: source `#@ persist queryMetadata.*` >
+ * model-file `## materialization.queryMetadata.*` (bare `## queryMetadata.*`
+ * underneath) > package `materialization.queryMetadata`.
+ *
+ * Takes tags rather than a {@link PersistSource} so the SERVE path can compose
+ * the same layers from a loaded model, where no `PersistSource` exists. A
+ * declaration describes the source's traffic, not only its build, so a served
+ * query carries it too; {@link resolveQueryMetadata} is the build-path caller,
+ * which still reads both tags off the persist source it is building.
+ *
+ * A layer whose tag is absent contributes nothing rather than clearing what a
+ * less specific layer set — so a package-wide `team` survives a source that only
+ * overrides `workload`, and a model with no `##` tag does not erase the package
+ * default. Null when no layer declares anything, so absence always means
+ * "declared nowhere" rather than "declared empty".
+ */
+export function composeDeclaredQueryMetadata(layers: {
+   packageMaterialization?: WirePackageMaterialization | null;
+   modelTag?: ReadableTag;
+   sourceTag?: ReadableTag;
+}): QueryMetadata | null {
    // Least specific first, so a more specific layer overwrites property by
    // property.
-   const layers: QueryMetadata[] = [
-      packageMaterialization?.queryMetadata ?? {},
-      ...modelTagLayers(safeModelTag(source))
-         .map(tagQueryMetadataLayer)
-         .reverse(),
-      tagQueryMetadataLayer(safeSourceTag(source)),
+   const ordered: QueryMetadata[] = [
+      layers.packageMaterialization?.queryMetadata ?? {},
+      ...modelTagLayers(layers.modelTag).map(tagQueryMetadataLayer).reverse(),
+      tagQueryMetadataLayer(layers.sourceTag),
    ];
-   const resolved: QueryMetadata = Object.assign({}, ...layers);
+   const resolved: QueryMetadata = Object.assign({}, ...ordered);
    return Object.keys(resolved).length > 0 ? resolved : null;
 }
 

--- a/packages/server/src/service/environment.ts
+++ b/packages/server/src/service/environment.ts
@@ -2320,6 +2320,7 @@ export class Environment {
          queryableSources?: "declared" | "all";
          manifestLocation?: string | null;
          scope?: ApiPackage["scope"];
+         queryMetadata?: ApiPackage["queryMetadata"];
          materialization?: ApiPackage["materialization"];
       },
    ): Promise<void> {
@@ -2370,11 +2371,16 @@ export class Environment {
          // `queryMetadata` is orthogonal to both: a client setting a schedule
          // has no reason to re-send the package's tags, and dropping them
          // silently untags every statement the package's builds issue. So it is
-         // preserved on omission, like `scope` above; an explicit null still
-         // clears it, which keeps the block expressible.
+         // preserved on omission, like `scope` above.
+         //
+         // A NULL is preserve too, not a clear — one rule at both wire homes.
+         // Null used to clear here while null on the canonical field preserved,
+         // which protected a client that serializes unset fields as null only
+         // if it had already migrated off this home. The clear is an EMPTY bag,
+         // which is unambiguous and which no such client emits by accident.
          const preservedQueryMetadata =
             metadata.materialization !== undefined &&
-            metadata.materialization?.queryMetadata === undefined &&
+            metadata.materialization?.queryMetadata == null &&
             onDiskMaterialization?.queryMetadata !== undefined
                ? { queryMetadata: onDiskMaterialization.queryMetadata }
                : {};
@@ -2389,6 +2395,29 @@ export class Environment {
             resolvedScope !== undefined
                ? { ...(materializationBase ?? {}), scope: resolvedScope }
                : materializationBase;
+
+         // `queryMetadata` has two homes as well, migrating the opposite way to
+         // `scope`: the manifest ROOT is canonical and the envelope is
+         // deprecated. Same dual-write rule and the same reason — writing only
+         // the root would leave an older publisher, which reads only the
+         // envelope, serving untagged statements for a package that asked to be
+         // tagged.
+         //
+         // A caller can express tags at either wire home, so precedence follows
+         // the same order the manifest resolver uses: the canonical top-level
+         // field, then the deprecated block, then what is already on disk. A
+         // client that has not migrated keeps working; one that has is not
+         // overruled by a block it did not send.
+         //
+         // A null anywhere in this chain is "not provided", never a clear — the
+         // one rule at both homes (see preservedQueryMetadata). Clearing is an
+         // empty bag, which parses to "no tags" and reaches both homes like any
+         // other value.
+         const resolvedQueryMetadata =
+            metadata.queryMetadata ??
+            (materializationBlock as { queryMetadata?: unknown } | undefined)
+               ?.queryMetadata ??
+            (existingManifest as { queryMetadata?: unknown }).queryMetadata;
 
          // Update with new metadata. `explores`/`queryableSources` are only
          // overwritten when the caller explicitly provides them; otherwise the
@@ -2408,8 +2437,25 @@ export class Environment {
                ? { manifestLocation: metadata.manifestLocation }
                : {}),
             ...(resolvedScope !== undefined ? { scope: resolvedScope } : {}),
+            ...(resolvedQueryMetadata !== undefined
+               ? { queryMetadata: resolvedQueryMetadata }
+               : {}),
+            // Mirrored into the deprecated home too, so a package tagged
+            // through the canonical field still reads as tagged on a publisher
+            // that only knows the envelope. Only when that home already exists
+            // or the caller wrote to it: mirroring unconditionally introduced a
+            // `materialization` block into a manifest that never had one, which
+            // is the shape being migrated AWAY from, appearing in a file whose
+            // author only ever used the canonical field.
             ...(materializationBlock !== undefined
-               ? { materialization: materializationBlock }
+               ? {
+                    materialization: {
+                       ...materializationBlock,
+                       ...(resolvedQueryMetadata !== undefined
+                          ? { queryMetadata: resolvedQueryMetadata }
+                          : {}),
+                    },
+                 }
                : {}),
          };
 
@@ -2483,9 +2529,36 @@ export class Environment {
          const materializationProvided = body.materialization != null;
          const editingPolicy = scopeProvided || materializationProvided;
          const scope = scopeProvided ? body.scope : existing.scope;
-         const materialization = materializationProvided
+         // Preserved unless provided, for the same reason as scope: this
+         // replaces the whole metadata object, so omitting it would make a
+         // name/description-only PATCH silently untag every query the package
+         // emits until the next reload. A null is treated as omitted for the
+         // same reason as scope — a client that serializes unset fields as null
+         // must not thereby untag a package. Clearing is an empty bag, which no
+         // such client produces by accident.
+         //
+         // Resolved ONCE across both wire homes and then written to BOTH, the
+         // way writePackageManifest resolves the file. Setting them
+         // independently left whichever home the caller did not send holding a
+         // stale bag, and the two are read by different paths: the serve path
+         // takes the canonical field through getDeclaredQueryMetadata, the build
+         // path takes the block. A migrated client PATCHing only the canonical
+         // field therefore tagged its served queries with the new bag and its
+         // builds with the old one, and getPackageMetadata returned the two
+         // homes contradicting each other on a schema that promises both.
+         const queryMetadata =
+            body.queryMetadata ??
+            body.materialization?.queryMetadata ??
+            existing.queryMetadata ??
+            existing.materialization?.queryMetadata ??
+            null;
+         const materializationBase = materializationProvided
             ? body.materialization
             : existing.materialization;
+         const materialization =
+            materializationBase || queryMetadata !== null
+               ? { ...(materializationBase ?? {}), queryMetadata }
+               : materializationBase;
          _package.setPackageMetadata({
             name: body.name,
             description: body.description,
@@ -2495,6 +2568,7 @@ export class Environment {
             queryableSources,
             manifestLocation,
             materialization,
+            queryMetadata,
             scope,
          });
 
@@ -2530,6 +2604,7 @@ export class Environment {
             // null-as-absent rule above, so a rebind PATCH neither wipes the
             // persisted policy nor writes a stray `scope: null`.
             scope: scopeProvided ? body.scope : undefined,
+            queryMetadata: body.queryMetadata ?? undefined,
             materialization: materializationProvided
                ? body.materialization
                : undefined,

--- a/packages/server/src/service/materialization_config_validation.spec.ts
+++ b/packages/server/src/service/materialization_config_validation.spec.ts
@@ -96,4 +96,39 @@ describe("materializationConfigWarnings", () => {
          materializationConfigWarnings({ sources: [source("orders", null)] }),
       ).toEqual([]);
    });
+
+   it("warns about a reserved name, naming the level that declared it", () => {
+      // A context name is dropped rather than attached, so declaring one
+      // publishes clean and then vanishes on every statement with nothing but a
+      // counter tick behind it. The level is what makes the message actionable.
+      const warnings = materializationConfigWarnings({
+         packageMaterialization: {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            queryMetadata: { model: "marts" } as any,
+         },
+      });
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toContain("materialization.queryMetadata");
+      expect(warnings[0].message).toContain("'model'");
+      expect(warnings[0].message).toContain("dropped rather than attached");
+   });
+
+   it("checks a model file that persists nothing", () => {
+      // The case this level exists for. A `##` declaration in a file with no
+      // persist source has no source to surface under, and still rides every
+      // query served from that file.
+      const warnings = materializationConfigWarnings({
+         modelDeclarations: [
+            {
+               modelPath: "marts.malloy",
+               // eslint-disable-next-line @typescript-eslint/no-explicit-any
+               queryMetadata: { run_id: "x" } as any,
+            },
+         ],
+         sources: [],
+      });
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].subject).toBe("marts.malloy");
+      expect(warnings[0].message).toContain("## materialization.queryMetadata");
+   });
 });

--- a/packages/server/src/service/materialization_config_validation.spec.ts
+++ b/packages/server/src/service/materialization_config_validation.spec.ts
@@ -1,30 +1,18 @@
 import { describe, expect, it } from "bun:test";
-import type { components } from "../api";
 import { materializationConfigWarnings } from "./materialization_config_validation";
 
-const source = (
-   name: string,
-   queryMetadata: Record<string, string> | null,
-): components["schemas"]["PersistSourcePlan"] => ({
-   name,
-   sourceID: `${name}@m`,
-   connectionName: "duckdb",
-   sourceEntityId: "bid",
-   sql: "SELECT 1",
-   columns: [],
-   queryMetadata,
-});
-
 describe("materializationConfigWarnings", () => {
-   it("says nothing about a clean config", () => {
+   it("says nothing about a clean set of declarations", () => {
       expect(
          materializationConfigWarnings({
-            packageMaterialization: {
-               schedule: null,
-               freshness: null,
-               queryMetadata: { team: "finance" },
-            },
-            sources: [source("orders", { team: "finance" })],
+            declarations: [
+               { level: "package", queryMetadata: { team: "finance" } },
+               {
+                  level: "source",
+                  subject: "orders",
+                  queryMetadata: { team: "finance" },
+               },
+            ],
          }),
       ).toEqual([]);
    });
@@ -39,62 +27,71 @@ describe("materializationConfigWarnings", () => {
 
    it("reports a package-level property that violates the contract", () => {
       const warnings = materializationConfigWarnings({
-         packageMaterialization: {
-            schedule: null,
-            freshness: null,
-            queryMetadata: { "team.name": "finance" },
-         },
+         declarations: [
+            { level: "package", queryMetadata: { "team.name": "finance" } },
+         ],
       });
       expect(warnings).toHaveLength(1);
-      expect(warnings[0].message).toContain("materialization.queryMetadata");
+      expect(warnings[0].message).toContain("queryMetadata");
       expect(warnings[0].message).toContain("team.name");
       expect(warnings[0].subject).toBeUndefined();
    });
 
-   it("reports the offending property at the source that resolves it", () => {
+   it("reports a source-level property at the source that declared it", () => {
       const warnings = materializationConfigWarnings({
-         sources: [source("orders", { "team.name": "finance" })],
+         declarations: [
+            {
+               level: "source",
+               subject: "orders",
+               queryMetadata: { "team.name": "finance" },
+            },
+         ],
       });
       expect(warnings).toHaveLength(1);
       expect(warnings[0].subject).toBe("orders");
-      expect(warnings[0].message).toContain("#@ persist queryMetadata");
+      expect(warnings[0].message).toContain("#@ queryMetadata");
    });
 
    it("reports a BigQuery-dropped name as a warning, not silence", () => {
       const warnings = materializationConfigWarnings({
-         sources: [source("orders", { _team: "finance" })],
+         declarations: [
+            {
+               level: "source",
+               subject: "orders",
+               queryMetadata: { _team: "finance" },
+            },
+         ],
       });
       expect(warnings).toHaveLength(1);
       expect(warnings[0].message).toMatch(/BigQuery/);
    });
 
-   it("reports the problem at every level that resolves it", () => {
-      // The package declares it and both sources inherit it. Reporting each
-      // level is what lets an author find the one they can edit; identical
-      // messages are collapsed, different levels are not.
+   it("reports once per DECLARATION, not once per source that inherits it", () => {
+      // The point of checking declarations rather than resolved bags. A package
+      // property is one mistake on one line; reporting it again at every source
+      // that inherits it sends the author to lines that do not contain it.
       const warnings = materializationConfigWarnings({
-         packageMaterialization: {
-            schedule: null,
-            freshness: null,
-            queryMetadata: { "team.name": "finance" },
-         },
-         sources: [
-            source("orders", { "team.name": "finance" }),
-            source("returns", { "team.name": "finance" }),
+         declarations: [
+            { level: "package", queryMetadata: { "team.name": "finance" } },
+            {
+               level: "source",
+               subject: "orders",
+               queryMetadata: { workload: "marts" },
+            },
+            {
+               level: "source",
+               subject: "returns",
+               queryMetadata: { workload: "marts" },
+            },
          ],
       });
-      expect(warnings).toHaveLength(3);
-      expect(warnings.map((w) => w.subject)).toEqual([
-         undefined,
-         "orders",
-         "returns",
-      ]);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].subject).toBeUndefined();
    });
 
-   it("ignores sources with no metadata", () => {
-      expect(
-         materializationConfigWarnings({ sources: [source("orders", null)] }),
-      ).toEqual([]);
+   it("ignores a level that declares nothing", () => {
+      expect(materializationConfigWarnings({ declarations: [] })).toEqual([]);
+      expect(materializationConfigWarnings({})).toEqual([]);
    });
 
    it("warns about a reserved name, naming the level that declared it", () => {
@@ -102,33 +99,205 @@ describe("materializationConfigWarnings", () => {
       // publishes clean and then vanishes on every statement with nothing but a
       // counter tick behind it. The level is what makes the message actionable.
       const warnings = materializationConfigWarnings({
-         packageMaterialization: {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            queryMetadata: { model: "marts" } as any,
-         },
+         declarations: [
+            { level: "package", queryMetadata: { model: "marts" } },
+         ],
       });
       expect(warnings).toHaveLength(1);
-      expect(warnings[0].message).toContain("materialization.queryMetadata");
+      expect(warnings[0].message).toContain("queryMetadata");
       expect(warnings[0].message).toContain("'model'");
       expect(warnings[0].message).toContain("dropped rather than attached");
    });
 
-   it("checks a model file that persists nothing", () => {
-      // The case this level exists for. A `##` declaration in a file with no
-      // persist source has no source to surface under, and still rides every
-      // query served from that file.
+   it("names each level in the spelling an author should write", () => {
+      // The label is the actionable half of the message, so it has to be the
+      // canonical spelling rather than the deprecated `materialization.` one.
       const warnings = materializationConfigWarnings({
-         modelDeclarations: [
+         declarations: [
             {
+               level: "model",
                modelPath: "marts.malloy",
-               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-               queryMetadata: { run_id: "x" } as any,
+               queryMetadata: { run_id: "x" },
+            },
+            {
+               level: "source",
+               subject: "orders_live",
+               modelPath: "marts.malloy",
+               queryMetadata: { run_id: "x" },
             },
          ],
-         sources: [],
+      });
+      expect(warnings).toHaveLength(2);
+      expect(warnings[0].model).toBe("marts.malloy");
+      expect(warnings[0].message).toContain("## queryMetadata");
+      expect(warnings[1].subject).toBe("orders_live");
+      expect(warnings[1].message).toContain("#@ queryMetadata");
+   });
+
+   it("puts a model path in `model`, never in `subject`", () => {
+      // The wire schema keeps the two apart: `model` is a package-relative model
+      // path and `subject` is a source / query / view. A model path in `subject`
+      // was invisible to a client filtering findings by model, and rendered a
+      // file name where a reader expects a source name.
+      const warnings = materializationConfigWarnings({
+         declarations: [
+            {
+               level: "model",
+               modelPath: "marts.malloy",
+               queryMetadata: { "team.name": "finance" },
+            },
+         ],
       });
       expect(warnings).toHaveLength(1);
-      expect(warnings[0].subject).toBe("marts.malloy");
-      expect(warnings[0].message).toContain("## materialization.queryMetadata");
+      expect(warnings[0].model).toBe("marts.malloy");
+      expect(warnings[0].subject).toBeUndefined();
+   });
+
+   it("locates a source finding by BOTH its model path and its name", () => {
+      // A source name is unique within a model, not within a package. Without
+      // the path, two models declaring a same-named source produced identical
+      // findings that deduped to one message naming neither file.
+      const warnings = materializationConfigWarnings({
+         declarations: [
+            {
+               level: "source",
+               subject: "orders",
+               modelPath: "a.malloy",
+               queryMetadata: { run_id: "x" },
+            },
+            {
+               level: "source",
+               subject: "orders",
+               modelPath: "b.malloy",
+               queryMetadata: { run_id: "x" },
+            },
+         ],
+      });
+      expect(warnings).toHaveLength(2);
+      expect(warnings.map((w) => w.model)).toEqual(["a.malloy", "b.malloy"]);
+   });
+
+   it("checks the MERGED bag against the budget, which no declaration can", () => {
+      // The author budget is MAX_PROPERTIES minus the context the server adds.
+      // Every layer here is individually under it while the merge is over, so
+      // checking declarations alone let a package publish clean and then shed
+      // context properties on every statement — visible afterwards only as a
+      // metric. No level label: no single line is at fault.
+      const six = (prefix: string) =>
+         Object.fromEntries(
+            Array.from({ length: 6 }, (_, i) => [`${prefix}${i}`, "v"]),
+         );
+      const warnings = materializationConfigWarnings({
+         declarations: [
+            { level: "package", queryMetadata: six("p") },
+            {
+               level: "model",
+               modelPath: "marts.malloy",
+               queryMetadata: six("m"),
+            },
+         ],
+         effectiveMerges: [
+            {
+               modelPath: "marts.malloy",
+               floorSize: 12,
+               sources: [{ subject: "orders", size: 12 }],
+            },
+         ],
+      });
+      const merged = warnings.filter((w) => w.message.includes("merged"));
+      expect(merged).toHaveLength(1);
+      expect(merged[0].model).toBe("marts.malloy");
+   });
+
+   it("catches a package+model overflow when NO source declares anything", () => {
+      // The case the merge check was added for and then missed: sizing only the
+      // declaring sources meant a package and a model file that overflow
+      // together published clean whenever no source in the file happened to add
+      // a tag of its own — and every query against every source in that file
+      // then shed context properties.
+      const warnings = materializationConfigWarnings({
+         effectiveMerges: [
+            { modelPath: "marts.malloy", floorSize: 12, sources: [] },
+         ],
+      });
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].model).toBe("marts.malloy");
+      expect(warnings[0].subject).toBeUndefined();
+      expect(warnings[0].message).toContain("package + model file, merged");
+   });
+
+   it("reports an overflowing floor ONCE, not once per source under it", () => {
+      // Every source in the file carries the floor, so naming each would be N
+      // messages for one mistake — and the sources are not where the fix goes.
+      const warnings = materializationConfigWarnings({
+         effectiveMerges: [
+            {
+               modelPath: "marts.malloy",
+               floorSize: 12,
+               sources: [
+                  { subject: "orders", size: 13 },
+                  { subject: "returns", size: 14 },
+               ],
+            },
+         ],
+      });
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].subject).toBeUndefined();
+   });
+
+   it("names the individual sources when the floor itself is fine", () => {
+      // Floor under budget, so each source that tips its own merge over is a
+      // separate mistake in a separate place and gets its own message.
+      const warnings = materializationConfigWarnings({
+         effectiveMerges: [
+            {
+               modelPath: "marts.malloy",
+               floorSize: 5,
+               sources: [
+                  { subject: "orders", size: 12 },
+                  { subject: "fine", size: 6 },
+                  { subject: "returns", size: 13 },
+               ],
+            },
+         ],
+      });
+      expect(warnings).toHaveLength(2);
+      expect(warnings.map((w) => w.subject)).toEqual(["orders", "returns"]);
+      expect(warnings[0].message).toContain(
+         "package + model file + source, merged",
+      );
+   });
+
+   it("says nothing about merges inside the budget", () => {
+      expect(
+         materializationConfigWarnings({
+            effectiveMerges: [
+               {
+                  modelPath: "marts.malloy",
+                  floorSize: 2,
+                  sources: [{ subject: "orders", size: 3 }],
+               },
+            ],
+         }),
+      ).toEqual([]);
+   });
+
+   it("checks a source whether or not it persists", () => {
+      // `queryMetadata` is a sibling of `persist` in the `#@` namespace, so a
+      // source that is never materialized declares tags the same way and they
+      // ride every query against it. Nothing about the build plan enters into
+      // whether its declaration is checked.
+      const warnings = materializationConfigWarnings({
+         declarations: [
+            {
+               level: "source",
+               subject: "orders_live",
+               queryMetadata: { run_id: "x" },
+            },
+         ],
+      });
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].subject).toBe("orders_live");
+      expect(warnings[0].message).toContain("dropped rather than attached");
    });
 });

--- a/packages/server/src/service/materialization_config_validation.ts
+++ b/packages/server/src/service/materialization_config_validation.ts
@@ -26,6 +26,7 @@ import type { components } from "../api";
 import {
    queryMetadataAdvisoryWarnings,
    queryMetadataBudgetWarning,
+   queryMetadataReservedWarnings,
    queryMetadataViolations,
    type QueryMetadata,
 } from "./query_metadata";
@@ -63,6 +64,7 @@ function metadataWarnings(
    return [
       ...queryMetadataViolations(metadata),
       ...queryMetadataAdvisoryWarnings(metadata),
+      ...queryMetadataReservedWarnings(metadata),
       ...(budget ? [budget] : []),
    ].map((message) => ({
       // The level is in the message because a reader needs to know WHICH

--- a/packages/server/src/service/materialization_config_validation.ts
+++ b/packages/server/src/service/materialization_config_validation.ts
@@ -41,6 +41,17 @@ export interface MaterializationConfigInput {
    /** The compiled plan's sources, carrying each one's RESOLVED metadata. */
    sources?: WirePersistSourcePlan[];
    /**
+    * Each model file's OWN `## materialization.queryMetadata.*`, keyed by path.
+    *
+    * Separate from {@link sources} because the two answer different questions. A
+    * source carries its RESOLVED bag, so a model-file property appears there
+    * attributed to the source and labelled `#@ persist queryMetadata` — which
+    * sends an author to a line that does not contain it. And a model file that
+    * persists nothing has no source to appear under at all, while still
+    * contributing a layer to every query served from it.
+    */
+   modelDeclarations?: { modelPath: string; queryMetadata: QueryMetadata }[];
+   /**
     * Deprecations the manifest parse tolerated (e.g. a root-level `scope`), which
     * a load keeps working but a publish should report.
     */
@@ -99,6 +110,16 @@ export function materializationConfigWarnings(
          input.packageMaterialization?.queryMetadata,
       ),
    );
+
+   for (const declaration of input.modelDeclarations ?? []) {
+      warnings.push(
+         ...metadataWarnings(
+            "## materialization.queryMetadata",
+            declaration.queryMetadata,
+            declaration.modelPath,
+         ),
+      );
+   }
 
    for (const source of input.sources ?? []) {
       warnings.push(

--- a/packages/server/src/service/materialization_config_validation.ts
+++ b/packages/server/src/service/materialization_config_validation.ts
@@ -22,7 +22,6 @@
  * moving them here is a mechanical follow-up with no behavior change.
  */
 
-import type { components } from "../api";
 import {
    queryMetadataAdvisoryWarnings,
    queryMetadataBudgetWarning,
@@ -31,26 +30,61 @@ import {
    type QueryMetadata,
 } from "./query_metadata";
 
-type WirePackageMaterialization =
-   components["schemas"]["PackageMaterializationConfig"];
-type WirePersistSourcePlan = components["schemas"]["PersistSourcePlan"];
+/** Where a `queryMetadata` bag was declared, which is what an author edits. */
+export type QueryMetadataLevel = "package" | "model" | "source";
+
+/** One author's declaration, as declared — not as resolved. */
+export interface QueryMetadataDeclaration {
+   level: QueryMetadataLevel;
+   /**
+    * The source to point the author at; absent for a package or a model file.
+    * A source name is not unique across a package, so a source declaration
+    * carries {@link modelPath} as well — without it two models declaring a
+    * same-named source produce identical findings that dedupe to one message
+    * naming neither file.
+    */
+   subject?: string;
+   /** The model file the declaration is in; absent for a package. */
+   modelPath?: string;
+   queryMetadata: QueryMetadata;
+}
 
 export interface MaterializationConfigInput {
-   /** The package manifest's `materialization` block, as parsed. */
-   packageMaterialization?: WirePackageMaterialization | null;
-   /** The compiled plan's sources, carrying each one's RESOLVED metadata. */
-   sources?: WirePersistSourcePlan[];
    /**
-    * Each model file's OWN `## materialization.queryMetadata.*`, keyed by path.
+    * Every `queryMetadata` bag an author declared, at whatever level.
     *
-    * Separate from {@link sources} because the two answer different questions. A
-    * source carries its RESOLVED bag, so a model-file property appears there
-    * attributed to the source and labelled `#@ persist queryMetadata` — which
-    * sends an author to a line that does not contain it. And a model file that
-    * persists nothing has no source to appear under at all, while still
-    * contributing a layer to every query served from it.
+    * One list rather than one field per level, and OWN declarations rather than
+    * resolved ones. A resolved bag answers "what will this source send"; a
+    * declaration answers "which line do I edit", and only the second is
+    * actionable in a warning. Reporting resolved bags is also what made a
+    * package property surface under a `#@ persist` label at a source that never
+    * mentioned it.
+    *
+    * Whether a source persists is irrelevant here: `queryMetadata` is a sibling
+    * of `persist` in the `#@` namespace, so any source can declare a bag and it
+    * rides every query against that source either way.
     */
-   modelDeclarations?: { modelPath: string; queryMetadata: QueryMetadata }[];
+   declarations?: QueryMetadataDeclaration[];
+   /**
+    * How many properties a statement actually SENDS, per model file, after the
+    * layers merge. The declarations above cannot answer this — each is
+    * individually under budget while their merge is over it — and the budget is
+    * a property of the merge.
+    *
+    * Given per model rather than per source because the overflow usually is not
+    * a source's fault. `floorSize` is package ⊕ model file: the bag EVERY source
+    * in that file carries, including the sources that declare nothing. Sizing
+    * only the declaring sources missed that case entirely — a package and a
+    * model file that overflow together published clean whenever no source in the
+    * file happened to add a tag of its own.
+    */
+   effectiveMerges?: {
+      modelPath: string;
+      /** package ⊕ model file — carried by every source in this file. */
+      floorSize: number;
+      /** Per source that declares its own bag: package ⊕ model ⊕ source. */
+      sources: { subject: string; size: number }[];
+   }[];
    /**
     * Deprecations the manifest parse tolerated (e.g. a root-level `scope`), which
     * a load keeps working but a publish should report.
@@ -58,9 +92,30 @@ export interface MaterializationConfigInput {
    manifestWarnings?: string[];
 }
 
-/** One finding, in the shape the wire package's operator warnings array uses. */
+/**
+ * How each level is spelled back to the author. The canonical spelling, not the
+ * deprecated `materialization.` one — a message should name the form we want
+ * them to write.
+ */
+const DECLARATION_LABELS: Record<QueryMetadataLevel, string> = {
+   package: "queryMetadata",
+   model: "## queryMetadata",
+   source: "#@ queryMetadata",
+};
+
+/**
+ * One finding, in the shape the wire package's operator warnings array uses.
+ *
+ * `model` and `subject` are separate because the schema separates them: `model`
+ * is a package-relative model path and `subject` is a source / query / view.
+ * Putting a model path in `subject` made a client filtering by `model` miss the
+ * finding entirely, and rendered `marts.malloy` where a reader expects a source
+ * name.
+ */
 export interface MaterializationConfigWarning {
-   /** The persist source the finding belongs to, absent for a package-level one. */
+   /** The model file the finding is in, absent for a package-level one. */
+   model?: string;
+   /** The source the finding belongs to, absent for package and model levels. */
    subject?: string;
    message: string;
 }
@@ -68,7 +123,7 @@ export interface MaterializationConfigWarning {
 function metadataWarnings(
    level: string,
    metadata: QueryMetadata | null | undefined,
-   subject?: string,
+   location: { model?: string; subject?: string },
 ): MaterializationConfigWarning[] {
    if (!metadata) return [];
    const budget = queryMetadataBudgetWarning(Object.keys(metadata).length);
@@ -81,7 +136,8 @@ function metadataWarnings(
       // The level is in the message because a reader needs to know WHICH
       // declaration to edit, and an inherited property has more than one.
       message: `${level}: ${message}`,
-      ...(subject ? { subject } : {}),
+      ...(location.model ? { model: location.model } : {}),
+      ...(location.subject ? { subject: location.subject } : {}),
    }));
 }
 
@@ -91,11 +147,10 @@ function metadataWarnings(
  * rule existed must keep loading, and a bad metadata property degrades
  * attribution rather than corrupting anything.
  *
- * A source's metadata is checked in its RESOLVED form (the effective bag from
- * package → model-file → `#@ persist`), because that is what will actually be
- * attached — a property inherited from the manifest is just as broken at the
- * source as it is at the package, and reporting it at both is how an author finds
- * the one they can edit.
+ * Each declaration is checked as DECLARED, at the level that declared it, so a
+ * message names the line an author can edit. Checking a source's resolved bag
+ * instead would report a package property at every source that inherits it,
+ * under a `#@ persist` label those sources never wrote.
  */
 export function materializationConfigWarnings(
    input: MaterializationConfigInput,
@@ -104,38 +159,63 @@ export function materializationConfigWarnings(
       input.manifestWarnings ?? []
    ).map((message) => ({ message }));
 
-   warnings.push(
-      ...metadataWarnings(
-         "materialization.queryMetadata",
-         input.packageMaterialization?.queryMetadata,
-      ),
-   );
-
-   for (const declaration of input.modelDeclarations ?? []) {
+   for (const declaration of input.declarations ?? []) {
       warnings.push(
          ...metadataWarnings(
-            "## materialization.queryMetadata",
+            DECLARATION_LABELS[declaration.level],
             declaration.queryMetadata,
-            declaration.modelPath,
+            { model: declaration.modelPath, subject: declaration.subject },
          ),
       );
    }
 
-   for (const source of input.sources ?? []) {
-      warnings.push(
-         ...metadataWarnings(
-            `#@ persist queryMetadata`,
-            source.queryMetadata,
-            source.name,
-         ),
-      );
+   // The budget is the one rule a single declaration cannot answer. Every check
+   // above is per-declaration on purpose — that is what lets a message name the
+   // line to edit — but the budget is about what a statement SENDS, and a
+   // statement sends the merge of every layer above it. Package 6 + model 6 is
+   // six properties at each declaration and twelve on the wire, which is over
+   // the author budget and sheds context properties on every statement: the
+   // exact failure `queryMetadataBudgetWarning` exists to prevent, published
+   // clean and visible afterwards only as a metric.
+   //
+   // No level label on these, because no single line is at fault.
+   for (const merge of input.effectiveMerges ?? []) {
+      // The floor first, and ALONE when it overflows. Every source in the file
+      // carries it, so naming each would be N messages for one mistake — and the
+      // sources are not where the fix goes, the manifest and this file are. Once
+      // the floor is back under budget a republish surfaces whichever individual
+      // sources are still over.
+      const floor = queryMetadataBudgetWarning(merge.floorSize);
+      if (floor) {
+         warnings.push({
+            model: merge.modelPath,
+            message: `queryMetadata (package + model file, merged): ${floor}`,
+         });
+         continue;
+      }
+      for (const { subject, size } of merge.sources) {
+         const budget = queryMetadataBudgetWarning(size);
+         if (!budget) continue;
+         warnings.push({
+            model: merge.modelPath,
+            subject,
+            message: `queryMetadata (package + model file + source, merged): ${budget}`,
+         });
+      }
    }
 
-   // Identical findings collapse (two sources inheriting one bad package
-   // property produce one message each, not one per level per source).
+   // Identical findings collapse (the same declaration reaching this function
+   // twice must not produce two messages).
    const seen = new Set<string>();
    return warnings.filter((warning) => {
-      const key = `${warning.subject ?? ""}\u0000${warning.message}`;
+      // Keyed on the model path as well as the source: a source name is
+      // unique within a model, not within a package, so keying on the name
+      // alone collapsed two files' findings into one message naming neither.
+      const key = [
+         warning.model ?? "",
+         warning.subject ?? "",
+         warning.message,
+      ].join("\u0000");
       if (seen.has(key)) return false;
       seen.add(key);
       return true;

--- a/packages/server/src/service/materialization_schedule_surface.spec.ts
+++ b/packages/server/src/service/materialization_schedule_surface.spec.ts
@@ -230,9 +230,13 @@ describe("materialization schedule surfacing", () => {
    );
 
    it(
-      "still lets an explicit null clear queryMetadata",
+      "treats an explicit null as omitted, at the deprecated home too",
       async () => {
-         // Preserved-on-omission must not make it unclearable.
+         // Null used to clear HERE while null on the canonical field preserved.
+         // That asymmetry protected a client which serializes unset fields as
+         // null only once it had migrated off this home — precisely the client
+         // that has not. One rule at both homes now: null preserves, an empty
+         // bag clears.
          const env = await Environment.create("testEnv", envPath, []);
          await writePackageDir({
             materialization: {
@@ -249,7 +253,269 @@ describe("materialization schedule surfacing", () => {
 
          expect(
             (await readManifest()).materialization as Record<string, unknown>,
-         ).toMatchObject({ schedule: "0 6 * * *", queryMetadata: null });
+         ).toMatchObject({
+            schedule: "0 6 * * *",
+            queryMetadata: { team: "finance" },
+         });
+      },
+      { timeout: 20000 },
+   );
+
+   it(
+      "surfaces a manifest's queryMetadata in both wire homes",
+      async () => {
+         // The canonical field is the one a client should read; the block is
+         // populated alongside it only so an un-migrated client keeps working.
+         const env = await Environment.create("testEnv", envPath, []);
+         await writePackageDir({ queryMetadata: { team: "fin" } });
+         await env.addPackage("pkg");
+
+         const pkg = await env.getPackage("pkg", false);
+         const metadata = pkg.getPackageMetadata();
+         expect(metadata.queryMetadata).toEqual({ team: "fin" });
+         expect(metadata.materialization).toMatchObject({
+            queryMetadata: { team: "fin" },
+         });
+         expect(pkg.getDeclaredQueryMetadata()).toEqual({ team: "fin" });
+      },
+      { timeout: 20000 },
+   );
+
+   it(
+      "preserves queryMetadata across a metadata PATCH",
+      async () => {
+         // Same failure mode as the schedule above: the whole metadata object is
+         // replaced, so a description-only PATCH would silently untag every
+         // query the package emits until the next reload.
+         const env = await Environment.create("testEnv", envPath, []);
+         await writePackageDir({ queryMetadata: { team: "fin" } });
+         await env.addPackage("pkg");
+
+         const updated = await env.updatePackage("pkg", {
+            name: "pkg",
+            description: "updated",
+         });
+         expect(updated.queryMetadata).toEqual({ team: "fin" });
+
+         const pkg = await env.getPackage("pkg", false);
+         expect(pkg.getDeclaredQueryMetadata()).toEqual({ team: "fin" });
+      },
+      { timeout: 20000 },
+   );
+
+   it(
+      "accepts queryMetadata at either wire home on a PATCH",
+      async () => {
+         // A migrated client sends the canonical field; an un-migrated one sends
+         // the block. Both have to reach the manifest, and both homes have to
+         // agree in what is written — the manifest this authors is loaded again
+         // on the next restart.
+         const env = await Environment.create("testEnv", envPath, []);
+         await writePackageDir({});
+         await env.addPackage("pkg");
+
+         await env.updatePackage("pkg", {
+            name: "pkg",
+            queryMetadata: { team: "fin" },
+         });
+         // Canonical home only. The deprecated block is mirrored into when it
+         // already exists or the caller wrote to it — synthesizing one here
+         // would introduce the shape being migrated AWAY from into a manifest
+         // whose author only ever used the canonical field.
+         const afterCanonical = await readManifest();
+         expect(afterCanonical.queryMetadata).toEqual({ team: "fin" });
+         expect(afterCanonical.materialization).toBeUndefined();
+
+         await env.updatePackage("pkg", {
+            name: "pkg",
+            materialization: { queryMetadata: { team: "ops" } },
+         });
+         expect(await readManifest()).toMatchObject({
+            queryMetadata: { team: "ops" },
+            materialization: { queryMetadata: { team: "ops" } },
+         });
+
+         const reloaded = await Environment.create("testEnv", envPath, []);
+         await reloaded.addPackage("pkg");
+         expect(
+            (
+               await reloaded.getPackage("pkg", false)
+            ).getDeclaredQueryMetadata(),
+         ).toEqual({ team: "ops" });
+      },
+      { timeout: 20000 },
+   );
+
+   it(
+      "clears a canonically-declared bag through the deprecated home, with an empty one",
+      async () => {
+         // The clear has to reach the root, not just the block it was sent in:
+         // a manifest written in the canonical form carries the bag at the root,
+         // so a PATCH that cleared only the block would leave the package tagged
+         // by the very field the loader prefers.
+         const env = await Environment.create("testEnv", envPath, []);
+         await writePackageDir({ queryMetadata: { team: "finance" } });
+         await env.addPackage("pkg");
+
+         await env.updatePackage("pkg", {
+            name: "pkg",
+            materialization: { queryMetadata: {} },
+         });
+
+         const manifest = await readManifest();
+         expect(manifest.queryMetadata).toEqual({});
+         expect(manifest.materialization).toMatchObject({
+            queryMetadata: {},
+         });
+
+         const reloaded = await Environment.create("testEnv", envPath, []);
+         await reloaded.addPackage("pkg");
+         expect(
+            (
+               await reloaded.getPackage("pkg", false)
+            ).getDeclaredQueryMetadata(),
+         ).toBeNull();
+      },
+      { timeout: 20000 },
+   );
+
+   it(
+      "clears a bag through the canonical home with an empty one",
+      async () => {
+         // A null is preserve-on-absent here, like scope, so a client that
+         // serializes unset fields as null cannot untag a package by accident.
+         // An empty bag is the unambiguous clear, and no such client produces
+         // one.
+         const env = await Environment.create("testEnv", envPath, []);
+         await writePackageDir({ queryMetadata: { team: "finance" } });
+         await env.addPackage("pkg");
+
+         await env.updatePackage("pkg", { name: "pkg", queryMetadata: null });
+         expect((await readManifest()).queryMetadata).toEqual({
+            team: "finance",
+         });
+
+         await env.updatePackage("pkg", { name: "pkg", queryMetadata: {} });
+         expect((await readManifest()).queryMetadata).toEqual({});
+
+         // An empty bag parses to "no tags", so the cleared package declares
+         // nothing rather than an empty layer that merges to the same thing.
+         const reloaded = await Environment.create("testEnv", envPath, []);
+         await reloaded.addPackage("pkg");
+         expect(
+            (
+               await reloaded.getPackage("pkg", false)
+            ).getDeclaredQueryMetadata(),
+         ).toBeNull();
+      },
+      { timeout: 20000 },
+   );
+
+   it(
+      "keeps BOTH in-memory homes agreeing after a PATCH",
+      async () => {
+         // The two homes are read by different paths — the serve path takes the
+         // canonical field through `getDeclaredQueryMetadata`, the build path
+         // takes the block — so setting them independently made a PATCH that
+         // touched one tag served queries with the new bag and builds with the
+         // old one. Asserted against the SAME env, not a fresh one: a reload
+         // resolves the manifest and would hide the divergence under test.
+         const env = await Environment.create("testEnv", envPath, []);
+         await writePackageDir({
+            materialization: { queryMetadata: { team: "finance" } },
+         });
+         await env.addPackage("pkg");
+
+         const updated = await env.updatePackage("pkg", {
+            name: "pkg",
+            queryMetadata: { team: "platform" },
+         });
+
+         expect(updated.queryMetadata).toEqual({ team: "platform" });
+         expect(updated.materialization).toMatchObject({
+            queryMetadata: { team: "platform" },
+         });
+
+         const pkg = await env.getPackage("pkg", false);
+         expect(pkg.getDeclaredQueryMetadata()).toEqual({ team: "platform" });
+         expect(pkg.getMaterializationConfig()?.queryMetadata).toEqual({
+            team: "platform",
+         });
+      },
+      { timeout: 20000 },
+   );
+
+   it(
+      "does not untag the package when a PATCH edits only the schedule",
+      async () => {
+         // A materialization PATCH replaces the block wholesale, and the block
+         // is what the BUILD path reads. Resolving the bag from the body alone
+         // would drop it, so the next build's statements go out untagged for a
+         // package that asked to be tagged.
+         const env = await Environment.create("testEnv", envPath, []);
+         await writePackageDir({
+            scope: "version",
+            queryMetadata: { team: "finance" },
+         });
+         await env.addPackage("pkg");
+
+         await env.updatePackage("pkg", {
+            name: "pkg",
+            materialization: { schedule: "0 6 * * *" },
+         });
+
+         const pkg = await env.getPackage("pkg", false);
+         expect(pkg.getDeclaredQueryMetadata()).toEqual({ team: "finance" });
+         expect(pkg.getMaterializationConfig()).toMatchObject({
+            schedule: "0 6 * * *",
+            queryMetadata: { team: "finance" },
+         });
+      },
+      { timeout: 20000 },
+   );
+
+   it(
+      "warns about a package+model tag overflow with no source declaring one",
+      async () => {
+         // End-to-end over a real Environment: the floor has to be SIZED, not
+         // just checkable. Sizing only the sources that declare their own bag
+         // meant this package published clean while every query it serves shed
+         // context properties.
+         const env = await Environment.create("testEnv", envPath, []);
+         const six = (prefix: string) =>
+            Object.fromEntries(
+               Array.from({ length: 6 }, (_, i) => [`${prefix}${i}`, "v"]),
+            );
+         const dir = path.join(envPath, "pkg");
+         await fs.mkdir(dir, { recursive: true });
+         await fs.writeFile(
+            path.join(dir, "publisher.json"),
+            JSON.stringify({
+               name: "pkg",
+               description: "fixture",
+               queryMetadata: six("p"),
+            }),
+         );
+         // Six more at the model file, and no `#@` on the source at all.
+         await fs.writeFile(
+            path.join(dir, "model.malloy"),
+            Object.entries(six("m"))
+               .map(([name, value]) => `## queryMetadata.${name}="${value}"`)
+               .join("\n") +
+               "\n" +
+               MODEL,
+         );
+         await env.addPackage("pkg");
+
+         const warnings =
+            (await env.getPackage("pkg", false)).getPackageMetadata()
+               .warnings ?? [];
+         const overflow = warnings.filter((w) =>
+            w.message?.includes("package + model file, merged"),
+         );
+         expect(overflow).toHaveLength(1);
+         expect(overflow[0].model).toBe("model.malloy");
+         expect(overflow[0].subject).toBeUndefined();
       },
       { timeout: 20000 },
    );

--- a/packages/server/src/service/model.spec.ts
+++ b/packages/server/src/service/model.spec.ts
@@ -1461,6 +1461,35 @@ describe("service/model", () => {
          expect(attached.class).toBe("interactive");
       });
 
+      it("reports the model file's own declaration, and parses it once", async () => {
+         // The publish gate reads this per model, and `getPackageMetadata()` runs
+         // once per package inside listPackages — so recomputing would walk the
+         // import closure and re-parse every `##` note on a listing. A compiled
+         // model's annotations never change, so the memo needs no invalidation;
+         // identity is the cheapest proof it is a memo and not a fresh parse.
+         const { model } = routedModel({
+            shapeBindings: [binding("daily", "live")],
+            storageFailsAt: "run",
+            modelNotes: ['## materialization.queryMetadata.tier="silver"\n'],
+         });
+
+         const first = model.getDeclaredQueryMetadata();
+         expect(first).toEqual({ tier: "silver" });
+         expect(model.getDeclaredQueryMetadata()).toBe(first);
+      });
+
+      it("reports no declaration as null, and does not re-derive it", async () => {
+         // `null` is a computed answer, not "unknown" — so the memo has to
+         // distinguish it from "not yet computed" or every call re-parses.
+         const { model } = routedModel({
+            shapeBindings: [binding("daily", "live")],
+            storageFailsAt: "run",
+         });
+
+         expect(model.getDeclaredQueryMetadata()).toBeNull();
+         expect(model.getDeclaredQueryMetadata()).toBeNull();
+      });
+
       it("returns servedFrom and an execution time to the caller", async () => {
          // A storage-served answer is byte-identical to a live one, so without
          // these two a caller cannot tell that materialization did anything.

--- a/packages/server/src/service/model.spec.ts
+++ b/packages/server/src/service/model.spec.ts
@@ -1190,6 +1190,76 @@ describe("service/model", () => {
          expect(result.queryCorrelationId).toBe("corr-1");
       });
 
+      it("carries the package's declared properties onto a SERVED query", async () => {
+         // The gap this closes: declared properties reached materialization
+         // statements and nothing else, so a deployment could attribute its
+         // builds and not the interactive traffic that is most of its warehouse
+         // bill. A served query arrived carrying the platform's context and none
+         // of the author's own vocabulary.
+         process.env.PUBLISHER_QUERY_METADATA = "on";
+         const { model, liveRun } = routedModel({
+            shapeBindings: [binding("daily", "live")],
+            storageFailsAt: "run",
+         });
+
+         await model.getQueryResults(
+            undefined,
+            undefined,
+            "run: daily -> x",
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            {
+               correlationId: "corr-2",
+               packageMaterialization: {
+                  queryMetadata: { team: "finance", tier: "bronze" },
+               },
+               connectionMetadata: () => ({ default: null, enforced: null }),
+            },
+         );
+
+         const attached = liveRun.firstCall.args[0].queryMetadata;
+         expect(attached.team).toBe("finance");
+         expect(attached.tier).toBe("bronze");
+         // Context still applies on top, and is what distinguishes a served
+         // statement from a build of the same source.
+         expect(attached.class).toBe("interactive");
+      });
+
+      it("lets the request override a declared property, and keeps the rest", async () => {
+         // Precedence across the two layers that were never composed together
+         // before: a caller's per-request bag is more specific than anything the
+         // author declared, but must not evict what it does not mention.
+         process.env.PUBLISHER_QUERY_METADATA = "on";
+         const { model, liveRun } = routedModel({
+            shapeBindings: [binding("daily", "live")],
+            storageFailsAt: "run",
+         });
+
+         await model.getQueryResults(
+            undefined,
+            undefined,
+            "run: daily -> x",
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            {
+               correlationId: "corr-3",
+               request: { tier: "platinum" },
+               packageMaterialization: {
+                  queryMetadata: { team: "finance", tier: "bronze" },
+               },
+               connectionMetadata: () => ({ default: null, enforced: null }),
+            },
+         );
+
+         const attached = liveRun.firstCall.args[0].queryMetadata;
+         expect(attached.tier).toBe("platinum");
+         expect(attached.team).toBe("finance");
+      });
+
       it("returns servedFrom and an execution time to the caller", async () => {
          // A storage-served answer is byte-identical to a live one, so without
          // these two a caller cannot tell that materialization did anything.

--- a/packages/server/src/service/model.spec.ts
+++ b/packages/server/src/service/model.spec.ts
@@ -1083,6 +1083,12 @@ describe("service/model", () => {
          modelNotes?: string[];
          sourceNotes?: Record<string, string[]>;
          /**
+          * `#@` notes on a NAMED QUERY of the same name, which `modelDef.contents`
+          * holds beside sources. Overwrites the source entry, so a test can prove
+          * which of the two a reader picked.
+          */
+         namedQueryNotes?: Record<string, string[]>;
+         /**
           * `##` notes on a DIFFERENT compilation node that this model inherits
           * from — i.e. an import. `modelAnnotations` folds these in and
           * `ownModelNotes` does not, which is the whole difference under test.
@@ -1157,10 +1163,49 @@ describe("service/model", () => {
                   Object.entries(opts.sourceNotes ?? {}).map(
                      ([name, texts]) => [
                         name,
-                        { annotations: { notes: texts.map(specNote) } },
+                        {
+                           // `type` is not decoration: `safeSourceTag` admits
+                           // only a real SourceDef, so a fixture without one is
+                           // a named query as far as malloy's `isSourceDef` is
+                           // concerned and contributes no source layer.
+                           type: "table",
+                           annotations: { notes: texts.map(specNote) },
+                        },
                      ],
                   ),
                ),
+               ...(opts.namedQueryNotes
+                  ? {
+                       contents: {
+                          ...Object.fromEntries(
+                             Object.entries(opts.sourceNotes ?? {}).map(
+                                ([name, texts]) => [
+                                   name,
+                                   {
+                                      type: "table",
+                                      annotations: {
+                                         notes: texts.map(specNote),
+                                      },
+                                   },
+                                ],
+                             ),
+                          ),
+                          ...Object.fromEntries(
+                             Object.entries(opts.namedQueryNotes).map(
+                                ([name, texts]) => [
+                                   `${name}_query`,
+                                   {
+                                      type: "query",
+                                      annotations: {
+                                         notes: texts.map(specNote),
+                                      },
+                                   },
+                                ],
+                             ),
+                          ),
+                       },
+                    }
+                  : {}),
                exports: [],
                queryList: [],
                // The file-level `##` tags come from the modelAnnotations
@@ -1384,9 +1429,7 @@ describe("service/model", () => {
             undefined,
             {
                correlationId: "corr-2",
-               packageMaterialization: {
-                  queryMetadata: { team: "finance", tier: "bronze" },
-               },
+               packageDeclaration: { team: "finance", tier: "bronze" },
                connectionMetadata: () => ({ default: null, enforced: null }),
             },
          );
@@ -1420,9 +1463,7 @@ describe("service/model", () => {
             {
                correlationId: "corr-3",
                request: { tier: "platinum" },
-               packageMaterialization: {
-                  queryMetadata: { team: "finance", tier: "bronze" },
-               },
+               packageDeclaration: { team: "finance", tier: "bronze" },
                connectionMetadata: () => ({ default: null, enforced: null }),
             },
          );
@@ -1462,9 +1503,7 @@ describe("service/model", () => {
             undefined,
             {
                correlationId: "corr-4",
-               packageMaterialization: {
-                  queryMetadata: { tier: "bronze", team: "finance" },
-               },
+               packageDeclaration: { tier: "bronze", team: "finance" },
                connectionMetadata: () => ({ default: null, enforced: null }),
             },
          );
@@ -1595,6 +1634,24 @@ describe("service/model", () => {
          const first = model.getDeclaredQueryMetadata();
          expect(first).toEqual({ tier: "silver" });
          expect(model.getDeclaredQueryMetadata()).toBe(first);
+      });
+
+      it("lists tagged SOURCES only, never a named query that carries a `#@`", async () => {
+         // `modelDef.contents` holds named queries beside sources. Iterating it
+         // blind read a query's `#@` as though a source had declared it, so the
+         // query's name turned up among the package's tagged sources — and any
+         // publish warning about that bag pointed an author at a `source:` that
+         // does not exist in the file.
+         const { model } = routedModel({
+            shapeBindings: [binding("daily", "live")],
+            storageFailsAt: "run",
+            sourceNotes: { daily: ['#@ queryMetadata.tier="gold"'] },
+            namedQueryNotes: { daily: ['#@ queryMetadata.tier="forged"'] },
+         });
+
+         expect(model.getDeclaredSourceQueryMetadata()).toEqual([
+            { sourceName: "daily", queryMetadata: { tier: "gold" } },
+         ]);
       });
 
       it("reports no declaration as null, and does not re-derive it", async () => {

--- a/packages/server/src/service/model.spec.ts
+++ b/packages/server/src/service/model.spec.ts
@@ -1082,6 +1082,8 @@ describe("service/model", () => {
           */
          modelNotes?: string[];
          sourceNotes?: Record<string, string[]>;
+         /** Named queries, for the `queryName` request shape. */
+         queries?: { name: string; sourceName: string }[];
       }) {
          const storageErr = new Error("store table missing");
          const storageRunnable = {
@@ -1155,7 +1157,9 @@ describe("service/model", () => {
                // eslint-disable-next-line @typescript-eslint/no-explicit-any
             } as any,
             undefined,
-            undefined,
+            // queries: how a `queryName` request resolves to its source.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            opts.queries as any,
             undefined,
             undefined,
             undefined,
@@ -1354,10 +1358,42 @@ describe("service/model", () => {
          expect(attached.team).toBe("finance");
       });
 
-      it("resolves the source layer for a query that names no source directly", async () => {
-         // A `queryName` request names exactly one source, indirectly. Passing
-         // the raw `sourceName` param would drop its declared layer — and that is
-         // the dominant REST and MCP call shape, not an edge case.
+      it("resolves the source layer from a named query, which supplies no sourceName", async () => {
+         // The dominant REST and MCP shape: `queryName` alone. `sourceName` is
+         // optional on that branch despite what the request-shape error string
+         // says, so passing the raw param would drop the declared layer for the
+         // call shape most callers use. Resolves through
+         // `queries.find(q => q.name === queryName)?.sourceName`.
+         process.env.PUBLISHER_QUERY_METADATA = "on";
+         const { model, liveRun } = routedModel({
+            shapeBindings: [binding("daily", "live")],
+            storageFailsAt: "run",
+            queries: [{ name: "daily_view", sourceName: "daily" }],
+            sourceNotes: {
+               daily: ['#@ persist queryMetadata.tier="gold"\n'],
+            },
+         });
+
+         await model.getQueryResults(
+            undefined,
+            "daily_view",
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            {
+               correlationId: "corr-7",
+               connectionMetadata: () => ({ default: null, enforced: null }),
+            },
+         );
+
+         expect(liveRun.firstCall.args[0].queryMetadata.tier).toBe("gold");
+      });
+
+      it("resolves the source layer from ad-hoc query text", async () => {
+         // The other branch of the same resolution: surface syntax on the run
+         // target, for a request that names nothing at all.
          process.env.PUBLISHER_QUERY_METADATA = "on";
          const { model, liveRun } = routedModel({
             shapeBindings: [binding("daily", "live")],

--- a/packages/server/src/service/model.spec.ts
+++ b/packages/server/src/service/model.spec.ts
@@ -1082,6 +1082,18 @@ describe("service/model", () => {
           */
          modelNotes?: string[];
          sourceNotes?: Record<string, string[]>;
+         /**
+          * `##` notes on a DIFFERENT compilation node that this model inherits
+          * from — i.e. an import. `modelAnnotations` folds these in and
+          * `ownModelNotes` does not, which is the whole difference under test.
+          */
+         importedModelNotes?: string[];
+         /**
+          * The source the COMPILED query reads, as `resolveAuthorizeSourceFromRunnable`
+          * would resolve it off the prepared query. Distinct from whatever the
+          * query TEXT names first.
+          */
+         compiledRunTarget?: string;
          /** Named queries, for the `queryName` request shape. */
          queries?: { name: string; sourceName: string }[];
       }) {
@@ -1108,12 +1120,21 @@ describe("service/model", () => {
          const liveRun = opts.liveRunFails
             ? sinon.stub().rejects(new Error("warehouse down"))
             : sinon.stub().resolves(fakeResult);
+         const preparedQuery = opts.compiledRunTarget
+            ? {
+                 getPreparedQuery: sinon.stub().resolves({
+                    _query: { structRef: opts.compiledRunTarget },
+                 }),
+              }
+            : {};
+         Object.assign(storageRunnable, preparedQuery);
          const liveRunnable = {
             getPreparedResult: sinon.stub().resolves({
                resultExplore: { limit: opts.livePreparedLimit ?? 0 },
                connectionName: "live_pg",
             }),
             run: liveRun,
+            ...preparedQuery,
          };
          sinon
             .stub(API.util, "wrapResult")
@@ -1146,14 +1167,31 @@ describe("service/model", () => {
                // REGISTRY keyed by modelID, not from a bare `annotation` field —
                // that indirection exists so an import's tags can be folded in.
                modelID: "m",
-               modelAnnotations: opts.modelNotes
-                  ? {
-                       m: {
-                          inheritsFrom: [],
-                          ownNotes: { notes: opts.modelNotes.map(specNote) },
-                       },
-                    }
-                  : undefined,
+               modelAnnotations:
+                  opts.modelNotes || opts.importedModelNotes
+                     ? {
+                          m: {
+                             inheritsFrom: opts.importedModelNotes
+                                ? ["file://imported.malloy"]
+                                : [],
+                             ownNotes: {
+                                notes: (opts.modelNotes ?? []).map(specNote),
+                             },
+                          },
+                          ...(opts.importedModelNotes
+                             ? {
+                                  "file://imported.malloy": {
+                                     inheritsFrom: [],
+                                     ownNotes: {
+                                        notes: opts.importedModelNotes.map(
+                                           specNote,
+                                        ),
+                                     },
+                                  },
+                               }
+                             : {}),
+                       }
+                     : undefined,
                // eslint-disable-next-line @typescript-eslint/no-explicit-any
             } as any,
             undefined,
@@ -1241,6 +1279,87 @@ describe("service/model", () => {
          expect(attached.tenant).toBe("acme");
          expect(attached.query_id).toBe("corr-1");
          expect(result.queryCorrelationId).toBe("corr-1");
+      });
+
+      it("tags the source the query RUNS, not the first one its text names", async () => {
+         // Malloy executes the LAST `run:`; `extractRunTargetSourceName` reads
+         // the FIRST. Tagging off the surface syntax therefore attributed an
+         // expensive statement to the cheap source's team and tier — worse than
+         // missing attribution, because the bill lands on a source that never
+         // ran. The authorize gate already resolves the compiled target for
+         // exactly this reason; metadata now reads the same answer.
+         process.env.PUBLISHER_QUERY_METADATA = "on";
+         const { model, liveRun } = routedModel({
+            shapeBindings: [binding("daily", "live")],
+            storageFailsAt: "run",
+            compiledRunTarget: "expensive",
+            sourceNotes: {
+               cheap: ['#@ queryMetadata.tier="bronze"'],
+               expensive: ['#@ queryMetadata.tier="platinum"'],
+            },
+         });
+
+         await model.getQueryResults(
+            undefined,
+            undefined,
+            "run: cheap -> x\nrun: expensive -> x",
+         );
+
+         expect(liveRun.firstCall.args[0].queryMetadata.tier).toBe("platinum");
+      });
+
+      it("does not fold an IMPORT's model-file tags into the importer", async () => {
+         // `modelAnnotations` folds the import lineage because a file-level
+         // `##(authorize)` gate an import could shed would be no gate at all. A
+         // tag is not a gate: folding one lets a shared include attribute every
+         // importing file's traffic to the include's team, and reports the
+         // resulting publish warning against a file that does not contain the
+         // line.
+         process.env.PUBLISHER_QUERY_METADATA = "on";
+         const { model, liveRun } = routedModel({
+            shapeBindings: [binding("daily", "live")],
+            storageFailsAt: "run",
+            importedModelNotes: ['## queryMetadata.team="platform"'],
+            modelNotes: ['## queryMetadata.surface="marts"'],
+         });
+
+         await model.getQueryResults(undefined, undefined, "run: daily -> x");
+
+         const attached = liveRun.firstCall.args[0].queryMetadata;
+         expect(attached.surface).toBe("marts");
+         expect(attached.team).toBeUndefined();
+      });
+
+      it("assembles no metadata layers at all when the feature is off", async () => {
+         // `mergeQueryMetadata` early-returns on `off`, so everything assembled
+         // for it is discarded. The mode is off unless an operator turns it on,
+         // so assembling anyway made the DEFAULT deployment pay an annotation
+         // walk and a connection lookup on every query for a bag nobody reads.
+         // The connection lookup is the observable half.
+         process.env.PUBLISHER_QUERY_METADATA = "off";
+         const { model, liveRun } = routedModel({
+            shapeBindings: [binding("daily", "live")],
+            storageFailsAt: "run",
+            modelNotes: ['## queryMetadata.surface="marts"'],
+         });
+         const connectionMetadata = sinon.stub().returns({
+            default: { team: "finance" },
+            enforced: null,
+         });
+
+         await model.getQueryResults(
+            undefined,
+            undefined,
+            "run: daily -> x",
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            { connectionMetadata },
+         );
+
+         expect(connectionMetadata.called).toBe(false);
+         expect(liveRun.firstCall.args[0].queryMetadata).toBeUndefined();
       });
 
       it("carries the package's declared properties onto a SERVED query", async () => {

--- a/packages/server/src/service/model.spec.ts
+++ b/packages/server/src/service/model.spec.ts
@@ -1050,12 +1050,38 @@ describe("service/model", () => {
        * compiles a transient model — the logic under test is the catch, and the
        * SHAPE'S bindings (not the package's) are what it must consult.
        */
+      /**
+       * A malloy `Note`. The `at` location is required, not decoration: without
+       * it `Annotations.parseAsTag` throws on `line.at.url`, and every reader of
+       * these annotations catches and degrades to "no layer" — so a note without
+       * it produces a green test that proves nothing.
+       */
+      const specNote = (text: string) => ({
+         text,
+         at: {
+            url: "file://mockModel.malloy",
+            range: {
+               start: { line: 0, character: 0 },
+               end: { line: 0, character: 1 },
+            },
+         },
+      });
+
       function routedModel(opts: {
          shapeBindings: unknown[];
          packageBindings?: unknown[];
          storageFailsAt: "prepare" | "run";
          liveRunFails?: boolean;
          livePreparedLimit?: number;
+         /**
+          * Raw `##` note texts for the model file, and `#@` note texts per
+          * source — the same annotation bundle the build path reads through
+          * `PersistSource.annotations`. Without these the modelDef has empty
+          * `contents` and the declared model/source layers resolve to nothing,
+          * which is a test that proves only the package layer.
+          */
+         modelNotes?: string[];
+         sourceNotes?: Record<string, string[]>;
       }) {
          const storageErr = new Error("store table missing");
          const storageRunnable = {
@@ -1103,8 +1129,31 @@ describe("service/model", () => {
             "model",
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             modelMaterializer as any,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            { contents: {}, exports: [], queryList: [] } as any,
+            {
+               contents: Object.fromEntries(
+                  Object.entries(opts.sourceNotes ?? {}).map(
+                     ([name, texts]) => [
+                        name,
+                        { annotations: { notes: texts.map(specNote) } },
+                     ],
+                  ),
+               ),
+               exports: [],
+               queryList: [],
+               // The file-level `##` tags come from the modelAnnotations
+               // REGISTRY keyed by modelID, not from a bare `annotation` field —
+               // that indirection exists so an import's tags can be folded in.
+               modelID: "m",
+               modelAnnotations: opts.modelNotes
+                  ? {
+                       m: {
+                          inheritsFrom: [],
+                          ownNotes: { notes: opts.modelNotes.map(specNote) },
+                       },
+                    }
+                  : undefined,
+               // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any,
             undefined,
             undefined,
             undefined,
@@ -1258,6 +1307,122 @@ describe("service/model", () => {
          const attached = liveRun.firstCall.args[0].queryMetadata;
          expect(attached.tier).toBe("platinum");
          expect(attached.team).toBe("finance");
+      });
+
+      it("composes all three declared layers, most specific winning", async () => {
+         // The package layer alone is not the claim — a model file's `##` tag and
+         // a source's `#@` tag have to reach a served statement too, with the
+         // same precedence the build path applies. Both are read through casts
+         // into `modelDef`, the shape where a field rename degrades to a silent
+         // no-layer, so an empty-`contents` fixture would pass while proving
+         // neither.
+         process.env.PUBLISHER_QUERY_METADATA = "on";
+         const { model, liveRun } = routedModel({
+            shapeBindings: [binding("daily", "live")],
+            storageFailsAt: "run",
+            modelNotes: [
+               '## materialization.queryMetadata.tier="silver"\n',
+               '## materialization.queryMetadata.from_model="yes"\n',
+            ],
+            sourceNotes: {
+               daily: ['#@ persist queryMetadata.tier="gold"\n'],
+            },
+         });
+
+         await model.getQueryResults(
+            undefined,
+            undefined,
+            "run: daily -> x",
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            {
+               correlationId: "corr-4",
+               packageMaterialization: {
+                  queryMetadata: { tier: "bronze", team: "finance" },
+               },
+               connectionMetadata: () => ({ default: null, enforced: null }),
+            },
+         );
+
+         const attached = liveRun.firstCall.args[0].queryMetadata;
+         // source > model file > package, per property.
+         expect(attached.tier).toBe("gold");
+         // Nothing more specific mentions these, so both survive.
+         expect(attached.from_model).toBe("yes");
+         expect(attached.team).toBe("finance");
+      });
+
+      it("resolves the source layer for a query that names no source directly", async () => {
+         // A `queryName` request names exactly one source, indirectly. Passing
+         // the raw `sourceName` param would drop its declared layer — and that is
+         // the dominant REST and MCP call shape, not an edge case.
+         process.env.PUBLISHER_QUERY_METADATA = "on";
+         const { model, liveRun } = routedModel({
+            shapeBindings: [binding("daily", "live")],
+            storageFailsAt: "run",
+            sourceNotes: {
+               daily: ['#@ persist queryMetadata.tier="gold"\n'],
+            },
+         });
+
+         await model.getQueryResults(
+            undefined,
+            undefined,
+            // Ad-hoc text whose run target is resolvable from surface syntax.
+            "run: daily -> x",
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            {
+               correlationId: "corr-5",
+               connectionMetadata: () => ({ default: null, enforced: null }),
+            },
+         );
+
+         expect(liveRun.firstCall.args[0].queryMetadata.tier).toBe("gold");
+      });
+
+      it("refuses a declared property that would forge build identity", async () => {
+         // Context only overwrites names it has a VALUE for, and a served query
+         // has no `source`, `trigger` or `run_id`. Without the reserved-name rule
+         // a model file could stamp `source=orders_daily` on interactive traffic,
+         // which in the warehouse's own history reads exactly like a build of
+         // that source — the confusion the declared layer was originally withheld
+         // to prevent.
+         process.env.PUBLISHER_QUERY_METADATA = "on";
+         const { model, liveRun } = routedModel({
+            shapeBindings: [binding("daily", "live")],
+            storageFailsAt: "run",
+            sourceNotes: {
+               daily: [
+                  '#@ persist queryMetadata.source="orders_daily" queryMetadata.run_id="forged" queryMetadata.tier="gold"\n',
+               ],
+            },
+         });
+
+         await model.getQueryResults(
+            undefined,
+            undefined,
+            "run: daily -> x",
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            {
+               correlationId: "corr-6",
+               connectionMetadata: () => ({ default: null, enforced: null }),
+            },
+         );
+
+         const attached = liveRun.firstCall.args[0].queryMetadata;
+         expect(attached.source).toBeUndefined();
+         expect(attached.run_id).toBeUndefined();
+         // The author's own property, which is not a context name, still lands.
+         expect(attached.tier).toBe("gold");
+         expect(attached.class).toBe("interactive");
       });
 
       it("returns servedFrom and an execution time to the caller", async () => {

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -7,6 +7,7 @@ import {
    isSourceDef,
    MalloyConfig,
    MalloyError,
+   Annotations,
    ModelDef,
    modelDefToModelInfo,
    ModelMaterializer,
@@ -76,6 +77,11 @@ import {
    ownLevelNoteTexts,
    ownModelNotes,
 } from "./annotations";
+import {
+   composeDeclaredQueryMetadata,
+   type ReadableTag,
+   type WirePackageMaterialization,
+} from "./build_plan";
 import {
    assertNoCallerAuthorizeAnnotation,
    collectAuthorizeExprs,
@@ -148,6 +154,13 @@ export interface ModelQueryMetadataInput {
       default?: QueryMetadata | null;
       enforced?: QueryMetadata | null;
    } | null;
+   /**
+    * The package manifest's `materialization` block, for its
+    * `queryMetadata` — the least specific author-declared layer. Supplied by the
+    * controller, which owns the package; the model knows only its own file and
+    * its package's NAME.
+    */
+   packageMaterialization?: WirePackageMaterialization | null;
 }
 
 type ApiCompiledModel = components["schemas"]["CompiledModel"];
@@ -3091,6 +3104,7 @@ export class Model {
          appliedQueryMetadata = this.resolveQueryMetadata(
             queryMetadataInput,
             preparedResult.connectionName,
+            sourceName,
          );
 
          queryResults = await runnable.run({
@@ -3248,6 +3262,7 @@ export class Model {
             appliedQueryMetadata = this.resolveQueryMetadata(
                queryMetadataInput,
                livePrepared.connectionName,
+               sourceName,
             );
             queryResults = await liveRunnable!.run({
                rowLimit,
@@ -3435,17 +3450,33 @@ export class Model {
     * default, the caller's request override, and the server's context (which
     * package, which model, which class of work), merged most-specific-wins.
     *
-    * There is no model-side layer here. `materialization.queryMetadata` describes
-    * how a persist source is BUILT; a live query against the model is a different
-    * unit of work, and inheriting a build's tags would attribute interactive
-    * traffic to the build that happens to share the source.
+    * The author-declared layers ARE included, composed by
+    * {@link composeDeclaredQueryMetadata} exactly as the build path composes
+    * them. This reverses an earlier decision to omit them, which read
+    * `materialization.queryMetadata` as describing only how a persist source is
+    * BUILT and reasoned that a live query is a different unit of work.
+    *
+    * What that reasoning missed is which properties the layer actually carries.
+    * The build-identifying properties — `run_id`, `trigger`, `source`, `class` —
+    * come from the CONTEXT layer, which is per-statement and never inherited, so
+    * a served query cannot be mistaken for a build no matter what the author
+    * declared. The declared layer carries the author's own vocabulary (a team, a
+    * cost centre, a data tier), which describes the SOURCE and is as true of a
+    * query reading it as of the build writing it. Omitting it meant a deployment
+    * could attribute its builds and not the interactive traffic that is most of
+    * its warehouse bill.
+    *
+    * The block is named `materialization.queryMetadata` for historical reasons;
+    * the name is narrower than the thing it declares.
     *
     * Fails open, like every other metadata path: a connection whose config can't
-    * be read contributes no default rather than failing the query.
+    * be read contributes no default rather than failing the query, and an
+    * unparseable annotation contributes no layer rather than throwing.
     */
    private resolveQueryMetadata(
       input: ModelQueryMetadataInput | undefined,
       connectionName: string | undefined,
+      sourceName?: string,
    ): QueryMetadata | undefined {
       let connectionLayers: {
          default?: QueryMetadata | null;
@@ -3461,6 +3492,11 @@ export class Model {
       const resolved = mergeQueryMetadata({
          connection: connectionLayers?.default,
          enforced: connectionLayers?.enforced,
+         model: composeDeclaredQueryMetadata({
+            packageMaterialization: input?.packageMaterialization,
+            modelTag: this.safeModelFileTag(),
+            sourceTag: this.safeSourceTag(sourceName),
+         }),
          request: input?.request,
          context: {
             queryClass: input?.queryClass ?? "interactive",
@@ -3478,6 +3514,52 @@ export class Model {
          });
       }
       return resolved.metadata;
+   }
+
+   /**
+    * The model file's own `##` tag, or undefined if it is absent or fails to
+    * parse. Read off `modelDef`, which survives the worker serialization
+    * boundary — so this works for a freshly-compiled model and a deserialized
+    * one alike, the same reason `fileLevelAuthorize` is derived there.
+    */
+   private safeModelFileTag(): ReadableTag | undefined {
+      if (!this.modelDef) return undefined;
+      try {
+         return new Annotations(modelAnnotations(this.modelDef)).parseAsTag()
+            .tag as ReadableTag;
+      } catch {
+         return undefined;
+      }
+   }
+
+   /**
+    * The named source's own `#@` tag, or undefined when the request named no
+    * source, the name is not a top-level source, or the annotation fails to
+    * parse.
+    *
+    * A request that does not name a source (ad-hoc query text, a notebook cell)
+    * gets the package and model-file layers but not this one: with no source
+    * named there is no single annotation to read, and a query may touch several
+    * sources whose declarations disagree. Guessing one would attribute a
+    * statement to a source the caller never asked for, which is worse than
+    * carrying one layer fewer.
+    */
+   private safeSourceTag(
+      sourceName: string | undefined,
+   ): ReadableTag | undefined {
+      if (!sourceName || !this.modelDef) return undefined;
+      try {
+         const contents = this.modelDef.contents as Record<
+            string,
+            { annotations?: unknown } | undefined
+         >;
+         const def = contents?.[sourceName];
+         if (!def?.annotations) return undefined;
+         return new Annotations(def.annotations).parseAsTag("@")
+            .tag as ReadableTag;
+      } catch {
+         return undefined;
+      }
    }
 
    private getStandardModel(): ApiCompiledModel {

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -1683,6 +1683,23 @@ export class Model {
    }
 
    /**
+    * This file's own `## materialization.queryMetadata.*` declaration, or null
+    * if it declares none.
+    *
+    * Exposed for the publish gate. That gate walks the package manifest and the
+    * build plan's persist sources, so a model file's declaration was only ever
+    * visible through a source that inherited it — and a file with NO persist
+    * source was invisible entirely. Since a model-file declaration now rides
+    * served queries whether or not the file persists anything, it needs a
+    * validation path of its own.
+    */
+   public getDeclaredQueryMetadata(): QueryMetadata | null {
+      return composeDeclaredQueryMetadata({
+         modelTag: this.safeModelFileTag(),
+      });
+   }
+
+   /**
     * Restrict a list of named objects to the model's re-export closure
     * (`modelDef.exports`) for discovery. This mirrors what Malloy's stable
     * `modelDefToModelInfo` already does for `modelInfo`/`sourceInfos` (and what

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -39,6 +39,7 @@ import {
    getDefaultQueryRowLimit,
    getMaxQueryRows,
    getMaxResponseBytes,
+   getQueryMetadataMode,
 } from "../config";
 import { MODEL_FILE_SUFFIX, NOTEBOOK_FILE_SUFFIX } from "../constants";
 import { HackyDataStylesAccumulator } from "../data_styles";
@@ -75,6 +76,7 @@ import { URL_READER } from "../utils";
 import {
    modelAnnotations,
    ownLevelNoteTexts,
+   ownModelAnnotations,
    ownModelNotes,
 } from "./annotations";
 import {
@@ -3146,7 +3148,16 @@ export class Model {
             // indirectly, and ad-hoc text resolves through the same surface-syntax
             // path. Reusing the gate's answer also keeps one definition of "which
             // source is this query against" rather than a second, weaker one.
-            earlySource,
+            //
+            // The COMPILED target specifically, for the reason the authorize gate
+            // treats it as the source of truth: `extractRunTargetSourceName`
+            // reads the FIRST `run:` and Malloy executes the LAST, so `run:
+            // cheap\nrun: expensive` would execute one source while tagging
+            // another's team and tier — attribution that is not merely missing
+            // but wrong, and wrong in the direction of blaming the cheap query.
+            // Falls back to the surface-syntax answer when the compiled one is
+            // unresolved, the same degradation the gate accepts.
+            compiledSource ?? earlySource,
          );
 
          queryResults = await runnable.run({
@@ -3304,7 +3315,9 @@ export class Model {
             appliedQueryMetadata = this.resolveQueryMetadata(
                queryMetadataInput,
                livePrepared.connectionName,
-               earlySource,
+               // Same compiled run target as the primary path — the retry runs
+               // the same query, so it must not tag a different source.
+               compiledSource ?? earlySource,
             );
             queryResults = await liveRunnable!.run({
                rowLimit,
@@ -3520,6 +3533,15 @@ export class Model {
       connectionName: string | undefined,
       sourceName?: string,
    ): QueryMetadata | undefined {
+      // Nothing below is observable when the feature is off: `mergeQueryMetadata`
+      // early-returns, so every layer assembled here is discarded. Assembling
+      // them anyway made a default deployment — the mode is off unless an
+      // operator turns it on — pay an annotation walk and a connection lookup on
+      // every query for a bag nobody reads. Read per statement rather than per
+      // boot for the same reason `mergeQueryMetadata` reads it there: the mode
+      // is allowed to change under a running server.
+      if (getQueryMetadataMode() === "off") return undefined;
+
       let connectionLayers: {
          default?: QueryMetadata | null;
          enforced?: QueryMetadata | null;
@@ -3563,11 +3585,21 @@ export class Model {
     * parse. Read off `modelDef`, which survives the worker serialization
     * boundary — so this works for a freshly-compiled model and a deserialized
     * one alike, the same reason `fileLevelAuthorize` is derived there.
+    *
+    * The file's OWN notes, not the folded import lineage. `modelAnnotations`
+    * folds deliberately, but only because a file-level `##(authorize)` gate an
+    * import could shed would be no gate at all; `annotations.ts` says to read
+    * through `ownModelNotes` for everything that is not a policy gate. A tag is
+    * not a gate, and folding one would let a shared include attribute every
+    * importing file's traffic to the include's team — the same misattribution
+    * {@link safeSourceTag} already refuses for a derivation base. It would also
+    * report the resulting publish warning against the importer's path, sending
+    * an author to a file that does not contain the line.
     */
    private safeModelFileTag(): ReadableTag | undefined {
       if (!this.modelDef) return undefined;
       try {
-         return new Annotations(modelAnnotations(this.modelDef)).parseAsTag()
+         return new Annotations(ownModelAnnotations(this.modelDef)).parseAsTag()
             .tag as ReadableTag;
       } catch {
          return undefined;
@@ -3816,6 +3848,13 @@ export class Model {
                   maxRows: cellMaxRows,
                },
             );
+            // The compiled run target, preferred over the cell's surface syntax
+            // for the reason getQueryResults prefers it: `extractRunTargetSourceName`
+            // reads the first `run:` and Malloy executes the last, so a cell
+            // holding more than one would tag the wrong source. The prepared
+            // query is read again below, so this costs nothing new.
+            const cellCompiledSource =
+               await this.resolveAuthorizeSourceFromRunnable(runnableToExecute);
             const result = await runnableToExecute.run({
                rowLimit,
                givens: cellSurfaceGivens,
@@ -3826,7 +3865,7 @@ export class Model {
                   preparedCell.connectionName,
                   // Same resolution the cell's own filter lookup uses, so a
                   // notebook cell carries the source's declared layer too.
-                  extractRunTargetSourceName(cell.text),
+                  cellCompiledSource ?? extractRunTargetSourceName(cell.text),
                ),
             });
             const query = (await runnableToExecute.getPreparedQuery())._query;

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -3104,7 +3104,13 @@ export class Model {
          appliedQueryMetadata = this.resolveQueryMetadata(
             queryMetadataInput,
             preparedResult.connectionName,
-            sourceName,
+            // The run-target source already resolved for the authorize gate, not
+            // the raw `sourceName` param: a `queryName` request names exactly one
+            // source and must not lose its declared layer for having named it
+            // indirectly, and ad-hoc text resolves through the same surface-syntax
+            // path. Reusing the gate's answer also keeps one definition of "which
+            // source is this query against" rather than a second, weaker one.
+            earlySource,
          );
 
          queryResults = await runnable.run({
@@ -3262,7 +3268,7 @@ export class Model {
             appliedQueryMetadata = this.resolveQueryMetadata(
                queryMetadataInput,
                livePrepared.connectionName,
-               sourceName,
+               earlySource,
             );
             queryResults = await liveRunnable!.run({
                rowLimit,
@@ -3533,16 +3539,23 @@ export class Model {
    }
 
    /**
-    * The named source's own `#@` tag, or undefined when the request named no
-    * source, the name is not a top-level source, or the annotation fails to
+    * The run-target source's own `#@` tag, or undefined when no source could be
+    * resolved, the name is not a top-level source, or the annotation fails to
     * parse.
     *
-    * A request that does not name a source (ad-hoc query text, a notebook cell)
-    * gets the package and model-file layers but not this one: with no source
-    * named there is no single annotation to read, and a query may touch several
-    * sources whose declarations disagree. Guessing one would attribute a
-    * statement to a source the caller never asked for, which is worse than
-    * carrying one layer fewer.
+    * Callers pass the source the server ALREADY resolved for the authorize gate,
+    * not the raw `sourceName` request param — a `queryName` request names one
+    * source indirectly and must not lose its declared layer for it, and ad-hoc
+    * text resolves through the same surface-syntax path. What remains
+    * unresolvable is a statement with no single run target (some notebook
+    * cells); those carry the package and model-file layers only.
+    *
+    * Reads the named source's OWN annotations and does not walk its derivation
+    * base, so `source: a is b extend {…}` inherits nothing from `b`'s
+    * declaration. This diverges from {@link ancestorGateExprs}, which walks
+    * ancestors deliberately because a gate an extension could shed would be no
+    * gate at all. A cost label carries no such requirement, and inheriting one
+    * would attribute `a`'s traffic to `b`'s team.
     */
    private safeSourceTag(
       sourceName: string | undefined,
@@ -3775,6 +3788,9 @@ export class Model {
                queryMetadata: this.resolveQueryMetadata(
                   queryMetadataInput,
                   preparedCell.connectionName,
+                  // Same resolution the cell's own filter lookup uses, so a
+                  // notebook cell carries the source's declared layer too.
+                  extractRunTargetSourceName(cell.text),
                ),
             });
             const query = (await runnableToExecute.getPreparedQuery())._query;

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -304,6 +304,11 @@ export class Model {
    /** Model-wide `##(authorize)` expressions; apply to every query in the
     *  model, including ad-hoc inline sources not declared in the model. */
    private fileLevelAuthorize: string[] = [];
+   /**
+    * Memo for {@link getDeclaredQueryMetadata}. `undefined` = not yet computed,
+    * `null` = computed and nothing declared.
+    */
+   private declaredQueryMetadataMemo: QueryMetadata | null | undefined;
    /** Given names (`$NAME`) referenced by any authorize gate reachable
     *  anywhere in this model -- the file-level gate, every top-level
     *  source's own gate, and every gate a top-level source carries in from
@@ -1683,8 +1688,11 @@ export class Model {
    }
 
    /**
-    * This file's own `## materialization.queryMetadata.*` declaration, or null
-    * if it declares none.
+    * This file's own model-level `queryMetadata` declaration, or null if it
+    * declares none. Covers both the `## materialization.queryMetadata.*` form
+    * and the bare `## queryMetadata.*` one beneath it, since
+    * {@link composeDeclaredQueryMetadata} reads the same two layers the build
+    * path does.
     *
     * Exposed for the publish gate. That gate walks the package manifest and the
     * build plan's persist sources, so a model file's declaration was only ever
@@ -1692,11 +1700,22 @@ export class Model {
     * source was invisible entirely. Since a model-file declaration now rides
     * served queries whether or not the file persists anything, it needs a
     * validation path of its own.
+    *
+    * Memoized, because the caller is not the cold path it looks like:
+    * `getPackageMetadata()` runs once per package inside `listPackages`, and
+    * several callers invoke it only to read `manifestLocation`. Recomputing
+    * would walk the import closure and re-parse every `##` note on each of those.
+    * A compiled model's annotations never change — a reload replaces the `Model`
+    * object outright — so the memo needs no invalidation.
     */
    public getDeclaredQueryMetadata(): QueryMetadata | null {
-      return composeDeclaredQueryMetadata({
-         modelTag: this.safeModelFileTag(),
-      });
+      // `undefined` means "not computed"; `null` is a computed answer of "none".
+      if (this.declaredQueryMetadataMemo === undefined) {
+         this.declaredQueryMetadataMemo = composeDeclaredQueryMetadata({
+            modelTag: this.safeModelFileTag(),
+         });
+      }
+      return this.declaredQueryMetadataMemo;
    }
 
    /**

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -79,11 +79,7 @@ import {
    ownModelAnnotations,
    ownModelNotes,
 } from "./annotations";
-import {
-   composeDeclaredQueryMetadata,
-   type ReadableTag,
-   type WirePackageMaterialization,
-} from "./build_plan";
+import { composeDeclaredQueryMetadata, type ReadableTag } from "./build_plan";
 import {
    assertNoCallerAuthorizeAnnotation,
    collectAuthorizeExprs,
@@ -157,12 +153,11 @@ export interface ModelQueryMetadataInput {
       enforced?: QueryMetadata | null;
    } | null;
    /**
-    * The package manifest's `materialization` block, for its
-    * `queryMetadata` — the least specific author-declared layer. Supplied by the
-    * controller, which owns the package; the model knows only its own file and
-    * its package's NAME.
+    * The package's declared bag — the least specific author-declared layer.
+    * Supplied by the controller, which owns the package; the model knows only
+    * its own file and its package's NAME.
     */
-   packageMaterialization?: WirePackageMaterialization | null;
+   packageDeclaration?: QueryMetadata | null;
 }
 
 type ApiCompiledModel = components["schemas"]["CompiledModel"];
@@ -311,6 +306,10 @@ export class Model {
     * `null` = computed and nothing declared.
     */
    private declaredQueryMetadataMemo: QueryMetadata | null | undefined;
+   /** Memo for {@link getDeclaredSourceQueryMetadata}. */
+   private declaredSourceQueryMetadataMemo:
+      | { sourceName: string; queryMetadata: QueryMetadata }[]
+      | undefined;
    /** Given names (`$NAME`) referenced by any authorize gate reachable
     *  anywhere in this model -- the file-level gate, every top-level
     *  source's own gate, and every gate a top-level source carries in from
@@ -1718,6 +1717,41 @@ export class Model {
          });
       }
       return this.declaredQueryMetadataMemo;
+   }
+
+   /**
+    * Each top-level source's OWN `#@ queryMetadata.*`, for the sources that
+    * declare one.
+    *
+    * `queryMetadata` is a sibling of `persist` in the `#@` namespace rather than
+    * a key inside it, so a source that persists nothing can declare tags and
+    * they ride every query against it. The publish gate reads persist sources
+    * from the build plan, so those declarations had no validation path — a
+    * reserved or malformed name published clean and vanished with only a metric
+    * behind it.
+    *
+    * Memoized for the same reason as {@link getDeclaredQueryMetadata}: the
+    * caller runs once per package inside `listPackages`.
+    */
+   public getDeclaredSourceQueryMetadata(): {
+      sourceName: string;
+      queryMetadata: QueryMetadata;
+   }[] {
+      if (this.declaredSourceQueryMetadataMemo === undefined) {
+         const contents = (this.modelDef?.contents ?? {}) as Record<
+            string,
+            unknown
+         >;
+         this.declaredSourceQueryMetadataMemo = Object.keys(contents).flatMap(
+            (sourceName) => {
+               const queryMetadata = composeDeclaredQueryMetadata({
+                  sourceTag: this.safeSourceTag(sourceName),
+               });
+               return queryMetadata ? [{ sourceName, queryMetadata }] : [];
+            },
+         );
+      }
+      return this.declaredSourceQueryMetadataMemo;
    }
 
    /**
@@ -3557,7 +3591,7 @@ export class Model {
          connection: connectionLayers?.default,
          enforced: connectionLayers?.enforced,
          model: composeDeclaredQueryMetadata({
-            packageMaterialization: input?.packageMaterialization,
+            packageDeclaration: input?.packageDeclaration,
             modelTag: this.safeModelFileTag(),
             sourceTag: this.safeSourceTag(sourceName),
          }),
@@ -3630,12 +3664,15 @@ export class Model {
    ): ReadableTag | undefined {
       if (!sourceName || !this.modelDef) return undefined;
       try {
-         const contents = this.modelDef.contents as Record<
-            string,
-            { annotations?: unknown } | undefined
-         >;
-         const def = contents?.[sourceName];
-         if (!def?.annotations) return undefined;
+         const entry = this.modelDef.contents?.[sourceName];
+         // The docstring's "not a top-level source" case, now actually checked.
+         // `contents` also holds NAMED QUERIES, and a `#@` on one of those is
+         // not a source's declaration — reading it resolved a query's tag as
+         // though a source had declared it, and listed the query's name among
+         // the package's tagged sources in the publish warnings.
+         if (!entry || !isSourceDef(entry)) return undefined;
+         const def = entry as unknown as { annotations?: unknown };
+         if (!def.annotations) return undefined;
          return new Annotations(def.annotations).parseAsTag("@")
             .tag as ReadableTag;
       } catch {

--- a/packages/server/src/service/package.spec.ts
+++ b/packages/server/src/service/package.spec.ts
@@ -609,4 +609,54 @@ describe("service/package", () => {
          expect(boundSources(pkg)).toEqual(["all_rows"]);
       });
    });
+
+   describe("getDeclaredQueryMetadata", () => {
+      const pkgWith = (metadata: Record<string, unknown>) =>
+         new Package(
+            "testProject",
+            "testPackage",
+            testPackageDirectory,
+            { name: "testPackage", ...metadata } as never,
+            [],
+            new Map(),
+         );
+
+      it("reads the canonical top-level field", () => {
+         expect(
+            pkgWith({
+               queryMetadata: { team: "finance" },
+            }).getDeclaredQueryMetadata(),
+         ).toEqual({ team: "finance" });
+      });
+
+      it("falls back to the deprecated materialization block", () => {
+         // An un-migrated client PATCHes the block and nothing else, so dropping
+         // the fallback would silently stop tagging that package's queries.
+         expect(
+            pkgWith({
+               materialization: { queryMetadata: { team: "finance" } },
+            }).getDeclaredQueryMetadata(),
+         ).toEqual({ team: "finance" });
+      });
+
+      it("prefers the canonical field when both are present", () => {
+         // Both homes are populated on the way out, so a client that sets only
+         // the new one must not have a stale block win over it.
+         expect(
+            pkgWith({
+               queryMetadata: { team: "finance" },
+               materialization: { queryMetadata: { team: "stale" } },
+            }).getDeclaredQueryMetadata(),
+         ).toEqual({ team: "finance" });
+      });
+
+      it("is null when neither home carries a bag", () => {
+         expect(pkgWith({}).getDeclaredQueryMetadata()).toBeNull();
+         expect(
+            pkgWith({
+               materialization: { schedule: null },
+            }).getDeclaredQueryMetadata(),
+         ).toBeNull();
+      });
+   });
 });

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -891,6 +891,15 @@ export class Package {
             sources: this.buildPlan?.sources
                ? Object.values(this.buildPlan.sources)
                : [],
+            // Every model file's own `##` declaration, including files that
+            // persist nothing: the declaration rides queries served from them,
+            // so it needs checking whether or not a build ever reads it.
+            modelDeclarations: [...this.models.values()].flatMap((model) => {
+               const queryMetadata = model.getDeclaredQueryMetadata();
+               return queryMetadata
+                  ? [{ modelPath: model.getPath(), queryMetadata }]
+                  : [];
+            }),
             manifestWarnings: this.manifestWarnings,
          }),
       ];

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -56,7 +56,11 @@ import {
    incrementalPolicyRejections,
    type IncrementalPolicySource,
 } from "./incremental_policy";
-import { materializationConfigWarnings } from "./materialization_config_validation";
+import {
+   materializationConfigWarnings,
+   type QueryMetadataDeclaration,
+} from "./materialization_config_validation";
+import type { QueryMetadata } from "./query_metadata";
 import { CronEvaluator } from "./cron_evaluator";
 import { filterFreshManifest } from "./freshness";
 import { isQuotedIdentifierPath, quoteManifestTablePath } from "./quoting";
@@ -559,6 +563,12 @@ export class Package {
             schedule: null,
             freshness: null,
          },
+         // The canonical home for the package's declared tags, mirrored from the
+         // block above — which is where the wire originally carried them. Both
+         // are populated for as long as the deprecated home is supported, so a
+         // client migrates when it chooses rather than when this ships.
+         queryMetadata:
+            outcome.packageMetadata.materialization?.queryMetadata ?? null,
          // Package-level persist scope mode, applied uniformly to every persist
          // source/index. Defaults to "package" (cross-version reuse) when the
          // manifest omits it.
@@ -834,6 +844,112 @@ export class Package {
       return this.packageMetadata.materialization ?? null;
    }
 
+   /**
+    * The package's declared `queryMetadata` — the least specific author-declared
+    * layer, and the counterpart to {@link Model.getDeclaredQueryMetadata}.
+    *
+    * Prefers the canonical top-level field and falls back to the deprecated
+    * `materialization.queryMetadata`. The fallback is not dead code: a PATCH may
+    * still set the block (an un-migrated client), and metadata assembled by
+    * anything that predates the top-level field carries only the block. Callers
+    * want the package's bag, not its build policy, and should not have to know
+    * which home it arrived in.
+    */
+   public getDeclaredQueryMetadata(): QueryMetadata | null {
+      return (
+         this.packageMetadata.queryMetadata ??
+         this.packageMetadata.materialization?.queryMetadata ??
+         null
+      );
+   }
+
+   /**
+    * Every `queryMetadata` bag this package's authors declared, at whatever
+    * level, as declared. What the publish gate needs in order to name the line
+    * to edit.
+    *
+    * Whether a source persists does not enter into it. A bag on a source rides
+    * every query against that source, materialized or not, so a source is listed
+    * because it declared something — not because a build reads it.
+    */
+   private queryMetadataDeclarations(): QueryMetadataDeclaration[] {
+      const packageDeclaration = this.getDeclaredQueryMetadata();
+      return [
+         ...(packageDeclaration
+            ? [{ level: "package" as const, queryMetadata: packageDeclaration }]
+            : []),
+         ...[...this.models.values()].flatMap((model) => {
+            const modelDeclaration = model.getDeclaredQueryMetadata();
+            return [
+               ...(modelDeclaration
+                  ? [
+                       {
+                          level: "model" as const,
+                          // The model path goes in `modelPath`, not `subject`:
+                          // the wire schema keeps the two apart, so a client
+                          // filtering findings by model missed every one of
+                          // these while `subject` read like a source name.
+                          modelPath: model.getPath(),
+                          queryMetadata: modelDeclaration,
+                       },
+                    ]
+                  : []),
+               ...model
+                  .getDeclaredSourceQueryMetadata()
+                  .map(({ sourceName, queryMetadata }) => ({
+                     level: "source" as const,
+                     subject: sourceName,
+                     // A source name is unique within a model, not within a
+                     // package: without the path, two models declaring a
+                     // same-named source produce identical findings that dedupe
+                     // to a single message naming neither file.
+                     modelPath: model.getPath(),
+                     queryMetadata,
+                  })),
+            ];
+         }),
+      ];
+   }
+
+   /**
+    * How many properties a statement actually SENDS, per model file, once the
+    * package, model-file and source layers have merged.
+    *
+    * The budget is the one rule that cannot be checked per declaration: every
+    * layer can sit under the author budget while their merge sits over it, and
+    * it is the merge that rides the statement.
+    *
+    * The FLOOR — package ⊕ model file — is reported for every model, whether or
+    * not any of its sources declares anything. Sizing only the declaring sources
+    * missed the common shape outright: a package and a model file that overflow
+    * together published clean whenever no source in the file happened to add a
+    * tag, and every query against every source in that file then shed context
+    * properties.
+    */
+   private queryMetadataEffectiveMerges(): {
+      modelPath: string;
+      floorSize: number;
+      sources: { subject: string; size: number }[];
+   }[] {
+      const packageDeclaration = this.getDeclaredQueryMetadata();
+      return [...this.models.values()].map((model) => {
+         const floor = {
+            ...(packageDeclaration ?? {}),
+            ...(model.getDeclaredQueryMetadata() ?? {}),
+         };
+         return {
+            modelPath: model.getPath(),
+            floorSize: Object.keys(floor).length,
+            sources: model
+               .getDeclaredSourceQueryMetadata()
+               .map(({ sourceName, queryMetadata }) => ({
+                  subject: sourceName,
+                  size: Object.keys({ ...floor, ...queryMetadata }).length,
+               })),
+         };
+      });
+   }
+
    public getPackageMetadata(): ApiPackage {
       // Overlay the server-computed fields onto the stored metadata: the
       // explores misconfig warnings (loading is fail-safe — the package still
@@ -887,19 +1003,8 @@ export class Package {
          // not do what it says, and manifest shapes that still parse but are
          // deprecated. Advisory by design — none of these blocks a publish.
          ...materializationConfigWarnings({
-            packageMaterialization: this.packageMetadata.materialization,
-            sources: this.buildPlan?.sources
-               ? Object.values(this.buildPlan.sources)
-               : [],
-            // Every model file's own `##` declaration, including files that
-            // persist nothing: the declaration rides queries served from them,
-            // so it needs checking whether or not a build ever reads it.
-            modelDeclarations: [...this.models.values()].flatMap((model) => {
-               const queryMetadata = model.getDeclaredQueryMetadata();
-               return queryMetadata
-                  ? [{ modelPath: model.getPath(), queryMetadata }]
-                  : [];
-            }),
+            declarations: this.queryMetadataDeclarations(),
+            effectiveMerges: this.queryMetadataEffectiveMerges(),
             manifestWarnings: this.manifestWarnings,
          }),
       ];

--- a/packages/server/src/service/package_manifest.spec.ts
+++ b/packages/server/src/service/package_manifest.spec.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import {
-   packageMaterializationWarnings,
+   materializationWithQueryMetadata,
    parsePackageMaterialization,
    parsePackageScope,
+   queryMetadataParseWarnings,
+   resolvePackageQueryMetadata,
    resolvePackageScope,
 } from "./package_manifest";
 
@@ -204,27 +206,146 @@ describe("service/package_manifest", () => {
       });
    });
 
-   describe("packageMaterializationWarnings", () => {
-      it("names a dropped non-string value", () => {
-         // The drop happens before the config validation that would otherwise
-         // report it, so without this an unquoted `"team": 123` — a plausible
-         // hand-edit — vanishes with nothing anywhere to point at.
-         const warnings = packageMaterializationWarnings({
-            queryMetadata: { team: "finance", retries: 3 },
+   describe("resolvePackageQueryMetadata", () => {
+      it("reads the canonical root home with no warning", () => {
+         expect(
+            resolvePackageQueryMetadata({ team: "finance" }, undefined),
+         ).toEqual({
+            queryMetadata: { team: "finance" },
+            home: "root",
+            warnings: [],
          });
-         expect(warnings).toHaveLength(1);
-         expect(warnings[0]).toContain("'retries'");
-         expect(warnings[0]).toContain("got number");
       });
 
-      it("says nothing about a block that parses cleanly", () => {
+      it("still honors the enveloped form, with a deprecation warning", () => {
+         const resolved = resolvePackageQueryMetadata(undefined, {
+            queryMetadata: { team: "finance" },
+         });
+         expect(resolved.queryMetadata).toEqual({ team: "finance" });
+         // The home is carried so a parse warning about one of these properties
+         // names the spelling this author actually wrote.
+         expect(resolved.home).toBe("envelope");
+         expect(resolved.warnings).toHaveLength(1);
+         expect(resolved.warnings[0]).toMatch(/deprecated/i);
+      });
+
+      it("accepts both homes agreeing without a warning", () => {
+         // The transition state the server writes itself: the root for this
+         // build, the envelope for an older publisher that reads only that.
          expect(
-            packageMaterializationWarnings({
-               schedule: "0 6 * * *",
-               queryMetadata: { team: "finance" },
-            }),
-         ).toEqual([]);
-         expect(packageMaterializationWarnings(undefined)).toEqual([]);
+            resolvePackageQueryMetadata(
+               { team: "finance" },
+               { queryMetadata: { team: "finance" } },
+            ),
+         ).toEqual({
+            queryMetadata: { team: "finance" },
+            home: "root",
+            warnings: [],
+         });
+      });
+
+      it("treats the same bag in a different key order as agreement", () => {
+         // Key order is not meaning. Comparing serialized forms directly called
+         // these a conflict and sent the author off to reconcile two homes that
+         // already agree — the root wins anyway, so the warning was pure noise
+         // pointing at a bag that needs no edit.
+         const resolved = resolvePackageQueryMetadata(
+            { team: "finance", tier: "gold" },
+            { queryMetadata: { tier: "gold", team: "finance" } },
+         );
+         expect(resolved.warnings).toEqual([]);
+         expect(resolved.queryMetadata).toEqual({
+            team: "finance",
+            tier: "gold",
+         });
+      });
+
+      it("still calls genuinely different bags a conflict", () => {
+         // The order-insensitive compare must not swallow a real disagreement.
+         expect(
+            resolvePackageQueryMetadata(
+               { team: "finance", tier: "gold" },
+               { queryMetadata: { tier: "bronze", team: "finance" } },
+            ).warnings[0],
+         ).toMatch(/conflicting/i);
+         // Same keys, one missing on the other side.
+         expect(
+            resolvePackageQueryMetadata(
+               { team: "finance", tier: "gold" },
+               { queryMetadata: { team: "finance" } },
+            ).warnings[0],
+         ).toMatch(/conflicting/i);
+      });
+
+      it("warns and prefers the root when the homes disagree", () => {
+         // Deliberately unlike `scope`, which throws. Scope decides whether an
+         // artifact is version-owned; a tag decides a label. Failing a package
+         // load over a label would break the rule the feature rests on.
+         const resolved = resolvePackageQueryMetadata(
+            { team: "finance" },
+            { queryMetadata: { team: "marketing" } },
+         );
+         expect(resolved.queryMetadata).toEqual({ team: "finance" });
+         expect(resolved.warnings[0]).toMatch(/conflicting/i);
+      });
+
+      it("declares nothing when neither home does", () => {
+         expect(resolvePackageQueryMetadata(undefined, undefined)).toEqual({
+            queryMetadata: undefined,
+            home: "root",
+            warnings: [],
+         });
+         expect(
+            resolvePackageQueryMetadata(undefined, { schedule: "0 6 * * *" }),
+         ).toEqual({ queryMetadata: undefined, home: "root", warnings: [] });
+      });
+   });
+
+   describe("queryMetadataParseWarnings", () => {
+      it("names the home the author actually wrote", () => {
+         // Hardcoding the enveloped spelling pointed the author of a root-only
+         // manifest at a `materialization` block their file does not have.
+         expect(queryMetadataParseWarnings({ team: 3 }, "root")[0]).toContain(
+            "queryMetadata: property 'team'",
+         );
+         expect(
+            queryMetadataParseWarnings({ team: 3 }, "envelope")[0],
+         ).toContain("materialization.queryMetadata: property 'team'");
+      });
+   });
+
+   describe("materializationWithQueryMetadata", () => {
+      it("builds a config for a manifest with tags and no build policy", () => {
+         // The shape the canonical form produces: a package that declares tags
+         // at the root has no `materialization` block to put them in, and its
+         // tags must not be lost for want of one.
+         expect(
+            materializationWithQueryMetadata(null, { team: "finance" }),
+         ).toEqual({
+            schedule: null,
+            freshness: null,
+            queryMetadata: { team: "finance" },
+         });
+      });
+
+      it("keeps the build policy while replacing the tags", () => {
+         expect(
+            materializationWithQueryMetadata(
+               parsePackageMaterialization({
+                  schedule: "0 6 * * *",
+                  queryMetadata: { team: "marketing" },
+               }),
+               { team: "finance" },
+            ),
+         ).toEqual({
+            schedule: "0 6 * * *",
+            freshness: null,
+            queryMetadata: { team: "finance" },
+         });
+      });
+
+      it("is null only when neither a policy nor a tag exists", () => {
+         expect(materializationWithQueryMetadata(null, undefined)).toBeNull();
       });
    });
 });

--- a/packages/server/src/service/package_manifest.ts
+++ b/packages/server/src/service/package_manifest.ts
@@ -100,6 +100,119 @@ const SCOPE_ROOT_DEPRECATION =
    `older publisher still reads the right value.`;
 
 /**
+ * Resolve the package's per-query metadata from its two homes: the manifest root
+ * (canonical) and `materialization.queryMetadata` (the original home, now
+ * deprecated).
+ *
+ * The move is the opposite direction to {@link resolvePackageScope}, for the
+ * opposite reason. Scope is a build knob, so it belongs with the build knobs.
+ * Query metadata is not one: the properties ride every statement the package's
+ * sources issue, a served query as much as a build. Declaring them inside
+ * `materialization` describes a scope the feature does not have, and sends an
+ * author hunting through build settings for a way to label their traffic.
+ *
+ * A conflict WARNS and prefers the root, where scope THROWS. Scope decides
+ * whether an artifact is version-owned, so guessing could reuse a table across
+ * versions that was never meant to be shared — worth failing a load over. A tag
+ * is observability only, excluded from `sourceEntityId` and from build identity,
+ * so the worst a wrong guess yields is a mislabelled statement. Failing a load
+ * over a label would break the rule the whole feature rests on: a tag must never
+ * be the reason something refuses to run.
+ */
+export function resolvePackageQueryMetadata(
+   rootRaw: unknown,
+   materializationRaw: unknown,
+): { queryMetadata: unknown; home: QueryMetadataHome; warnings: string[] } {
+   const envelopeRaw =
+      materializationRaw && typeof materializationRaw === "object"
+         ? (materializationRaw as { queryMetadata?: unknown }).queryMetadata
+         : undefined;
+   const rootDeclared = rootRaw !== undefined && rootRaw !== null;
+   const envelopeDeclared = envelopeRaw !== undefined && envelopeRaw !== null;
+
+   if (rootDeclared && envelopeDeclared) {
+      // Both homes agreeing is the transition state the server itself writes,
+      // so it is not worth a word to an operator who cannot act on it.
+      if (sameQueryMetadataBag(rootRaw, envelopeRaw)) {
+         return { queryMetadata: rootRaw, home: "root", warnings: [] };
+      }
+      return {
+         queryMetadata: rootRaw,
+         home: "root",
+         warnings: [QUERY_METADATA_CONFLICT],
+      };
+   }
+   if (envelopeDeclared) {
+      return {
+         queryMetadata: envelopeRaw,
+         home: "envelope",
+         warnings: [QUERY_METADATA_ENVELOPE_DEPRECATION],
+      };
+   }
+   return { queryMetadata: rootRaw, home: "root", warnings: [] };
+}
+
+/**
+ * Whether two raw `queryMetadata` declarations say the same thing, INSENSITIVE
+ * to key order. `{team, tier}` and `{tier, team}` are the same bag; comparing
+ * serialized forms directly called them a conflict and sent an author off to
+ * reconcile two homes that already agreed.
+ *
+ * Runs on RAW, pre-validation input, so it cannot assume a flat string map — a
+ * value may be a number, a null, an array or an object. Compared through a
+ * key-sorted re-serialization that recurses, so nesting is handled rather than
+ * assumed away.
+ */
+function sameQueryMetadataBag(a: unknown, b: unknown): boolean {
+   return keySortedJson(a) === keySortedJson(b);
+}
+
+function keySortedJson(value: unknown): string {
+   if (value === null || typeof value !== "object") {
+      // `undefined` has no JSON form; name it so two absent values still match.
+      return JSON.stringify(value) ?? "undefined";
+   }
+   if (Array.isArray(value)) {
+      return `[${value.map(keySortedJson).join(",")}]`;
+   }
+   const entries = Object.entries(value as Record<string, unknown>).sort(
+      ([left], [right]) => (left < right ? -1 : left > right ? 1 : 0),
+   );
+   return `{${entries
+      .map(
+         ([name, nested]) => `${JSON.stringify(name)}:${keySortedJson(nested)}`,
+      )
+      .join(",")}}`;
+}
+
+/**
+ * Which home a resolved bag came from. Carried so a parse warning about one of
+ * its properties can name the home the author actually wrote, rather than a
+ * hardcoded spelling that is wrong for whichever home did not win.
+ */
+export type QueryMetadataHome = "root" | "envelope";
+
+const QUERY_METADATA_HOME_LABELS: Record<QueryMetadataHome, string> = {
+   root: "queryMetadata",
+   envelope: "materialization.queryMetadata",
+};
+
+const QUERY_METADATA_ENVELOPE_DEPRECATION =
+   `"queryMetadata" inside "materialization" is deprecated: declare it at the ` +
+   `manifest root instead. It is not a build setting — the properties ride ` +
+   `every statement the package's sources issue, including served queries. The ` +
+   `enveloped form still works and will be removed in a future release; until ` +
+   `then the server keeps both homes in sync when it writes the manifest, so an ` +
+   `older publisher still reads the right value.`;
+
+const QUERY_METADATA_CONFLICT =
+   `Conflicting "queryMetadata" in publisher.json: the manifest root and ` +
+   `"materialization.queryMetadata" declare different bags, and the root wins. ` +
+   `Delete "materialization": { "queryMetadata": ... } — the server rewrites ` +
+   `both homes on its next manifest write, so an older publisher still reads ` +
+   `the right value.`;
+
+/**
  * The manifest's `materialization.freshness` block, surfaced verbatim for the
  * control plane (which owns the scheduling and query-time gating logic).
  * Fields are kept only when valid — an invalid value is dropped, never
@@ -171,7 +284,10 @@ function parseFreshness(raw: unknown): PackageFreshnessConfig | null {
  * plausible hand-edit, and without this it disappears with nothing anywhere to
  * point at.
  */
-function parseQueryMetadata(raw: unknown): {
+function parseQueryMetadata(
+   raw: unknown,
+   label = QUERY_METADATA_HOME_LABELS.envelope,
+): {
    metadata: Record<string, string> | null;
    warnings: string[];
 } {
@@ -185,7 +301,7 @@ function parseQueryMetadata(raw: unknown): {
          out[name] = value;
       } else {
          warnings.push(
-            `materialization.queryMetadata: property '${name}' must be a ` +
+            `${label}: property '${name}' must be a ` +
                `string (got ${value === null ? "null" : typeof value}); it is ` +
                `not attached to any statement`,
          );
@@ -227,15 +343,36 @@ export function parsePackageMaterialization(
 }
 
 /**
- * What the `materialization` parse tolerated but could not keep, for the
- * operator warnings array. Reads the same parse as
- * {@link parsePackageMaterialization} rather than re-deriving it, so the two
- * cannot disagree about what was dropped.
+ * The package's materialization config with `queryMetadata` taken from whichever
+ * home won (see {@link resolvePackageQueryMetadata}), so every consumer keeps
+ * reading one accessor and no caller has to know there are two homes.
+ *
+ * Returns a config even when the manifest has NO `materialization` block, which
+ * is the shape the canonical form produces: a package that declares tags at the
+ * root and nothing else has no build policy to express. Null only when neither
+ * home declares anything.
  */
-export function packageMaterializationWarnings(raw: unknown): string[] {
-   if (!raw || typeof raw !== "object") {
-      return [];
-   }
-   const { queryMetadata } = raw as { queryMetadata?: unknown };
-   return parseQueryMetadata(queryMetadata).warnings;
+export function materializationWithQueryMetadata(
+   parsed: PackageMaterializationConfig | null,
+   queryMetadataRaw: unknown,
+): PackageMaterializationConfig | null {
+   const queryMetadata = parseQueryMetadata(queryMetadataRaw).metadata;
+   if (!parsed && !queryMetadata) return null;
+   return {
+      schedule: parsed?.schedule ?? null,
+      freshness: parsed?.freshness ?? null,
+      queryMetadata,
+   };
+}
+
+/**
+ * Properties the winning `queryMetadata` home declared but could not keep,
+ * named after THAT home. Hardcoding the enveloped spelling pointed the author of
+ * a root-only manifest at a `materialization` block their file does not have.
+ */
+export function queryMetadataParseWarnings(
+   raw: unknown,
+   home: QueryMetadataHome = "root",
+): string[] {
+   return parseQueryMetadata(raw, QUERY_METADATA_HOME_LABELS[home]).warnings;
 }

--- a/packages/server/src/service/query_metadata.ts
+++ b/packages/server/src/service/query_metadata.ts
@@ -157,6 +157,26 @@ export function queryMetadataAdvisoryWarnings(meta: QueryMetadata): string[] {
 }
 
 /**
+ * Declared properties whose names the server owns, and which
+ * {@link mergeQueryMetadata} therefore drops from a declaration.
+ *
+ * Separate from {@link queryMetadataAdvisoryWarnings} because the failure is a
+ * different one: an advisory property is attached and then discarded by ONE
+ * backend, while a reserved one is never attached at all. Both belong at a
+ * declaration boundary rather than in a metric — a `queryMetadata` block naming
+ * `model` publishes clean, vanishes on every statement, and reports it only as a
+ * counter tick, which is the shape of thing an author cannot debug.
+ */
+export function queryMetadataReservedWarnings(meta: QueryMetadata): string[] {
+   return Object.keys(meta)
+      .filter((name) => RESERVED_NAMES.has(name))
+      .map(
+         (name) =>
+            `queryMetadata property '${name}' is a name the server sets itself, so it is dropped rather than attached; rename it (for example '${name}_label')`,
+      );
+}
+
+/**
  * The budget warning for a declaration of `declared` properties, or undefined
  * when it fits.
  *

--- a/packages/server/src/service/query_metadata.ts
+++ b/packages/server/src/service/query_metadata.ts
@@ -321,8 +321,18 @@ export interface QueryMetadataLayers {
 export type QueryMetadataDropReason =
    | "invalid_name"
    | "invalid_value"
+   | "reserved_name"
    | "property_cap"
    | "serialized_cap";
+
+/**
+ * Index of the author-declared layer in the merge order below — the layer whose
+ * properties come from a package manifest, a model file or a source annotation.
+ */
+const DECLARED_LAYER_INDEX = 1;
+
+/** Context names, which an author may not declare. See the merge loop. */
+const RESERVED_NAMES = new Set(CONTEXT_SHED_ORDER);
 
 export interface ResolvedQueryMetadata {
    /** The bag to hand to Malloy; undefined when there is nothing to attach. */
@@ -399,6 +409,22 @@ export function mergeQueryMetadata(
             name.length > MAX_PROPERTY_NAME_LENGTH
          ) {
             drops.push({ name, reason: "invalid_name" });
+            continue;
+         }
+         // A DECLARED property may not take a context name. Context only
+         // overwrites names it has a VALUE for, and a served query has no
+         // `source`, `trigger` or `run_id` — so without this a model file's
+         // `queryMetadata.source="orders_daily"` would ride an interactive
+         // statement and read, in the warehouse's own history, exactly like a
+         // build of that source. Reserving the whole context vocabulary rather
+         // than the three that leak today keeps the rule statable: context names
+         // describe what the server did, and are never an author's to set.
+         //
+         // Scoped to the declared layer deliberately. The connection and request
+         // layers can do the same thing and always could; widening to them is a
+         // separate decision with its own compatibility question.
+         if (index === DECLARED_LAYER_INDEX && RESERVED_NAMES.has(name)) {
+            drops.push({ name, reason: "reserved_name" });
             continue;
          }
          if (typeof value !== "string") {


### PR DESCRIPTION
Author-declared query metadata now rides **every statement touching a source**, not only the ones a
build issues.

A package's `materialization.queryMetadata`, a model file's `## materialization.queryMetadata.*` and
a source's `#@ persist queryMetadata.*` reached materialization statements and stopped there. A served
query arrived carrying the server's own context — `class`, `package`, `model`, `query_id` — and none
of the author's vocabulary. So a deployment could attribute its builds and not the interactive
traffic that is most of a warehouse bill.

Confirmed against live warehouses on both BigQuery (`INFORMATION_SCHEMA.JOBS.labels`) and Snowflake
(`QUERY_HISTORY.query_tag`): a build statement carried 14 properties, and a served statement from the
same package on the same connection carried 9.

## What a served query resolves

Same layers as a build, same precedence, through the same function:

| layer | source of truth |
|---|---|
| package `materialization.queryMetadata` | the controller, which holds the package handle |
| model file `## materialization.queryMetadata.*` | `modelDef`, which survives the worker serialization boundary |
| source `#@ persist queryMetadata.*` | the run-target source's own annotation |

`composeDeclaredQueryMetadata` is factored out of the build-path resolver and takes tags rather than a
`PersistSource`, so precedence cannot drift between the two paths.

The source layer resolves from the run target the server already computes for the authorize gate —
the explicit `sourceName`, a `queryName`'s source, or the run target in ad-hoc text. A statement with
no single run target, such as some notebook cells, carries the package and model-file layers only.

The MCP query boundary resolves the same layers as the HTTP controllers. It builds its own metadata
input, and agent traffic is interactive traffic.

## Context names are reserved against a declaration

Context is applied above every declared layer, but it only overwrites a name it has a **value** for —
and a served query has no `source`, `trigger` or `run_id`. Without a rule, a model file declaring
`queryMetadata.source="orders_daily"` would stamp it on interactive statements, which in the
warehouse's own history read exactly like a build of that source.

A declared context name (`class`, `environment`, `package`, `model`, `source`, `trigger`, `run_id`,
`query_id`, `version`) is therefore **dropped rather than attached**, and metered as `reserved_name`.

A silent drop is not much better than a silent attach, so the publish gate reports it as a message
naming the level that declared it. That gate now walks all three declaration levels: the package
manifest, each persist source, and each model file's own `##` block — including a model file that
persists nothing, which contributes a layer to every query served from it while having no source to
be reported under.

Scoped to the model-side declaration. A connection default and a per-request bag can still set these
names, as they always could: a request setting `queryClass` is a caller describing its own call, and
narrowing either is a compatibility decision of its own. What the rule covers is the layer that
describes *other people's* statements — a declaration rides every query against that source,
including ones its author never sees.

**This changes the build path slightly.** A declared `source` was already overwritten by context there,
so reserving it is a no-op; `model` and `version` are context names a build does not set, so a
declaration of either survived before and now drops. Both are server-owned names, and a uniform rule
is easier to state and to trust than a per-path exemption list.

## Documentation

`docs/query-metadata.md` and `docs/materialization.md` stated the rule this changes, in the sections
an author reads before declaring anything. The OpenAPI descriptions did too — including
`PersistSourcePlan.queryMetadata`, which invited a caller to copy the reported bag onto its own
queries, and which can now report a name the publisher will refuse. All corrected here.

## Tests

The regression test fails without the fix — verified by reverting `model.ts`:

```
Expected: "finance"
Received: undefined
```

There was no serve-path query-metadata test before this. Added: all three declared layers composing
with source-beats-model-beats-package precedence; the source layer resolving from a named query and
from ad-hoc text separately, since those are different branches; a request property overriding a
declared one without evicting what it does not mention; a declared `source`/`run_id` refused while the
author's own property still lands; and the publish gate warning about a reserved name at the level
that declared it, including a model file with no persist source.

Suite: **2,422 pass, 0 fail, 3 skip** across 123 files. `tsc --noEmit` and prettier clean.

## Behaviour that is unchanged

Wire and API shape, precedence order, the enforced layer, and the feature's default —
`PUBLISHER_QUERY_METADATA` is `off` unless a deployment opts in, so none of this reaches a deployment
that has not asked for attribution.

