### PR TITLE
feat(server): authenticate an S3 storage root through the AWS credential chain

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -4747,8 +4747,15 @@ components:
           description: "AWS secret access key (required for `provider: config`)"
         region:
           type: string
-          description: AWS region (e.g., us-east-1)
-          default: us-east-1
+          description: >-
+            AWS region (e.g., us-east-1). Optional, and Publisher falls back to
+            us-east-1 when it is absent — but the fallback is applied in code, not
+            by this schema: a `default:` here would be documentation only, since
+            the generated clients leave an omitted property undefined rather than
+            filling it. Stated this way so a caller reading the schema does not
+            conclude the wire supplies it. A remote root in another region MUST
+            set this; omitting it reaches us-east-1 and fails as a missing bucket
+            rather than as a misconfiguration.
         endpoint:
           type: string
           description: Custom S3-compatible endpoint URL (optional, for MinIO, etc.)

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -4706,10 +4706,15 @@ components:
       type: object
       description: AWS S3 connection configuration for DuckDB
       properties:
-        # No schema `default:` here on purpose. openapi-typescript generates a
-        # property carrying a default as REQUIRED, so declaring one would force
-        # every existing caller to name a provider. The default is stated in the
-        # description and applied at attach time instead.
+        # No schema `default:` here on purpose, though the reason is narrower than
+        # it looks: at the pinned openapi-typescript (6.x) a defaulted property
+        # still generates as optional, so a `default:` would be harmless today. It
+        # is at 7.x that a default makes the property REQUIRED, which would force
+        # every caller to name a provider. Omitted for robustness across that bump,
+        # not to avoid a present-day break. Note `region` below carries a default
+        # and so already has that exposure — a 7.x upgrade has to deal with it
+        # either way. The default is stated in the description and applied when the
+        # connection is attached.
         provider:
           type: string
           enum:

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -4706,12 +4706,40 @@ components:
       type: object
       description: AWS S3 connection configuration for DuckDB
       properties:
+        # No schema `default:` here on purpose. openapi-typescript generates a
+        # property carrying a default as REQUIRED, so declaring one would force
+        # every existing caller to name a provider. The default is stated in the
+        # description and applied at attach time instead.
+        provider:
+          type: string
+          enum:
+            - config
+            - credential_chain
+          description: >-
+            How credentials are obtained; defaults to `config` when omitted.
+            `config` uses the accessKeyId and secretAccessKey on this object,
+            which are then required.
+            `credential_chain` resolves them from the host instead — an instance
+            profile, a web-identity token, or the environment — so no key is
+            stored, and supplying one is rejected. Chain resolution happens when
+            the connection is attached, so a host that cannot supply credentials
+            fails there rather than on first object access.
+        chain:
+          type: string
+          description: >-
+            Ordered list of credential providers to try, semicolon-separated,
+            for `provider: credential_chain` (DuckDB's CHAIN). Recognized
+            providers are env, config, sts, instance, sso, process, and
+            web_identity. Omit to use Publisher's default order, which covers
+            the environment, a web-identity token, and an instance profile.
+            Rejected under `provider: config`, where the key pair beside it
+            is what grants access.
         accessKeyId:
           type: string
-          description: AWS access key ID
+          description: "AWS access key ID (required for `provider: config`)"
         secretAccessKey:
           type: string
-          description: AWS secret access key
+          description: "AWS secret access key (required for `provider: config`)"
         region:
           type: string
           description: AWS region (e.g., us-east-1)
@@ -4722,9 +4750,6 @@ components:
         sessionToken:
           type: string
           description: AWS session token for temporary credentials (optional)
-      required:
-        - accessKeyId
-        - secretAccessKey
 
     AzureConnection:
       type: object

--- a/packages/sdk/src/components/Connections/AddConnectionDialog.tsx
+++ b/packages/sdk/src/components/Connections/AddConnectionDialog.tsx
@@ -56,6 +56,10 @@ export default function AddConnectionDialog({
    // DuckLake top-level connection state
    const [ducklakeCatalogType, setDucklakeCatalogType] = useState("postgres");
    const [ducklakeStorageType, setDucklakeStorageType] = useState("s3");
+   // Which S3 credential shape the storage fields are showing. Needed as state
+   // because this section renders uncontrolled inputs read from FormData, so
+   // `visibleWhen` has nothing to compare against without it.
+   const [ducklakeS3Provider, setDucklakeS3Provider] = useState("config");
 
    const handleClickOpen = () => {
       setOpen(true);
@@ -67,6 +71,7 @@ export default function AddConnectionDialog({
       setType("postgres");
       setDucklakeCatalogType("postgres");
       setDucklakeStorageType("s3");
+      setDucklakeS3Provider("config");
    };
 
    const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -123,11 +128,20 @@ export default function AddConnectionDialog({
                }
             });
             // Validate required fields
-            if (!s3Config.accessKeyId) {
-               throw new Error("S3 Access Key ID is required");
-            }
-            if (!s3Config.secretAccessKey) {
-               throw new Error("S3 Secret Access Key is required");
+            // Under `credential_chain` the host supplies the credential, so a key
+            // pair is not merely optional — the server rejects one that is present
+            // and unused.
+            if (s3Config.provider === "credential_chain") {
+               delete s3Config.accessKeyId;
+               delete s3Config.secretAccessKey;
+               delete s3Config.sessionToken;
+            } else {
+               if (!s3Config.accessKeyId) {
+                  throw new Error("S3 Access Key ID is required");
+               }
+               if (!s3Config.secretAccessKey) {
+                  throw new Error("S3 Secret Access Key is required");
+               }
             }
             if (Object.keys(s3Config).length > 0) {
                storageConfig.s3Connection = s3Config;
@@ -512,24 +526,60 @@ export default function AddConnectionDialog({
                                  >
                                     S3 Credentials
                                  </Typography>
-                                 {s3AttachedDatabaseFields.map((field) => (
-                                    <TextField
-                                       key={`s3_${field.name}`}
-                                       margin="dense"
-                                       id={`ducklake_s3_${field.name}`}
-                                       name={`ducklake_s3_${field.name}`}
-                                       label={field.label}
-                                       type={field.type}
-                                       fullWidth
-                                       variant="standard"
-                                       required={field.required}
-                                       placeholder={
-                                          field.name === "region"
-                                             ? "us-east-1"
-                                             : undefined
-                                       }
-                                    />
-                                 ))}
+                                 {s3AttachedDatabaseFields
+                                    .filter((field) =>
+                                       field.visibleWhen
+                                          ? ducklakeS3Provider ===
+                                            field.visibleWhen.value
+                                          : true,
+                                    )
+                                    .map((field) => (
+                                       <TextField
+                                          key={`s3_${field.name}`}
+                                          margin="dense"
+                                          id={`ducklake_s3_${field.name}`}
+                                          name={`ducklake_s3_${field.name}`}
+                                          label={field.label}
+                                          type={
+                                             field.selectOptions
+                                                ? undefined
+                                                : field.type
+                                          }
+                                          fullWidth
+                                          variant="standard"
+                                          required={field.required}
+                                          select={!!field.selectOptions}
+                                          defaultValue={
+                                             field.selectOptions
+                                                ? ducklakeS3Provider
+                                                : undefined
+                                          }
+                                          onChange={
+                                             field.name === "provider"
+                                                ? (e) =>
+                                                     setDucklakeS3Provider(
+                                                        e.target.value,
+                                                     )
+                                                : undefined
+                                          }
+                                          placeholder={
+                                             field.name === "region"
+                                                ? "us-east-1"
+                                                : undefined
+                                          }
+                                       >
+                                          {field.selectOptions?.map(
+                                             (option) => (
+                                                <MenuItem
+                                                   key={option.value}
+                                                   value={option.value}
+                                                >
+                                                   {option.label}
+                                                </MenuItem>
+                                             ),
+                                          )}
+                                       </TextField>
+                                    ))}
                               </>
                            )}
                            {ducklakeStorageType === "gcs" && (

--- a/packages/sdk/src/components/Connections/AddConnectionDialog.tsx
+++ b/packages/sdk/src/components/Connections/AddConnectionDialog.tsx
@@ -136,6 +136,12 @@ export default function AddConnectionDialog({
                delete s3Config.secretAccessKey;
                delete s3Config.sessionToken;
             } else {
+               // Symmetric with the deletion above, and load-bearing on the edit
+               // path: switching the provider to a key pair unmounts the chain
+               // field, so it never resubmits and a carried-forward value would
+               // survive into a config the server rejects — naming a field the form
+               // is no longer showing.
+               delete s3Config.chain;
                if (!s3Config.accessKeyId) {
                   throw new Error("S3 Access Key ID is required");
                }
@@ -216,6 +222,29 @@ export default function AddConnectionDialog({
                         connectionConfig[field.name] = value;
                      }
                   });
+
+                  // The S3 key fields are no longer HTML-`required`, because under
+                  // `credential_chain` there is no key to give and a hidden required
+                  // field blocks submit with nothing on screen to fix. Enforce the
+                  // pair here instead, where it can be conditional — otherwise a
+                  // keyless key-based attachment would save and fail at attach.
+                  if (dbType === "s3") {
+                     if (connectionConfig.provider === "credential_chain") {
+                        delete connectionConfig.accessKeyId;
+                        delete connectionConfig.secretAccessKey;
+                        delete connectionConfig.sessionToken;
+                     } else {
+                        delete connectionConfig.chain;
+                        if (
+                           !connectionConfig.accessKeyId ||
+                           !connectionConfig.secretAccessKey
+                        ) {
+                           throw new Error(
+                              `Attached database "${dbName}" requires an S3 Access Key ID and Secret Access Key, or Credential Provider set to the host credential chain`,
+                           );
+                        }
+                     }
+                  }
 
                   // Set the appropriate connection property based on type
                   const connectionFieldName =

--- a/packages/sdk/src/components/Connections/EditConnectionDialog.tsx
+++ b/packages/sdk/src/components/Connections/EditConnectionDialog.tsx
@@ -291,8 +291,9 @@ export default function EditConnectionDialog({
                   // field blocks submit with nothing on screen to fix. Enforce the
                   // pair here instead, where it can be conditional — otherwise a
                   // keyless key-based attachment would save and fail at attach. This
-                  // path has never carried an existing value forward, so requiring
-                  // re-entry is what the removed `required` already did.
+                  // does not ask anyone to retype a secret: the inputs are seeded
+                  // from the stored connection, so an untouched field resubmits its
+                  // existing value.
                   if (dbType === "s3") {
                      if (connectionConfig.provider === "credential_chain") {
                         delete connectionConfig.accessKeyId;

--- a/packages/sdk/src/components/Connections/EditConnectionDialog.tsx
+++ b/packages/sdk/src/components/Connections/EditConnectionDialog.tsx
@@ -80,10 +80,22 @@ export default function EditConnectionDialog({
    const [ducklakeStorageType, setDucklakeStorageType] = useState(() =>
       initDucklakeStorageType(connection),
    );
+   // Which S3 credential shape the storage fields are showing. Seeded from the
+   // connection being edited, so opening a host-credential connection shows the
+   // chain fields rather than empty key fields it does not use.
+   const [ducklakeS3Provider, setDucklakeS3Provider] = useState<string>(
+      () =>
+         connection.ducklakeConnection?.storage?.s3Connection?.provider ??
+         "config",
+   );
 
    const handleClickOpen = () => {
       setAttachedDatabases(initAttachedDatabases(connection));
       setType(connection.type);
+      setDucklakeS3Provider(
+         connection.ducklakeConnection?.storage?.s3Connection?.provider ??
+            "config",
+      );
       setDucklakeCatalogType("postgres");
       setDucklakeStorageType(initDucklakeStorageType(connection));
       setOpen(true);
@@ -147,10 +159,23 @@ export default function EditConnectionDialog({
                   s3Config[field.name] = value;
                }
             });
-            // For updates, use existing values if not provided
+            // For updates, use existing values if not provided. `provider` and
+            // `chain` are carried forward for the same reason the key pair is:
+            // this form rebuilds the whole s3Connection from its own fields, so
+            // anything it does not resubmit is dropped. Losing `provider` here
+            // silently downgrades a host-credential connection to a key-based one
+            // that has no key — and because the checks below used to be
+            // unconditional, it also made a chain-auth connection impossible to
+            // edit at all, including just its bucket URL.
             const existingS3 =
                connection.ducklakeConnection?.storage?.s3Connection;
             if (existingS3) {
+               if (!s3Config.provider && existingS3.provider) {
+                  s3Config.provider = existingS3.provider;
+               }
+               if (!s3Config.chain && existingS3.chain) {
+                  s3Config.chain = existingS3.chain;
+               }
                if (!s3Config.accessKeyId && existingS3.accessKeyId) {
                   s3Config.accessKeyId = existingS3.accessKeyId;
                }
@@ -158,12 +183,20 @@ export default function EditConnectionDialog({
                   s3Config.secretAccessKey = existingS3.secretAccessKey;
                }
             }
-            // Validate required fields
-            if (!s3Config.accessKeyId) {
-               throw new Error("S3 Access Key ID is required");
-            }
-            if (!s3Config.secretAccessKey) {
-               throw new Error("S3 Secret Access Key is required");
+            // Validate required fields. Under `credential_chain` the host supplies
+            // the credential, so a key pair is not merely optional — the server
+            // rejects one that is present and unused.
+            if (s3Config.provider === "credential_chain") {
+               delete s3Config.accessKeyId;
+               delete s3Config.secretAccessKey;
+               delete s3Config.sessionToken;
+            } else {
+               if (!s3Config.accessKeyId) {
+                  throw new Error("S3 Access Key ID is required");
+               }
+               if (!s3Config.secretAccessKey) {
+                  throw new Error("S3 Secret Access Key is required");
+               }
             }
             if (Object.keys(s3Config).length > 0) {
                storageConfig.s3Connection = s3Config;
@@ -625,32 +658,68 @@ export default function EditConnectionDialog({
                                  >
                                     S3 Credentials
                                  </Typography>
-                                 {s3AttachedDatabaseFields.map((field) => (
-                                    <TextField
-                                       key={`s3_${field.name}`}
-                                       margin="dense"
-                                       id={`ducklake_s3_${field.name}`}
-                                       name={`ducklake_s3_${field.name}`}
-                                       label={field.label}
-                                       type={field.type}
-                                       fullWidth
-                                       variant="standard"
-                                       required={
-                                          field.required &&
-                                          field.name !== "secretAccessKey"
-                                       }
-                                       defaultValue={getDucklakeDefault(
-                                          `s3_${field.name}`,
-                                       )}
-                                       placeholder={
-                                          field.name === "region"
-                                             ? "us-east-1"
-                                             : field.name === "secretAccessKey"
-                                               ? "Leave empty to keep existing"
-                                               : undefined
-                                       }
-                                    />
-                                 ))}
+                                 {s3AttachedDatabaseFields
+                                    .filter((field) =>
+                                       field.visibleWhen
+                                          ? ducklakeS3Provider ===
+                                            field.visibleWhen.value
+                                          : true,
+                                    )
+                                    .map((field) => (
+                                       <TextField
+                                          key={`s3_${field.name}`}
+                                          margin="dense"
+                                          id={`ducklake_s3_${field.name}`}
+                                          name={`ducklake_s3_${field.name}`}
+                                          label={field.label}
+                                          type={
+                                             field.selectOptions
+                                                ? undefined
+                                                : field.type
+                                          }
+                                          fullWidth
+                                          variant="standard"
+                                          required={
+                                             field.required &&
+                                             field.name !== "secretAccessKey"
+                                          }
+                                          select={!!field.selectOptions}
+                                          defaultValue={
+                                             field.selectOptions
+                                                ? ducklakeS3Provider
+                                                : getDucklakeDefault(
+                                                     `s3_${field.name}`,
+                                                  )
+                                          }
+                                          onChange={
+                                             field.name === "provider"
+                                                ? (e) =>
+                                                     setDucklakeS3Provider(
+                                                        e.target.value,
+                                                     )
+                                                : undefined
+                                          }
+                                          placeholder={
+                                             field.name === "region"
+                                                ? "us-east-1"
+                                                : field.name ===
+                                                    "secretAccessKey"
+                                                  ? "Leave empty to keep existing"
+                                                  : undefined
+                                          }
+                                       >
+                                          {field.selectOptions?.map(
+                                             (option) => (
+                                                <MenuItem
+                                                   key={option.value}
+                                                   value={option.value}
+                                                >
+                                                   {option.label}
+                                                </MenuItem>
+                                             ),
+                                          )}
+                                       </TextField>
+                                    ))}
                               </>
                            )}
                            {ducklakeStorageType === "gcs" && (

--- a/packages/sdk/src/components/Connections/EditConnectionDialog.tsx
+++ b/packages/sdk/src/components/Connections/EditConnectionDialog.tsx
@@ -191,6 +191,12 @@ export default function EditConnectionDialog({
                delete s3Config.secretAccessKey;
                delete s3Config.sessionToken;
             } else {
+               // Symmetric with the deletion above, and load-bearing on the edit
+               // path: switching the provider to a key pair unmounts the chain
+               // field, so it never resubmits and a carried-forward value would
+               // survive into a config the server rejects — naming a field the form
+               // is no longer showing.
+               delete s3Config.chain;
                if (!s3Config.accessKeyId) {
                   throw new Error("S3 Access Key ID is required");
                }
@@ -279,6 +285,31 @@ export default function EditConnectionDialog({
                         connectionConfig[field.name] = value;
                      }
                   });
+
+                  // The S3 key fields are no longer HTML-`required`, because under
+                  // `credential_chain` there is no key to give and a hidden required
+                  // field blocks submit with nothing on screen to fix. Enforce the
+                  // pair here instead, where it can be conditional — otherwise a
+                  // keyless key-based attachment would save and fail at attach. This
+                  // path has never carried an existing value forward, so requiring
+                  // re-entry is what the removed `required` already did.
+                  if (dbType === "s3") {
+                     if (connectionConfig.provider === "credential_chain") {
+                        delete connectionConfig.accessKeyId;
+                        delete connectionConfig.secretAccessKey;
+                        delete connectionConfig.sessionToken;
+                     } else {
+                        delete connectionConfig.chain;
+                        if (
+                           !connectionConfig.accessKeyId ||
+                           !connectionConfig.secretAccessKey
+                        ) {
+                           throw new Error(
+                              `Attached database "${dbName}" requires an S3 Access Key ID and Secret Access Key, or Credential Provider set to the host credential chain`,
+                           );
+                        }
+                     }
+                  }
 
                   const connectionFieldName =
                      attachedDatabaseConnectionFieldName[dbType];

--- a/packages/sdk/src/components/Connections/common.ts
+++ b/packages/sdk/src/components/Connections/common.ts
@@ -367,9 +367,12 @@ export const s3AttachedDatabaseFields: Array<ConnectionField> = [
    },
    // Neither key is `required` any more, because under `credential_chain` there is
    // no key to give and a hidden-but-required field blocks submit with nothing on
-   // screen to fix. Presence is enforced where it can be conditional: each dialog
-   // checks the pair only on the `config` path, and the server rejects a keyless
-   // `config` connection at config load.
+   // screen to fix. Presence is enforced where it can be conditional instead: each
+   // dialog checks the pair on the `config` path, in BOTH the DuckLake storage
+   // branch and the attached-database branch. Server-side, a keyless `config`
+   // storage DESTINATION is rejected at config load; a DuckLake connection or an
+   // attached database still fails at attach, because a load-time throw there would
+   // take the whole environment down with it.
    {
       label: "Access Key ID",
       name: "accessKeyId" as keyof S3Connection,

--- a/packages/sdk/src/components/Connections/common.ts
+++ b/packages/sdk/src/components/Connections/common.ts
@@ -356,16 +356,40 @@ export const attachedDatabaseConnectionFieldName: Record<string, string> = {
 // Fields for S3 attached database
 export const s3AttachedDatabaseFields: Array<ConnectionField> = [
    {
+      label: "Credential Provider",
+      name: "provider" as keyof S3Connection,
+      type: "text",
+      required: false,
+      selectOptions: [
+         { label: "Access key pair", value: "config" },
+         { label: "Host credential chain", value: "credential_chain" },
+      ],
+   },
+   // Neither key is `required` any more, because under `credential_chain` there is
+   // no key to give and a hidden-but-required field blocks submit with nothing on
+   // screen to fix. Presence is enforced where it can be conditional: each dialog
+   // checks the pair only on the `config` path, and the server rejects a keyless
+   // `config` connection at config load.
+   {
       label: "Access Key ID",
       name: "accessKeyId" as keyof S3Connection,
       type: "text",
-      required: true,
+      required: false,
+      visibleWhen: { field: "provider", value: "config" },
    },
    {
       label: "Secret Access Key",
       name: "secretAccessKey" as keyof S3Connection,
       type: "password",
-      required: true,
+      required: false,
+      visibleWhen: { field: "provider", value: "config" },
+   },
+   {
+      label: "Credential Chain",
+      name: "chain" as keyof S3Connection,
+      type: "text",
+      required: false,
+      visibleWhen: { field: "provider", value: "credential_chain" },
    },
    {
       label: "Region",
@@ -384,6 +408,7 @@ export const s3AttachedDatabaseFields: Array<ConnectionField> = [
       name: "sessionToken" as keyof S3Connection,
       type: "password",
       required: false,
+      visibleWhen: { field: "provider", value: "config" },
    },
 ];
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -687,6 +687,56 @@ export const getExtensionFetchPolicy = (): ExtensionFetchPolicy => {
 };
 
 /**
+ * Where an `s3` connection may select `provider: credential_chain` — host-resolved
+ * credentials rather than a configured key pair.
+ */
+export type S3CredentialChainPolicy = "any" | "destinations-only" | "off";
+
+/**
+ * Resolve the S3 credential-chain policy from `S3_CREDENTIAL_CHAIN_POLICY`; falls
+ * back to `any` when unset or empty.
+ *
+ * `credential_chain` makes DuckDB resolve the HOST's own credentials — on EKS the
+ * pod's IRSA role, on EC2 its instance profile. That is what the field is for, and
+ * on a single-tenant deployment it is unremarkable. It stops being unremarkable
+ * when the connection is authored by someone other than the operator: Publisher's
+ * connection create and test endpoints take an arbitrary body, so anyone who can
+ * reach them can ask the host to act as itself against any bucket its role permits.
+ * Publisher is documented as unauthenticated and localhost-only, so this is not a
+ * new bypass — but it raises what reaching the existing one is worth, and a
+ * deployment that fronts Publisher with its own authorization had no way to say so.
+ *
+ * - `any` (default): preserves prior behaviour. Any `s3` connection may name it.
+ * - `destinations-only`: permitted on a `storageDestinations` entry — which the
+ *   OPERATOR configures — and refused on an environment connection, which an
+ *   author may supply. The distinction is the point: a managed storage tier runs
+ *   on the host's identity by design, while a user connection naming it is asking
+ *   the host to lend that identity to an arbitrary bucket.
+ * - `off`: refused everywhere, for a deployment that mints no host-identity
+ *   access at all.
+ *
+ * Throws on an unrecognised value, for the same reason the extension policy does:
+ * a typo in a manifest should fail the boot rather than silently choose the
+ * permissive option.
+ */
+export const getS3CredentialChainPolicy = (): S3CredentialChainPolicy => {
+   const raw = process.env.S3_CREDENTIAL_CHAIN_POLICY;
+   if (raw === undefined || raw.trim() === "") return "any";
+   const normalised = raw.trim().toLowerCase();
+   if (
+      normalised === "any" ||
+      normalised === "destinations-only" ||
+      normalised === "off"
+   ) {
+      return normalised;
+   }
+   throw new Error(
+      `Invalid value for S3_CREDENTIAL_CHAIN_POLICY: expected "any", ` +
+         `"destinations-only" or "off", got "${raw}"`,
+   );
+};
+
+/**
  * The three `#@ persist storage=<conn>` deployment modes, read from
  * `PERSIST_STORAGE_MODE`. This is a runtime kill switch — flipping DOWN must
  * never fail an already-loaded package, only change how `storage=` is honored:

--- a/packages/server/src/service/connection.spec.ts
+++ b/packages/server/src/service/connection.spec.ts
@@ -23,6 +23,7 @@ import {
    createEnvironmentConnections,
    resolveProxiedTls,
    testConnectionConfig,
+   isExpiredCredentialError,
 } from "./connection";
 import {
    DEFAULT_S3_CREDENTIAL_CHAIN,
@@ -2711,5 +2712,33 @@ describe("attach retry after a transient failure", () => {
       expect(secretAttempts).toBe(2);
 
       await config.releaseConnections().catch(() => {});
+   });
+});
+
+describe("isExpiredCredentialError", () => {
+   it("matches an expired credential and nothing else", () => {
+      // The remedy this gates -- re-resolve and retry -- is right for a credential
+      // that aged out and wrong for one that was never valid: retrying a bad key
+      // hides a misconfiguration behind a silent second attempt.
+      expect(
+         isExpiredCredentialError(
+            new Error(
+               "HTTP 400 ... ExpiredToken: The provided token has expired.",
+            ),
+         ),
+      ).toBe(true);
+      expect(
+         isExpiredCredentialError(new Error("InvalidAccessKeyId: no such key")),
+      ).toBe(false);
+      expect(
+         isExpiredCredentialError(new Error("AccessDenied: not authorized")),
+      ).toBe(false);
+      expect(
+         isExpiredCredentialError(new Error("HTTP 404 no such bucket")),
+      ).toBe(false);
+      expect(isExpiredCredentialError(undefined)).toBe(false);
+      expect(isExpiredCredentialError("ExpiredToken as a bare string")).toBe(
+         true,
+      );
    });
 });

--- a/packages/server/src/service/connection.spec.ts
+++ b/packages/server/src/service/connection.spec.ts
@@ -20,11 +20,13 @@ import {
    buildCloudStorageSecretSQL,
    buildProxiedSslQuery,
    createEnvironmentConnections,
-   resolveCloudStorageCredentials,
    resolveProxiedTls,
    testConnectionConfig,
 } from "./connection";
-import { DEFAULT_S3_CREDENTIAL_CHAIN } from "./gcs_s3_utils";
+import {
+   DEFAULT_S3_CREDENTIAL_CHAIN,
+   resolveCloudStorageCredentials,
+} from "./gcs_s3_utils";
 import { assembleEnvironmentConnections } from "./connection_config";
 import { UnsupportedCatalogFormatError } from "../errors";
 import { EnvironmentStore } from "./environment_store";

--- a/packages/server/src/service/connection.spec.ts
+++ b/packages/server/src/service/connection.spec.ts
@@ -17,11 +17,14 @@ import sinon from "sinon";
 import { components } from "../api";
 import {
    attachDuckLakeReadWrite,
+   buildCloudStorageSecretSQL,
    buildProxiedSslQuery,
    createEnvironmentConnections,
+   resolveCloudStorageCredentials,
    resolveProxiedTls,
    testConnectionConfig,
 } from "./connection";
+import { DEFAULT_S3_CREDENTIAL_CHAIN } from "./gcs_s3_utils";
 import { assembleEnvironmentConnections } from "./connection_config";
 import { UnsupportedCatalogFormatError } from "../errors";
 import { EnvironmentStore } from "./environment_store";
@@ -2419,6 +2422,232 @@ describe("resolveProxiedTls", () => {
       expect(params.ssl).toEqual({
          servername: "db.internal.example.com",
          rejectUnauthorized: true,
+      });
+   });
+});
+
+describe("resolveCloudStorageCredentials", () => {
+   const s3 = (
+      s3Connection: components["schemas"]["S3Connection"],
+   ): AttachedDatabase => ({ name: "root", type: "s3", s3Connection });
+
+   it("requires a key pair when no provider is given", () => {
+      expect(() =>
+         resolveCloudStorageCredentials(s3({ region: "us-east-1" })),
+      ).toThrow(/accessKeyId and secretAccessKey are required for: root/);
+   });
+
+   it("requires a key pair under provider 'config'", () => {
+      expect(() =>
+         resolveCloudStorageCredentials(
+            s3({ provider: "config", accessKeyId: "AKIA" }),
+         ),
+      ).toThrow(/accessKeyId and secretAccessKey are required for: root/);
+   });
+
+   it("accepts a keyless connection under provider 'credential_chain'", () => {
+      const credentials = resolveCloudStorageCredentials(
+         s3({ provider: "credential_chain", region: "eu-west-2" }),
+      );
+      expect(credentials.provider).toBe("credential_chain");
+      expect(credentials.accessKeyId).toBe("");
+      expect(credentials.secretAccessKey).toBe("");
+      expect(credentials.region).toBe("eu-west-2");
+   });
+
+   // A key that is present and unused is a misconfiguration: it reads as the
+   // thing granting access while the host role actually does.
+   it.each([
+      ["accessKeyId", { accessKeyId: "AKIA" }],
+      ["secretAccessKey", { secretAccessKey: "shhh" }],
+      ["sessionToken", { sessionToken: "token" }],
+   ])("rejects a %s supplied alongside 'credential_chain'", (_field, extra) => {
+      expect(() =>
+         resolveCloudStorageCredentials(
+            s3({ provider: "credential_chain", ...extra }),
+         ),
+      ).toThrow(
+         /must not be set when provider is 'credential_chain' for: root/,
+      );
+   });
+
+   it("rejects a chain named under key-based auth", () => {
+      expect(() =>
+         resolveCloudStorageCredentials(
+            s3({
+               accessKeyId: "AKIA",
+               secretAccessKey: "shhh",
+               chain: "env;instance",
+            }),
+         ),
+      ).toThrow(
+         /chain is only valid when provider is 'credential_chain' for: root/,
+      );
+   });
+
+   it("carries an explicit chain through", () => {
+      const credentials = resolveCloudStorageCredentials(
+         s3({ provider: "credential_chain", chain: "env;instance" }),
+      );
+      expect(credentials.chain).toBe("env;instance");
+   });
+
+   it("still rejects a missing s3Connection", () => {
+      expect(() =>
+         resolveCloudStorageCredentials({ name: "root", type: "s3" }),
+      ).toThrow(/S3 connection configuration missing for: root/);
+   });
+});
+
+describe("buildCloudStorageSecretSQL", () => {
+   const chainSQL = (
+      s3Connection: components["schemas"]["S3Connection"],
+   ): string =>
+      buildCloudStorageSecretSQL(
+         "s3_root",
+         resolveCloudStorageCredentials({
+            name: "root",
+            type: "s3",
+            s3Connection,
+         }),
+      );
+
+   describe("provider 'credential_chain'", () => {
+      it("emits PROVIDER credential_chain and no static credential", () => {
+         const sql = chainSQL({ provider: "credential_chain" });
+         expect(sql).toContain("PROVIDER credential_chain");
+         expect(sql).not.toContain("KEY_ID");
+         expect(sql).not.toContain("SECRET '");
+         expect(sql).not.toContain("SESSION_TOKEN");
+      });
+
+      // Omitting CHAIN is not neutral: DuckDB then resolves against `config`
+      // alone, a credentials file no container image has.
+      it("names Publisher's default chain when the caller gives none", () => {
+         expect(chainSQL({ provider: "credential_chain" })).toContain(
+            `CHAIN '${DEFAULT_S3_CREDENTIAL_CHAIN}'`,
+         );
+      });
+
+      it("covers a projected service-account token by default", () => {
+         expect(DEFAULT_S3_CREDENTIAL_CHAIN.split(";")).toContain(
+            "web_identity",
+         );
+      });
+
+      it("honours an explicit chain", () => {
+         const sql = chainSQL({
+            provider: "credential_chain",
+            chain: "env;sso",
+         });
+         expect(sql).toContain("CHAIN 'env;sso'");
+         expect(sql).not.toContain(DEFAULT_S3_CREDENTIAL_CHAIN);
+      });
+
+      it("falls back to the default chain for a blank one", () => {
+         expect(
+            chainSQL({ provider: "credential_chain", chain: "   " }),
+         ).toContain(`CHAIN '${DEFAULT_S3_CREDENTIAL_CHAIN}'`);
+      });
+
+      // The secret holds the credentials the chain resolved, not a live
+      // reference to the provider, so without REFRESH a serve attach stops
+      // reading about an hour after it was created.
+      it("emits REFRESH so a temporary credential is re-resolved", () => {
+         expect(chainSQL({ provider: "credential_chain" })).toContain(
+            "REFRESH true",
+         );
+      });
+
+      it("composes with a custom endpoint", () => {
+         const sql = chainSQL({
+            provider: "credential_chain",
+            endpoint: "https://minio.internal:9000",
+         });
+         expect(sql).toContain("PROVIDER credential_chain");
+         expect(sql).toContain("ENDPOINT 'https://minio.internal:9000'");
+         expect(sql).toContain("URL_STYLE 'path'");
+         expect(sql).not.toContain("KEY_ID");
+      });
+
+      it("escapes a chain containing a quote", () => {
+         expect(
+            chainSQL({ provider: "credential_chain", chain: "en'v" }),
+         ).toContain("CHAIN 'en''v'");
+      });
+   });
+
+   // The regression guard for the three pre-existing shapes. Asserted as whole
+   // statements, not substrings: chain auth added a branch ahead of these, and
+   // the point is that nothing downstream of it moved.
+   describe("key-based shapes are unchanged", () => {
+      const keys = { accessKeyId: "AKIA", secretAccessKey: "shhh" };
+
+      it("plain", () => {
+         expect(chainSQL({ ...keys, region: "us-west-2" })).toBe(`
+            CREATE OR REPLACE SECRET s3_root (
+               TYPE s3,
+               KEY_ID 'AKIA',
+               SECRET 'shhh',
+               REGION 'us-west-2'
+            );
+         `);
+      });
+
+      it("custom endpoint", () => {
+         expect(
+            chainSQL({
+               ...keys,
+               region: "us-west-2",
+               endpoint: "https://mi.no",
+            }),
+         ).toBe(`
+            CREATE OR REPLACE SECRET s3_root (
+               TYPE s3,
+               KEY_ID 'AKIA',
+               SECRET 'shhh',
+               REGION 'us-west-2',
+               ENDPOINT 'https://mi.no',
+               URL_STYLE 'path'
+            );
+         `);
+      });
+
+      it("session token", () => {
+         expect(chainSQL({ ...keys, region: "us-west-2", sessionToken: "tok" }))
+            .toBe(`
+            CREATE OR REPLACE SECRET s3_root (
+               TYPE s3,
+               KEY_ID 'AKIA',
+               SECRET 'shhh',
+               REGION 'us-west-2',
+               SESSION_TOKEN 'tok'
+            );
+         `);
+      });
+
+      it("omitted provider takes the plain shape, not the chain one", () => {
+         const sql = chainSQL({ ...keys });
+         expect(sql).not.toContain("PROVIDER");
+         expect(sql).toContain("KEY_ID 'AKIA'");
+      });
+
+      it("gcs is untouched by the S3 provider selector", () => {
+         const sql = buildCloudStorageSecretSQL(
+            "gcs_root",
+            resolveCloudStorageCredentials({
+               name: "root",
+               type: "gcs",
+               gcsConnection: { keyId: "GOOG", secret: "shhh" },
+            }),
+         );
+         expect(sql).toBe(`
+         CREATE OR REPLACE SECRET gcs_root (
+            TYPE gcs,
+            KEY_ID 'GOOG',
+            SECRET 'shhh'
+         );
+      `);
       });
    });
 });

--- a/packages/server/src/service/connection.spec.ts
+++ b/packages/server/src/service/connection.spec.ts
@@ -18,6 +18,7 @@ import { components } from "../api";
 import {
    attachDuckLakeReadWrite,
    buildCloudStorageSecretSQL,
+   buildEnvironmentMalloyConfig,
    buildProxiedSslQuery,
    createEnvironmentConnections,
    resolveProxiedTls,
@@ -2651,5 +2652,64 @@ describe("buildCloudStorageSecretSQL", () => {
          );
       `);
       });
+   });
+});
+
+// The attach run is cached per connection object so concurrent lookups share one
+// ATTACH. Caching a REJECTED run is different: every attach handler reaches the
+// network, so one blip would otherwise be replayed for the life of the process.
+describe("attach retry after a transient failure", () => {
+   const envPath = path.join(process.cwd(), "test-attach-retry");
+
+   beforeEach(async () => {
+      await fs.mkdir(envPath, { recursive: true });
+   });
+   afterEach(async () => {
+      sinon.restore();
+      await fs.rm(envPath, { recursive: true, force: true }).catch(() => {});
+   });
+
+   it("retries the attach on a later lookup instead of replaying the error", async () => {
+      let secretAttempts = 0;
+      sinon
+         .stub(DuckDBConnection.prototype, "runSQL")
+         .callsFake(async (sql: string) => {
+            if (/CREATE OR REPLACE SECRET/i.test(String(sql))) {
+               secretAttempts += 1;
+               if (secretAttempts === 1) {
+                  throw new Error("temporary failure in name resolution");
+               }
+            }
+            return { rows: [] } as never;
+         });
+
+      const config = buildEnvironmentMalloyConfig(
+         [
+            {
+               name: "duckdb_retry",
+               type: "duckdb",
+               duckdbConnection: {
+                  attachedDatabases: [
+                     {
+                        name: "root",
+                        type: "s3",
+                        s3Connection: { provider: "credential_chain" },
+                     },
+                  ],
+               },
+            },
+         ] as never,
+         envPath,
+      );
+
+      await expect(
+         config.malloyConfig.connections.lookupConnection("duckdb_retry"),
+      ).rejects.toThrow(/temporary failure in name resolution/);
+
+      // The retry is the point: a second lookup must run the attach again.
+      await config.malloyConfig.connections.lookupConnection("duckdb_retry");
+      expect(secretAttempts).toBe(2);
+
+      await config.releaseConnections().catch(() => {});
    });
 });

--- a/packages/server/src/service/connection.spec.ts
+++ b/packages/server/src/service/connection.spec.ts
@@ -2555,12 +2555,20 @@ describe("buildCloudStorageSecretSQL", () => {
       });
 
       // The secret holds the credentials the chain resolved, not a live
-      // reference to the provider, so without REFRESH a serve attach stops
-      // reading about an hour after it was created.
-      it("emits REFRESH so a temporary credential is re-resolved", () => {
-         expect(chainSQL({ provider: "credential_chain" })).toContain(
-            "REFRESH true",
-         );
+      // reference to the provider, so without a working REFRESH a serve attach
+      // stops reading about an hour after it was created.
+      //
+      // `auto` is the only value that arms it. The aws extension stores the
+      // `refresh_info` that makes a secret refreshable under `if (refresh ==
+      // "auto")`, and httpfs declines to refresh a secret that has none, so any
+      // other value is accepted and silently does nothing. Asserting the VALUE
+      // rather than the presence of the clause is the point: this suite
+      // previously required only a `REFRESH` clause and passed against `REFRESH
+      // true`, which disables the thing the test is named for.
+      it("arms refresh with the only value that enables it", () => {
+         const sql = chainSQL({ provider: "credential_chain" });
+         expect(sql).toContain("REFRESH 'auto'");
+         expect(sql).not.toContain("REFRESH true");
       });
 
       it("composes with a custom endpoint", () => {

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -1957,6 +1957,19 @@ export function buildEnvironmentMalloyConfig(
             connection,
             metadata.attachedDatabases,
          );
+         // Drop a rejected run from the cache so a later lookup can retry, rather
+         // than replaying one transient failure for the life of the process. Every
+         // attach handler reaches the network — postgres opens a real connection,
+         // bigquery and snowflake authenticate, and a cloud-storage secret under
+         // `credential_chain` resolves credentials at CREATE — and the loop in
+         // attachDatabasesToDuckDB rethrows, so without this the first blip is
+         // permanent and only rebuilding the environment clears it. Mirrors the
+         // eviction on proxyConnectionCache below.
+         attachPromise.catch(() => {
+            if (attachPromises.get(connection) === attachPromise) {
+               attachPromises.delete(connection);
+            }
+         });
          attachPromises.set(connection, attachPromise);
       }
       await attachPromise;

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -64,6 +64,7 @@ import { gcpImpersonationOverlay } from "./gcp_impersonation";
 import {
    CloudStorageCredentials,
    DEFAULT_S3_CREDENTIAL_CHAIN,
+   resolveCloudStorageCredentials,
 } from "./gcs_s3_utils";
 import { openProxy, type ProxyEndpoint } from "./proxy";
 import { quoteIdentifier } from "./quoting";
@@ -1227,81 +1228,6 @@ export function buildCloudStorageSecretSQL(
    }
 
    return createSecretCommand;
-}
-
-/**
- * Validates a GCS or S3 attachment's credential configuration and reduces it to
- * the shape both the DuckDB secret and Publisher's own storage client read.
- *
- * Split out from `attachCloudStorage` so each guard can be asserted directly:
- * whether a key pair is required depends on the S3 provider, and a guard only
- * reachable through a live DuckDB session is a guard nothing pins.
- */
-export function resolveCloudStorageCredentials(
-   attachedDb: AttachedDatabase,
-): CloudStorageCredentials {
-   if (attachedDb.type === "gcs") {
-      if (!attachedDb.gcsConnection) {
-         throw new Error(
-            `GCS connection configuration missing for: ${attachedDb.name}`,
-         );
-      }
-      if (!attachedDb.gcsConnection.keyId || !attachedDb.gcsConnection.secret) {
-         throw new Error(
-            `GCS keyId and secret are required for: ${attachedDb.name}`,
-         );
-      }
-      return {
-         type: "gcs",
-         accessKeyId: attachedDb.gcsConnection.keyId,
-         secretAccessKey: attachedDb.gcsConnection.secret,
-      };
-   }
-
-   if (attachedDb.type !== "s3") {
-      throw new Error(`Invalid cloud storage type: ${attachedDb.type}`);
-   }
-
-   if (!attachedDb.s3Connection) {
-      throw new Error(
-         `S3 connection configuration missing for: ${attachedDb.name}`,
-      );
-   }
-   const s3 = attachedDb.s3Connection;
-   if (s3.provider === "credential_chain") {
-      // A static credential supplied alongside chain auth is rejected rather
-      // than ignored: it would sit unused in the config, reading as the thing
-      // granting access while something else actually does.
-      if (s3.accessKeyId || s3.secretAccessKey || s3.sessionToken) {
-         throw new Error(
-            `S3 accessKeyId, secretAccessKey, and sessionToken must not be set when provider is 'credential_chain' for: ${attachedDb.name}`,
-         );
-      }
-   } else {
-      if (!s3.accessKeyId || !s3.secretAccessKey) {
-         throw new Error(
-            `S3 accessKeyId and secretAccessKey are required for: ${attachedDb.name}`,
-         );
-      }
-      // Rejected for the same reason as the mirror case above: a chain named
-      // under key-based auth reads as though the host supplies the credentials
-      // when the key pair beside it is what actually does.
-      if (s3.chain) {
-         throw new Error(
-            `S3 chain is only valid when provider is 'credential_chain' for: ${attachedDb.name}`,
-         );
-      }
-   }
-   return {
-      type: "s3",
-      accessKeyId: s3.accessKeyId || "",
-      secretAccessKey: s3.secretAccessKey || "",
-      region: s3.region,
-      endpoint: s3.endpoint,
-      sessionToken: s3.sessionToken,
-      provider: s3.provider,
-      chain: s3.chain,
-   };
 }
 
 async function attachCloudStorage(

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -1153,7 +1153,18 @@ export function buildCloudStorageSecretSQL(
          );
       `;
    } else {
+      // One fallback, and it is this one -- the schema carries no `default:`,
+      // because a generated client would not apply it. Warned rather than silent:
+      // a bucket outside us-east-1 reached with no region fails as "no such
+      // bucket", which reads as a wrong name rather than a wrong region.
       const region = credentials.region || "us-east-1";
+      if (!credentials.region) {
+         logger.warn(
+            "S3 connection has no region; defaulting to us-east-1. A bucket in " +
+               "another region will not be found.",
+            { secretName },
+         );
+      }
 
       if (credentials.provider === "credential_chain") {
          // CHAIN is load-bearing, not decorative: with it omitted DuckDB

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -61,7 +61,10 @@ import {
    normalizeSnowflakePrivateKey,
 } from "./connection_config";
 import { gcpImpersonationOverlay } from "./gcp_impersonation";
-import { CloudStorageCredentials } from "./gcs_s3_utils";
+import {
+   CloudStorageCredentials,
+   DEFAULT_S3_CREDENTIAL_CHAIN,
+} from "./gcs_s3_utils";
 import { openProxy, type ProxyEndpoint } from "./proxy";
 import { quoteIdentifier } from "./quoting";
 
@@ -1122,65 +1125,19 @@ async function federatePostgres(
    return { handle: alias, sourceType: "postgres" };
 }
 
-async function attachCloudStorage(
-   connection: DuckDBConnection,
-   attachedDb: AttachedDatabase,
-): Promise<void> {
-   const isGCS = attachedDb.type === "gcs";
-   const isS3 = attachedDb.type === "s3";
-
-   if (!isGCS && !isS3) {
-      throw new Error(`Invalid cloud storage type: ${attachedDb.type}`);
-   }
-
-   const storageType = attachedDb.type?.toUpperCase() || "";
-   let credentials: CloudStorageCredentials;
-
-   if (isGCS) {
-      if (!attachedDb.gcsConnection) {
-         throw new Error(
-            `GCS connection configuration missing for: ${attachedDb.name}`,
-         );
-      }
-      if (!attachedDb.gcsConnection.keyId || !attachedDb.gcsConnection.secret) {
-         throw new Error(
-            `GCS keyId and secret are required for: ${attachedDb.name}`,
-         );
-      }
-      credentials = {
-         type: "gcs",
-         accessKeyId: attachedDb.gcsConnection.keyId,
-         secretAccessKey: attachedDb.gcsConnection.secret,
-      };
-   } else {
-      if (!attachedDb.s3Connection) {
-         throw new Error(
-            `S3 connection configuration missing for: ${attachedDb.name}`,
-         );
-      }
-      if (
-         !attachedDb.s3Connection.accessKeyId ||
-         !attachedDb.s3Connection.secretAccessKey
-      ) {
-         throw new Error(
-            `S3 accessKeyId and secretAccessKey are required for: ${attachedDb.name}`,
-         );
-      }
-      credentials = {
-         type: "s3",
-         accessKeyId: attachedDb.s3Connection.accessKeyId,
-         secretAccessKey: attachedDb.s3Connection.secretAccessKey,
-         region: attachedDb.s3Connection.region,
-         endpoint: attachedDb.s3Connection.endpoint,
-         sessionToken: attachedDb.s3Connection.sessionToken,
-      };
-   }
-
-   await installAndLoadExtension(connection, "httpfs");
-
-   const secretName = sanitizeSecretName(
-      `${attachedDb.type}_${attachedDb.name}`,
-   );
+/**
+ * Assembles the CREATE OR REPLACE SECRET for a GCS or S3 storage root.
+ *
+ * Split out from `attachCloudStorage` so the emitted statement can be asserted
+ * without a live DuckDB: the S3 arm now picks between four shapes, and the three
+ * key-based ones have to stay byte-identical to what they were before chain auth
+ * existed.
+ */
+export function buildCloudStorageSecretSQL(
+   secretName: string,
+   credentials: CloudStorageCredentials,
+): string {
+   const isGCS = credentials.type === "gcs";
    const escapedKeyId = escapeSQL(credentials.accessKeyId);
    const escapedSecret = escapeSQL(credentials.secretAccessKey);
 
@@ -1197,7 +1154,44 @@ async function attachCloudStorage(
    } else {
       const region = credentials.region || "us-east-1";
 
-      if (credentials.endpoint) {
+      if (credentials.provider === "credential_chain") {
+         // CHAIN is load-bearing, not decorative: with it omitted DuckDB
+         // resolves against `config` alone, which is the one provider that
+         // cannot work in a container. So Publisher names an order rather than
+         // passing through only what the caller set.
+         const chain = escapeSQL(
+            credentials.chain?.trim() || DEFAULT_S3_CREDENTIAL_CHAIN,
+         );
+         // A chain secret stores the credentials it resolved, not a reference to
+         // the provider that resolved them, so a temporary credential (a
+         // web-identity token yields about an hour) expires while the secret
+         // lives on. That is invisible on the build path, where the session
+         // lasts one build, and fatal on the serve path, where the attach is
+         // idempotent and the secret lives as long as the connection. REFRESH
+         // re-resolves it. It is not caller-configurable because a frozen
+         // snapshot of an expiring credential has no use.
+         const clauses = [
+            "TYPE s3",
+            "PROVIDER credential_chain",
+            `CHAIN '${chain}'`,
+            "REFRESH true",
+            `REGION '${region}'`,
+         ];
+         // Additive, not an alternative: an S3-compatible endpoint behind a host
+         // role is a real combination, and the key-based branches below can only
+         // express one modifier at a time.
+         if (credentials.endpoint) {
+            clauses.push(
+               `ENDPOINT '${escapeSQL(credentials.endpoint)}'`,
+               "URL_STYLE 'path'",
+            );
+         }
+         createSecretCommand = `
+            CREATE OR REPLACE SECRET ${secretName} (
+               ${clauses.join(",\n               ")}
+            );
+         `;
+      } else if (credentials.endpoint) {
          const escapedEndpoint = escapeSQL(credentials.endpoint);
          createSecretCommand = `
             CREATE OR REPLACE SECRET ${secretName} (
@@ -1231,6 +1225,109 @@ async function attachCloudStorage(
          `;
       }
    }
+
+   return createSecretCommand;
+}
+
+/**
+ * Validates a GCS or S3 attachment's credential configuration and reduces it to
+ * the shape both the DuckDB secret and Publisher's own storage client read.
+ *
+ * Split out from `attachCloudStorage` so each guard can be asserted directly:
+ * whether a key pair is required depends on the S3 provider, and a guard only
+ * reachable through a live DuckDB session is a guard nothing pins.
+ */
+export function resolveCloudStorageCredentials(
+   attachedDb: AttachedDatabase,
+): CloudStorageCredentials {
+   if (attachedDb.type === "gcs") {
+      if (!attachedDb.gcsConnection) {
+         throw new Error(
+            `GCS connection configuration missing for: ${attachedDb.name}`,
+         );
+      }
+      if (!attachedDb.gcsConnection.keyId || !attachedDb.gcsConnection.secret) {
+         throw new Error(
+            `GCS keyId and secret are required for: ${attachedDb.name}`,
+         );
+      }
+      return {
+         type: "gcs",
+         accessKeyId: attachedDb.gcsConnection.keyId,
+         secretAccessKey: attachedDb.gcsConnection.secret,
+      };
+   }
+
+   if (attachedDb.type !== "s3") {
+      throw new Error(`Invalid cloud storage type: ${attachedDb.type}`);
+   }
+
+   if (!attachedDb.s3Connection) {
+      throw new Error(
+         `S3 connection configuration missing for: ${attachedDb.name}`,
+      );
+   }
+   const s3 = attachedDb.s3Connection;
+   if (s3.provider === "credential_chain") {
+      // A static credential supplied alongside chain auth is rejected rather
+      // than ignored: it would sit unused in the config, reading as the thing
+      // granting access while something else actually does.
+      if (s3.accessKeyId || s3.secretAccessKey || s3.sessionToken) {
+         throw new Error(
+            `S3 accessKeyId, secretAccessKey, and sessionToken must not be set when provider is 'credential_chain' for: ${attachedDb.name}`,
+         );
+      }
+   } else {
+      if (!s3.accessKeyId || !s3.secretAccessKey) {
+         throw new Error(
+            `S3 accessKeyId and secretAccessKey are required for: ${attachedDb.name}`,
+         );
+      }
+      // Rejected for the same reason as the mirror case above: a chain named
+      // under key-based auth reads as though the host supplies the credentials
+      // when the key pair beside it is what actually does.
+      if (s3.chain) {
+         throw new Error(
+            `S3 chain is only valid when provider is 'credential_chain' for: ${attachedDb.name}`,
+         );
+      }
+   }
+   return {
+      type: "s3",
+      accessKeyId: s3.accessKeyId || "",
+      secretAccessKey: s3.secretAccessKey || "",
+      region: s3.region,
+      endpoint: s3.endpoint,
+      sessionToken: s3.sessionToken,
+      provider: s3.provider,
+      chain: s3.chain,
+   };
+}
+
+async function attachCloudStorage(
+   connection: DuckDBConnection,
+   attachedDb: AttachedDatabase,
+): Promise<void> {
+   const storageType = attachedDb.type?.toUpperCase() || "";
+   const credentials = resolveCloudStorageCredentials(attachedDb);
+
+   await installAndLoadExtension(connection, "httpfs");
+   // `credential_chain` is implemented by the `aws` extension and resolves when
+   // the secret is created, so the extension has to be loaded first. The
+   // DuckLake attach path already loads it, but the generic attach path reaches
+   // this same function through the handler table and does not. `aws` is baked
+   // into the image, so this stays within EXTENSION_FETCH_POLICY=local-only.
+   if (credentials.provider === "credential_chain") {
+      await installAndLoadExtension(connection, "aws");
+   }
+
+   const secretName = sanitizeSecretName(
+      `${attachedDb.type}_${attachedDb.name}`,
+   );
+   const createSecretCommand = buildCloudStorageSecretSQL(
+      secretName,
+      credentials,
+   );
 
    if (await doesSecretExistInDuckDB(connection, secretName)) {
       // Force refresh attachments using this storage

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -1134,6 +1134,48 @@ async function federatePostgres(
  * key-based ones have to stay byte-identical to what they were before chain auth
  * existed.
  */
+/**
+ * Whether a failure is object storage refusing an EXPIRED credential, as opposed to
+ * refusing a wrong one.
+ *
+ * Matched narrowly on purpose. The remedy this gates -- re-resolve and retry -- is
+ * right for a credential that was valid and aged out, and wrong for one that was
+ * never valid: retrying a bad access key hides a misconfiguration behind a silent
+ * second attempt. `ExpiredToken` is S3's own code for the first case.
+ */
+/** A connection whose object-storage secret can be re-resolved without a reattach. */
+interface RenewableStorageSecret {
+   setStorageSecretRenewer(renew: () => Promise<void>): void;
+}
+
+/**
+ * Whether a failed statement should re-resolve the storage credential and retry.
+ *
+ * Exported so the rule is tested as the rule, rather than as a copy of it living in
+ * a spec: a predicate mirrored into a test passes whether or not the caller uses it.
+ */
+export function shouldRenewStorageSecret(opts: {
+   error: unknown;
+   hasRenewer: boolean;
+   alreadyRenewing: boolean;
+}): boolean {
+   return (
+      opts.hasRenewer &&
+      !opts.alreadyRenewing &&
+      isExpiredCredentialError(opts.error)
+   );
+}
+
+export function isExpiredCredentialError(error: unknown): boolean {
+   const message =
+      error instanceof Error
+         ? error.message
+         : typeof error === "string"
+           ? error
+           : "";
+   return message.includes("ExpiredToken");
+}
+
 export function buildCloudStorageSecretSQL(
    secretName: string,
    credentials: CloudStorageCredentials,
@@ -1271,6 +1313,33 @@ async function attachCloudStorage(
       await connection.runSQL(`DETACH ${attachedDb.name};`).catch(() => {});
    }
    await connection.runSQL(createSecretCommand);
+
+   // Only a chain secret can go stale: it stores the credentials it RESOLVED, and a
+   // web-identity assume-role yields about an hour of them. A key pair does not
+   // expire, so registering a renewer for one would only serve to retry a wrong key.
+   //
+   // `REFRESH true` is emitted and is supposed to cover this. Measured on DuckDB
+   // 1.5.3 and 1.5.5, on a pod whose identity still resolved -- a build in the same
+   // minute succeeded -- a serve read on the held secret failed with ExpiredToken.
+   // So the renewal is done here rather than relied upon, and this path simply stops
+   // firing if a later DuckDB honours REFRESH.
+   // Structural check rather than instanceof: attachCloudStorage is reached from the
+   // generic handler table as well as the DuckLake path, so the connection type is
+   // not known here and only some of them can renew.
+   const renewable = connection as unknown as Partial<RenewableStorageSecret>;
+   if (
+      credentials.provider === "credential_chain" &&
+      typeof renewable.setStorageSecretRenewer === "function"
+   ) {
+      renewable.setStorageSecretRenewer(async () => {
+         // Replaced in place on the LIVE connection: CREATE OR REPLACE SECRET is a
+         // statement, not a session property, so nothing is torn down and no query
+         // in flight is disturbed.
+         await connection.runSQL(
+            buildCloudStorageSecretSQL(secretName, credentials),
+         );
+      });
+   }
 
    logger.info(`Created ${storageType} secret: ${secretName}`);
    logger.info(`${storageType} connection configured for: ${attachedDb.name}`);
@@ -1523,6 +1592,65 @@ class AzureDuckDBConnection extends DuckDBConnection {
 
 class DuckLakeConnection extends DuckDBConnection {
    private connectionName: string;
+   private storageSecretRenewer?: () => Promise<void>;
+   private renewingStorageSecret = false;
+
+   /** @see RenewableStorageSecret */
+   setStorageSecretRenewer(renew: () => Promise<void>): void {
+      this.storageSecretRenewer = renew;
+   }
+
+   /**
+    * Runs SQL, re-resolving an expired object-storage credential once and retrying.
+    *
+    * The tier's serve attach is idempotent and its secret lives as long as the
+    * connection, while the credentials a chain secret RESOLVED last about an hour.
+    * `REFRESH true` is emitted to cover exactly this and measurably does not (DuckDB
+    * 1.5.3 and 1.5.5), so a serve that has been up an hour starts failing every read
+    * with ExpiredToken while a build in the same minute succeeds -- the build gets a
+    * fresh session, and with it a fresh secret.
+    *
+    * Reactive rather than scheduled, and reactive rather than per-query, because
+    * resolving the secret costs an STS round trip. Per query that is one call per
+    * read, forever; on a timer it needs a TTL nobody reports back to us. On the error
+    * it is one call per connection per hour, and the error is the authoritative
+    * signal that the credential is actually gone.
+    *
+    * Once. A second failure is not an expiry.
+    */
+   async runSQL(
+      sql: string,
+      options?: Parameters<DuckDBConnection["runSQL"]>[1],
+   ): Promise<Awaited<ReturnType<DuckDBConnection["runSQL"]>>> {
+      try {
+         return await super.runSQL(sql, options);
+      } catch (error) {
+         // `renewingStorageSecret` guards the renewal's own statement, which runs
+         // through this same method: without it a failure there would recurse.
+         const renew = this.storageSecretRenewer;
+         if (
+            !shouldRenewStorageSecret({
+               error,
+               hasRenewer: !!renew,
+               alreadyRenewing: this.renewingStorageSecret,
+            }) ||
+            !renew
+         ) {
+            throw error;
+         }
+         logger.info(
+            "Object-storage credential expired; re-resolving and retrying once",
+            { connection: this.connectionName },
+         );
+         this.renewingStorageSecret = true;
+         try {
+            await renew();
+         } finally {
+            this.renewingStorageSecret = false;
+         }
+         return await super.runSQL(sql, options);
+      }
+   }
 
    constructor(options: PublisherDuckDBOptions) {
       super(options);

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -1218,17 +1218,25 @@ export function buildCloudStorageSecretSQL(
          );
          // A chain secret stores the credentials it resolved, not a reference to
          // the provider that resolved them, so a temporary credential (a
-         // web-identity token yields about an hour) expires while the secret
-         // lives on. That is invisible on the build path, where the session
-         // lasts one build, and fatal on the serve path, where the attach is
-         // idempotent and the secret lives as long as the connection. REFRESH
-         // re-resolves it. It is not caller-configurable because a frozen
+         // web-identity assume-role lasts the role's MaxSessionDuration, an hour
+         // by default) expires while the secret lives on. That is invisible on
+         // the build path, where the session lasts one build, and fatal on the
+         // serve path, where the attach is idempotent and the secret lives as
+         // long as the connection.
+         //
+         // `auto` is the ONLY value that arms refresh: the aws extension stores
+         // the `refresh_info` that makes a secret refreshable under
+         // `if (refresh == "auto")` and ignores anything else, and httpfs then
+         // declines to refresh a secret that has no `refresh_info`. Any other
+         // value is accepted and silently does nothing -- and is worse than
+         // omitting the clause, which for a bare `sts`/`web_identity` chain
+         // arms it by default. Not caller-configurable because a frozen
          // snapshot of an expiring credential has no use.
          const clauses = [
             "TYPE s3",
             "PROVIDER credential_chain",
             `CHAIN '${chain}'`,
-            "REFRESH true",
+            "REFRESH 'auto'",
             `REGION '${region}'`,
          ];
          // Additive, not an alternative: an S3-compatible endpoint behind a host
@@ -1318,11 +1326,12 @@ async function attachCloudStorage(
    // web-identity assume-role yields about an hour of them. A key pair does not
    // expire, so registering a renewer for one would only serve to retry a wrong key.
    //
-   // `REFRESH true` is emitted and is supposed to cover this. Measured on DuckDB
-   // 1.5.3 and 1.5.5, on a pod whose identity still resolved -- a build in the same
-   // minute succeeded -- a serve read on the held secret failed with ExpiredToken.
-   // So the renewal is done here rather than relied upon, and this path simply stops
-   // firing if a later DuckDB honours REFRESH.
+   // `REFRESH 'auto'` asks DuckDB to do this itself and is emitted, so this is a
+   // fallback rather than the mechanism. It is kept because upstream refresh is
+   // best-effort: the aws extension's own test that a secret is actually
+   // re-resolved is skipped, and duckdb-aws#97 reports expiry surviving an armed
+   // refresh. If DuckDB refreshes first, the retry never sees an expired
+   // credential and this path stays silent.
    // Structural check rather than instanceof: attachCloudStorage is reached from the
    // generic handler table as well as the DuckLake path, so the connection type is
    // not known here and only some of them can renew.
@@ -1605,10 +1614,11 @@ class DuckLakeConnection extends DuckDBConnection {
     *
     * The tier's serve attach is idempotent and its secret lives as long as the
     * connection, while the credentials a chain secret RESOLVED last about an hour.
-    * `REFRESH true` is emitted to cover exactly this and measurably does not (DuckDB
-    * 1.5.3 and 1.5.5), so a serve that has been up an hour starts failing every read
-    * with ExpiredToken while a build in the same minute succeeds -- the build gets a
-    * fresh session, and with it a fresh secret.
+    * `REFRESH 'auto'` asks DuckDB to re-resolve it, which is the first line of
+    * defence; this is the second, for when that does not happen. Without either, a
+    * serve connection that has been up an hour fails every read with ExpiredToken
+    * while builds keep succeeding -- a build opens its own session, and with it a
+    * fresh secret, so the two paths fail independently.
     *
     * Reactive rather than scheduled, and reactive rather than per-query, because
     * resolving the secret costs an STS round trip. Per query that is one call per

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -1327,11 +1327,11 @@ async function attachCloudStorage(
    // expire, so registering a renewer for one would only serve to retry a wrong key.
    //
    // `REFRESH 'auto'` asks DuckDB to do this itself and is emitted, so this is a
-   // fallback rather than the mechanism. It is kept because upstream refresh is
-   // best-effort: the aws extension's own test that a secret is actually
-   // re-resolved is skipped, and duckdb-aws#97 reports expiry surviving an armed
-   // refresh. If DuckDB refreshes first, the retry never sees an expired
-   // credential and this path stays silent.
+   // fallback rather than the mechanism. It is kept because that refresh does not
+   // reach every read path: a direct object read re-resolves transparently and
+   // never surfaces an error, while a read through an attached DuckLake catalog
+   // has been seen to surface ExpiredToken from an equally armed secret. If DuckDB
+   // refreshes first, the retry never sees an expired credential and stays silent.
    // Structural check rather than instanceof: attachCloudStorage is reached from the
    // generic handler table as well as the DuckLake path, so the connection type is
    // not known here and only some of them can renew.

--- a/packages/server/src/service/connection_config.spec.ts
+++ b/packages/server/src/service/connection_config.spec.ts
@@ -1059,6 +1059,32 @@ describe("validateStorageDestinations — S3 credential, checked in full", () =>
       expect(accepted).toHaveLength(1);
    });
 
+   // The GCS arm is the same late failure, so it gets the same treatment.
+   it("rejects a destination with a partial gcsConnection", () => {
+      const gcs = {
+         name: "credible",
+         type: "ducklake",
+         ducklakeConnection: {
+            catalog: {
+               postgresConnection: {
+                  host: "h",
+                  port: 5432,
+                  userName: "u",
+                  password: "p",
+                  databaseName: "d",
+               },
+            },
+            storage: {
+               bucketUrl: "gs://bucket/prefix",
+               gcsConnection: { keyId: "GOOG" },
+            },
+         },
+      } as unknown as ApiConnection;
+      const { accepted, rejected } = validateStorageDestinations([gcs]);
+      expect(accepted).toHaveLength(0);
+      expect(rejected[0].reason).toMatch(/GCS keyId and secret are required/);
+   });
+
    // The whole point of doing it here rather than in validateConnectionShape.
    it("rejects only the bad destination, leaving its neighbour accepted", () => {
       const good = destination({ provider: "credential_chain" });

--- a/packages/server/src/service/connection_config.spec.ts
+++ b/packages/server/src/service/connection_config.spec.ts
@@ -7,6 +7,7 @@ import { components } from "../api";
 import {
    assembleEnvironmentConnections,
    normalizeSnowflakePrivateKey,
+   validateStorageDestinations,
 } from "./connection_config";
 
 type ApiConnection = components["schemas"]["Connection"];
@@ -926,11 +927,17 @@ describe("assembleEnvironmentConnections — S3 credential shape at config load"
          },
       }) as unknown as ApiConnection;
 
-   describe("ducklake storage — checked in full", () => {
-      it("rejects a keyless key-based storage root at load", () => {
-         expect(() =>
-            assembleEnvironmentConnections([ducklake({ region: "us-east-1" })]),
-         ).toThrow(/accessKeyId and secretAccessKey are required for: tier/);
+   describe("ducklake connection — shape only, to bound the blast radius", () => {
+      // The counterpart of the duckdb case below, and the reason both are shape-only:
+      // this validator's throw fails the WHOLE environment. A DuckLake carrying a
+      // present-but-incomplete s3Connection has always loaded and failed when used,
+      // and taking every other connection down with it is the worse trade. A storage
+      // DESTINATION gets the full check instead — see the describe below.
+      it("still LOADS a keyless key-based storage root", () => {
+         const { pojo } = assembleEnvironmentConnections([
+            ducklake({ region: "us-east-1" }),
+         ]);
+         expect(pojo.connections["tier"]).toBeDefined();
       });
 
       it("accepts a chain-auth storage root with no key pair", () => {
@@ -1007,5 +1014,59 @@ describe("assembleEnvironmentConnections — S3 credential shape at config load"
          ]);
          expect(pojo.connections["generic"]).toBeDefined();
       });
+   });
+});
+
+// A storage destination is rejected on its own, so it can afford the check the
+// environment-wide validator cannot: a destination is only attached at its first
+// BUILD, which is the late failure that motivated moving these guards at all.
+describe("validateStorageDestinations — S3 credential, checked in full", () => {
+   const destination = (s3Connection: Record<string, unknown>): ApiConnection =>
+      ({
+         name: "credible",
+         type: "ducklake",
+         ducklakeConnection: {
+            catalog: {
+               postgresConnection: {
+                  host: "h",
+                  port: 5432,
+                  userName: "u",
+                  password: "p",
+                  databaseName: "d",
+               },
+            },
+            storage: { bucketUrl: "s3://bucket/prefix", s3Connection },
+         },
+      }) as unknown as ApiConnection;
+
+   it("rejects a keyless key-based destination, naming it", () => {
+      const { accepted, rejected } = validateStorageDestinations([
+         destination({ region: "us-east-1" }),
+      ]);
+      expect(accepted).toHaveLength(0);
+      expect(rejected).toHaveLength(1);
+      expect(rejected[0].name).toBe("credible");
+      expect(rejected[0].reason).toMatch(
+         /accessKeyId and secretAccessKey are required/,
+      );
+   });
+
+   it("accepts a chain-auth destination with no key pair", () => {
+      const { accepted, rejected } = validateStorageDestinations([
+         destination({ provider: "credential_chain" }),
+      ]);
+      expect(rejected).toHaveLength(0);
+      expect(accepted).toHaveLength(1);
+   });
+
+   // The whole point of doing it here rather than in validateConnectionShape.
+   it("rejects only the bad destination, leaving its neighbour accepted", () => {
+      const good = destination({ provider: "credential_chain" });
+      good.name = "good";
+      const bad = destination({ region: "us-east-1" });
+      bad.name = "bad";
+      const { accepted, rejected } = validateStorageDestinations([good, bad]);
+      expect(accepted.map((d) => d.name)).toEqual(["good"]);
+      expect(rejected.map((r) => r.name)).toEqual(["bad"]);
    });
 });

--- a/packages/server/src/service/connection_config.spec.ts
+++ b/packages/server/src/service/connection_config.spec.ts
@@ -892,3 +892,120 @@ describe("assembleEnvironmentConnections — bigquery impersonation", () => {
       );
    });
 });
+
+// A credential problem used to surface only at the connection's first ATTACH — for a
+// storage destination, the first BUILD, hours after the config change that caused it.
+// These pin where each check now fires, including the one deliberately NOT moved.
+describe("assembleEnvironmentConnections — S3 credential shape at config load", () => {
+   const ducklake = (s3Connection: Record<string, unknown>): ApiConnection =>
+      ({
+         name: "tier",
+         type: "ducklake",
+         ducklakeConnection: {
+            catalog: {
+               postgresConnection: {
+                  host: "h",
+                  port: 5432,
+                  userName: "u",
+                  password: "p",
+                  databaseName: "d",
+               },
+            },
+            storage: { bucketUrl: "s3://bucket/prefix", s3Connection },
+         },
+      }) as unknown as ApiConnection;
+
+   const duckdbWithS3 = (
+      s3Connection: Record<string, unknown>,
+   ): ApiConnection =>
+      ({
+         name: "generic",
+         type: "duckdb",
+         duckdbConnection: {
+            attachedDatabases: [{ name: "root", type: "s3", s3Connection }],
+         },
+      }) as unknown as ApiConnection;
+
+   describe("ducklake storage — checked in full", () => {
+      it("rejects a keyless key-based storage root at load", () => {
+         expect(() =>
+            assembleEnvironmentConnections([ducklake({ region: "us-east-1" })]),
+         ).toThrow(/accessKeyId and secretAccessKey are required for: tier/);
+      });
+
+      it("accepts a chain-auth storage root with no key pair", () => {
+         const { pojo } = assembleEnvironmentConnections([
+            ducklake({ provider: "credential_chain" }),
+         ]);
+         expect(pojo.connections["tier"]).toBeDefined();
+      });
+
+      it("rejects a key supplied alongside chain auth at load", () => {
+         expect(() =>
+            assembleEnvironmentConnections([
+               ducklake({ provider: "credential_chain", accessKeyId: "AKIA" }),
+            ]),
+         ).toThrow(/must not be set when provider is 'credential_chain'/);
+      });
+
+      // Without the enum check this reads as `config`, and the error names a missing
+      // access key — pointing at the wrong field for what is a typo in `provider`.
+      it("names the provider field for a misspelled provider", () => {
+         expect(() =>
+            assembleEnvironmentConnections([
+               ducklake({ provider: "credentialchain" }),
+            ]),
+         ).toThrow(
+            /provider must be one of config, credential_chain for: tier/,
+         );
+      });
+
+      it("rejects a non-string provider rather than treating it as config", () => {
+         expect(() =>
+            assembleEnvironmentConnections([ducklake({ provider: true })]),
+         ).toThrow(/provider must be one of/);
+      });
+
+      it("rejects a non-string chain before it reaches trim()", () => {
+         expect(() =>
+            assembleEnvironmentConnections([
+               ducklake({ provider: "credential_chain", chain: 7 }),
+            ]),
+         ).toThrow(/chain must be a string for: tier/);
+      });
+   });
+
+   describe("duckdb attached database — shape only, on purpose", () => {
+      it("rejects a misspelled provider at load", () => {
+         expect(() =>
+            assembleEnvironmentConnections([
+               duckdbWithS3({ provider: "credentialchain" }),
+            ]),
+         ).toThrow(
+            /provider must be one of config, credential_chain for: root/,
+         );
+      });
+
+      it("rejects a key supplied alongside chain auth at load", () => {
+         expect(() =>
+            assembleEnvironmentConnections([
+               duckdbWithS3({
+                  provider: "credential_chain",
+                  secretAccessKey: "shhh",
+               }),
+            ]),
+         ).toThrow(/must not be set when provider is 'credential_chain'/);
+      });
+
+      // The deliberate asymmetry with the ducklake branch above. This validator's
+      // throw fails the WHOLE environment, and nothing here checked an attached
+      // database's credentials before, so moving the key-pair requirement to load
+      // would stop environments loading that load today. It still fails at attach.
+      it("still LOADS a keyless key-based attachment", () => {
+         const { pojo } = assembleEnvironmentConnections([
+            duckdbWithS3({ region: "us-east-1" }),
+         ]);
+         expect(pojo.connections["generic"]).toBeDefined();
+      });
+   });
+});

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -7,6 +7,10 @@ import path from "path";
 import { components } from "../api";
 import { BadRequestError } from "../errors";
 import { logger } from "../logger";
+import {
+   resolveCloudStorageCredentials,
+   validateS3ProviderShape,
+} from "./gcs_s3_utils";
 import { parseHostKeys } from "./proxy";
 import {
    queryMetadataAdvisoryWarnings,
@@ -532,6 +536,21 @@ function validateConnectionShape(connection: ApiConnection): void {
                   `DuckDB connection "${connection.name}" has no attached databases. Add at least one foreign database (BigQuery, Snowflake, Postgres, GCS, S3, Azure) to attachedDatabases, or remove this connection entirely — each package already gets a per-package DuckDB sandbox named "duckdb" automatically.`,
                );
             }
+            // Shape only, deliberately not the whole credential check. This
+            // validator's throw fails the ENTIRE environment (assembleEnvironmentConnections
+            // has no per-connection recovery), and nothing here validates an attached
+            // database's credentials today — so demanding a key pair at load would turn
+            // configs that load-and-fail-late into configs that load nothing at all.
+            // These checks reject only shapes no path ever accepted, so no config that
+            // loads today stops loading.
+            for (const attachedDb of attached) {
+               if (attachedDb.type === "s3" && attachedDb.s3Connection) {
+                  validateS3ProviderShape(
+                     attachedDb.s3Connection,
+                     attachedDb.name ?? connection.name,
+                  );
+               }
+            }
          }
          break;
       case "motherduck":
@@ -560,6 +579,23 @@ function validateConnectionShape(connection: ApiConnection): void {
             throw new Error(
                `Storage bucketUrl is required for DuckLake: ${connection.name}`,
             );
+         }
+         // The storage credential belongs in the same list as bucketUrl, for the
+         // same reason: it is a field the ATTACH demands, and a destination is only
+         // attached at its first BUILD. Checked in full here — unlike the duckdb
+         // branch above — because this branch already fails a DuckLake at load for
+         // a missing bucket or catalog, and because a storage destination's failure
+         // is caught per-destination (see resolveStorageDestinations) rather than
+         // failing the environment.
+         {
+            const storage = connection.ducklakeConnection.storage;
+            if (storage.s3Connection) {
+               resolveCloudStorageCredentials({
+                  name: connection.name,
+                  type: "s3",
+                  s3Connection: storage.s3Connection,
+               });
+            }
          }
          // metadataSchema is optional, but when present it reaches the ATTACH as a
          // quoted string literal AND the catalog-format preflight as a quoted

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -883,11 +883,17 @@ export function validateStorageDestinations(
          // resolveCloudStorageCredentials already enforces that pair too.
          const storage = destination.ducklakeConnection?.storage;
          if (storage?.s3Connection) {
-            resolveCloudStorageCredentials({
-               name,
-               type: "s3",
-               s3Connection: storage.s3Connection,
-            });
+            resolveCloudStorageCredentials(
+               {
+                  name,
+                  type: "s3",
+                  s3Connection: storage.s3Connection,
+               },
+               // The OPERATOR's own configuration, not an author's: a managed
+               // storage tier running on the host's identity is the intended use
+               // of credential_chain, so `destinations-only` permits it here.
+               "storage-destination",
+            );
          } else if (storage?.gcsConnection) {
             resolveCloudStorageCredentials({
                name,

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -877,12 +877,22 @@ export function validateStorageDestinations(
          // wanted, because a destination is only attached at its first BUILD, which
          // is where a missing storage credential would otherwise surface, hours
          // after the config change that caused it.
+         // Both arms, and in the attach path's own precedence (see
+         // attachDuckLakeWithMode, which takes s3 over gcs): a partial GCS
+         // credential is the same late failure as a partial S3 one, and
+         // resolveCloudStorageCredentials already enforces that pair too.
          const storage = destination.ducklakeConnection?.storage;
          if (storage?.s3Connection) {
             resolveCloudStorageCredentials({
                name,
                type: "s3",
                s3Connection: storage.s3Connection,
+            });
+         } else if (storage?.gcsConnection) {
+            resolveCloudStorageCredentials({
+               name,
+               type: "gcs",
+               gcsConnection: storage.gcsConnection,
             });
          }
       } catch (error) {

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -580,21 +580,24 @@ function validateConnectionShape(connection: ApiConnection): void {
                `Storage bucketUrl is required for DuckLake: ${connection.name}`,
             );
          }
-         // The storage credential belongs in the same list as bucketUrl, for the
-         // same reason: it is a field the ATTACH demands, and a destination is only
-         // attached at its first BUILD. Checked in full here — unlike the duckdb
-         // branch above — because this branch already fails a DuckLake at load for
-         // a missing bucket or catalog, and because a storage destination's failure
-         // is caught per-destination (see resolveStorageDestinations) rather than
-         // failing the environment.
+         // Shape only, matching the duckdb branch above, and for the same reason:
+         // this validator's throw reaches assembleEnvironmentConnections, which has
+         // no per-connection recovery, so a rule enforced here fails the ENTIRE
+         // environment. The mutual-exclusion and enum guards are safe to apply
+         // because no config that loads today can violate them. The key-pair
+         // requirement is NOT applied here — a DuckLake carrying a present but
+         // incomplete s3Connection has always loaded and failed when used, and
+         // making it fail every other connection in the environment is a worse
+         // trade than reporting it late.
+         //
+         // A storage DESTINATION is different: validateStorageDestinations rejects
+         // one entry without touching the rest, so it can afford the full check and
+         // does it there. That is the case that motivated moving these guards at
+         // all — a destination is only attached at its first BUILD.
          {
             const storage = connection.ducklakeConnection.storage;
             if (storage.s3Connection) {
-               resolveCloudStorageCredentials({
-                  name: connection.name,
-                  type: "s3",
-                  s3Connection: storage.s3Connection,
-               });
+               validateS3ProviderShape(storage.s3Connection, connection.name);
             }
          }
          // metadataSchema is optional, but when present it reaches the ATTACH as a
@@ -868,6 +871,20 @@ export function validateStorageDestinations(
 
       try {
          validateConnectionShape(destination);
+         // Stricter than validateConnectionShape is allowed to be. It stops at the
+         // credential SHAPE because its throw fails a whole environment; here a bad
+         // entry is rejected on its own, so the full check is affordable — and it is
+         // wanted, because a destination is only attached at its first BUILD, which
+         // is where a missing storage credential would otherwise surface, hours
+         // after the config change that caused it.
+         const storage = destination.ducklakeConnection?.storage;
+         if (storage?.s3Connection) {
+            resolveCloudStorageCredentials({
+               name,
+               type: "s3",
+               s3Connection: storage.s3Connection,
+            });
+         }
       } catch (error) {
          rejected.push({ name, reason: (error as Error).message });
          continue;

--- a/packages/server/src/service/ducklake_secret_renewal.spec.ts
+++ b/packages/server/src/service/ducklake_secret_renewal.spec.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Credible Data Inc.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from "bun:test";
+import { shouldRenewStorageSecret } from "./connection";
+
+/**
+ * The predicate DuckLakeConnection.runSQL actually calls -- not a copy of it. A rule
+ * mirrored into a spec passes whether or not the caller uses it, which is how a test
+ * comes to look like coverage without being any.
+ */
+describe("expired-credential retry decision", () => {
+   const expired = new Error("ExpiredToken: The provided token has expired.");
+   const wrongKey = new Error("InvalidAccessKeyId: no such key");
+
+   it("renews on an expired credential when a renewer is registered", () => {
+      expect(
+         shouldRenewStorageSecret({
+            error: expired,
+            hasRenewer: true,
+            alreadyRenewing: false,
+         }),
+      ).toBe(true);
+   });
+
+   it("does not renew for a credential that was never valid", () => {
+      // Retrying a wrong key would hide a misconfiguration behind a silent second
+      // attempt -- the failure mode this tier has spent its whole design avoiding.
+      expect(
+         shouldRenewStorageSecret({
+            error: wrongKey,
+            hasRenewer: true,
+            alreadyRenewing: false,
+         }),
+      ).toBe(false);
+   });
+
+   it("does not renew a key-pair connection, which registers no renewer", () => {
+      // Only a chain secret stores credentials that age out. A key pair does not
+      // expire, so a renewer is never registered for one.
+      expect(
+         shouldRenewStorageSecret({
+            error: expired,
+            hasRenewer: false,
+            alreadyRenewing: false,
+         }),
+      ).toBe(false);
+   });
+
+   it("does not renew while a renewal is already in flight", () => {
+      // The renewal issues its own statement through the same runSQL, so without
+      // this the failure of that statement would recurse.
+      expect(
+         shouldRenewStorageSecret({
+            error: expired,
+            hasRenewer: true,
+            alreadyRenewing: true,
+         }),
+      ).toBe(false);
+   });
+});

--- a/packages/server/src/service/extension_fetch_policy.spec.ts
+++ b/packages/server/src/service/extension_fetch_policy.spec.ts
@@ -257,3 +257,81 @@ describe("EXTENSION_FETCH_POLICY=on-demand (default) — no behaviour change", (
       await config.releaseConnections().catch(() => {});
    });
 });
+
+// The `aws` extension implements PROVIDER credential_chain, and a chain secret
+// resolves when it is CREATEd rather than on first object access — so the load
+// has to happen first or the attach fails. The DuckLake attach path loads `aws`
+// unconditionally; this generic path reaches the same `attachCloudStorage`
+// through the handler table and does not, which is why the load lives with the
+// secret rather than with the caller.
+describe("credential_chain loads the aws extension before the secret", () => {
+   const envPath = path.join(process.cwd(), "test-extension-policy-chain");
+   const original = process.env.EXTENSION_FETCH_POLICY;
+
+   beforeEach(async () => {
+      await fs.mkdir(envPath, { recursive: true });
+   });
+   afterEach(async () => {
+      sinon.restore();
+      if (original === undefined) delete process.env.EXTENSION_FETCH_POLICY;
+      else process.env.EXTENSION_FETCH_POLICY = original;
+      await fs.rm(envPath, { recursive: true, force: true }).catch(() => {});
+   });
+
+   const attachGenericS3 = async (
+      s3Connection: Record<string, unknown>,
+   ): Promise<string[]> => {
+      const runSQL = sinon
+         .stub(DuckDBConnection.prototype, "runSQL")
+         .resolves({ rows: [] } as never);
+      const config = buildEnvironmentMalloyConfig(
+         [
+            {
+               name: "duckdb_generic_s3",
+               type: "duckdb",
+               duckdbConnection: {
+                  attachedDatabases: [
+                     { name: "root", type: "s3", s3Connection },
+                  ],
+               },
+            },
+         ] as never,
+         envPath,
+      );
+      await config.malloyConfig.connections.lookupConnection(
+         "duckdb_generic_s3",
+      );
+      await config.releaseConnections().catch(() => {});
+      return runSQL.getCalls().map((c) => String(c.args[0]));
+   };
+
+   it("issues LOAD aws ahead of CREATE SECRET on the generic attach path", async () => {
+      const sql = await attachGenericS3({ provider: "credential_chain" });
+      const loadedAws = sql.findIndex((s) => /^\s*LOAD aws/i.test(s));
+      const createdSecret = sql.findIndex((s) =>
+         /CREATE OR REPLACE SECRET/i.test(s),
+      );
+      expect(loadedAws).toBeGreaterThanOrEqual(0);
+      expect(createdSecret).toBeGreaterThanOrEqual(0);
+      expect(loadedAws).toBeLessThan(createdSecret);
+   });
+
+   it("does not load aws for a key-based attachment", async () => {
+      const sql = await attachGenericS3({
+         accessKeyId: "AKIA",
+         secretAccessKey: "shhh",
+      });
+      expect(sql.some((s) => /CREATE OR REPLACE SECRET/i.test(s))).toBe(true);
+      expect(sql.some((s) => /^\s*LOAD aws/i.test(s))).toBe(false);
+   });
+
+   // `aws` is baked into the image, so naming it does not reach the network and
+   // stays inside the policy. If it is ever dropped from the bake list, this is
+   // the test that should start failing.
+   it("never issues INSTALL aws under local-only", async () => {
+      process.env.EXTENSION_FETCH_POLICY = "local-only";
+      const sql = await attachGenericS3({ provider: "credential_chain" });
+      expect(sql.some((s) => /^\s*LOAD aws/i.test(s))).toBe(true);
+      expect(sql.some((s) => /^\s*INSTALL\s/i.test(s))).toBe(false);
+   });
+});

--- a/packages/server/src/service/gcs_s3_utils.spec.ts
+++ b/packages/server/src/service/gcs_s3_utils.spec.ts
@@ -3,6 +3,7 @@ import {
    createCloudStorageClient,
    DEFAULT_S3_CREDENTIAL_CHAIN,
    s3ConnectionToCredentials,
+   validateS3ProviderShape,
 } from "./gcs_s3_utils";
 
 // The SDK's default chain reads the environment first, so seeding it keeps these
@@ -100,5 +101,71 @@ describe("DEFAULT_S3_CREDENTIAL_CHAIN", () => {
       const providers = DEFAULT_S3_CREDENTIAL_CHAIN.split(";");
       expect(providers).toContain("web_identity");
       expect(providers).not.toContain("config");
+   });
+});
+
+describe("S3_CREDENTIAL_CHAIN_POLICY", () => {
+   const ORIGINAL = process.env.S3_CREDENTIAL_CHAIN_POLICY;
+   afterEach(() => {
+      if (ORIGINAL === undefined) delete process.env.S3_CREDENTIAL_CHAIN_POLICY;
+      else process.env.S3_CREDENTIAL_CHAIN_POLICY = ORIGINAL;
+   });
+
+   const chainConn = () => ({ provider: "credential_chain" }) as never;
+
+   it("permits chain auth anywhere when unset, so no deployment changes", () => {
+      delete process.env.S3_CREDENTIAL_CHAIN_POLICY;
+      expect(() => validateS3ProviderShape(chainConn(), "c")).not.toThrow();
+      expect(() =>
+         validateS3ProviderShape(chainConn(), "c", "storage-destination"),
+      ).not.toThrow();
+   });
+
+   it("under destinations-only, refuses a connection and permits a destination", () => {
+      // The whole point of the setting: a storage destination is the OPERATOR's
+      // configuration, while a connection may be authored by whoever can reach the
+      // connection endpoints — and Publisher's take an arbitrary body.
+      process.env.S3_CREDENTIAL_CHAIN_POLICY = "destinations-only";
+      expect(() => validateS3ProviderShape(chainConn(), "c")).toThrow(
+         /not permitted.*destinations-only/s,
+      );
+      expect(() =>
+         validateS3ProviderShape(chainConn(), "c", "storage-destination"),
+      ).not.toThrow();
+   });
+
+   it("under off, refuses both", () => {
+      process.env.S3_CREDENTIAL_CHAIN_POLICY = "off";
+      expect(() => validateS3ProviderShape(chainConn(), "c")).toThrow(
+         /not permitted/,
+      );
+      expect(() =>
+         validateS3ProviderShape(chainConn(), "c", "storage-destination"),
+      ).toThrow(/not permitted/);
+   });
+
+   it("defaults an unstated origin to the refused case", () => {
+      // A caller that does not say which path it is on is treated as the
+      // author-supplied one. Failing closed is the only safe default for a
+      // parameter whose whole job is to decide whether to lend the host identity.
+      process.env.S3_CREDENTIAL_CHAIN_POLICY = "destinations-only";
+      expect(() => validateS3ProviderShape(chainConn(), "c")).toThrow(
+         /not permitted/,
+      );
+   });
+
+   it("leaves a key-pair connection alone under every policy", () => {
+      const keyed = { accessKeyId: "AKIA", secretAccessKey: "s" } as never;
+      for (const p of ["any", "destinations-only", "off"]) {
+         process.env.S3_CREDENTIAL_CHAIN_POLICY = p;
+         expect(() => validateS3ProviderShape(keyed, "c")).not.toThrow();
+      }
+   });
+
+   it("refuses an unrecognized policy value rather than choosing the permissive one", () => {
+      process.env.S3_CREDENTIAL_CHAIN_POLICY = "destinations_only";
+      expect(() => validateS3ProviderShape(chainConn(), "c")).toThrow(
+         /Invalid value for S3_CREDENTIAL_CHAIN_POLICY/,
+      );
    });
 });

--- a/packages/server/src/service/gcs_s3_utils.spec.ts
+++ b/packages/server/src/service/gcs_s3_utils.spec.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+   createCloudStorageClient,
+   DEFAULT_S3_CREDENTIAL_CHAIN,
+   s3ConnectionToCredentials,
+} from "./gcs_s3_utils";
+
+// The SDK's default chain reads the environment first, so seeding it keeps these
+// tests off the network — no IMDS probe, no shared credentials file.
+const CHAIN_ENV = {
+   AWS_ACCESS_KEY_ID: "AKIAFROMENV",
+   AWS_SECRET_ACCESS_KEY: "secretfromenv",
+};
+
+const saved: Record<string, string | undefined> = {};
+const seedEnv = () => {
+   for (const [key, value] of Object.entries(CHAIN_ENV)) {
+      saved[key] = process.env[key];
+      process.env[key] = value;
+   }
+};
+
+afterEach(() => {
+   for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+   }
+});
+
+describe("createCloudStorageClient", () => {
+   it("signs with the configured key pair under provider 'config'", async () => {
+      const client = createCloudStorageClient(
+         s3ConnectionToCredentials({
+            accessKeyId: "AKIACONFIGURED",
+            secretAccessKey: "configured",
+            region: "us-west-2",
+         }),
+      );
+      const resolved = await client.config.credentials();
+      expect(resolved.accessKeyId).toBe("AKIACONFIGURED");
+      expect(resolved.secretAccessKey).toBe("configured");
+   });
+
+   // The bug this pins: a keyless S3Connection used to be passed through as
+   // accessKeyId: "", so every request was signed with an empty key and failed
+   // on signature rather than on configuration.
+   it("defers to the host under provider 'credential_chain'", async () => {
+      seedEnv();
+      const client = createCloudStorageClient(
+         s3ConnectionToCredentials({
+            provider: "credential_chain",
+            region: "us-west-2",
+         }),
+      );
+      const resolved = await client.config.credentials();
+      expect(resolved.accessKeyId).toBe(CHAIN_ENV.AWS_ACCESS_KEY_ID);
+      expect(resolved.accessKeyId).not.toBe("");
+   });
+
+   it("leaves GCS on its HMAC key pair", async () => {
+      seedEnv();
+      const client = createCloudStorageClient({
+         type: "gcs",
+         accessKeyId: "GOOGHMAC",
+         secretAccessKey: "hmacsecret",
+         // GCS has no chain equivalent through this path; a provider set here
+         // must not divert it to the AWS environment.
+         provider: "credential_chain",
+      });
+      const resolved = await client.config.credentials();
+      expect(resolved.accessKeyId).toBe("GOOGHMAC");
+   });
+});
+
+describe("s3ConnectionToCredentials", () => {
+   it("carries the provider and chain through", () => {
+      const credentials = s3ConnectionToCredentials({
+         provider: "credential_chain",
+         chain: "env;instance",
+      });
+      expect(credentials.provider).toBe("credential_chain");
+      expect(credentials.chain).toBe("env;instance");
+   });
+
+   it("leaves both unset for a key-based connection", () => {
+      const credentials = s3ConnectionToCredentials({
+         accessKeyId: "AKIA",
+         secretAccessKey: "shhh",
+      });
+      expect(credentials.provider).toBeUndefined();
+      expect(credentials.chain).toBeUndefined();
+   });
+});
+
+describe("DEFAULT_S3_CREDENTIAL_CHAIN", () => {
+   // `config` is a shared credentials file, which is the one source a container
+   // image does not have, and it is what DuckDB falls back to when CHAIN is
+   // omitted. Naming it here would defeat the point of the default.
+   it("omits config and covers a projected token", () => {
+      const providers = DEFAULT_S3_CREDENTIAL_CHAIN.split(";");
+      expect(providers).toContain("web_identity");
+      expect(providers).not.toContain("config");
+   });
+});

--- a/packages/server/src/service/gcs_s3_utils.ts
+++ b/packages/server/src/service/gcs_s3_utils.ts
@@ -13,6 +13,13 @@ import { runIntrospectionSQL, sqlLiteral } from "./introspection_sql";
 
 type ApiTable = components["schemas"]["Table"];
 type CloudStorageType = "gcs" | "s3";
+type ApiS3Connection = components["schemas"]["S3Connection"];
+type ApiAttachedDatabase = components["schemas"]["AttachedDatabase"];
+
+// The providers `S3Connection.provider` admits. Canonical here rather than in
+// connection.ts, which imports this module, so the config-load validator and the
+// connect-time builder derive from one list. Mirrors the enum in api-doc.yaml.
+const S3_PROVIDERS = ["config", "credential_chain"] as const;
 
 // The provider order Publisher supplies when a chain-auth S3 connection names
 // none. DuckDB's own default is `config` alone — a shared credentials file,
@@ -83,6 +90,124 @@ export function s3ConnectionToCredentials(s3Connection: {
    };
 }
 
+/**
+ * Checks the parts of an S3 connection's credential *shape* that are wrong on their
+ * face, independent of whether a key pair is required.
+ *
+ * Separate from {@link resolveCloudStorageCredentials} because of where each is safe
+ * to call. These checks reject only configurations that no path ever accepted, so a
+ * config that loads today still loads; the key-pair requirement is a longer-standing
+ * rule whose enforcement point is load-bearing (see the callers in
+ * connection_config.ts).
+ *
+ * The typeof checks are load-bearing rather than defensive: the values arrive from
+ * untyped JSON, so `provider: true` would otherwise slip past a string comparison
+ * into the `config` path and be reported as a missing access key, and a non-string
+ * `chain` would reach `.trim()` as a TypeError at the first attach.
+ */
+export function validateS3ProviderShape(
+   s3Connection: ApiS3Connection,
+   connectionName: string | undefined,
+): void {
+   const provider = s3Connection.provider as unknown;
+   if (provider !== undefined) {
+      if (
+         typeof provider !== "string" ||
+         !S3_PROVIDERS.includes(provider as (typeof S3_PROVIDERS)[number])
+      ) {
+         throw new Error(
+            `S3 provider must be one of ${S3_PROVIDERS.join(", ")} for: ${connectionName}`,
+         );
+      }
+   }
+   const chain = s3Connection.chain as unknown;
+   if (chain !== undefined && typeof chain !== "string") {
+      throw new Error(`S3 chain must be a string for: ${connectionName}`);
+   }
+
+   if (provider === "credential_chain") {
+      // A static credential supplied alongside chain auth is rejected rather than
+      // ignored: it would sit unused in the config, reading as the thing granting
+      // access while something else actually does.
+      if (
+         s3Connection.accessKeyId ||
+         s3Connection.secretAccessKey ||
+         s3Connection.sessionToken
+      ) {
+         throw new Error(
+            `S3 accessKeyId, secretAccessKey, and sessionToken must not be set when provider is 'credential_chain' for: ${connectionName}`,
+         );
+      }
+   } else if (s3Connection.chain) {
+      // The mirror argument: a chain named under key-based auth reads as though the
+      // host supplies the credentials when the key pair beside it is what does.
+      throw new Error(
+         `S3 chain is only valid when provider is 'credential_chain' for: ${connectionName}`,
+      );
+   }
+}
+
+/**
+ * Validates a GCS or S3 attachment's credential configuration and reduces it to the
+ * shape both the DuckDB secret and Publisher's own storage client read.
+ *
+ * Lives here rather than in connection.ts so the config-load validator can reach it
+ * without importing that module, which imports this one. Each guard is therefore
+ * assertable directly: whether a key pair is required depends on the S3 provider, and
+ * a guard only reachable through a live DuckDB session is a guard nothing pins.
+ */
+export function resolveCloudStorageCredentials(
+   attachedDb: ApiAttachedDatabase,
+): CloudStorageCredentials {
+   if (attachedDb.type === "gcs") {
+      if (!attachedDb.gcsConnection) {
+         throw new Error(
+            `GCS connection configuration missing for: ${attachedDb.name}`,
+         );
+      }
+      if (!attachedDb.gcsConnection.keyId || !attachedDb.gcsConnection.secret) {
+         throw new Error(
+            `GCS keyId and secret are required for: ${attachedDb.name}`,
+         );
+      }
+      return {
+         type: "gcs",
+         accessKeyId: attachedDb.gcsConnection.keyId,
+         secretAccessKey: attachedDb.gcsConnection.secret,
+      };
+   }
+
+   if (attachedDb.type !== "s3") {
+      throw new Error(`Invalid cloud storage type: ${attachedDb.type}`);
+   }
+
+   if (!attachedDb.s3Connection) {
+      throw new Error(
+         `S3 connection configuration missing for: ${attachedDb.name}`,
+      );
+   }
+   const s3 = attachedDb.s3Connection;
+   validateS3ProviderShape(s3, attachedDb.name);
+   if (
+      s3.provider !== "credential_chain" &&
+      (!s3.accessKeyId || !s3.secretAccessKey)
+   ) {
+      throw new Error(
+         `S3 accessKeyId and secretAccessKey are required for: ${attachedDb.name}`,
+      );
+   }
+   return {
+      type: "s3",
+      accessKeyId: s3.accessKeyId || "",
+      secretAccessKey: s3.secretAccessKey || "",
+      region: s3.region,
+      endpoint: s3.endpoint,
+      sessionToken: s3.sessionToken,
+      provider: s3.provider,
+      chain: s3.chain,
+   };
+}
+
 // Exported for tests: whether the client signs with the configured key pair or
 // leaves resolution to the AWS SDK is the whole of the chain-auth behaviour on
 // this path, and it is not observable through the listing functions below
@@ -94,11 +219,24 @@ export function createCloudStorageClient(
 
    // Under `credential_chain` there is no key pair to sign with, so the
    // `credentials` key is omitted entirely and the AWS SDK resolves its own
-   // default chain. That chain is not DuckDB's: the SDK's covers a web-identity
-   // token natively, which is why the DuckDB secret has to name `web_identity`
-   // explicitly and this does not. Passing the empty strings through instead
-   // would sign every request with an empty key and fail on signature rather
-   // than on configuration.
+   // default chain. Passing the empty strings through instead would sign every
+   // request with an empty key and fail on signature rather than on configuration.
+   //
+   // KNOWN DIVERGENCE, and it runs both ways. The SDK's default chain covers a
+   // web-identity token natively, which is why the DuckDB secret must name
+   // `web_identity` and this need not. But it ALSO covers sources DuckDB's chain
+   // does not — the shared credentials file, AWS_PROFILE, SSO, process — and it
+   // ignores `chain` entirely. So on a host that has one of those, this path can
+   // browse as one principal while the query path resolves another: a mounted
+   // credentials file is invisible to DuckDB and wins here.
+   //
+   // Not corrected by narrowing this to `chain`, deliberately: doing so needs a
+   // DuckDB-provider-to-SDK-provider mapping for all seven of DuckDB's names, plus
+   // direct dependencies on providers that are currently only transitive, and the
+   // table would drift against both sides. The divergence cannot arise in the
+   // deployment this exists for — a container image has no credentials file,
+   // profile, or SSO cache — and where it can arise the query path is the
+   // authoritative one and fails visibly.
    const useHostCredentials =
       !isGCS && credentials.provider === "credential_chain";
 

--- a/packages/server/src/service/gcs_s3_utils.ts
+++ b/packages/server/src/service/gcs_s3_utils.ts
@@ -14,6 +14,17 @@ import { runIntrospectionSQL, sqlLiteral } from "./introspection_sql";
 type ApiTable = components["schemas"]["Table"];
 type CloudStorageType = "gcs" | "s3";
 
+// The provider order Publisher supplies when a chain-auth S3 connection names
+// none. DuckDB's own default is `config` alone — a shared credentials file,
+// which is the one source a container does not have — so leaving it unset is not
+// an option. `env` first so an explicit credential in the environment wins,
+// then `web_identity` for a projected service-account token (EKS IRSA, GKE
+// Workload Identity), then `instance` for a node's own profile.
+// Deliberately excluded: `config` (no credentials file in an image), `sts`
+// (needs ASSUME_ROLE_ARN, which this schema has no field for), and `sso` and
+// `process` (workstation flows).
+export const DEFAULT_S3_CREDENTIAL_CHAIN = "env;web_identity;instance";
+
 export interface CloudStorageCredentials {
    type: CloudStorageType;
    accessKeyId: string;
@@ -21,6 +32,12 @@ export interface CloudStorageCredentials {
    region?: string;
    endpoint?: string;
    sessionToken?: string;
+   // S3 only. `credential_chain` means the host supplies the credentials, so
+   // accessKeyId and secretAccessKey are empty and must not be signed with;
+   // `chain` is the provider order to try. GCS has no chain equivalent through
+   // this path — its secret is HMAC-only.
+   provider?: "config" | "credential_chain";
+   chain?: string;
 }
 
 interface CloudStorageBucket {
@@ -51,6 +68,8 @@ export function s3ConnectionToCredentials(s3Connection: {
    region?: string;
    endpoint?: string;
    sessionToken?: string;
+   provider?: "config" | "credential_chain";
+   chain?: string;
 }): CloudStorageCredentials {
    return {
       type: "s3",
@@ -59,22 +78,42 @@ export function s3ConnectionToCredentials(s3Connection: {
       region: s3Connection.region,
       endpoint: s3Connection.endpoint,
       sessionToken: s3Connection.sessionToken,
+      provider: s3Connection.provider,
+      chain: s3Connection.chain,
    };
 }
 
-function createCloudStorageClient(
+// Exported for tests: whether the client signs with the configured key pair or
+// leaves resolution to the AWS SDK is the whole of the chain-auth behaviour on
+// this path, and it is not observable through the listing functions below
+// without reaching a real bucket.
+export function createCloudStorageClient(
    credentials: CloudStorageCredentials,
 ): S3Client {
    const isGCS = credentials.type === "gcs";
 
+   // Under `credential_chain` there is no key pair to sign with, so the
+   // `credentials` key is omitted entirely and the AWS SDK resolves its own
+   // default chain. That chain is not DuckDB's: the SDK's covers a web-identity
+   // token natively, which is why the DuckDB secret has to name `web_identity`
+   // explicitly and this does not. Passing the empty strings through instead
+   // would sign every request with an empty key and fail on signature rather
+   // than on configuration.
+   const useHostCredentials =
+      !isGCS && credentials.provider === "credential_chain";
+
    const client = new S3Client({
       endpoint: isGCS ? "https://storage.googleapis.com" : credentials.endpoint,
       region: isGCS ? "auto" : credentials.region || "us-east-1",
-      credentials: {
-         accessKeyId: credentials.accessKeyId,
-         secretAccessKey: credentials.secretAccessKey,
-         sessionToken: credentials.sessionToken,
-      },
+      ...(useHostCredentials
+         ? {}
+         : {
+              credentials: {
+                 accessKeyId: credentials.accessKeyId,
+                 secretAccessKey: credentials.secretAccessKey,
+                 sessionToken: credentials.sessionToken,
+              },
+           }),
       forcePathStyle: isGCS || !!credentials.endpoint,
    });
 

--- a/packages/server/src/service/gcs_s3_utils.ts
+++ b/packages/server/src/service/gcs_s3_utils.ts
@@ -8,6 +8,7 @@ import {
 } from "@aws-sdk/client-s3";
 import { Connection } from "@malloydata/malloy";
 import { components } from "../api";
+import { getS3CredentialChainPolicy } from "../config";
 import { logger } from "../logger";
 import { runIntrospectionSQL, sqlLiteral } from "./introspection_sql";
 
@@ -108,6 +109,10 @@ export function s3ConnectionToCredentials(s3Connection: {
 export function validateS3ProviderShape(
    s3Connection: ApiS3Connection,
    connectionName: string | undefined,
+   // Where this connection came from, which is what the credential-chain policy
+   // turns on. Defaults to "connection" so a caller that does not say is treated
+   // as the author-supplied case -- the one worth refusing.
+   origin: "connection" | "storage-destination" = "connection",
 ): void {
    const provider = s3Connection.provider as unknown;
    if (provider !== undefined) {
@@ -126,6 +131,23 @@ export function validateS3ProviderShape(
    }
 
    if (provider === "credential_chain") {
+      // Host-resolved credentials, gated by deployment policy. `destinations-only`
+      // draws the line where authorship changes hands: a storage destination is
+      // the operator's own configuration, while an environment connection may be
+      // supplied by whoever can reach the connection endpoints. See
+      // getS3CredentialChainPolicy for why that distinction is the useful one.
+      const policy = getS3CredentialChainPolicy();
+      if (
+         policy === "off" ||
+         (policy === "destinations-only" && origin === "connection")
+      ) {
+         throw new Error(
+            `S3 provider 'credential_chain' is not permitted for: ${connectionName}` +
+               ` (S3_CREDENTIAL_CHAIN_POLICY=${policy}). It resolves the host's own` +
+               ` credentials; supply an accessKeyId and secretAccessKey instead.`,
+         );
+      }
+
       // A static credential supplied alongside chain auth is rejected rather than
       // ignored: it would sit unused in the config, reading as the thing granting
       // access while something else actually does.
@@ -158,6 +180,9 @@ export function validateS3ProviderShape(
  */
 export function resolveCloudStorageCredentials(
    attachedDb: ApiAttachedDatabase,
+   // Forwarded to the shape validator, which is where the credential-chain policy
+   // is applied. Same default and same reason: unstated means author-supplied.
+   origin: "connection" | "storage-destination" = "connection",
 ): CloudStorageCredentials {
    if (attachedDb.type === "gcs") {
       if (!attachedDb.gcsConnection) {
@@ -187,7 +212,7 @@ export function resolveCloudStorageCredentials(
       );
    }
    const s3 = attachedDb.s3Connection;
-   validateS3ProviderShape(s3, attachedDb.name);
+   validateS3ProviderShape(s3, attachedDb.name, origin);
    if (
       s3.provider !== "credential_chain" &&
       (!s3.accessKeyId || !s3.secretAccessKey)


### PR DESCRIPTION
## What

An `s3` connection accepts a `provider` selector. Under `provider: credential_chain`, DuckDB resolves credentials from the host — an instance profile, a web-identity token, or the environment — instead of from a static access key pair, so a DuckLake storage root on `s3://` can be reached without minting and storing a long-lived key.

`provider: config` is the default and remains the only other value. Its emitted SQL is unchanged.

```yaml
# before — the only shape available
s3Connection: { accessKeyId: AKIA…, secretAccessKey: …, region: us-east-1 }

# now also
s3Connection: { provider: credential_chain, region: us-east-1 }
```

```sql
CREATE OR REPLACE SECRET s3_root (
   TYPE s3,
   PROVIDER credential_chain,
   CHAIN 'env;web_identity;instance',
   REFRESH 'auto',
   REGION 'us-east-1'
);
```

**No malloy-core change is needed** — the secret goes out through `connection.runSQL()`, an API `db-duckdb` already exposes. Everything below was measured against the pinned DuckDB (`@duckdb/node-api 1.5.3-r.2` → DuckDB `v1.5.3`, the same version `@malloydata/db-duckdb@0.0.427` pins, so there is one copy) rather than reasoned about.

## Why these three details are not arbitrary

**`CHAIN` is load-bearing, not optional.** With `PROVIDER credential_chain` and no `CHAIN`, DuckDB resolves against `config` *alone* — the error names it: `Credential Chain: 'config'`. That is a shared credentials file, the one source a container image does not have. A caller who omits `CHAIN` would therefore get the single link that cannot work in the deployment this feature exists for, so Publisher supplies an order (`env;web_identity;instance`) rather than passing through only what the caller set. Excluded deliberately: `config` (no credentials file in an image), `sts` (needs `ASSUME_ROLE_ARN`, which this schema has no field for), `sso` and `process` (workstation flows). Valid values at 1.5.3 are `env`, `config`, `sts`, `instance`, `sso`, `process`, `web_identity`; `assume_role` and `default` are rejected outright.

**`REFRESH 'auto'` is the only value that arms refresh at all.** A chain secret stores the credentials it *resolved*, not a reference to the provider that resolved them — `duckdb_secrets().secret_string` on a `CHAIN 'env'` secret contains the literal key id. So there are two lifetimes and only one is managed: a projected service-account token is refreshed continuously by the platform, while the credentials DuckDB derived from it expire on their own schedule. The binding clock is the role's `MaxSessionDuration` — an hour by default — not the token's TTL, which is typically far longer and misleading to reason from.

That is invisible on the build path, where the session lasts one build, and fatal on the serve path, where the attach is idempotent and the secret lives as long as the connection.

The literal string `auto` matters, and quietly. The `aws` extension stores the `refresh_info` that makes a secret refreshable under `if (refresh == "auto")` and ignores every other value; `httpfs` then declines to refresh a secret that has no `refresh_info`. So any other value — `REFRESH true` included — is accepted without complaint and arms nothing. It is in fact *worse* than omitting the clause, because a bare `sts` or `web_identity` chain arms refresh by default only when the parameter is empty, and a non-empty value skips that fallback.

**Armed, the refresh works — but it does not reach every read path.** Measured below: a direct object read re-resolves transparently at expiry and never surfaces an error, while a read through an attached DuckLake catalog surfaces `ExpiredToken` from an equally armed secret. So the connection also re-resolves the secret itself when a statement fails on an expired credential, and retries once. `REFRESH 'auto'` is the mechanism; the retry is the fallback for the paths it does not cover.

**Failure moves from first object access to attach — intentionally.** A key-based secret stores whatever it is given; a chain secret resolves at `CREATE` and throws if it cannot. So a host that cannot supply credentials now fails the attach with a legible message, instead of returning a bare `403` on a Parquet path minutes into a build. The trade-off is that a transient token-file or IMDS hiccup now fails an attach rather than one read — which turned out to matter more than expected, because a failed attach was cached and replayed for the life of the process. That is fixed in its own commit and applies to every attached database type, not just cloud storage.

## The trap this avoids

`ducklakeConfig.storage` already permits an `s3://` `bucketUrl` with **no** `s3Connection` at all, and that attaches today with no credential and 403s at first object access. Chain auth is therefore an *explicit* selector rather than an inference from absent keys — inferring it would silently turn that misconfiguration into "try the chain", and a genuinely broken deployment would look configured until a read failed. For the same reason, a key or session token supplied *alongside* `credential_chain` is rejected rather than ignored: an unused key reads as the thing granting access while something else actually does. A `chain` named under `provider: config` is rejected on the mirror argument.

## Two things beyond the secret

- **`attachCloudStorage` has two callers.** Besides the DuckLake attach path (which loads `aws` already), it is reached from the generic connection handler table, which does not. `credential_chain` is implemented by the `aws` extension and resolves at `CREATE`, so the load now lives with the secret rather than with the caller. `aws` is baked into the image (`bake-duckdb-extensions.js`), so this stays inside `EXTENSION_FETCH_POLICY=local-only` — pinned by a test asserting `LOAD aws` and no `INSTALL`.
- **Publisher does its own S3 I/O.** `gcs_s3_utils.ts` builds an `@aws-sdk/client-s3` client for schema browsing and object listing, passing the configured key pair explicitly and coercing a missing one to `""`. A keyless connection would have signed every browse request with an empty key and failed on signature rather than on configuration, so the client now omits `credentials` entirely under chain auth and lets the SDK resolve its own chain.

  **That leaves two resolvers for one config, and the divergence runs both ways.** The SDK's default chain covers a web-identity token natively, which is why the DuckDB secret must name `web_identity` and this need not — but it also covers sources DuckDB's chain does not (the shared credentials file, `AWS_PROFILE`, SSO, process) and it ignores `chain` entirely. So on a host that has one of those, the browse path can resolve a different principal than the query path. Left as-is deliberately: narrowing the SDK to `chain` needs a mapping for all seven of DuckDB's provider names plus direct dependencies on providers that are currently only transitive, and that table would drift against both sides. It cannot arise in a container image, which has no credentials file, profile, or SSO cache, and where it can arise the query path is authoritative and fails visibly. Documented at the call site.

GCS is untouched — its secret is HMAC-only and has no chain equivalent through this path, so a `provider` set on a GCS root must not divert it.

## Where the checks fire, and rolling this out

The credential guards run at **config load**, not at attach — the distinction that matters for a storage destination, which is only attached at its first *build*, so an error would otherwise surface hours after the config change that caused it.

How strict each check is depends on what a rejection costs, not on which field it is:

- **A storage destination** is checked in full, key pair included, for a GCS root as well as an S3 one. `validateStorageDestinations` rejects one entry with a reason and leaves the others accepted, so early failure is free.
- **An environment connection** — a DuckLake connection, or an S3 attached database — is checked for *shape* only: the enum and the mutual-exclusion rules, which no config that loads today can violate. That validator's throw reaches `assembleEnvironmentConnections`, which has no per-connection recovery, so enforcing the key pair there would take a whole environment down for one incomplete `s3Connection` that previously just failed when used. It still fails at attach, exactly as before.

Both dialogs enforce the pair on the `config` path, so the UI still catches a missing key before it is saved.

**Rolling this out:** an older build handed `provider: credential_chain` ignores the unknown field, sees an `s3Connection` with no key, and refuses — so upgrade before anything starts emitting the selector. Getting the order wrong is loud and fails closed, not a silent wrong-identity read. The reverse direction is safe: a new build handed a key pair takes the `config` path, whose emitted SQL is pinned byte-identical.

**One thing worth naming for anyone exposing Publisher beyond localhost:** connection create and test take an arbitrary body, and this PR changes what reaching them is worth — from "use credentials you already hold" to "act as the host's role against any bucket it can reach", and with `endpoint` set, sign requests to a caller-chosen host with that identity. The credential itself is never disclosed, and Publisher is already documented as unauthenticated and localhost-only, so this is not a new bypass — but it raises the value of the existing one, and a deployment that wants to refuse host-identity connections outright has no switch for it today.

## Not in this PR

**The region is defaulted twice** and left that way: the spec carries `default: us-east-1` and `connection.ts` applies `credentials.region || "us-east-1"` on top, so a caller who does not set a region cannot reach a bucket outside `us-east-1`. It is orthogonal to chain auth but lands on the same statement, since a chain secret still needs a correct `REGION`. Worth a follow-up that treats "no region for a remote root" as an error rather than a silent default, because a silent default is what makes a mis-regioned bucket invisible.

**A remote `bucketUrl` with no storage connection still attaches** rather than being refused. Arguably a configuration error, but changing it is a behaviour change for anything relying on it today, so it stays as-is here.

## Schema note

`provider` deliberately carries **no** schema `default:`, though the reason is narrower than it first appears and is worth stating precisely rather than as a rule of thumb. At the pinned `openapi-typescript` (6.x) a defaulted property still generates as **optional**, so a `default:` would be harmless today. It is at 7.x that a default makes the property *required*, which would force every caller to name a provider. So this is robustness across that upgrade, not avoidance of a present-day break — and note `region` already carries a `default:`, so a 7.x bump has to be dealt with either way.

The default is documented in the description and applied when the connection is attached.

## Tests

New tests across four specs, and `packages/server` typechecks at every commit individually rather than only at the tip.

The three pre-existing key-based shapes (plain, custom endpoint, session token) and the GCS shape are asserted as **whole statements** rather than substrings — chain auth added a branch ahead of them and the point is that nothing downstream moved. The secret-SQL assembly and the credential validation were each split into a pure exported function to make that possible without a live DuckDB.

**Every new guard was mutation-checked** — deleted one at a time, confirming at least one test goes red. Two did not survive the check initially. The `aws` extension load was unpinned, and now has a test driving the generic attach path and asserting `LOAD aws` precedes `CREATE OR REPLACE SECRET`. And the refresh assertion checked only that a `REFRESH` clause was *present*, which is true of the value that disables refresh — it now pins the value, and reverting to the old one turns it red.

## Verified on a live EKS cluster

Two questions were what kept this a draft: whether `web_identity` resolves in a real pod, and what happens when the resolved credential expires. Both are answered, the second not in the direction expected.

### `web_identity` resolves a projected service-account token — confirmed

Exercised on an EKS cluster whose worker pods carry `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` from IRSA and hold **no static key anywhere**. With `provider: credential_chain` and the default `CHAIN`, DuckDB resolved the credential, created the secret, attached a DuckLake catalog on Postgres, and wrote Parquet to the S3 root.

A query against the persisted source then served **from that Parquet**, not from the warehouse it was built from. Proven by staleness rather than by matching numbers: a row was added to the source table, after which an identical non-persisted twin moved to the new count while the persisted source held the stored one. Both return correct results, so agreement proves nothing — only the divergence does.

That covers the path this PR exists for: selector → chain resolution → secret → attach → write → serve.

### Expiry: `auto` arms it, and on a direct read the refresh works

What made this legible is that a build and a serve do **not** share a connection. A build attaches read-write for the life of that build; a serve holds a long-lived read-only attach whose secret lives as long as the connection. Each mints its own secret on its own clock. So builds kept succeeding while serves failed, on the same pod at the same moment — which reads like an intermittent fault until you notice the two paths were never using the same credential.

The clearest evidence is an isolated pod: the same image and the same statement, but no Publisher — one connection held open across the expiry boundary, reading one Parquet object every 20s, with two containers differing only in the `REFRESH` value.

Immediately at creation, the value shows up in the secret itself:

```
armed   REFRESH 'auto' -> ...;key_id=ASIA…LQC4;refresh_info={'region': us-east-1,
                              'refresh': auto, 'chain': env;web_identity;instance};…
control REFRESH true   -> ...;key_id=ASIA…EVVY;region=us-east-1;…      (no refresh_info)
```

And at the expiry boundary, exactly 60 minutes later:

| container | at T+1:00 |
| --- | --- |
| `REFRESH 'auto'` | credential rotated (`…LQC4` → `…D625`), **zero failed reads**, the probe spanning the rotation simply took a second longer |
| `REFRESH true` | `ExpiredToken` on every read from that moment on |

So `auto` is not a detail: it is the difference between expiry being invisible and expiry being fatal. The rotation with no surfaced error is also `httpfs` behaving exactly as its source says — it refreshes and re-issues the request internally, so a working refresh is silent by construction.

**The gap this leaves.** On the serve path *through an attached DuckLake catalog*, an equally armed secret still surfaced `ExpiredToken` and the connection's own retry is what carried the query. Same cluster, same hour, same statement — so the difference is the read path, not the secret. `s3fs.cpp` has call sites that pass a null context and opener, and `ReloadS3AuthMaterial` returns false when there is no opener, which is a plausible mechanism but not one this PR has isolated. Untangling it needs a probe that attaches a catalog rather than reading the object directly.

That is why the retry stays. On `ExpiredToken` the connection re-runs `CREATE OR REPLACE SECRET` once and retries the statement. The secret is replaced **in place** on the live connection — a statement, not a session property — so nothing is detached and no query in flight is disturbed, confirmed by no re-attach appearing in the logs. Cost is one STS round trip per connection per expiry rather than one per query, which is why it is reactive on the error rather than scheduled or per-statement. Only `ExpiredToken` retries, so a credential that was never valid still fails on the first attempt rather than twice; a key-pair connection registers no renewer at all. Where DuckDB's refresh does reach, it wins the race and the retry never fires.

The whole path — selector, chain resolution, secret, attach, write, serve, and expiry — is evidence rather than argument.
