### PR TITLE
chore: stamp the shipped release notes, bump skills, and document the release process

### DIFF
--- a/.claude/skills/publisher-release/SKILL.md
+++ b/.claude/skills/publisher-release/SKILL.md
@@ -170,15 +170,32 @@ Check each against the commit that last set its version, over the paths its
   `packages/skills/package.json` (its publish job bakes the skills version into
   its dependency range)
 
+**First ask whether it is already bumped.** A push only runs `check_pack`, so a
+merged bump sits on `main` while npm still reports the old version — which is
+the normal state between a release-prep merge and the dispatch. Skip this whole
+step when `main` is already ahead:
+
+```bash
+npm view @malloy-publisher/skills version                       # what is published
+node -p "require('./packages/skills/package.json').version"     # what main declares
+```
+
+Different means it is bumped and pending; leave it alone. Only when they
+**match** does the content question arise:
+
 ```bash
 vb=$(git log --format=%h -S"\"version\": \"$(npm view @malloy-publisher/skills version)\"" \
        -- packages/skills/package.json | tail -1)
 git log --oneline "$vb..origin/main" -- skills/ packages/skills/ bun.lock package.json
 ```
 
-Any output means bump `packages/skills/package.json`. Same shape for the
+Any output there means bump `packages/skills/package.json`. Same shape for the
 scaffolder. This must be **merged to `main` before the dispatch**: the release
 reads `main`, not the release branch.
+
+Do not skip the equality check and read the log alone. Anchored at the commit
+that set npm's version, the log still reports a bump that has already merged,
+and "any output means bump" then walks the version a second time for nothing.
 
 ### 3. Stamp the release notes that already shipped
 
@@ -270,9 +287,21 @@ editing.
 
 - **Only `publish-packages` is red** → the sdk/app/server release completed and
   the tag exists; that job sits outside `gh-release`'s `needs`. Use *Re-run
-  failed jobs*, or dispatch `skills-npm.yml` then `create-malloy-package-npm.yml`
-  on `main`, in that order. Both skip a version already on npm. **Do not re-run
-  the release** — it walks the version forward and burns three npm versions.
+  failed jobs*, which re-enters that job alone and skips whatever already landed.
+  **Do not re-run the release** — it walks the version forward and burns three
+  npm versions.
+
+  Dispatching the children by hand also works, but it is *not* the same thing and
+  the skip does not come with it. Only `publish-packages` asks the registry and
+  skips; each child carries a **Verify this version is not already published**
+  step that `exit 1`s on a version npm already holds. So dispatching a child that
+  already published fails the run rather than no-opping. Ask npm first and
+  dispatch only the package still missing, keeping skills before the scaffolder:
+
+  ```bash
+  npm view @malloy-publisher/skills version
+  npm view @malloy-publisher/create-malloy-package version
+  ```
 - **"main moved during this release"** → expected and retryable, same recovery.
   It can fire on the second package after the first already published, so read
   the job summary rather than assuming nothing shipped.

--- a/.claude/skills/publisher-release/SKILL.md
+++ b/.claude/skills/publisher-release/SKILL.md
@@ -101,13 +101,23 @@ Three things are wrong with that, in rising order of consequence:
 - **It grows.** `main` never advances, so the walk restarts from the same old
   number every release and costs one `ls-remote` per step, forever.
 - **It stops at the first *free* number, not above the *highest*.** It is correct
-  today only because the tag sequence happens to be gapless and old release
-  branches are never deleted, giving it a second independent record. Neither is
-  enforced anywhere. Open a gap — delete a stale release branch whose tag was
-  never cut — and the next default run publishes *into* the gap, moving npm's
-  `latest` **backwards**.
+  today only because the tag sequence happens to be gapless, so "first free" and
+  "above the highest" are the same number. Nothing enforces that.
 - **It never asks npm**, which is the only authority on what is actually
-  published.
+  published — so a free branch-and-tag pair is all it takes, whatever the
+  registry holds.
+
+The two combine badly, and **passing an explicit version is what opens the
+hole.** Dispatch `0.0.250` while the walk would have reached `0.0.248`, and
+`0.0.248`/`0.0.249` become permanent gaps below the high-water mark. The next
+run dispatched *without* a version walks up, finds `0.0.248` free of branch and
+tag, publishes it, and `npm publish` moves the `latest` dist-tag **backwards** to
+a version older than the one before it. Nothing fails; the release goes green.
+
+Deleting a stale release branch whose tag was never cut opens a gap the same
+way. That one is likelier to fail loudly — if npm already holds the version, the
+publish 403s on immutability — but it fails loudly only by luck, and only if the
+version got as far as npm.
 
 The durable fix is to derive the floor from `npm view @malloy-publisher/sdk
 version` rather than from `main`. Until that lands, pass the version explicitly

--- a/.claude/skills/publisher-release/SKILL.md
+++ b/.claude/skills/publisher-release/SKILL.md
@@ -76,40 +76,51 @@ stamped in advance can name a version that does not exist.
 
 ## Which number to bump
 
-**Breaking changes take a minor bump.** A change that turns a package which
-loaded or built yesterday into one that does not — a refused annotation, a
+**A breaking change should take a minor bump** — a change that turns a package
+which loaded or built yesterday into one that does not: a refused annotation, a
 refused `#@ persist` combination, a load-time failure on syntax that previously
-passed — is breaking, however small the diff. Everything else is a patch.
+passed. Everything else is a patch.
 
-Being on `0.x` is not a licence to ship breaks as patches. Read the release
-note's own claims rather than the heading: a section can be titled `(BREAKING)`
-while its individual bullets say *"this cannot affect an existing package"*, and
-the reverse happens too. What counts is whether an existing package changes
-behaviour or stops working.
+That is the direction, not yet the record. **Every release on this line has been
+a patch**, including 0.0.242's `/pages` → `/data-apps` rename, which was
+breaking. So do not infer the bump from the diff on your own: propose it and get
+the maintainer's call. A narrow break may still be judged patch-worthy, and that
+judgement is theirs.
 
-### The floor problem, and why it only appears above 0.0.x
+Read the release note's own claims rather than its heading, either way. A
+section can be titled `(BREAKING)` while its individual bullets say *"this
+cannot affect an existing package"*, and the reverse happens too.
 
-`prepare`'s default version is a **patch bump of `main`'s stale
-`packages/sdk/package.json`**, walked forward until the branch and tag are free.
-That file lags npm permanently, so the walk is only ever safe while the released
-line is `0.0.x` and the walk lands above the last release by accident.
+### `prepare`'s default version is not trustworthy — always pass `-f version=`
 
-The first minor bump ends that. Once `0.1.0` is on npm, a run dispatched with
-**no version input** walks up from `main`'s old number, finds `0.0.248`
-unclaimed, publishes it, and `npm publish` moves the `latest` dist-tag
-**backwards**. Nothing in the workflow catches it.
+`prepare`'s default patch-bumps **`main`'s `packages/sdk/package.json`**, which
+lags npm permanently because release branches are never merged back, then walks
+forward until it finds a version whose release branch and tag are both free.
+Three things are wrong with that, in rising order of consequence:
 
-Two things keep it closed:
+- **It grows.** `main` never advances, so the walk restarts from the same old
+  number every release and costs one `ls-remote` per step, forever.
+- **It stops at the first *free* number, not above the *highest*.** It is correct
+  today only because the tag sequence happens to be gapless and old release
+  branches are never deleted, giving it a second independent record. Neither is
+  enforced anywhere. Open a gap — delete a stale release branch whose tag was
+  never cut — and the next default run publishes *into* the gap, moving npm's
+  `latest` **backwards**.
+- **It never asks npm**, which is the only authority on what is actually
+  published.
 
-- **Always pass `-f version=`.** Never rely on the default walk.
-- **After a minor release, bump `main`'s sdk/app/server to the version that just
-  shipped**, in the post-release PR. That resets the floor so even the default
-  walk lands above it.
+The durable fix is to derive the floor from `npm view @malloy-publisher/sdk
+version` rather than from `main`. Until that lands, pass the version explicitly
+on every dispatch.
 
-Do that bump **after** the release, never before. `prepare` runs `set_version`
-and then `git add` + `git commit -s` over those three files only; if `main`
-already carries the version being released, there is no diff, `git commit` exits
-non-zero, and the step dies under `set -euo pipefail` before anything is pushed.
+**If the line ever moves off `0.0.x`,** the second problem stops being
+hypothetical: with `0.1.0` published, a default run walks up from `main`'s old
+number, finds `0.0.248` free, and publishes below `latest`. Reset the floor by
+setting `main`'s sdk/app/server to the version that just shipped — in the
+**post-release** PR, never before. `prepare` runs `set_version`, `git add` and
+`git commit -s` over those three files only; if `main` already carries the
+version being released there is no diff, `git commit` exits non-zero, and the
+step dies under `set -euo pipefail` before anything is pushed.
 
 ## The three version trains
 
@@ -198,8 +209,8 @@ need it while you have the mapping in front of you.
 
 Pass the version explicitly — always, and not merely to know the number in
 advance. Left to itself `prepare` patch-bumps `main`'s stale sdk version and
-walks forward until it finds a free branch and tag, which can publish *below*
-`latest`; see *The floor problem*, above.
+walks forward until it finds a free branch and tag, which is not the same as a
+version above `latest`; see *`prepare`'s default version is not trustworthy*.
 
 ```bash
 gh workflow run release.yml --repo malloydata/publisher --ref main -f version=<next>
@@ -235,7 +246,7 @@ Keep the generated header and append the sections beneath it. Then open the
 post-release PR to `main`, carrying:
 
 - the section stamped `## [<version>] — …`;
-- for a **minor or major** release, `packages/sdk`, `packages/app` and
+- for a **minor or major** release only, `packages/sdk`, `packages/app` and
   `packages/server` set to the version that just shipped, resetting the floor.
   Only now — doing it before the dispatch kills `prepare`'s commit.
 

--- a/.claude/skills/publisher-release/SKILL.md
+++ b/.claude/skills/publisher-release/SKILL.md
@@ -10,8 +10,7 @@ A release is one `workflow_dispatch` of `Release (NPM + Docker)`
 work has to land on `main` **before** that dispatch, or be written **after** it
 completes — and the step that is always skipped is the last one.
 
-Read [`.github/workflows/CONTEXT.md`](../../../.github/workflows/CONTEXT.md)
-before acting. It carries the publishing rules that are not guessable from the
+Read `.github/workflows/CONTEXT.md` (path from the repo root) before acting. It carries the publishing rules that are not guessable from the
 YAML, and it is the authority when this file and it disagree.
 
 ## Release notes: when to write one, and what number goes on it

--- a/.claude/skills/publisher-release/SKILL.md
+++ b/.claude/skills/publisher-release/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: publisher-release
+description: Cut a Malloy Publisher release, and write the RELEASE_NOTES.md entries a release ships. Use when asked to release, cut a release, ship a version, or publish Publisher to npm/Docker — and when a change needs a release note, or you are deciding whether it does and what version to stamp on it.
+---
+
+# Releasing Publisher
+
+A release is one `workflow_dispatch` of `Release (NPM + Docker)`
+(`.github/workflows/release.yml`). Everything else in this skill exists because
+work has to land on `main` **before** that dispatch, or be written **after** it
+completes — and the step that is always skipped is the last one.
+
+Read [`.github/workflows/CONTEXT.md`](../../../.github/workflows/CONTEXT.md)
+before acting. It carries the publishing rules that are not guessable from the
+YAML, and it is the authority when this file and it disagree.
+
+## Release notes: when to write one, and what number goes on it
+
+`RELEASE_NOTES.md` is not written at release time. **The PR that changes the
+behaviour writes the note**, in the same PR, as a `## [Unreleased]` section. The
+releaser only stamps a version on what is already there. Every section in that
+file arrived this way, and it is the only way the note gets written by someone
+who knows what changed.
+
+### Does this change need one?
+
+`gh-release` already attaches an auto-generated "What's Changed" list of merged
+PRs. **That list is sufficient for a routine patch**, so a note is not a per-PR
+chore. Write one when the PR list would leave a reader unable to act — when a
+user or operator has to *do* something, or would otherwise draw a wrong
+conclusion from an unchanged-looking system:
+
+- A **breaking change**, or anything needing a migration step. Mark the heading
+  `(BREAKING)`.
+- A **new or removed API field, endpoint, or response shape** — anything that
+  breaks a strict generated client, or that consumers should move onto.
+- A **deprecation**: what still works, for how long, and what to move to.
+- **Changed meaning of an existing signal** — a metric label, a counter, an
+  error code. A value that keeps its name and changes its basis is the case
+  most worth writing, because nothing else will surface it.
+- **A silent failure that is now visible**, or a bug whose symptom users have
+  been living with. Say who was affected and how to tell.
+- A **new capability with a cost or a limit** worth knowing before adopting it.
+
+Skip it for refactors, tests, docs, CI, and internal changes with no observable
+effect. When unsure, ask whether a reader upgrading blind could be surprised. If
+not, the PR list covers it.
+
+Write it for the person upgrading: what changed, what breaks, what to do. The
+existing sections are the house style — prose, not bullets-only, and specific
+about the failure mode.
+
+### What number goes on it
+
+Three states, in order:
+
+1. **`## [Unreleased] — <what changed>`** while the change sits on `main`
+   unreleased. This is what an authoring PR writes. Always.
+2. **Amend that same section in place** if a follow-up PR lands before the
+   release and changes the same behaviour. Do not add a second section — the two
+   ship together as one story, and the reader has never seen the first version.
+   #1024 (pre-aggregation off by default) and #1030 (on by default) are one
+   section for exactly this reason.
+3. **`## [<version>] — <what changed>`** once a release has shipped it. Stamped
+   by the releaser, in a PR to `main`, after the release succeeds — see step 6.
+   The number is the version that actually shipped it, which for a backlogged
+   section is *not* the release you are cutting.
+
+Once a section is stamped, it is history and does not get rewritten. A follow-up
+that changes that behaviour opens a **new** `[Unreleased]` section referencing
+the shipped version by number, the way the build-failures section names 0.0.245
+and 0.0.246 when describing what 0.0.247 changed.
+
+Never write a version number into a note speculatively. Release numbers are
+assigned by `prepare` at dispatch time and a release can fail, so a section
+stamped in advance can name a version that does not exist.
+
+## Which number to bump
+
+**Breaking changes take a minor bump.** A change that turns a package which
+loaded or built yesterday into one that does not — a refused annotation, a
+refused `#@ persist` combination, a load-time failure on syntax that previously
+passed — is breaking, however small the diff. Everything else is a patch.
+
+Being on `0.x` is not a licence to ship breaks as patches. Read the release
+note's own claims rather than the heading: a section can be titled `(BREAKING)`
+while its individual bullets say *"this cannot affect an existing package"*, and
+the reverse happens too. What counts is whether an existing package changes
+behaviour or stops working.
+
+### The floor problem, and why it only appears above 0.0.x
+
+`prepare`'s default version is a **patch bump of `main`'s stale
+`packages/sdk/package.json`**, walked forward until the branch and tag are free.
+That file lags npm permanently, so the walk is only ever safe while the released
+line is `0.0.x` and the walk lands above the last release by accident.
+
+The first minor bump ends that. Once `0.1.0` is on npm, a run dispatched with
+**no version input** walks up from `main`'s old number, finds `0.0.248`
+unclaimed, publishes it, and `npm publish` moves the `latest` dist-tag
+**backwards**. Nothing in the workflow catches it.
+
+Two things keep it closed:
+
+- **Always pass `-f version=`.** Never rely on the default walk.
+- **After a minor release, bump `main`'s sdk/app/server to the version that just
+  shipped**, in the post-release PR. That resets the floor so even the default
+  walk lands above it.
+
+Do that bump **after** the release, never before. `prepare` runs `set_version`
+and then `git add` + `git commit -s` over those three files only; if `main`
+already carries the version being released, there is no diff, `git commit` exits
+non-zero, and the step dies under `set -euo pipefail` before anything is pushed.
+
+## The three version trains
+
+| Packages | Version | Bumped by |
+| --- | --- | --- |
+| `sdk`, `app`, `server` | lockstep | `release.yml` itself, on a `release/sdk-<v>` branch never merged back |
+| `skills` | its own line | you, by hand, on `main` |
+| `create-malloy-package` | its own line | you, by hand, on `main` |
+
+`main`'s `packages/sdk/package.json` lags npm permanently — release branches are
+never merged back. Never treat it as the current version; ask npm.
+
+## Order, and why each step is where it is
+
+### 1. Establish where things actually stand
+
+```bash
+git fetch --tags origin
+npm view @malloy-publisher/server version              # the real current version
+git log --oneline "v$(npm view @malloy-publisher/server version)..origin/main"
+```
+
+That commit list is what this release ships. If it is empty, there is nothing to
+release.
+
+### 2. Bump the independently-versioned packages, if their content changed
+
+`publish-packages` decides purely on the version in `main`'s `package.json`, and
+**a change that lands without a bump is skipped while the release stays green.**
+Nothing else in CI requires the bump, so nothing else will catch it.
+
+Check each against the commit that last set its version, over the paths its
+*published content* is built from — which is not the same as where it lives:
+
+- `skills` → `skills/`, `packages/skills/`, `bun.lock`, root `package.json`
+- `create-malloy-package` → `packages/create-malloy-package/`, and
+  `packages/skills/package.json` (its publish job bakes the skills version into
+  its dependency range)
+
+```bash
+vb=$(git log --format=%h -S"\"version\": \"$(npm view @malloy-publisher/skills version)\"" \
+       -- packages/skills/package.json | tail -1)
+git log --oneline "$vb..origin/main" -- skills/ packages/skills/ bun.lock package.json
+```
+
+Any output means bump `packages/skills/package.json`. Same shape for the
+scaffolder. This must be **merged to `main` before the dispatch**: the release
+reads `main`, not the release branch.
+
+### 3. Stamp the release notes that already shipped
+
+`RELEASE_NOTES.md` accumulates `## [Unreleased]` sections. Stamping them is a
+manual post-release step, so it is the step that gets dropped — and the sections
+then pile up silently across several releases, because nothing in CI reads this
+file. Before cutting, reconcile the backlog: for each `[Unreleased]` section,
+find the commit that introduced it and the first release tag containing that
+commit.
+
+```bash
+grep '^## \[Unreleased\]' RELEASE_NOTES.md | while IFS= read -r h; do
+  body="${h#*— }"
+  c=$(git log --format=%h -S"$body" -- RELEASE_NOTES.md | tail -1)
+  t=$(git tag --contains "$c" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | head -1)
+  printf '%s\n  %s  first tag: %s\n' "$body" "$c" "${t:-NOT YET RELEASED}"
+done
+```
+
+A tag means that section already shipped and belongs to that version, not to the
+release you are cutting. Two traps:
+
+- **A section is often edited after it lands.** Stamp the version whose behaviour
+  the section as currently written describes, not the one that created the file.
+  Re-run the loop over every commit that touched the section, not just the first.
+- **There is regularly more than one live section.** They are separate entries in
+  the same release, not alternatives. Shipping "the relevant one" drops the rest.
+
+Land the backfill stamps with the step-2 bump, in one PR. Leave the section for
+the work being released now as `[Unreleased]` — its number is not final until
+the release succeeds (see *What number goes on it*, above).
+
+A backlogged section also means its own release page never got the narrative.
+Backfilling those pages is step 6's job, not this one, but note which versions
+need it while you have the mapping in front of you.
+
+### 4. Dispatch
+
+Pass the version explicitly — always, and not merely to know the number in
+advance. Left to itself `prepare` patch-bumps `main`'s stale sdk version and
+walks forward until it finds a free branch and tag, which can publish *below*
+`latest`; see *The floor problem*, above.
+
+```bash
+gh workflow run release.yml --repo malloydata/publisher --ref main -f version=<next>
+```
+
+**Do not merge to `main` while it runs.** `publish-packages` aborts if `main`
+moves under a watched path mid-release. A `RELEASE_NOTES.md`-only merge is not
+watched, but the window is short — just wait.
+
+### 5. Verify what actually shipped
+
+A green tick is not evidence. Read the run's **job summary**, which names each
+independently-versioned package as published or skipped and why.
+
+```bash
+npm view @malloy-publisher/server version
+npm view @malloy-publisher/skills version
+gh release view "v<version>" --repo malloydata/publisher
+```
+
+### 6. Write the narrative onto the release page
+
+`gh-release` writes a fixed header (npm links, Docker pull, branch) plus an
+auto-generated PR list. It does **not** read `RELEASE_NOTES.md`. Narrative —
+breaking changes, migration steps, new fields, changed metric labels — reaches
+users only if you paste it:
+
+```bash
+gh release edit "v<version>" --repo malloydata/publisher --notes-file <file>
+```
+
+Keep the generated header and append the sections beneath it. Then open the
+post-release PR to `main`, carrying:
+
+- the section stamped `## [<version>] — …`;
+- for a **minor or major** release, `packages/sdk`, `packages/app` and
+  `packages/server` set to the version that just shipped, resetting the floor.
+  Only now — doing it before the dispatch kills `prepare`'s commit.
+
+If step 3 turned up sections that shipped in *earlier* releases, those release
+pages are missing their narrative too. Edit each one with the sections that
+version actually shipped — the same `gh release edit` call, per tag. This is a
+public, already-published page, so show the body and get sign-off before
+editing.
+
+## If it fails
+
+- **Only `publish-packages` is red** → the sdk/app/server release completed and
+  the tag exists; that job sits outside `gh-release`'s `needs`. Use *Re-run
+  failed jobs*, or dispatch `skills-npm.yml` then `create-malloy-package-npm.yml`
+  on `main`, in that order. Both skip a version already on npm. **Do not re-run
+  the release** — it walks the version forward and burns three npm versions.
+- **"main moved during this release"** → expected and retryable, same recovery.
+  It can fire on the second package after the first already published, so read
+  the job summary rather than assuming nothing shipped.
+- **Anything after `npm-sdk.yml` published** → not resumable at the same version.
+  npm versions are immutable; move forward.
+
+## Prereleases
+
+Any hyphen in the version skips `gh-release` *and* both independently-versioned
+packages, because their own versions carry no hyphen and would take over the
+`latest` tag. Ship those from an ordinary release.

--- a/.github/workflows/CONTEXT.md
+++ b/.github/workflows/CONTEXT.md
@@ -99,21 +99,26 @@ workflow file, and wire it into `release.yml`'s `publish-packages` so a release 
 
 ### Recovering a failed release
 
-The two independently-versioned packages are safe to retry: `publish-packages` asks the registry
-first and skips a version that is already published, so re-running it republishes nothing.
+The two independently-versioned packages are safe to retry **through `publish-packages`**: that job
+asks the registry first and skips a version that is already published, so re-running it republishes
+nothing. The skip lives in that job, not in the children — each child's "Verify this version is not
+already published" step `exit 1`s on a version npm already holds, so a hand-dispatched child that
+already published fails rather than no-opping.
 
 **If `publish-packages` is the only red job, do not re-run the release.** It sits outside
 `gh-release`'s `needs`, so it neither blocked nor undid the tag: the sdk/app/server release completed
 and only the two dispatches are outstanding. Use "Re-run failed jobs", which re-enters that job alone
-against a now-settled `main` and skips whatever already landed, or dispatch `skills-npm.yml` and then
-`create-malloy-package-npm.yml` on `main` by hand, in that order. Re-running `release.yml` instead
-walks the version forward and burns three npm versions for nothing.
+against a now-settled `main` and skips whatever already landed. Dispatching `skills-npm.yml` and then
+`create-malloy-package-npm.yml` on `main` by hand also works, in that order, but ask npm which of the
+two is still missing and dispatch only that one — per the note above, a child whose version is already
+published fails its own guard. Re-running `release.yml` instead walks the version forward and burns
+three npm versions for nothing.
 
 The "main moved during this release" abort is an expected, retryable failure of this kind. It fails
 before dispatching the package it names, but note it can fire on the second package after the first
 has already published, so read the job summary for what actually shipped rather than assuming the
-registry is untouched. Either recovery above is safe either way, because both skip a version that is
-already on npm.
+registry is untouched. Re-running `publish-packages` is safe either way, because it skips a version
+that is already on npm; a hand dispatch is safe only for the package that has not published yet.
 
 It fires only when `main` moved **under the paths that package's published content is built from**, not
 on any movement at all: the second package is checked after the first has finished a full

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,82 +18,7 @@ One behaviour change to know about: `skills-npm.yml` now publishes only from `ma
 
 ---
 
-## [Unreleased] — a build that loses one source keeps the rest
 
-A build that failed on any source abandoned the whole command: it stopped at the first failure, reclaimed the tables already written, and reported one message for the entire run. A package where one source of five had a bad grant was indistinguishable from a package that was entirely broken, and the four tables that had already materialized were dropped on the way out.
-
-A source that fails is now recorded in the manifest with the reason it gave, and the build continues. The sources that materialized stay usable, and a consumer can tell which source failed rather than inferring it from an absent entry. A build that loses *every* source still fails — it produced nothing, so it must not report itself as a success with errors attached. A reuse-only run, which builds nothing of its own, is unaffected.
-
-**New response field.** `BuildManifest.failures` maps a sourceEntityId to a `SourceFailure` carrying `reason`, redacted against that source's own connection. A consumer generating a strict client from `api-doc.yaml` rejects the field until it regenerates; the key is absent on a run where every source built.
-
-Failures are reported *beside* `entries` rather than inside one, which is the part worth knowing if you consume a manifest. A failure carries the `physicalTableName` the source was headed for — useful for correlating with the request, and never a table to read: the build that would have created it is what failed, and a failed *rebuild* leaves the prior generation in place under that same name, so resolving it serves stale data rather than nothing.
-
-**`ManifestEntry.error` is deprecated.** 0.0.245 and 0.0.246 report a failed source as an entry carrying `error`, and that remains true for one more deprecation cycle: a failure is written to **both** `failures` and a mirrored entry, so a consumer reading `error` keeps working unchanged. Move to `failures` — `error` will be removed, and once it is, `entries` holds only sources that built.
-
-Until then a consumer that resolves an entry to a table must skip entries whose `error` is set. This is not hypothetical for stored manifests either: one committed by 0.0.245 or 0.0.246 on a partially-failed build records the failed source inside `entries` with a `physicalTableName` that was never created, and that state survives an upgrade. This build drops such entries where a persisted manifest is read back (serve rebind, reuse, reference resolution) rather than binding the name.
-
-**New metric label values.** `outcome` on the run counter gains `partial`, for a run that committed a manifest while some of its sources failed; the sources counter gains `failed`. A success-rate expression written as `success / (success + failed)` now drops `partial` into neither bucket, so a partial failure reads as a dip in volume rather than a failure. Alerting on that ratio should add `partial` to the denominator, or to the numerator's complement, depending on whether a partially served package counts as healthy for that deployment.
-
-**One existing label value changes meaning.** `outcome="built"` on the sources counter is counted from what the build returned, where before this release it was the length of the instruction list. An instruction can be skipped without building — an incremental source whose boundary already covers the requested range, or one with no matching compiled source — and the old count reported those as built. The new figure is lower by however many a run skips, so a deployment trending `built` will see a step change at upgrade that is a correction rather than a drop in work done. The change came with the partial-failure work above; it is called out here because the counter itself predates it.
-
-## [Unreleased] — `publisher.db` picks up new columns on upgrade
-
-An existing `publisher.db` has always picked up a new **table** added by a later build, because `CREATE TABLE IF NOT EXISTS` is idempotent. It never picked up a new **column**: that same statement is a no-op against a table that already exists, however its columns differ. So a store created before a column was introduced never gained it, schema initialization reported success anyway, and the first write naming that column failed at the binder.
-
-**If your `publisher.db` predates 2026-06-19, every `POST .../materializations` has been returning 500** with `Binder Error: Table "materializations" does not have a column with name "manifest"`. That store now repairs itself on the next boot. Materialization is the only thing that was affected; nothing else names the column.
-
-### What changed
-
-- **Schema init now reconciles columns.** After the `CREATE TABLE` pass, the declared shape is compared against what is on disk and anything declared-but-absent is added. Additions only, and only for columns carrying no constraint. A declared `DEFAULT` **is** carried across and backfills existing rows.
-- **What it cannot fix, it now says at boot.** A constrained column that cannot be added, or a column already present whose type, nullability, default or constraints have changed, is logged as a warning naming the column, instead of surfacing later as a binder error on an unrelated request. This is the part that keeps earning its keep after this particular column is behind us.
-- **Nothing is ever dropped.** Columns and tables an older store has and this build no longer declares are left in place and reported at debug level. `materializations.build_plan` (added and removed within four days in June 2026) and the `build_manifests` table are both inert relics of this kind; removing them is a decision for an operator, not something an upgrade should do quietly.
-
-### What is and is not carried across
-
-`ALTER TABLE ... ADD COLUMN` in DuckDB rejects a column carrying any constraint — `NOT NULL`, `PRIMARY KEY`, `UNIQUE`, `CHECK`, `FOREIGN KEY` — with or without a `DEFAULT`. A bare `DEFAULT` is accepted. So the safe subset is not a policy this code chose; it is the boundary the engine enforces.
-
-Constraints are read from `duckdb_constraints()` rather than inferred from nullability, which matters more than it sounds: a `UNIQUE` or `CHECK` column reports as _nullable_, so screening on nullability alone would add it as a bare column and leave the store holding the right column under the wrong rules — two servers on the same build enforcing differently depending on how their store was created. Such a column is refused and named in the warning instead.
-
-A future column outside the safe subset needs a hand-written step, and the boot warning is what tells you the day one appears.
-
-Constraints are also now compared on columns both sides already have, and reported the same way. A constraint added to an existing table's DDL is as invisible to `CREATE TABLE IF NOT EXISTS` as a column is, and the consequence is quieter: the older store keeps accepting rows a fresh one rejects, with nothing failing to say so.
-
-There is still no schema-version marker, and none is needed: the comparison is against the database itself. The expected shape is not written down twice either — it is read back from a scratch in-memory database the same DDL has just been run against, so the `CREATE TABLE` statements remain the single declaration of the schema.
-
-### On a large store
-
-Adding a column without a default is a catalog operation, not a data rewrite — on a 5M-row, 205MB `materializations` table it took 17ms and grew the file by 0.1%. Adding one **with** a `DEFAULT` backfills every existing row, so that path is a real write: ~81ms on the same table, with a longer checkpoint. Both are trivial against a boot that compiles packages, and both happen before the server accepts traffic, but only the first is free.
-
-### Why it took an upgrade to find
-
-CI starts from a clean checkout with no `publisher.db`, so the create path always runs with the current DDL and the drift cannot arise. The gap was never a missing assertion — it was that no test had ever booted against a store older than the build. There is one now.
----
-
-## [Unreleased] — measures can be pre-aggregated
-
-A measure annotated `#@ preaggregate grain="…"` is rolled up into a stored table at that grain, and a query the rollup covers reads the small table instead of the base. Queries name the original source and nothing about them changes; the rollup is selected behind it, or bypassed, with a per-query fallback to live for anything no rollup covers.
-
-[docs/preaggregation.md](docs/preaggregation.md) is the guide. Two limits to know before reaching for it, both of which cost acceleration and not correctness. **A query that names a `view:` does not route:** rollups are offered through a composite source, which carries its members' fields but not their views, so `run: orders -> by_category` serves live while the same query written out reads the rollup — which covers the REST `queryName` form and Console dashboards. **A query that supplies a `given:` does not route** either, since a model-level given does not cross into the synthesized model; that one is partly inherent, because a rollup is built with the givens in force at build time and could not answer a different value from stored rows anyway. Between them, a workload of named views or a filter-driven data app sees little benefit today.
-
-**The annotation is all it takes — there is no deployment flag to enable.** Writing one is the decision to build and serve a rollup, so a package that carries no `#@ preaggregate` is untouched: nothing extra is planned, built, or compiled for it. Worth knowing before adding your first annotation, because the build is not free: a rollup is materialized like any `#@ persist` source, and a grain whose cardinality approaches the base table's spends nearly as much as the base while saving little. `buildPlan.sources` with `origin: preaggregate` is where to see what a package will build before it builds it.
-
-**A measure may be declared at several grains, one annotation line each, and that is a cost decision.** A rollup also serves queries grouped by any *subset* of its grain, so one rollup at `category, order_day` correctly answers by-category, by-day and grand-total queries. But a combined grain has roughly the product of its dimensions' cardinalities, so `customer_id, order_day` can approach the base table's row count and save almost nothing where either grain alone is small. Declaring both separately gives each query a small table to read, at the price of two tables to build and refresh. Rollups are grouped by grain, not by measure: ten measures sharing a grain are one table and one `GROUP BY`. Note that where two declared grains both cover a query, the one used is the first in the composite's member order, which is by generated name rather than by size — so grains are worth declaring for queries they cover *differently*, not to offer the same query a choice.
-
-**Unusable annotations are refused at publish, and again at load.** Pre-aggregation's failure mode is an annotation that silently does nothing while the plan looks correct, so anything that cannot be built is a 400 rather than a warning. Refused: an annotation anywhere but on a measure; a measure whose aggregate cannot be re-aggregated from a stored partial (only `sum`, `count`, `min` and `max` can — pre-aggregate a sum and a count and divide them in a view instead); a grain naming anything but a dimension the source itself declares, which rules out an inline truncation like `grain="order_time.day"` (declare `dimension: order_day is order_time.day` and name that, after which coarser truncations of it route too); and a base source with a fan-out join, since `join_many` and `join_cross` can multiply rows. A `join_one` is permitted, and a measure that aggregates through one is served normally. Enforcing at load as well as at publish matters because re-aggregatability is derived from the compiled model: a Malloy version change can in principle reclassify a measure that published cleanly, and that surfaces as a package that stops loading (reported in `ServerStatus.loadErrors`) rather than one quietly paying for rollups that answer nothing.
-
-**API.** `PersistSourcePlan` gains `origin` (`persist` for a `#@ persist` the modeler wrote, `preaggregate` for a rollup the publisher synthesized) and `preaggregate`, a `PreaggregatePlan` naming the base source, the grain's dimensions, and the measures served at it. A synthesized rollup is declared by no file, so it reports the model holding the annotations it came from, which is where an author would go to change it. Nothing about a synthesized rollup appears in model discovery: the author's model is never edited, so it still exports the source it always did.
-
----
-
-## [Unreleased] — a `storage=` build's warehouse read is now attributable
-
-A `storage=` build reads its source through DuckDB's native query-passthrough, where no Malloy connector is in the call path to apply the query-metadata bag. Every such build therefore reached the warehouse untagged — the one kind of work a deployment could not attribute. It now carries the same bag the colocated path does, resolved through the same layering.
-
-**Snowflake** takes it as a session `QUERY_TAG`; its read is unchanged. **BigQuery** takes it as `@@query_label`, which it cannot do without splitting the read: `bigquery_query()` accepts no labels parameter and cannot run the script that would set one. So a labelled BigQuery read runs as `bigquery_execute` over a two-statement script, and the anonymous result table that job wrote is then read with `bigquery_scan`. Reading that table goes through the Storage Read API and creates no new query job, so the split is not a second scan. **Postgres** has no per-statement tag and is unaffected.
-
-**New operational prerequisite on BigQuery.** A labelled read locates its result table by listing the executed script's child job, an API surface the unsplit read never touched. A connection that cannot list its own jobs keeps the read it had before and loses attribution rather than its build — the fallback is decided by a probe issued _before_ anything runs, and counted by `publisher_storage_build_attribution_skipped_total`. Separately, and independent of tagging, the passthrough streams its results over the Storage Read API on every path: `bigquery.readsessions.create` (`roles/bigquery.readSessionUser`) is a standing requirement for materializing any BigQuery source into a storage destination.
-
-`ManifestEntry.queryCostBytes` is populated for a tagged `storage=` build, and the full per-engine cost — billed bytes, slot or execution time, the cache flag, the warehouse's own job ids — goes to the build's log line.
 ## [Unreleased] — `#(authorize)` can gate rows, not just the whole source (BREAKING)
 
 A gate whose expression reads no row field works exactly as before; a gate that reads one — its
@@ -196,7 +121,89 @@ whole source. This ships on, unconditionally — there is no flag to stage the r
 
 ---
 
-## [Unreleased] — queries report how they were served, and what they cost
+## [0.0.247] — a build that loses one source keeps the rest
+
+A build that failed on any source abandoned the whole command: it stopped at the first failure, reclaimed the tables already written, and reported one message for the entire run. A package where one source of five had a bad grant was indistinguishable from a package that was entirely broken, and the four tables that had already materialized were dropped on the way out.
+
+A source that fails is now recorded in the manifest with the reason it gave, and the build continues. The sources that materialized stay usable, and a consumer can tell which source failed rather than inferring it from an absent entry. A build that loses *every* source still fails — it produced nothing, so it must not report itself as a success with errors attached. A reuse-only run, which builds nothing of its own, is unaffected.
+
+**New response field.** `BuildManifest.failures` maps a sourceEntityId to a `SourceFailure` carrying `reason`, redacted against that source's own connection. A consumer generating a strict client from `api-doc.yaml` rejects the field until it regenerates; the key is absent on a run where every source built.
+
+Failures are reported *beside* `entries` rather than inside one, which is the part worth knowing if you consume a manifest. A failure carries the `physicalTableName` the source was headed for — useful for correlating with the request, and never a table to read: the build that would have created it is what failed, and a failed *rebuild* leaves the prior generation in place under that same name, so resolving it serves stale data rather than nothing.
+
+**`ManifestEntry.error` is deprecated.** 0.0.245 and 0.0.246 report a failed source as an entry carrying `error`, and that remains true for one more deprecation cycle: a failure is written to **both** `failures` and a mirrored entry, so a consumer reading `error` keeps working unchanged. Move to `failures` — `error` will be removed, and once it is, `entries` holds only sources that built.
+
+Until then a consumer that resolves an entry to a table must skip entries whose `error` is set. This is not hypothetical for stored manifests either: one committed by 0.0.245 or 0.0.246 on a partially-failed build records the failed source inside `entries` with a `physicalTableName` that was never created, and that state survives an upgrade. This build drops such entries where a persisted manifest is read back (serve rebind, reuse, reference resolution) rather than binding the name.
+
+**New metric label values.** `outcome` on the run counter gains `partial`, for a run that committed a manifest while some of its sources failed; the sources counter gains `failed`. A success-rate expression written as `success / (success + failed)` now drops `partial` into neither bucket, so a partial failure reads as a dip in volume rather than a failure. Alerting on that ratio should add `partial` to the denominator, or to the numerator's complement, depending on whether a partially served package counts as healthy for that deployment.
+
+**One existing label value changes meaning.** `outcome="built"` on the sources counter is counted from what the build returned, where before this release it was the length of the instruction list. An instruction can be skipped without building — an incremental source whose boundary already covers the requested range, or one with no matching compiled source — and the old count reported those as built. The new figure is lower by however many a run skips, so a deployment trending `built` will see a step change at upgrade that is a correction rather than a drop in work done. The change came with the partial-failure work above; it is called out here because the counter itself predates it.
+
+---
+
+## [0.0.246] — measures can be pre-aggregated
+
+A measure annotated `#@ preaggregate grain="…"` is rolled up into a stored table at that grain, and a query the rollup covers reads the small table instead of the base. Queries name the original source and nothing about them changes; the rollup is selected behind it, or bypassed, with a per-query fallback to live for anything no rollup covers.
+
+[docs/preaggregation.md](docs/preaggregation.md) is the guide. Two limits to know before reaching for it, both of which cost acceleration and not correctness. **A query that names a `view:` does not route:** rollups are offered through a composite source, which carries its members' fields but not their views, so `run: orders -> by_category` serves live while the same query written out reads the rollup — which covers the REST `queryName` form and Console dashboards. **A query that supplies a `given:` does not route** either, since a model-level given does not cross into the synthesized model; that one is partly inherent, because a rollup is built with the givens in force at build time and could not answer a different value from stored rows anyway. Between them, a workload of named views or a filter-driven data app sees little benefit today.
+
+**The annotation is all it takes — there is no deployment flag to enable.** Writing one is the decision to build and serve a rollup, so a package that carries no `#@ preaggregate` is untouched: nothing extra is planned, built, or compiled for it. Worth knowing before adding your first annotation, because the build is not free: a rollup is materialized like any `#@ persist` source, and a grain whose cardinality approaches the base table's spends nearly as much as the base while saving little. `buildPlan.sources` with `origin: preaggregate` is where to see what a package will build before it builds it.
+
+**A measure may be declared at several grains, one annotation line each, and that is a cost decision.** A rollup also serves queries grouped by any *subset* of its grain, so one rollup at `category, order_day` correctly answers by-category, by-day and grand-total queries. But a combined grain has roughly the product of its dimensions' cardinalities, so `customer_id, order_day` can approach the base table's row count and save almost nothing where either grain alone is small. Declaring both separately gives each query a small table to read, at the price of two tables to build and refresh. Rollups are grouped by grain, not by measure: ten measures sharing a grain are one table and one `GROUP BY`. Note that where two declared grains both cover a query, the one used is the first in the composite's member order, which is by generated name rather than by size — so grains are worth declaring for queries they cover *differently*, not to offer the same query a choice.
+
+**Unusable annotations are refused at publish, and again at load.** Pre-aggregation's failure mode is an annotation that silently does nothing while the plan looks correct, so anything that cannot be built is a 400 rather than a warning. Refused: an annotation anywhere but on a measure; a measure whose aggregate cannot be re-aggregated from a stored partial (only `sum`, `count`, `min` and `max` can — pre-aggregate a sum and a count and divide them in a view instead); a grain naming anything but a dimension the source itself declares, which rules out an inline truncation like `grain="order_time.day"` (declare `dimension: order_day is order_time.day` and name that, after which coarser truncations of it route too); and a base source with a fan-out join, since `join_many` and `join_cross` can multiply rows. A `join_one` is permitted, and a measure that aggregates through one is served normally. Enforcing at load as well as at publish matters because re-aggregatability is derived from the compiled model: a Malloy version change can in principle reclassify a measure that published cleanly, and that surfaces as a package that stops loading (reported in `ServerStatus.loadErrors`) rather than one quietly paying for rollups that answer nothing.
+
+**API.** `PersistSourcePlan` gains `origin` (`persist` for a `#@ persist` the modeler wrote, `preaggregate` for a rollup the publisher synthesized) and `preaggregate`, a `PreaggregatePlan` naming the base source, the grain's dimensions, and the measures served at it. A synthesized rollup is declared by no file, so it reports the model holding the annotations it came from, which is where an author would go to change it. Nothing about a synthesized rollup appears in model discovery: the author's model is never edited, so it still exports the source it always did.
+
+---
+
+## [0.0.245] — `publisher.db` picks up new columns on upgrade
+
+An existing `publisher.db` has always picked up a new **table** added by a later build, because `CREATE TABLE IF NOT EXISTS` is idempotent. It never picked up a new **column**: that same statement is a no-op against a table that already exists, however its columns differ. So a store created before a column was introduced never gained it, schema initialization reported success anyway, and the first write naming that column failed at the binder.
+
+**If your `publisher.db` predates 2026-06-19, every `POST .../materializations` has been returning 500** with `Binder Error: Table "materializations" does not have a column with name "manifest"`. That store now repairs itself on the next boot. Materialization is the only thing that was affected; nothing else names the column.
+
+### What changed
+
+- **Schema init now reconciles columns.** After the `CREATE TABLE` pass, the declared shape is compared against what is on disk and anything declared-but-absent is added. Additions only, and only for columns carrying no constraint. A declared `DEFAULT` **is** carried across and backfills existing rows.
+- **What it cannot fix, it now says at boot.** A constrained column that cannot be added, or a column already present whose type, nullability, default or constraints have changed, is logged as a warning naming the column, instead of surfacing later as a binder error on an unrelated request. This is the part that keeps earning its keep after this particular column is behind us.
+- **Nothing is ever dropped.** Columns and tables an older store has and this build no longer declares are left in place and reported at debug level. `materializations.build_plan` (added and removed within four days in June 2026) and the `build_manifests` table are both inert relics of this kind; removing them is a decision for an operator, not something an upgrade should do quietly.
+
+### What is and is not carried across
+
+`ALTER TABLE ... ADD COLUMN` in DuckDB rejects a column carrying any constraint — `NOT NULL`, `PRIMARY KEY`, `UNIQUE`, `CHECK`, `FOREIGN KEY` — with or without a `DEFAULT`. A bare `DEFAULT` is accepted. So the safe subset is not a policy this code chose; it is the boundary the engine enforces.
+
+Constraints are read from `duckdb_constraints()` rather than inferred from nullability, which matters more than it sounds: a `UNIQUE` or `CHECK` column reports as _nullable_, so screening on nullability alone would add it as a bare column and leave the store holding the right column under the wrong rules — two servers on the same build enforcing differently depending on how their store was created. Such a column is refused and named in the warning instead.
+
+A future column outside the safe subset needs a hand-written step, and the boot warning is what tells you the day one appears.
+
+Constraints are also now compared on columns both sides already have, and reported the same way. A constraint added to an existing table's DDL is as invisible to `CREATE TABLE IF NOT EXISTS` as a column is, and the consequence is quieter: the older store keeps accepting rows a fresh one rejects, with nothing failing to say so.
+
+There is still no schema-version marker, and none is needed: the comparison is against the database itself. The expected shape is not written down twice either — it is read back from a scratch in-memory database the same DDL has just been run against, so the `CREATE TABLE` statements remain the single declaration of the schema.
+
+### On a large store
+
+Adding a column without a default is a catalog operation, not a data rewrite — on a 5M-row, 205MB `materializations` table it took 17ms and grew the file by 0.1%. Adding one **with** a `DEFAULT` backfills every existing row, so that path is a real write: ~81ms on the same table, with a longer checkpoint. Both are trivial against a boot that compiles packages, and both happen before the server accepts traffic, but only the first is free.
+
+### Why it took an upgrade to find
+
+CI starts from a clean checkout with no `publisher.db`, so the create path always runs with the current DDL and the drift cannot arise. The gap was never a missing assertion — it was that no test had ever booted against a store older than the build. There is one now.
+
+---
+
+## [0.0.244] — a `storage=` build's warehouse read is now attributable
+
+A `storage=` build reads its source through DuckDB's native query-passthrough, where no Malloy connector is in the call path to apply the query-metadata bag. Every such build therefore reached the warehouse untagged — the one kind of work a deployment could not attribute. It now carries the same bag the colocated path does, resolved through the same layering.
+
+**Snowflake** takes it as a session `QUERY_TAG`; its read is unchanged. **BigQuery** takes it as `@@query_label`, which it cannot do without splitting the read: `bigquery_query()` accepts no labels parameter and cannot run the script that would set one. So a labelled BigQuery read runs as `bigquery_execute` over a two-statement script, and the anonymous result table that job wrote is then read with `bigquery_scan`. Reading that table goes through the Storage Read API and creates no new query job, so the split is not a second scan. **Postgres** has no per-statement tag and is unaffected.
+
+**New operational prerequisite on BigQuery.** A labelled read locates its result table by listing the executed script's child job, an API surface the unsplit read never touched. A connection that cannot list its own jobs keeps the read it had before and loses attribution rather than its build — the fallback is decided by a probe issued _before_ anything runs, and counted by `publisher_storage_build_attribution_skipped_total`. Separately, and independent of tagging, the passthrough streams its results over the Storage Read API on every path: `bigquery.readsessions.create` (`roles/bigquery.readSessionUser`) is a standing requirement for materializing any BigQuery source into a storage destination.
+
+`ManifestEntry.queryCostBytes` is populated for a tagged `storage=` build, and the full per-engine cost — billed bytes, slot or execution time, the cache flag, the warehouse's own job ids — goes to the build's log line.
+
+---
+
+## [0.0.244] — queries report how they were served, and what they cost
 
 The server measured several things and then discarded them, and the query
 histogram carried two labels that grew without bound. Both are addressed.
@@ -225,7 +232,7 @@ On the serve side, check `servedFrom` before reading a null as "free": a `storag
 
 ---
 
-## [Unreleased] — `storage=` builds from a Snowflake source now work (Docker image)
+## [0.0.243] — `storage=` builds from a Snowflake source now work (Docker image)
 
 The 0.0.236 notes below list `snowflake_query` among the native query-passthroughs a `storage=` source is materialized through. That was true of the code and never true of the published image: **materializing a Snowflake source into a storage destination has not worked at all.** Two independent faults, both fixed.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,7 +18,6 @@ One behaviour change to know about: `skills-npm.yml` now publishes only from `ma
 
 ---
 
-
 ## [Unreleased] — `#(authorize)` can gate rows, not just the whole source (BREAKING)
 
 A gate whose expression reads no row field works exactly as before; a gate that reads one — its

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/skills",
    "description": "Agent skills for Malloy and the Malloy Publisher",
-   "version": "0.1.5",
+   "version": "0.1.6",
    "license": "MIT",
    "type": "module",
    "main": "dist/index.js",


### PR DESCRIPTION
Prep for the next release. Three things, all of which have to be on `main` before the release workflow is dispatched.

### Stamp the release notes that already shipped

`RELEASE_NOTES.md` had **six `[Unreleased]` sections that were already out**. Stamping them is a manual post-release step, nothing in CI reads the file, so it got dropped after 0.0.242 and the backlog quietly compounded across five releases.

Each is now stamped with the version that actually shipped it:

| Section | Stamped |
| --- | --- |
| `storage=` builds from a Snowflake source | 0.0.243 |
| queries report how they were served, and what they cost | 0.0.244 |
| a `storage=` build's warehouse read is attributable | 0.0.244 |
| `publisher.db` picks up new columns on upgrade | 0.0.245 |
| measures can be pre-aggregated | 0.0.246 |
| a build that loses one source keeps the rest | 0.0.247 |

The last two take the **later** of the two versions that touched them. Pre-aggregation landed off-by-default in 0.0.245, then #1030 rewrote the section for 0.0.246's on-by-default behaviour; build-failures landed in 0.0.245, then #1023 rewrote it for 0.0.247's `failures` collection. In both cases the section as written describes the later version, and the build-failures text already narrates what 0.0.245 and 0.0.246 did.

The stamped region is also reordered newest-first. Ordering only started to signify once the headings stopped all reading `[Unreleased]`.

The `#(authorize)` section stays `[Unreleased]` — its number isn't final until the release succeeds.

### Bump `@malloy-publisher/skills` to 0.1.6

`skills/` changed in #1012 and #1013 since 0.1.5 published. `publish-packages` decides purely on the version in `main`'s `package.json`, and nothing else in CI requires the bump — so without this the release **skips the package and stays green**, which is one of the two silent skips `.github/workflows/CONTEXT.md` calls out.

`create-malloy-package` is untouched since 0.0.7 and is correctly skipped.

### Add `.claude/skills/publisher-release`

The release process was undocumented outside `CONTEXT.md`, which covers the workflow mechanics but not the human steps around them — which is roughly where the six stale sections came from. The skill covers:

- **When a change earns a release note at all.** The auto-generated PR list already covers routine patches, so a note is for breaking changes, API surface changes, deprecations, a signal that keeps its name and changes its meaning, and silent failures that are now visible.
- **The three heading states** — `[Unreleased]` written by the PR that changes the behaviour, amended in place if a follow-up lands before the release, stamped `[<version>]` after it ships.
- **Ordering constraints not visible in `release.yml`**: independently-versioned bumps must land before the dispatch, `main` must not move during the run, and the narrative has to be pasted onto the release page because `gh-release` doesn't read `RELEASE_NOTES.md`.
- **The floor problem.** `prepare`'s default version patch-bumps `main`'s permanently-stale `packages/sdk/package.json`. That's only safe while the released line is `0.0.x` and the walk lands above the last release by accident. Above that it can publish *below* `latest` and drag the dist-tag backwards. Recorded along with the fix, and with why the floor bump has to happen *after* a release — set it before and `prepare`'s `git commit` has nothing to commit and dies under `set -euo pipefail`.

### Tested

- Verified the notes reorder is content-preserving: sorted non-blank, non-separator, non-heading lines are byte-identical before and after, and the heading count is 16 either side. The diff is stamps and moves only.
- Mapped every stamp by locating the commit that introduced each section (`git log -S` over `RELEASE_NOTES.md`) and taking the first release tag containing it, then re-checking every later commit that touched the section.
- Confirmed `skills` needs the bump and `create-malloy-package` does not, by diffing each against the commit that last set its version over the paths its published content is built from — for skills that's `skills/`, `packages/skills/`, `bun.lock` and the root `package.json`, not just where the package lives.
