### PR TITLE
fix(server): make pre-aggregation's live fallback actually fall back

### DIFF
--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -334,6 +334,8 @@ export class Model {
     *  (or returning undefined) means no override: the runtime-baked manifest
     *  applies, which serves live when unbound. */
    private freshnessResolver?: () => BuildManifest["entries"] | undefined;
+   /** See {@link setPreaggregateEntityIdResolver}. */
+   private preaggregateEntityIdResolver?: () => ReadonlySet<string>;
    /** Entry-point gates per declared source name — see
     *  {@link computeEntryPointGatesBySource}. The one answer that
     *  `sources[].authorize`, {@link getAuthorize} and the early gate all read. */
@@ -1709,6 +1711,53 @@ export class Model {
       return entries ? { entries, strict: false } : undefined;
    }
 
+   /**
+    * Set by the owning Package (see Package.wireFreshnessResolvers). Supplies the
+    * `sourceEntityId`s of the rollups pre-aggregation synthesized, which
+    * {@link withoutPreaggregateEntries} strips from the manifest. A resolver
+    * rather than a value because the build plan it reads is computed AFTER the
+    * models are wired.
+    */
+   public setPreaggregateEntityIdResolver(
+      resolver: () => ReadonlySet<string>,
+   ): void {
+      this.preaggregateEntityIdResolver = resolver;
+   }
+
+   /**
+    * `manifest` with pre-aggregation's own rollup entries removed.
+    *
+    * A synthesized rollup exists ONLY in the companion model (see
+    * preaggregation_synthesis) — the author's model never declares it and can
+    * never reference it, so its manifest entry can substitute nothing there. It
+    * is not merely useless: Malloy refuses a non-empty `buildManifest` against a
+    * model without `##! experimental.persistence`, and a model that declares
+    * `#@ preaggregate` has no reason to carry that flag, since the companion
+    * declares its own. Passing the full manifest to the author's model therefore
+    * turned every query on it into a 400 the moment a build bound a manifest —
+    * which is what `build-only` does by definition, and what `on` does for any
+    * query that does not compile against the companion.
+    *
+    * So the rule is by ORIGIN, not by mode: only the companion sees the rollups.
+    * Returns undefined when nothing survives, matching
+    * {@link resolveFreshBuildManifest}'s "no override ⇒ serve live".
+    */
+   private withoutPreaggregateEntries(
+      manifest: BuildManifest | undefined,
+   ): BuildManifest | undefined {
+      if (!manifest) return undefined;
+      const preaggregateIds = this.preaggregateEntityIdResolver?.();
+      if (!preaggregateIds || preaggregateIds.size === 0) return manifest;
+      const entries = Object.fromEntries(
+         Object.entries(manifest.entries).filter(
+            ([sourceEntityId]) => !preaggregateIds.has(sourceEntityId),
+         ),
+      );
+      return Object.keys(entries).length > 0
+         ? { ...manifest, entries }
+         : undefined;
+   }
+
    public getSources(): ApiSource[] | undefined {
       return this.curateForDiscovery(this.sources);
    }
@@ -2620,8 +2669,31 @@ export class Model {
       // to live — which must NOT count as a storage hit, since the hit rate is
       // the tier's headline KPI and would otherwise rise while the tier is down.
       let servedFrom: ServedFrom | undefined;
+      // Set when the query compiled against the pre-aggregation companion model
+      // and will run there. Decides which build manifest the run gets: only the
+      // companion may see pre-aggregation's own rollup entries (see
+      // {@link withoutPreaggregateEntries}).
+      let preaggRouted = false;
       if (!this.modelMaterializer || !this.modelDef || !this.modelInfo)
          throw new BadRequestError("Model has no queryable entities.");
+
+      // Per-query freshness gate (persistence.md §9.3): resolve the
+      // freshness-filtered manifest once and thread it into both the prepare
+      // (for the row limit) and the run so a stale persist source falls back per
+      // its declared policy — and prep/run agree on the same substitution.
+      //
+      // Resolved HERE, above the routing block below, because the pre-aggregation
+      // probe has to compile against the same manifest the run will use.
+      const buildManifest = this.resolveFreshBuildManifest();
+      // The same manifest with pre-aggregation's rollups removed, for every
+      // runnable that is NOT the companion. See the method for why.
+      const liveBuildManifest = this.withoutPreaggregateEntries(buildManifest);
+      // Givens supplied only so a joined source's authorize gate could see
+      // them (checked below, against the full unfiltered set) must not reach
+      // the real query if this model doesn't itself surface them — see
+      // filterGivensToModelSurface. Resolved here for the same reason as
+      // `buildManifest`: the pre-aggregation probe needs them.
+      const querySurfaceGivens = this.filterGivensToModelSurface(givens);
 
       // Query boundary FIRST (the *what* axis): reject a target that isn't in
       // the package's queryable surface with a generic 404, before authorize
@@ -2833,10 +2905,25 @@ export class Model {
             !serveVirtualMap
          ) {
             try {
-               runnable =
+               const candidate =
                   this.preaggregateServeMaterializer.loadRestrictedQuery(
                      queryString,
                   );
+               // Compile eagerly, for the same reason loadServeShapeQuery does:
+               // Malloy compiles LAZILY, so `loadRestrictedQuery` cannot throw
+               // here and without this the error escapes at prepare/run instead,
+               // past the catch below — which made a query naming any source the
+               // companion does not import a hard 400 rather than a live answer.
+               // Cheap relative to the run. The companion's rollup members
+               // resolve through the build manifest and its bases surface the
+               // model's givens, so the probe must use both, or it rejects a
+               // query the run would have accepted.
+               await candidate.getSQL({
+                  givens: querySurfaceGivens,
+                  buildManifest,
+               });
+               runnable = candidate;
+               preaggRouted = true;
             } catch (preaggErr) {
                // Expected, and common: the synthesized model imports only the
                // sources it rolls up, so a query touching anything else does not
@@ -2934,19 +3021,22 @@ export class Model {
 
       const maxRows = getMaxQueryRows();
       const maxBytes = getMaxResponseBytes();
-      // Per-query freshness gate (persistence.md §9.3): resolve the
-      // freshness-filtered manifest once and thread it into both the prepare
-      // (for the row limit) and the run so a stale persist source falls back per
-      // its declared policy — and prep/run agree on the same substitution.
-      const buildManifest = this.resolveFreshBuildManifest();
+      // `buildManifest` / `liveBuildManifest` / `querySurfaceGivens` are resolved
+      // above the routing block, which needs them for its compile probe.
+      //
       // The serve-shape runnable resolves its tables through `virtualMap`, not
       // the same-connection build manifest, and its transient model carries no
       // `##! experimental.persistence` — so passing a non-empty buildManifest to
-      // it errors. When routing through the shape, suppress the manifest; the
-      // original (live) runnable still gets it.
+      // it errors. When routing through the shape, suppress the manifest.
+      //
+      // Only the pre-aggregation companion may see the FULL manifest: its rollup
+      // entries name sources that exist nowhere else, and the author's model has
+      // no reason to carry the persistence flag those entries require.
       const effectiveBuildManifest = serveVirtualMap
          ? undefined
-         : buildManifest;
+         : preaggRouted
+           ? buildManifest
+           : liveBuildManifest;
 
       // Prepare INSIDE the run try/catch: a bad-given / value-type throw at
       // prepare time (getPreparedResult binds the givens) gets the same
@@ -2959,11 +3049,6 @@ export class Model {
       let executionTime = 0;
       let queryResults;
       let appliedQueryMetadata: QueryMetadata | undefined;
-      // Givens supplied only so a joined source's authorize gate could see
-      // them (checked above, against the full unfiltered set) must not reach
-      // the real query if this model doesn't itself surface them — see
-      // filterGivensToModelSurface.
-      const querySurfaceGivens = this.filterGivensToModelSurface(givens);
       // Same reason as effectiveBuildManifest: the serve shape is built from
       // given-FREE sources, so it surfaces no `given:` and Malloy rejects any
       // supplied name with "unknown given" — a spurious 400, past the routing
@@ -3123,9 +3208,12 @@ export class Model {
             // the connector reads as a hard cap and stops before the first row: a
             // successful, EMPTY answer. Asking the live shape is also the honest
             // limit, since the live shape is what runs.
+            // `liveBuildManifest`, not `buildManifest`: this retry runs on the
+            // AUTHOR's model, which can neither reference a synthesized rollup
+            // nor be assumed to carry `##! experimental.persistence`.
             const livePrepared = await liveRunnable!.getPreparedResult({
                givens: querySurfaceGivens,
-               buildManifest,
+               buildManifest: liveBuildManifest,
             });
             const livePreparedLimit = livePrepared.resultExplore.limit;
             rowLimitSource = queryRowLimitSource(livePreparedLimit);
@@ -3147,7 +3235,7 @@ export class Model {
                rowLimit,
                givens: querySurfaceGivens,
                abortSignal,
-               buildManifest,
+               buildManifest: liveBuildManifest,
                queryMetadata: appliedQueryMetadata,
             });
          } catch (retryError) {
@@ -3556,8 +3644,15 @@ export class Model {
             const cellMaxRows = getMaxQueryRows();
             const cellMaxBytes = getMaxResponseBytes();
             // Per-query freshness gate (see getQueryResults): the same
-            // freshness-filtered manifest gates notebook-cell queries.
-            const buildManifest = this.resolveFreshBuildManifest();
+            // freshness-filtered manifest gates notebook-cell queries — minus
+            // pre-aggregation's rollups, which belong to the companion model and
+            // are never referenced from a notebook cell. A notebook has no
+            // companion (it declares no sources to roll up), so unlike
+            // getQueryResults there is no branch here: the live view is the only
+            // one that applies.
+            const buildManifest = this.withoutPreaggregateEntries(
+               this.resolveFreshBuildManifest(),
+            );
             // See getQueryResults / filterGivensToModelSurface: the gate
             // above already saw the full unfiltered givens.
             const cellSurfaceGivens = this.filterGivensToModelSurface(givens);

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -175,6 +175,11 @@ export class Package {
    // no persist source. Surfaced read-only on getPackageMetadata() so a caller
    // can derive build instructions without a separate plan round-trip.
    private buildPlan: BuildPlan | null = null;
+   // Memoized {@link getPreaggregateEntityIds}, keyed on the plan it was derived
+   // from so a reload recomputes without an explicit invalidation.
+   private preaggregateEntityIdCache:
+      | { plan: BuildPlan | null; ids: ReadonlySet<string> }
+      | undefined;
    // Sources annotated `#@ persist` that Malloy's getBuildPlan() did not
    // recognize as a materializable build root, so they produced no plan entry
    // and would be a silent no-op (served live). Surfaced as an operator warning
@@ -989,7 +994,37 @@ export class Package {
    private wireFreshnessResolvers(): void {
       for (const model of this.models.values()) {
          model.setFreshnessResolver(() => this.getFreshBuildManifest());
+         model.setPreaggregateEntityIdResolver(() =>
+            this.getPreaggregateEntityIds(),
+         );
       }
+   }
+
+   /**
+    * The `sourceEntityId`s of the sources pre-aggregation SYNTHESIZED, as
+    * distinct from the `#@ persist` sources an author declared. Read off the
+    * build plan's `origin`, which exists to carry exactly this provenance — not
+    * matched on the rollup naming convention, which would silently misclassify
+    * an author's source that happened to share the shape.
+    *
+    * Consumed by Model.withoutPreaggregateEntries, which keeps these entries away
+    * from every runnable except the companion model that declares them.
+    *
+    * Memoized on the build plan's identity: the plan is replaced wholesale on
+    * load, so reference equality is a sufficient and always-correct key.
+    */
+   public getPreaggregateEntityIds(): ReadonlySet<string> {
+      if (this.preaggregateEntityIdCache?.plan === this.buildPlan) {
+         return this.preaggregateEntityIdCache.ids;
+      }
+      const ids = new Set<string>();
+      for (const source of Object.values(this.buildPlan?.sources ?? {})) {
+         if (source.origin === "preaggregate" && source.sourceEntityId) {
+            ids.add(source.sourceEntityId);
+         }
+      }
+      this.preaggregateEntityIdCache = { plan: this.buildPlan, ids };
+      return ids;
    }
 
    /**

--- a/packages/server/src/service/preaggregation_seams.spec.ts
+++ b/packages/server/src/service/preaggregation_seams.spec.ts
@@ -168,6 +168,37 @@ source: orders is raw -> { group_by: category; aggregate: amount_sum is amount.s
       },
       { timeout: 60000 },
    );
+
+   it(
+      "reports the synthesized rollups, and only those, as preaggregate-origin",
+      async () => {
+         // The set Model.withoutPreaggregateEntries strips from the manifest, so
+         // getting it wrong in either direction is a live bug: too wide drops an
+         // author's own persist routing, too narrow puts a rollup entry in front
+         // of a model that cannot use it. Read off the plan's `origin` rather
+         // than matched on the `__preagg__` naming convention, which an author's
+         // source could collide with.
+         process.env.PREAGGREGATE_MODE = "build-only";
+         const pkg =
+            await loadPackage(`##! experimental { persistence composite_sources }
+source: raw is duckdb.sql("""SELECT 10 AS amount, 'A' AS category""")
+
+#@ persist name="orders_t"
+source: orders is raw -> { group_by: category; aggregate: amount_sum is amount.sum() } extend {
+  #@ preaggregate grain="category"
+  measure: total is amount_sum.sum()
+}
+`);
+         const sources = planSources(pkg);
+         const authored = sources.find((s) => s.origin === "persist");
+         const synthesized = sources.find((s) => s.origin === "preaggregate");
+         const ids = pkg.getPreaggregateEntityIds();
+         expect(ids.size).toBe(1);
+         expect(ids.has(synthesized!.sourceEntityId!)).toBe(true);
+         expect(ids.has(authored!.sourceEntityId!)).toBe(false);
+      },
+      { timeout: 60000 },
+   );
 });
 
 describe("the serve seam", () => {
@@ -192,7 +223,14 @@ describe("the serve seam", () => {
       );
    }
 
-   const COVERED = "run: orders -> { group_by: category; aggregate: total }";
+   // `order_by: category` is load-bearing, not tidiness. Both categories total
+   // 30, so Malloy's default ordering (by the first measure, descending) is a
+   // TIE, and the two shapes below break it differently — the live shape reads
+   // the base while the routed one reads the composite. Without an explicit
+   // order the row-for-row comparison in the first test failed on roughly two
+   // runs in three, which reads as a routing bug and is not one.
+   const COVERED =
+      "run: orders -> { group_by: category; aggregate: total; order_by: category }";
 
    it(
       "answers a covered query identically with routing on and off",
@@ -268,6 +306,94 @@ source: orders is duckdb.sql("""SELECT 10 AS amount, 'A' AS category""") extend 
 `);
          const rows = await run(pkg, COVERED);
          expect(rows).toEqual([{ category: "A", total: 10 }]);
+      },
+      { timeout: 60000 },
+   );
+
+   it(
+      "serves a source the companion does not import, rather than failing",
+      async () => {
+         // The case the routing block's catch exists for, and the one neither
+         // test above reaches: annotations DO exist (so a companion is compiled
+         // and every query on the file is offered to it) but the query names a
+         // source the companion never imported, because that source has no
+         // measure to roll up.
+         //
+         // `"falls back to live for a query no rollup covers"` does not cover
+         // this: it groups by a field ON the annotated source, which compiles
+         // against the companion fine and returns through the base member.
+         // `"leaves a model with no annotations untouched"` does not either:
+         // with no annotations there is no companion and the block is skipped.
+         //
+         // Malloy compiles lazily, so before the eager `getSQL` probe the
+         // compile error escaped PAST that catch and surfaced as a 400 —
+         // `Reference to undefined object 'regions'` — for every query naming an
+         // unannotated sibling.
+         process.env.PREAGGREGATE_MODE = "on";
+         const pkg = await loadPackage(`${MODEL}
+source: regions is duckdb.sql("""
+  SELECT * FROM (VALUES ('north'), ('north'), ('south')) AS t(region)
+""") extend {
+  measure: region_count is count()
+}
+`);
+         const rows = await run(
+            pkg,
+            "run: regions -> { group_by: region; aggregate: region_count; order_by: region }",
+         );
+         expect(rows).toEqual([
+            { region: "north", region_count: 2 },
+            { region: "south", region_count: 1 },
+         ]);
+         // And the annotated source in the same file still routes.
+         expect(await run(pkg, COVERED)).toEqual([
+            { category: "A", total: 30 },
+            { category: "B", total: 30 },
+         ]);
+      },
+      { timeout: 60000 },
+   );
+
+   it(
+      "keeps a synthesized rollup's manifest entry away from the author's model",
+      async () => {
+         // A rollup exists only in the companion, so its manifest entry can
+         // substitute nothing in the author's model — and handing it over is not
+         // merely useless: Malloy refuses a non-empty `buildManifest` against a
+         // model without `##! experimental.persistence`, which a model that only
+         // declares `#@ preaggregate` has no reason to carry (the companion
+         // declares its own flags). So a bound manifest used to turn EVERY query
+         // on such a model into a 400 — which is what `build-only` does by
+         // definition, since it binds a manifest and compiles no companion.
+         process.env.PREAGGREGATE_MODE = "build-only";
+         const pkg = await loadPackage(`source: orders is duckdb.sql("""
+  SELECT * FROM (VALUES (10, 'A'), (20, 'A'), (30, 'B')) AS t(amount, category)
+""") extend {
+  #@ preaggregate grain="category"
+  measure: total is amount.sum()
+}
+`);
+         const rollupIds = [...pkg.getPreaggregateEntityIds()];
+         expect(rollupIds).toHaveLength(1);
+         // Deliberately a table that does not exist: if the entry ever reaches
+         // the author's model this test fails loudly rather than passing on a
+         // substitution that happened to work.
+         pkg.bindColocatedServeManifest(
+            Object.fromEntries(
+               rollupIds.map((id) => [
+                  id,
+                  {
+                     tableName: "no_such_rollup_table",
+                     connectionName: "duckdb",
+                  },
+               ]),
+            ),
+         );
+         expect(pkg.hasBoundTableNameManifest()).toBe(true);
+         expect(await run(pkg, COVERED)).toEqual([
+            { category: "A", total: 30 },
+            { category: "B", total: 30 },
+         ]);
       },
       { timeout: 60000 },
    );


### PR DESCRIPTION
Follow-up to #1024. Two bugs made `PREAGGREGATE_MODE` unusable above `off`. They ship together because fixing the first alone only moves the failure: it makes the live path reachable in `on`, which is where the second one lives.

## `on` broke every unannotated source in an annotated model file

The routing block swaps in the companion model for **every** query on a file that declares `#@ preaggregate` anywhere, and wraps the swap in a `try`/`catch` meant to serve live when the query does not compile there. But `loadRestrictedQuery` returns a **lazy** `QueryMaterializer` — it cannot throw at that point. The compile error escaped at prepare/run, past the catch, as `Reference to undefined object '<source>'`.

So a source with no measure to roll up was unqueryable the moment a sibling source in the same file got an annotation. From boot, no build involved. On a realistic package that is most of it.

The storage tier hit this exact problem and left the fix documented in `loadServeShapeQuery`:

> Compile eagerly so ineligibility surfaces HERE — Malloy compiles lazily, so without this the error would escape at prepare/run instead of at the caller's try, defeating the safe fallback.

Pre-aggregation copied the `try`/`catch` but not the `await`. This adds it, threading the **givens and build manifest the run will use** — without them the probe would reject a `given:`-using query the run would have accepted, which is a silent loss of acceleration rather than an error, and this feature's worst failure mode.

## `build-only` broke every query on a model without `##! experimental.persistence`

`build-only` builds the rollups and binds a manifest, but compiles no companion. Those entries reached the author's model — which has no reason to carry the persistence flag, since the companion declares its own — and Malloy refuses a non-empty `buildManifest` without it:

```
HTTP 400: A non-empty `buildManifest` was supplied, but the model is
missing `##! experimental.persistence`.
```

Every query on the model, covered or not. `on` masked it only because every query reached the companion, which does have the flag.

The rule is by **origin, not by mode**: a synthesized rollup exists only in the companion and can substitute nothing anywhere else, so its entry is stripped from the manifest handed to the author's model — on the query path, on the runtime live-fallback retry, and in notebook cells alike. Read off the build plan's `origin`, which exists to carry exactly this provenance, rather than the `__preagg__` naming convention an author's source could collide with. There is precedent in the same function: the storage tier already suppresses the manifest for its transient shape for the same reason.

## Tests

Three regression cases, each **verified to fail on `dff6642b`** and pass here:

- a query naming a source the companion does not import
- a bound rollup manifest against a flagless model, pointed at a deliberately non-existent table so a regression fails loudly rather than passing on a substitution that happened to work
- the origin classification, against a package holding both an authored `#@ persist` source and a synthesized rollup

Neither existing serve-seam test reached the catch, which is why this went unnoticed: `"falls back to live for a query no rollup covers"` groups by a field **on** the annotated source, which compiles against the companion fine and returns through the base member; `"leaves a model with no annotations untouched"` has no annotations, so no companion is built and the block is skipped. The gap was the case where both are true at once.

Also pins the row order in the shared `COVERED` fixture query. Both categories total 30, so the default ordering is a tie the live and routed shapes break differently — it fails roughly two full-file runs in three on the parent commit, which reads as a routing bug and is not one. Separate defect from the two above; happy to split it out.

## Verification

- `bun run test:unit` — 2609 pass, 0 fail. `tsc --noEmit`, eslint and prettier clean on all touched files.
- `bun run test:integration` — 255 pass. The 1 failure is the concurrent-package E2E timing out on `gs://publisher_test_packages/gcs_faa.zip` (needs GCS access), the same one #1024's test plan documented; of the 4 errors, 3 are `beforeAll() expects a function as the second argument` parse failures in spec files this diff does not touch, and 1 is a ConnectionRefused cascading from the GCS timeout.
- End to end on a DuckDB package (20k rows, three grains across `count`/`sum`/`max`): in `on`, unannotated siblings now answer; routing is unchanged, proven by mutating the base after a build and confirming the six covered queries still return pre-build numbers byte-identically to before this change while the two uncovered ones pick up the new rows. In `build-only`, all eight queries answer live at live latency while three rollups still build and bind.
- No measurable cost from the extra probe: routed queries 3-12ms vs live 33-35ms, unchanged.

## Not addressed

`#1024`'s cost argument for multiple grains rests on picking the *smallest* rollup that covers a query, but the composite members are emitted sorted by synthesized name (grain slug plus digest, unrelated to cardinality) and the resolver takes the first member that covers. My fixtures could not distinguish first-wins from smallest-wins, because the alphabetically-first covering member also happened to be the smallest. Worth a separate look; it is a cost question, not a correctness one.

No routing metric added. `preaggRouted` means "compiled against the companion", not "served from a rollup" — a query can compile there and still resolve to the base member — so reporting it as a hit rate would be wrong, and #1024's reasoning for having no such metric stands.