### PR TITLE
feat(sdk,app): render a dashboard, and route to it from the Console

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -417,12 +417,26 @@ embedding host renders the same component the Console does.
   Without it the given is the dimension name exactly as the model spells it, so
   `dimension: brand_name` looks for a given called `brand_name` and a model declaring `BRAND` does
   not match: the cell still reads as clickable and the click lands on an unfiltered page. A
-  difference of case alone is forgiven, since both surfaces fold case at lookup, and a `to=self`
-  drill seeding a given no model declares is reported at load.
+  difference of case alone is forgiven only for `to=self`, where the surface resolves the name
+  against the givens it declares and folds case doing it. A `to=<slug>` drill does no lookup: the
+  name goes into the destination's URL as the tag spells it and the destination binds only the
+  parameters it declares, spelled identically, so `given=brand` into a dashboard declaring `BRAND`
+  opens it unfiltered. A `to=self` drill seeding a given no model declares is reported at load.
 - **A file that does not compile fails the whole package.** Loading aborts on the first model error,
   so the dashboards endpoint answers 424 and none of that package's dashboards are served, including
   the ones that compiled. A failed `?reload=true` is refused the same way and leaves the previously
   compiled package serving, which is the behaviour to rely on while editing.
+
+One consequence of the new route, the same one the `data-apps` rename had: the app now claims the
+`dashboards` segment, so `/{env}/{pkg}/dashboards/<file>` is no longer redirected to the static
+route. It has to be claimed, because a slug is a filename with `.malloy` removed and
+`dashboards/report.csv.malloy` therefore publishes the slug `report.csv`, which would otherwise be
+diverted as an asset and 404 on a deep link or a refresh. The case to know about is a package that
+itself ships a `public/dashboards/` directory. Unlike `data-apps`, there is no viewer one segment
+down to catch those: `/{env}/{pkg}/dashboards/<file>` now opens the dashboard viewer, which answers
+"no such dashboard". Address them on the standalone URL,
+`/environments/{env}/packages/{pkg}/dashboards/<file>`, which serves them unchanged as it always
+did.
 
 `docs/dashboards.md` is the guide. No bundled example ships a `dashboards/` directory yet; that
 arrives with the examples change that follows this one.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -405,10 +405,13 @@ embedding host renders the same component the Console does.
 - **A `# drill` naming a dashboard navigates from a notebook cell**, which completes the primitive
   that shipped inert. Where a tag offers two destinations, the click opens a menu naming the
   dashboard and the current surface.
-- **Drill is reachable without a mouse.** Marked cells take `tabindex` and `role="button"`, focus is
-  styled the way hover is, and Enter or Space activates. Previously the only signals a cell did
-  anything were a pointer cursor and a hover colour, neither of which a keyboard or touch user can
-  produce.
+- **Drill is reachable without a mouse.** Marked cells take `role="button"`, focus is styled the way
+  hover is, and Enter or Space activates. Previously the only signals a cell did anything were a
+  pointer cursor and a hover colour, neither of which a keyboard or touch user can produce. A
+  drillable column takes ONE tab stop rather than one per row, with ArrowUp/ArrowDown and Home/End
+  moving within it: tabbing through every cell of a result would have been its own accessibility
+  problem, since a result at the row cap would have stood between the reader and everything after
+  it.
 - **A `select` control looks like one.** MUI hides the dropdown arrow whenever a combobox accepts
   free text, which it must here since a `suggest` returns the common values rather than every legal
   one, so a picker rendered as a plain text box and its option list was undiscoverable.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -297,7 +297,7 @@ This is a **breaking release for SDK consumers**: five removals and one narrowed
 ### What changed
 
 - **A notebook's parameters live in its URL.** `Notebook` takes `givens` and `onGivensChange`, and the Console wires them to the query string. Opening a notebook at `?REGION=West` runs every cell with that value on the first pass rather than running bare and running again. The host is handed the names the notebook manages alongside the values, so it can update its own query string without disturbing parameters that are not its business.
-- **`# drill { to=self }` works in a notebook cell.** A cell that groups by a dimension carrying the tag becomes clickable and filters the notebook in place with the clicked value, provided the notebook declares the given the tag names: one that names a given the document does not declare stays plain rather than offering a click that cannot be honoured. Drillable cells read as links on hover, via a new mode-keyed `drillLink` theme colour. Two cases are deliberately left unmarked: a blank cell, whose click is refused anyway (a blank value is far likelier a misclick than a request for the rows that are blank), and every cell of a `# transpose` table, because the renderer lays that layout out without the per-cell `grid-column` the marking matches on. A transposed table's drill still WORKS when clicked; it is undiscoverable, which is the one place on this surface where the affordance and the behaviour disagree. A drill naming a *dashboard* destination is deliberately inert for now: the route it would navigate to does not exist yet, and painting a cell as a link to a page that answers "Nothing to open at this path" is worse than leaving it plain, so those cells are not marked either. The primitives handle it; the surface will honour it once the dashboard route lands.
+- **`# drill { to=self }` works in a notebook cell.** A cell that groups by a dimension carrying the tag becomes clickable and filters the notebook in place with the clicked value, provided the notebook declares the given the tag names: one that names a given the document does not declare stays plain rather than offering a click that cannot be honoured. Drillable cells read as links on hover, via a new mode-keyed `drillLink` theme colour. Two cases are deliberately left unmarked: a blank cell, whose click is refused anyway (a blank value is far likelier a misclick than a request for the rows that are blank), and every cell of a `# transpose` table, because the renderer lays that layout out without the per-cell `grid-column` the marking matches on. A transposed table's drill still WORKS when clicked; it is undiscoverable, which is the one place on this surface where the affordance and the behaviour disagree. A drill naming a *dashboard* destination is honoured too, now that the dashboard route exists: the cell is marked, and clicking it opens that dashboard with the value seeded. On a host that has not wired the navigation the destination stays unmarked and inert rather than painting a cell as a link to a page that answers "Nothing to open at this path".
 - **`select` / `multiselect` controls backed by `suggest`.** The option list comes from an ordinary query on the governed query endpoint, so row caps and `#(authorize)` gates apply to a dropdown exactly as they do to the surface's own queries. A suggest query that fails now says so on the control instead of rendering as a dimension with no values, and the generated query carries an explicit `limit:` and ordering rather than relying on the server's default row cap to truncate it in whatever order the warehouse returned.
 - **Filter values are escaped by Malloy's own filter package.** A `filter<…>` value picked in a control is now printed with `@malloydata/malloy-filter`'s `StringFilterExpression.unparse`, and read back with its parser. The previous scheme wrapped values in double quotes, which Malloy's string-filter grammar has no notion of: backslash is its only escape, so the quoting escaped nothing and several ordinary values silently meant something else. Measured against the `storefront` model, filtering its `category` dimension: a picked `-Outerwear` ran as a negation and returned 22,821 of 25,356 rows instead of the 2,535 that category holds; `%` bypassed the filter and returned all 25,356; `null` hit the null operator and returned 0; and `Ben & Jerry, Inc` was read as two brands. All of these now match themselves, pinned by a round-trip test against the real parser.
 - **The notebook's controls are `given:` only.** The Filters panel that rendered `#(filter)` and `##(filters)` annotations is gone, and the notebook no longer sends `filterParams`. **This is a behaviour change for a model that uses `#(filter)`, and the deprecation note under 0.0.201 said otherwise.** Concretely: a cell fails when its run target is a source that declares a `required` filter, because the server still refuses one with no value and there is no longer a UI that can supply it. That is narrower than "every cell" in two ways worth knowing before you audit a model: enforcement is per run-target source, so cells querying a source with no filters are unaffected, and a **block-form** `#(filter) … required` is not collected at all, so it never raised the error in the first place (`source_extraction.ts` documents that gap deliberately). A model with only optional `#(filter)` annotations still runs, but is no longer filterable from the notebook. The REST parameters, the `Deprecation` header, and the server-side enforcement are all unchanged: this is the UI half of the migration landing ahead of the server half. Migrate to `given:`: [docs/givens.md](docs/givens.md) has a **"Coming from `#(filter)`"** section with a worked conversion and the three things that do not map across.
@@ -375,6 +375,56 @@ A production deployment answers it **404 as JSON**, so a client sees a clean err
 Why the REST path breaks cleanly while the browser URL gets a grace period: the two have different costs and different owners. Carrying both spellings in the spec would mean two paths, two operationIds and two generated client methods for one listing, with every future change to it made twice, and the one known consumer of the endpoint reviewed this change and chose the clean break, having already accepted the short window during a rollout where some of its machines answer 404. A bookmark has no owner to consult, and the person who saved it is not reading these notes, so that surface redirects for one release rather than failing. The endpoint is documented (in [docs/html-data-apps.md](docs/html-data-apps.md) and [docs/api-overview.md](docs/api-overview.md), both updated here), so the REST break is a real one for anyone who took it up rather than a quiet one. If that trade is wrong for your deployment, say so on the PR.
 
 One more consequence of the SPA route move, easy to miss: the app now claims the `data-apps` segment, so `/{env}/{pkg}/data-apps/<file>` is no longer redirected to the static route. Clicking a data app in the Console is unaffected, because the listing already includes the file's path relative to `public/`. What changes is a hand-written URL of that shape: it opens the embedded viewer one segment down, on `public/<file>`, rather than redirecting. A package that itself ships a `public/data-apps/` directory is the case to know about, since its files are addressed as `/{env}/{pkg}/data-apps/data-apps/<file>`; the standalone URL `/environments/{env}/packages/{pkg}/data-apps/<file>` serves them unchanged either way. This mirrors what `public/pages/` had before, so it is not a new class of collision, but `data-apps` is a likelier directory name than `pages` was.
+
+## [Unreleased]: dashboards render, and the Console serves them
+
+The server half of dashboards had no UI. It has one now: a package's dashboards are listed on its
+page and open at `/{env}/{package}/dashboards/{name}`, and `<Dashboard>` is a public SDK export so an
+embedding host renders the same component the Console does.
+
+### What changed
+
+- **A dashboard page.** `<Dashboard>` reads the manifest and renders either form: a single query
+  whose result is the page, or a composite whose tiles each run on their own and combine into one
+  `dashboardColumns` grid. A tile owning its own query is what lets one broken tile show its error in
+  place while the rest of the grid still renders. It takes props rather than reading a router, so the
+  Console and an external React app differ only in what they do with `onNavigate` and
+  `onGivensChange`.
+- **Control state is URL state.** Filtering replaces history so Back leaves the dashboard rather than
+  walking through every value tried; drilling pushes it so Back returns to where the drill started.
+  A `# artifact { autorun=false }` dashboard batches changes behind Apply.
+- **A Dashboards section on the package page**, listed first because it is the at-a-glance artifact a
+  visitor most likely wants, and hidden when the package has none. A dashboard's own file is filtered
+  out of Semantic Models so it is listed once; untagged shared includes under `dashboards/` are not
+  dashboards and stay in the model list. Notebooks are now listed by title too, with the filename as
+  the secondary label.
+- **`## autorun=false` is honoured in notebooks**, which had hardcoded it true while nothing produced
+  the field. The server derives it now, so a notebook gets the same Apply batching a dashboard does.
+- **A `# drill` naming a dashboard navigates from a notebook cell**, which completes the primitive
+  that shipped inert. Where a tag offers two destinations, the click opens a menu naming the
+  dashboard and the current surface.
+- **Drill is reachable without a mouse.** Marked cells take `tabindex` and `role="button"`, focus is
+  styled the way hover is, and Enter or Space activates. Previously the only signals a cell did
+  anything were a pointer cursor and a hover colour, neither of which a keyboard or touch user can
+  produce.
+- **A `select` control looks like one.** MUI hides the dropdown arrow whenever a combobox accepts
+  free text, which it must here since a `suggest` returns the common values rather than every legal
+  one, so a picker rendered as a plain text box and its option list was undiscoverable.
+
+### Two things to know when authoring
+
+- **Write `given=` on a `# drill` tag.** Without it the given is the dimension name exactly as the
+  model spells it, so a lowercase `dimension: category` looks for a given called `category`. A
+  dashboard declaring `CATEGORY` does not match, the cell still reads as clickable, and the click
+  lands on an unfiltered page. The load-time lint does not catch it, because it upper-cases the
+  dimension name before checking while the click does not.
+- **A file that does not compile fails the whole package.** Loading aborts on the first model error,
+  so the dashboards endpoint answers 424 and none of that package's dashboards are served, including
+  the ones that compiled. A failed `?reload=true` is refused the same way and leaves the previously
+  compiled package serving, which is the behaviour to rely on while editing.
+
+`docs/dashboards.md` is the guide. No bundled example ships a `dashboards/` directory yet; that
+arrives with the examples change that follows this one.
 
 ## [Unreleased]: dashboards are discovered and served over REST
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -411,8 +411,9 @@ embedding host renders the same component the Console does.
   drillable column takes ONE tab stop rather than one per row, with ArrowUp/ArrowDown and Home/End
   moving within it: tabbing through every cell of a result would have been its own accessibility
   problem, since a result at the row cap would have stood between the reader and everything after
-  it. The stop is per table, so a drill inside a `nest:`, which the renderer draws as a table per
-  parent row, still contributes one stop per parent row.
+  it. The stop is per drillable COLUMN within a table, so a table grouping by two drilled dimensions
+  carries two, and a drill inside a `nest:`, which the renderer draws as a table per parent row, still
+  contributes one stop per parent row.
 - **A `select` control looks like one.** MUI hides the dropdown arrow whenever a combobox accepts
   free text, which it must here since a `suggest` returns the common values rather than every legal
   one, so a picker rendered as a plain text box and its option list was undiscoverable.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -391,7 +391,9 @@ embedding host renders the same component the Console does.
   Console and an external React app differ only in what they do with `onNavigate` and
   `onGivensChange`.
 - **Control state is URL state.** Filtering replaces history so Back leaves the dashboard rather than
-  walking through every value tried; drilling pushes it so Back returns to where the drill started.
+  walking through every value tried; a `to=<slug>` drill pushes it, so Back returns to the dashboard the
+  drill started from. A `to=self` drill filters in place, so it takes the same replace as any other
+  control change and Back leaves the dashboard rather than undoing the drill.
   A `# artifact { autorun=false }` dashboard batches changes behind Apply.
 - **A Dashboards section on the package page**, listed first because it is the at-a-glance artifact a
   visitor most likely wants, and hidden when the package has none. A dashboard's own file is filtered

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -440,8 +440,8 @@ route. It has to be claimed, because a slug is a filename with `.malloy` removed
 `dashboards/report.csv.malloy` therefore publishes the slug `report.csv`, which would otherwise be
 diverted as an asset and 404 on a deep link or a refresh. The case to know about is a package that
 itself ships a `public/dashboards/` directory. Unlike `data-apps`, there is no viewer one segment
-down to catch those: `/{env}/{pkg}/dashboards/<file>` now opens the dashboard viewer, which answers
-"no such dashboard". Address them on the standalone URL,
+down to catch those: `/{env}/{pkg}/dashboards/<file>` now opens the dashboard viewer, which reports
+that the package has no dashboard by that name. Address them on the standalone URL,
 `/environments/{env}/packages/{pkg}/dashboards/<file>`, which serves them unchanged as it always
 did.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -411,7 +411,8 @@ embedding host renders the same component the Console does.
   drillable column takes ONE tab stop rather than one per row, with ArrowUp/ArrowDown and Home/End
   moving within it: tabbing through every cell of a result would have been its own accessibility
   problem, since a result at the row cap would have stood between the reader and everything after
-  it.
+  it. The stop is per table, so a drill inside a `nest:`, which the renderer draws as a table per
+  parent row, still contributes one stop per parent row.
 - **A `select` control looks like one.** MUI hides the dropdown arrow whenever a combobox accepts
   free text, which it must here since a `suggest` returns the common values rather than every legal
   one, so a picker rendered as a plain text box and its option list was undiscoverable.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -413,11 +413,12 @@ embedding host renders the same component the Console does.
 
 ### Two things to know when authoring
 
-- **Write `given=` on a `# drill` tag.** Without it the given is the dimension name exactly as the
-  model spells it, so a lowercase `dimension: category` looks for a given called `category`. A
-  dashboard declaring `CATEGORY` does not match, the cell still reads as clickable, and the click
-  lands on an unfiltered page. The load-time lint does not catch it, because it upper-cases the
-  dimension name before checking while the click does not.
+- **Write `given=` on a `# drill` tag whenever the dimension is not named after the given.**
+  Without it the given is the dimension name exactly as the model spells it, so
+  `dimension: brand_name` looks for a given called `brand_name` and a model declaring `BRAND` does
+  not match: the cell still reads as clickable and the click lands on an unfiltered page. A
+  difference of case alone is forgiven, since both surfaces fold case at lookup, and a `to=self`
+  drill seeding a given no model declares is reported at load.
 - **A file that does not compile fails the whole package.** Loading aborts on the first model error,
   so the dashboards endpoint answers 424 and none of that package's dashboards are served, including
   the ones that compiled. A failed `?reload=true` is refused the same way and leaves the previously

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ every doc below points back to one of them, and each example's README points bac
 | ---------------------------------------------- | -------------------------------------------------------------------------------------- |
 | [console.md](console.md)                       | Navigate the Publisher Console, the built-in web UI, and see how constructs surface.   |
 | [explorer.md](explorer.md)                     | Build queries with the no-code visual query builder.                                   |
+| [dashboards.md](dashboards.md)                 | Write a `dashboards/*.malloy` file: a filterable, clickable dashboard declared in tags. |
 | [ai-agents.md](ai-agents.md)                   | Connect an AI agent, over MCP or (unattended) over REST, and ground it in your models. |
 | [html-data-apps.md](html-data-apps.md)         | Ship a no-build HTML dashboard **inside a package**, hosted by Publisher.              |
 | [embedded-data-apps.md](embedded-data-apps.md) | _Advanced/internal:_ the React SDK the Console is built from.                          |

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -358,8 +358,9 @@ the ends, and the movement stops at the ends rather than wrapping. The tab stop 
 row however you got there, clicking included, so leaving the result and tabbing back returns to the
 row you were on.
 
-That is one stop per TABLE, which is not the same as one per result when a drill sits inside a
-`nest:`. The renderer draws a nested table per parent row, each with its own columns, so a drillable
+That is one stop per drillable COLUMN, scoped to its table, which is not the same as one per result
+in two cases. A table that groups by two drilled dimensions gets a stop for each, measured: two
+drillable columns in one table produce two stops. And a drill inside a `nest:` The renderer draws a nested table per parent row, each with its own columns, so a drillable
 dimension inside a nest still contributes a stop per parent row: measured 2 parent rows, 2 stops,
 against 1 for the same dimension grouped flat. Sharing a stop across those tables needs the marking
 to match on field identity rather than on a rendered column, which is the same limitation noted in
@@ -369,7 +370,16 @@ Those signals are the only thing saying a cell does anything, so it is worth kno
 off: a destination the surface cannot reach is not offered and not marked, deliberately, since a dead
 link is worse than none. A `to=self` drill read in a document that declares no control for its given
 is the usual case, and it stays plain text rather than swallowing the click. The same rule decides
-the menu, so what looks clickable and what a click does cannot drift apart.
+the menu, so on an ordinary table what looks clickable and what a click does agree.
+
+**One layout where they do not agree: `# transpose`.** The renderer lays a transposed table out
+without the per-cell `grid-column` the marking reads, so no cell in one is marked: no pointer cursor,
+no hover colour, no button role, no tab stop. The renderer still routes the click, so the drill FIRES
+if a reader hits the cell anyway. A transposed tile therefore navigates on a click that looked like
+plain text. Marking it needs a second strategy keyed on that layout, and until then a `# drill`
+dimension is better kept out of a `# transpose` tile. The same gap applies, for a different reason, to
+a drillable column whose header text is also rendered by a non-drillable field: the marking cannot
+tell the two columns apart, so it leaves both unmarked rather than painting a dead link.
 
 Declaring it on the dimension is what makes it work everywhere: any result that groups by that
 dimension is clickable, in a dashboard tile and in a **notebook cell** alike, with no per-document

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -346,10 +346,16 @@ source: order_items is duckdb.table('data/order_items.parquet') extend {
   given no model in the package declares is an error at load.
 
 **What a reader sees.** Cells in a drillable column take a pointer cursor, and turn blue and
-underlined under the pointer: plain text at rest, a link when you reach for them. They are also in
-the tab order and carry a button role, so a keyboard reaches them and Enter or Space fires the drill,
-with focus styled the way hover is. That matters because a pointer cursor and a hover colour are the
-two things a keyboard or touch user can never produce.
+underlined under the pointer: plain text at rest, a link when you reach for them. They carry a button
+role and are reachable from the keyboard, with focus styled the way hover is, and Enter or Space
+fires the drill. That matters because a pointer cursor and a hover colour are the two things a
+keyboard or touch user can never produce.
+
+**Tab reaches the column; the arrows move within it.** A drillable column puts ONE cell in the tab
+order, not one per row, so Tab does not walk a reader through a thousand cells to reach whatever
+follows the result. From a cell in the column, ArrowDown and ArrowUp step a row, Home and End jump to
+the ends, and the movement stops at the ends rather than wrapping. The tab stop follows the focused
+row, so leaving the result and tabbing back returns to the row you were on.
 
 Those signals are the only thing saying a cell does anything, so it is worth knowing what turns them
 off: a destination the surface cannot reach is not offered and not marked, deliberately, since a dead

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -316,7 +316,12 @@ source: order_items is duckdb.table('data/order_items.parquet') extend {
 - `to=<slug>` navigates to that dashboard with the clicked value written into the named given.
 - `to=self` filters wherever the click came from, without leaving the page.
 - More than one destination pops a menu, because a choice is not a guess.
-- `given=` names the given to seed. Without it the given is the dimension name upper-cased.
+- `given=` names the given to seed. **Write it.** Without it the given is the dimension name
+  exactly as the model spells it, so a lowercase `dimension: category` looks for a given called
+  `category`. A dashboard whose model declares `CATEGORY` does not match it, and the failure is
+  quiet: the cell still reads as clickable, and the click lands on an unfiltered page with an
+  empty control. Note the load-time lint does not catch this, because it upper-cases the
+  dimension name before checking while the click does not.
 
 **What a reader sees.** Cells in a drillable column take a pointer cursor, and turn blue and
 underlined under the pointer — plain text at rest, a link when you reach for them. That is the only
@@ -336,7 +341,11 @@ interaction which kind of document they are in — only the menu's `to=self` ent
 this notebook" against "Filter this dashboard").
 
 A drill only lands somewhere useful if the destination declares a control for the given being
-seeded — that is where the value goes. Publisher checks both halves at package load (below).
+seeded, since that is where the value goes. **Publisher does not check that half.** The load-time
+lint checks that the destination slug is a dashboard in the package, and for `to=self` that some
+model in the package declares the given at all; nothing reads the destination dashboard's own
+givens. So a drill can pass the lint and still land on a page with no control for the value it
+carried.
 
 Two practical notes. Drill fires from **table cells** reliably; chart marks depend on the renderer's
 own hit testing, and carry no hover affordance either way, so a reader has no way to know a bar is

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -462,14 +462,43 @@ import { Dashboard, encodeResourceUri } from "@malloy-publisher/sdk";
   })}
   dashboard="overview"
   givens={Object.fromEntries(searchParams)}
-  onGivensChange={(next) => setSearchParams(next, { replace: true })}
+  // MERGE, do not replace. `managed` is every given this dashboard declares,
+  // including the ones holding no value right now, and it is there because
+  // `next` alone cannot tell a control the reader CLEARED from a parameter that
+  // was never yours. Replacing the whole query string drops an unrelated
+  // parameter as soon as the manifest arrives, before the reader touches
+  // anything.
+  onGivensChange={(next, managed) =>
+    setSearchParams(
+      (current) => {
+        for (const name of managed) {
+          if (!Object.prototype.hasOwnProperty.call(next, name)) {
+            current.delete(name);
+          }
+        }
+        for (const [name, value] of Object.entries(next)) {
+          current.set(name, value);
+        }
+        return current;
+      },
+      // Filtering is not a navigation step.
+      { replace: true },
+    )
+  }
+  // The slug is ENCODED, because it is a filename: it can hold a character that
+  // would read as structure in a path or start the query string early.
   onNavigate={(target) =>
     navigate(
-      `/dashboards/${target.dashboard}?${new URLSearchParams(target.givens)}`,
+      `/dashboards/${encodeURIComponent(target.dashboard)}` +
+        `?${new URLSearchParams(target.givens)}`,
     )
   }
 />;
 ```
+
+A host that keeps its own names in the query string should also remember the ones
+it has written, so a given the dashboard stops declaring is still cleaned up;
+`DashboardPage` does that with a `writtenRef`.
 
 Without `onNavigate`, drilling to another dashboard is inert, and by the rule above those cells do
 not read as clickable either, so a host that has not wired navigation shows no affordance rather than

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -476,7 +476,7 @@ import {
   ServerProvider,
 } from "@malloy-publisher/sdk";
 
-<ServerProvider baseURL="https://publisher.example.com">
+<ServerProvider baseURL="https://publisher.example.com/api/v0">
   <Dashboard
     resourceUri={encodeResourceUri({
       environmentName: "examples",

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -1,0 +1,449 @@
+# Dashboards
+
+> **What this is:** how to write a `dashboards/*.malloy` file — a filterable, clickable, grid-laid-out
+> dashboard declared entirely in Malloy tags, with no code and no build step.
+
+A dashboard is a self-contained `.malloy` file in a package's `dashboards/` directory. The file _is_
+the dashboard: it imports the model parts it needs, declares its query, applies its filtering, and
+tags the layout. Publisher discovers it at package load, lists it on the package page, and serves it
+at `/<env>/<package>/dashboards/<name>`.
+
+Everything on the page comes from one tagged query. The controls at the top are not written anywhere
+in the page; they are rendered from the `given:` declarations the query filters by. Cells are
+clickable where the model's dimension carries a `# drill` tag.
+
+> **No bundled example ships a dashboard yet.** The `dashboards/` directory in the `storefront`
+> example, and the screenshots of it, arrive with the examples change that follows this one. Until
+> then this page is the reference and the quickest way to see one is to write it, in any package.
+
+The format is the one [Malloyyo](https://github.com/malloydata/malloyyo) uses, kept byte-compatible on purpose, so
+a model repo with a `dashboards/` directory works unchanged in either.
+
+## Where the pieces live
+
+```
+storefront/
+  publisher.json           # package manifest
+  storefront.malloy        # sources, measures, reusable views, # drill tags
+  givens.malloy            # given: declarations — the filter controls
+  dashboards/
+    overview.malloy        # a dashboard: imports the model, declares its query
+    category.malloy
+    regions.malloy
+    seasonality.malloy     # a composite: a list of views, no query of its own
+    _shared.malloy         # no artifact tag ⇒ a shared include, not a dashboard
+```
+
+Two conventions carry most of the weight:
+
+- **The filename is the dashboard's name.** `overview.malloy` is the slug in its URL, the name in
+  the package listing, and what a `# drill { to=overview }` elsewhere in the model points at. The
+  query inside it can be called anything — `regions.malloy` names its query `regional_sales`,
+  because the `regions` source it imports already owns that name in the file.
+- **A file in `dashboards/` with no `# artifact` tag is a shared include.** Discovery skips it. It
+  is where to put anything more than one dashboard needs.
+
+Each dashboard file compiles **as its own entry**, which is why it imports what it uses rather than
+inheriting it: model-level annotations do not cross an import, so the `# artifact` tag is only
+readable when the file is the thing being compiled.
+
+## A first dashboard
+
+The whole grammar in one file:
+
+```malloy
+##! experimental.givens
+import { order_items, products } from '../storefront.malloy'
+import { CATEGORY, MIN_SALE } from '../givens.malloy'
+
+#" Revenue and margin at a glance, and where they come from.
+# artifact { title="Business Overview" } dashboard { columns=12 }
+query: overview is order_items -> {
+  where: category ~ $CATEGORY and sale_price ~ $MIN_SALE
+
+  aggregate:
+    # label="Revenue"
+    # currency
+    # colspan=3
+    total_sales
+    # label="Gross margin"
+    # currency
+    # colspan=3
+    total_margin
+    # label="Orders"
+    # colspan=3
+    order_count
+    # label="Avg order value"
+    # currency
+    # colspan=3
+    avg_order_value
+
+  nest:
+    # break
+    # colspan=6
+    # label="Revenue by month"
+    sales_by_month
+    # colspan=6
+    # label="Revenue by state"
+    sales_by_state
+  nest:
+    # colspan=12
+    # label="Category performance"
+    category_performance
+}
+```
+
+- `# artifact { … }` is what makes the file a dashboard. `title=` names it; without one the title
+  falls back to the `#"` doc comment above, then to the slug.
+- `# dashboard { columns=N }` is the renderer's grid — a standard `@malloydata/render` tag, not a
+  Publisher one.
+- `where:` naming a given is what puts a control on the page. Two names here, so two controls.
+- In a `# dashboard` view, fields render **by role**: a top-level `aggregate:` measure becomes a KPI
+  card, and each `nest:` becomes a tile.
+
+### Laying out the grid
+
+Cards and tiles share one grid, so a page that lines up is a matter of four tags. Using one recipe
+across a package's dashboards is what makes them read as one product rather than as several pages:
+
+- **`columns=12`.** Twelve divides by 2, 3, 4 and 6, so a row comes out even whether it holds three
+  cards or four. Pick one number and use it on every dashboard in the package.
+- **A colspan on every card and every tile, summing to `columns` per row.** Four cards at 3, three at
+  4, two tiles at 6, a full-width table at 12. Leave them off and each item takes its natural width,
+  which is how a page ends up looking accidental. A `# colspan` without `columns=` on the
+  `# dashboard` tag is ignored with a warning — the usual reason a grid comes out as one column.
+- **`# break` on the first tile after the cards.** Without it the first tile flows into whatever
+  columns are left beside the cards and the next one wraps. A break is for interrupting a row that
+  would otherwise be shared, not for every new row: once a row's colspans sum to `columns`, the next
+  item wraps on its own with the same gap.
+- **`# label="…"` on every nest.** The tile's heading is otherwise the view's name —
+  `sales_by_month` over a chart, which reads like a database column. Labelling on the nest rather
+  than the view lets the same view carry different words on different pages.
+
+Two things about cards specifically. A top-level `aggregate:` measure _is_ the card, so do not nest a
+`# big_value` view to get one: nested in a dashboard it renders embedded, and each measure becomes a
+full-width bar inside a single tile instead of a row of cards. And a card's label is one line that
+ellipses rather than wrapping, so a narrow card truncates it silently — "Orders / customer" reads as
+"ORDERS / CUSTOMEI" at 1 column of 6.
+
+Tiles size themselves to the width their colspan gives them, so leave `# size=fill` off. Inside a
+dashboard, fill measures against the container the whole grid was handed rather than against the
+tile, which produces a chart thousands of pixels tall from a tag that reads like "fit the tile."
+
+### Labels the renderer takes from somewhere else
+
+Two places read a field's **name** rather than its `# label`, so a labelled model still shows
+`total_sales` on the page:
+
+- **A `# shape_map`'s color legend** is titled with the measure's field name. Rename the measure in
+  the view — `aggregate: revenue is total_sales` — rather than only labelling it.
+- **A chart's series legend** reserves its width from the longer of the series label and its widest
+  value, then truncates both to fit. A 4-character label over 4-digit years clips to `20…`; naming
+  the series `# label="Order year"` instead of `"Year"` buys the column enough room. A legend showing
+  `…` is this, not a data problem.
+
+Both are upstream renderer behavior, not Publisher's, and both are cheap to work around in the
+model.
+
+All of this applies equally to a `# dashboard` **view** run in a notebook cell — the two surfaces
+render through the same code, so a view laid out with these tags looks the same in a cell as on a
+dashboard page. The storefront model's `business_overview` view is the worked case, and the notebook's
+first cell is that view. Height is the one thing the surface decides rather than the tags: a dashboard
+renders at its natural height, while a notebook caps a chart cell and lets a table cell hug its rows,
+so one long result cannot push the prose off the page.
+
+### Tag reference
+
+| Construct                                                        | What it does                                                                                                                   |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `# artifact { title= givens{…} autorun= }` on a `query:`                | Declares the dashboard. `title` falls back to the `#"` doc comment; `givens` sets starting control values; see [Apply](#apply) |
+| `## artifact { title= tiles=[…] dashboard_columns=N }`           | Declares a **composite** — model-level, because there is no query of its own to hang a `#` tag on                              |
+| `# dashboard { columns=N }`, `# colspan=K`, `# break`            | The renderer grid — see [Laying out the grid](#laying-out-the-grid). `# colspan` does nothing without `columns=`               |
+| `# label="…"` on an aggregate                                    | What the KPI card is headed. Without it a card reads `total_sales`, which is a column name, not a number a reader came for     |
+| `# drill { to=[…] given=… }` on a source `dimension:`            | Makes cells that group by it clickable — see [Drill](#drill)                                                                   |
+| A `dashboards/*.malloy` with **no** artifact tag                 | A shared include, skipped by discovery                                                                                         |
+
+Two spellings that bite:
+
+- **A model-level `##` tag has to be on one line.** Wrapping a long `## artifact { … }` across lines
+  is a compile error, and it fails the whole package rather than the one file.
+- **`# artifact` is read off a `query:`, not off a `view:`.** A source-level view carrying the tag is
+  not discovered, and nothing says so: the file is treated as a shared include and quietly produces
+  no dashboard. Give the dashboard its own `query:`, as every example here does.
+
+## Filter controls
+
+Controls are not declared on the dashboard. They come from the `given:` declarations the query
+references, and the tags on each declaration are its control contract:
+
+```malloy
+##! experimental.givens
+
+# label="Category" control=select suggest { source=products dimension=category }
+given: CATEGORY :: filter<string> is f''
+
+# label="Brand" control=multiselect suggest { query=brand_suggest dimension=brand }
+given: BRAND :: filter<string> is f''
+
+# label="Minimum line total" range_min=0 range_max=250
+given: MIN_SALE :: filter<number> is f''
+
+# label="Ordered since"
+given: SINCE :: date is @2023-01-01
+```
+
+| Tag                                             | Renders as                                         |
+| ----------------------------------------------- | -------------------------------------------------- |
+| `control=select` + `suggest { … }`              | A dropdown whose options are queried from the data |
+| `control=multiselect` + `suggest { … }`         | The same, taking several values                    |
+| `range_min=` / `range_max=` on `filter<number>` | A slider instead of a text box                     |
+| none, on a `date` or `timestamp`                | A date picker                                      |
+| none, on a `filter<string>`                     | A text box taking Malloy filter syntax             |
+
+A `suggest` reads either a `source=` and `dimension=` pair, or a named `query=` when the option list
+needs its own ordering or filtering. **The source or query has to resolve in the dashboard file**,
+so import it there — a dashboard that surfaces a given whose suggest names something it cannot see
+is a package warning at load, not a surprise when someone opens the dropdown.
+
+In a package that [curates its surface](discovery-and-access.md) (`explores` plus
+`queryableSources: "declared"`), resolving is not enough: an option list is an ordinary query, so
+the source or query behind it must also be _queryable_ from the dashboard file, which under curation
+means exported from it. Re-export what the controls read, and note that an explicit `export { … }`
+replaces the default "everything top-level", so the dashboard's own query belongs on the list too:
+
+```malloy
+export { governed_overview, region_suggest, status_suggest }
+```
+
+Leave a suggest off and only that dropdown comes up empty; leave the dashboard's own query off and
+the grid stops loading. A package with no `explores` has curation off, so an import is all it
+needs.
+
+Which controls appear is decided per dashboard, by which givens its query references. Declaring ten
+and referencing two shows two. That is what lets one `CATEGORY` declaration scope revenue on one
+dashboard and margin on another without either redeclaring it.
+
+**Importing a given is what makes it bindable.** Malloy's given namespace is per-file, so a
+dashboard can only be _run_ with the givens its own file imports, even when the `where:` that
+references one lives up an import chain. A given the file does not import gets no control, and
+sending it at run time fails with "unknown given". Everything about givens themselves —
+declaration, types, defaults, access control — is in [givens.md](givens.md).
+
+<a id="apply"></a>
+
+### Apply, starting values, and the URL
+
+```malloy
+#" Sales by region
+# artifact { autorun=false givens { REGION=f'West' } }
+# dashboard { columns=12 }
+query: regional_sales is order_items -> { … }
+```
+
+- **`autorun=false`** puts an Apply button on the control row and batches changes behind it, so
+  moving a date and picking a region re-runs the page once instead of twice. Worth it as soon as a
+  page is slow enough that a reader notices.
+- **`givens { … }`** sets this dashboard's _starting_ values. It is an opening position, not a
+  redeclaration.
+- **Control state lives in the URL**, so a filtered dashboard is a shareable link. A URL parameter
+  beats the dashboard's own starting values.
+
+All three behave identically in a notebook, which spells them at the file level — `## autorun=false`
+and `## givens { REGION=f'West' }` — and gets the same controls, the same URL state, and the same
+Apply button from the same code.
+
+## Composite dashboards
+
+When the views are already modelled and the dashboard is a matter of choosing which to show
+together, there is nothing left to write a query for. A composite names them instead:
+
+```malloy
+##! experimental.givens
+## artifact { title="Seasonality" tiles=["scoped_sales -> sales_by_month", "scoped_sales -> sales_by_year", "scoped_sales -> seasonality"] dashboard_columns=3 }
+import { scoped_sales } from './_shared.malloy'
+import { products } from '../storefront.malloy'
+import { CATEGORY, SINCE } from '../givens.malloy'
+```
+
+
+Each tile runs as its own query, which means a broken tile shows its error in place instead of
+blanking the page, and a control change re-runs only the tiles that reference it. The control row is
+the union across the tiles.
+
+A composite's tiles are equal-width — `dashboard_columns` is the whole layout, and there is no
+per-tile colspan, since each tile is a separate result rather than a field in one. So choose a column
+count the tile list divides evenly (three tiles at 3, four at 2 or 4), and expect each chart to have
+`1/N` of the page: a monthly trend at a third of the width gets crowded x labels, which is a reason
+to prefer the single-query form when one tile deserves more room than the others.
+
+A composite has no query of its own, so the filtering it applies has to live in what it composes.
+That is the job the shared include does here — `_shared.malloy` scopes the source once:
+
+```malloy
+// dashboards/_shared.malloy — no artifact tag, so an include rather than a dashboard.
+##! experimental.givens
+import { order_items } from '../storefront.malloy'
+import { CATEGORY, SINCE } from '../givens.malloy'
+
+source: scoped_sales is order_items extend {
+  where: category ~ $CATEGORY and created_at >= $SINCE
+}
+```
+
+Note the imports in the composite itself. Nothing in that file mentions `CATEGORY` or `SINCE` — the
+`where:` that does is one file over — but the given namespace is per-file, so without importing them
+the control row would be empty and the tiles would silently run at their defaults.
+
+<a id="drill"></a>
+
+## Drill: making cells clickable
+
+`# drill` is declared on a model **dimension**, not on a dashboard:
+
+```malloy
+source: order_items is duckdb.table('data/order_items.parquet') extend {
+  # drill { to=["category", "self"] given=CATEGORY }
+  dimension: category is products.category
+
+  # drill { to=self given=BRAND }
+  dimension: brand is products.brand
+
+  # drill { to=regions given=REGION }
+  dimension: region is regions.region
+}
+```
+
+- `to=<slug>` navigates to that dashboard with the clicked value written into the named given.
+- `to=self` filters wherever the click came from, without leaving the page.
+- More than one destination pops a menu, because a choice is not a guess.
+- `given=` names the given to seed. Without it the given is the dimension name upper-cased.
+
+**What a reader sees.** Cells in a drillable column take a pointer cursor, and turn blue and
+underlined under the pointer — plain text at rest, a link when you reach for them. That is the only
+signal a cell does anything, so it is worth knowing what turns it off: a destination the surface
+cannot reach is not offered and not marked, deliberately, since a dead link is worse than none. A
+`to=self` drill read in a document that declares no control for its given is the usual case, and it
+stays plain text rather than swallowing the click. The same rule decides the menu, so what looks
+clickable and what a click does can't drift apart.
+
+Declaring it on the dimension is what makes it work everywhere: any result that groups by that
+dimension is clickable, in a dashboard tile and in a **notebook cell** alike, with no per-document
+wiring. A notebook cell grouping by a tagged dimension is clickable for exactly this reason, and
+says nothing about drill itself: it imports the given for its own Parameters panel, which is all
+`to=self` needs. Both surfaces run the same
+implementation, down to the hover styling and the menu, so a reader cannot tell from the
+interaction which kind of document they are in — only the menu's `to=self` entry names it ("Filter
+this notebook" against "Filter this dashboard").
+
+A drill only lands somewhere useful if the destination declares a control for the given being
+seeded — that is where the value goes. Publisher checks both halves at package load (below).
+
+Two practical notes. Drill fires from **table cells** reliably; chart marks depend on the renderer's
+own hit testing, and carry no hover affordance either way, so a reader has no way to know a bar is
+clickable. If a dashboard is meant to be drilled, give it at least one untagged (table) tile. And a
+dimension that only exists to be grouped by is worth declaring for its own sake: group by a local
+`category` rather than by `products.category`, so the cells carry the tag, with identical output
+field names and identical numbers.
+
+## What Publisher checks at load
+
+Every package load lints the dashboards and reports findings as package warnings, visible on the
+package page and in the server log. They catch the failures that are otherwise silent — a control
+that never appears, a click that goes nowhere. Broadly, they cover:
+
+- **Drill targets.** A `# drill { to=… }` naming a dashboard that does not exist in the package, or
+  one that exists but is not served; a `# drill` with no destination at all; and a `to=self` drill
+  whose given no model in the package declares, so the clicked value has nowhere to land.
+- **Controls.** A given surfaced by a dashboard whose `suggest` names a source, query or dimension
+  that file cannot see, or declares a `suggest` in a form that cannot fetch options at all.
+- **Layout and tiles.** A composite tile that does not resolve to a real view, and a `columns=` or
+  `dashboard_columns=` that is not a positive integer.
+- **Tags that did not parse**, on the dashboard or on a `given:` declaration, which otherwise lose
+  their whole line in silence.
+- **Curation.** A dashboard whose entry file is not listed in `explores` under
+  `queryableSources: "declared"`, so its queries would be refused. It is not served.
+- **Renderer tags the validator rejects.**
+
+That is the shape of the list rather than the whole of it: the findings on the package page are the
+authoritative set, and they are worth reading directly rather than counting against this page. Note
+too that a tag which does not parse is reported for **syntax** only. An unresolved reference inside a
+tag that parses is not a parse finding, and no finding carries a position, so an empty result is not
+proof that a tag is well formed.
+
+The drill checks read **every** model in the package, not just the files under `dashboards/`, since
+a tag reachable only from a notebook is exactly as breakable.
+
+**A file that does not compile fails the package, rather than appearing as a broken dashboard.**
+Loading aborts on the first model error, so the package answers `424` and no dashboard from it is
+served, including the ones that were fine. A reload that fails to compile is refused the same way and
+leaves the previously compiled package serving, which is the behaviour to rely on while editing: fix
+the file, reload again.
+
+## Serving, URLs, and the API
+
+| Path                                                       | What it is                                                  |
+| ---------------------------------------------------------- | ----------------------------------------------------------- |
+| `/<env>/<pkg>/dashboards/<name>`                           | The Console page                                            |
+| `/<env>/<pkg>/dashboards/<name>?CATEGORY=Outerwear`        | The same page, filtered — control state is URL state        |
+| `GET /api/v0/environments/<env>/packages/<pkg>/dashboards` | List them                                                   |
+| `GET …/dashboards/<name>`                                  | The manifest: title, autorun, columns, control specs, tiles |
+
+A dashboard's query runs through the ordinary query endpoint against
+`dashboards/<name>.malloy`, with givens in the request body — there is no dashboard-specific
+execution path, so authorization, row limits, and query caps behave exactly as they do everywhere
+else. [ai-agents.md](ai-agents.md) has the REST playbook.
+
+After editing a dashboard file, `GET …/packages/<pkg>?reload=true` recompiles the package in place,
+and a reload that fails to compile leaves the previously compiled model serving.
+[AGENTS.md](../AGENTS.md) §6 covers the edit loop and watch mode.
+
+## Rendering one in your own React app
+
+`<Dashboard>` is a public export of `@malloy-publisher/sdk`, and the Publisher Console is one
+consumer of it rather than its home. It takes props instead of reading a router, so the host decides
+what a drill and a filter change mean:
+
+```tsx
+import { Dashboard, encodeResourceUri } from "@malloy-publisher/sdk";
+
+<Dashboard
+  resourceUri={encodeResourceUri({
+    environmentName: "examples",
+    packageName: "storefront",
+  })}
+  dashboard="overview"
+  givens={Object.fromEntries(searchParams)}
+  onGivensChange={(next) => setSearchParams(next, { replace: true })}
+  onNavigate={(target) =>
+    navigate(
+      `/dashboards/${target.dashboard}?${new URLSearchParams(target.givens)}`,
+    )
+  }
+/>;
+```
+
+Without `onNavigate`, drilling to another dashboard is inert — and, by the rule above, those cells do
+not read as clickable either, so a host that has not wired navigation shows no affordance rather than
+a dead one. `to=self` still works, since it never leaves the component. [`examples/data-app`](../examples/data-app) is a running standalone app that
+does this.
+
+Embedding into a **non-React** host page is a follow-up
+([#931](https://github.com/malloydata/publisher/issues/931)); `Publisher.embed` cannot usefully
+target a dashboard route yet, so an [HTML data app](html-data-apps.md) remains the surface with the
+complete embedding story.
+
+## Where dashboards stop
+
+Whatever renderer tags can express is the ceiling. There is deliberately no code escape hatch — no
+custom component, no authored JavaScript — because a page that needs to go past the tags is an
+[HTML data app](html-data-apps.md), which already does that job at whole-page scope with a real
+runtime and a real embedding story. The reasoning, including why the sandboxed-component approach
+was built and then cut, is in
+[malloyyo-dashboards-design.md](malloyyo-dashboards-design.md#custom-jsx-components-cut).
+
+## See also
+
+- [givens.md](givens.md) — the parameter mechanism the controls are built on
+- [malloyyo-dashboards-design.md](malloyyo-dashboards-design.md) — the design, and the grammar's provenance
+- [console.md](console.md) — the rest of the Publisher Console
+- [`examples/storefront`](../examples/storefront), the ecommerce model this page's examples build on

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -152,9 +152,14 @@ and the notebook's first cell is that view. Read it as a working example of the 
 agreeing, not of the layout recipe above, which it predates: it carries no `columns=`, no colspans,
 and it nests a `# big_value` for its KPIs, which is the one thing this page says not to do. Height
 is the one thing the surface decides rather than the tags: a single-query dashboard renders at its
-natural height, a composite caps each tile so one long table cannot set its row's height, and a
-notebook caps a chart cell and lets a table cell hug its rows so one long result cannot push the
-prose off the page.
+natural height when the result reports one, which a `# dashboard` grid does, a composite caps each
+tile so one long table cannot set its row's height, and a notebook caps a chart cell and lets a table
+cell hug its rows so one long result cannot push the prose off the page.
+
+One exception, and it argues for always tagging the grid. A single-query dashboard whose top-level
+result is a bare chart has no height of its own to report: a chart with no grid around it sizes to
+whatever container it is handed, so it stretches to the first-paint height. Measured on a two-row bar
+chart: 1992px bare, against 227px for the same query under a `# dashboard` tag.
 
 ### Tag reference
 
@@ -322,7 +327,11 @@ source: order_items is duckdb.table('data/order_items.parquet') extend {
   destination's given should be a `filter<…>` one. Seeding a plain `string` given across dashboards
   delivers the escaped spelling (`Ben\ &\ Jerry` for a cell reading `Ben & Jerry`), which matches
   nothing. `to=self` is exempt: there the surface knows the declared type and re-encodes for it.
-- `to=self` filters wherever the click came from, without leaving the page.
+- `to=self` filters wherever the click came from, without leaving the page. Under `autorun=false` it
+  stages the value as a draft instead: neither the page nor the URL changes until Apply is pressed.
+  Worth knowing because the same menu's `to=<slug>` entry navigates and arrives already applied, so
+  one menu offers two entries with different timing. Measured on `regions`: with two regions applied,
+  choosing "Filter this dashboard" on one of them left the URL alone and enabled Apply.
 - More than one destination pops a menu, because a choice is not a guess.
 - `given=` names the given to seed. **Write it whenever the dimension is not named after the
   given.** Without it the given is the dimension name exactly as the model spells it, so

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -89,7 +89,7 @@ query: overview is order_items -> {
   nest:
     # colspan=12
     # label="Category performance"
-    category_performance
+    by_category
 }
 ```
 
@@ -277,7 +277,10 @@ import { CATEGORY, SINCE } from '../givens.malloy'
 
 Each tile runs as its own query, which means a broken tile shows its error in place instead of
 blanking the page, and a control change re-runs only the tiles that reference it. The control row is
-the union across the tiles.
+the union across the tiles, with one exception worth knowing: if a tile cannot be resolved, the row
+widens to every given the entry file surfaces rather than narrowing to the tiles that did resolve. The
+unresolvable tile is a package warning of its own, so the state is visible, but the control row is
+usually where it is noticed first.
 
 A composite's tiles are equal-width: `dashboard_columns` is the whole layout, and there is no
 per-tile colspan, since each tile is a separate result rather than a field in one. So choose a column
@@ -359,12 +362,12 @@ row however you got there, clicking included, so leaving the result and tabbing 
 row you were on.
 
 That is one stop per drillable COLUMN, scoped to its table, which is not the same as one per result
-in two cases. A table that groups by two drilled dimensions gets a stop for each, measured: two
-drillable columns in one table produce two stops. And a drill inside a `nest:` The renderer draws a nested table per parent row, each with its own columns, so a drillable
-dimension inside a nest still contributes a stop per parent row: measured 2 parent rows, 2 stops,
-against 1 for the same dimension grouped flat. Sharing a stop across those tables needs the marking
-to match on field identity rather than on a rendered column, which is the same limitation noted in
-`markDrillableCells`.
+in two cases. A table grouping by two drilled dimensions gets a stop for each: measured, two drillable
+columns in one table produce two stops. And a drill inside a `nest:` gets one per parent row, because
+the renderer draws a nested table per row, each with its own columns: measured, 2 parent rows give 2
+stops against 1 for the same dimension grouped flat. Sharing a stop across those tables needs the
+marking to match on field identity rather than on a rendered column, which is the limitation
+`markDrillableCells` already records.
 
 Those signals are the only thing saying a cell does anything, so it is worth knowing what turns them
 off: a destination the surface cannot reach is not offered and not marked, deliberately, since a dead
@@ -383,8 +386,8 @@ tell the two columns apart, so it leaves both unmarked rather than painting a de
 
 Declaring it on the dimension is what makes it work everywhere: any result that groups by that
 dimension is clickable, in a dashboard tile and in a **notebook cell** alike, with no per-document
-wiring. A notebook cell grouping by a tagged dimension is clickable for exactly this reason, and
-says nothing about drill itself: it imports the given for its own Parameters panel, which is all
+wiring. A notebook cell that groups by a tagged dimension is clickable for exactly this reason, while
+saying nothing about drill itself: the notebook imports the given for its own controls, which is all
 `to=self` needs. Both surfaces run the same
 implementation, down to the hover styling and the menu, so a reader cannot tell from the
 interaction which kind of document they are in. Only the menu's `to=self` entry names it ("Filter
@@ -462,48 +465,58 @@ and a reload that fails to compile leaves the previously compiled model serving.
 consumer of it rather than its home. It takes props instead of reading a router, so the host decides
 what a drill and a filter change mean:
 
-```tsx
-import { Dashboard, encodeResourceUri } from "@malloy-publisher/sdk";
+`<Dashboard>` reads its server through context, so it has to sit inside a `<ServerProvider>`; without
+one it throws `useServer must be used within a ServerProvider`. Mount the provider once, near the root
+of your app, not per dashboard.
 
-<Dashboard
-  resourceUri={encodeResourceUri({
-    environmentName: "examples",
-    packageName: "storefront",
-  })}
-  dashboard="overview"
-  givens={Object.fromEntries(searchParams)}
-  // MERGE, do not replace. `managed` is every given this dashboard declares,
-  // including the ones holding no value right now, and it is there because
-  // `next` alone cannot tell a control the reader CLEARED from a parameter that
-  // was never yours. Replacing the whole query string drops an unrelated
-  // parameter as soon as the manifest arrives, before the reader touches
-  // anything.
-  onGivensChange={(next, managed) =>
-    setSearchParams(
-      (current) => {
-        for (const name of managed) {
-          if (!Object.prototype.hasOwnProperty.call(next, name)) {
-            current.delete(name);
+```tsx
+import {
+  Dashboard,
+  encodeResourceUri,
+  ServerProvider,
+} from "@malloy-publisher/sdk";
+
+<ServerProvider baseURL="https://publisher.example.com">
+  <Dashboard
+    resourceUri={encodeResourceUri({
+      environmentName: "examples",
+      packageName: "storefront",
+    })}
+    dashboard="overview"
+    givens={Object.fromEntries(searchParams)}
+    // MERGE, do not replace. `managed` is every given this dashboard declares,
+    // including the ones holding no value right now, and it is there because
+    // `next` alone cannot tell a control the reader CLEARED from a parameter
+    // that was never yours. Replacing the whole query string drops an unrelated
+    // parameter as soon as the manifest arrives, before the reader touches
+    // anything.
+    onGivensChange={(next, managed) =>
+      setSearchParams(
+        (current) => {
+          for (const name of managed) {
+            if (!Object.prototype.hasOwnProperty.call(next, name)) {
+              current.delete(name);
+            }
           }
-        }
-        for (const [name, value] of Object.entries(next)) {
-          current.set(name, value);
-        }
-        return current;
-      },
-      // Filtering is not a navigation step.
-      { replace: true },
-    )
-  }
-  // The slug is ENCODED, because it is a filename: it can hold a character that
-  // would read as structure in a path or start the query string early.
-  onNavigate={(target) =>
-    navigate(
-      `/dashboards/${encodeURIComponent(target.dashboard)}` +
-        `?${new URLSearchParams(target.givens)}`,
-    )
-  }
-/>;
+          for (const [name, value] of Object.entries(next)) {
+            current.set(name, value);
+          }
+          return current;
+        },
+        // Filtering is not a navigation step.
+        { replace: true },
+      )
+    }
+    // The slug is ENCODED, because it is a filename: it can hold a character
+    // that would read as structure in a path or start the query string early.
+    onNavigate={(target) =>
+      navigate(
+        `/dashboards/${encodeURIComponent(target.dashboard)}` +
+          `?${new URLSearchParams(target.givens)}`,
+      )
+    }
+  />
+</ServerProvider>;
 ```
 
 A host that keeps its own names in the query string should also remember the ones

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -313,7 +313,11 @@ source: order_items is duckdb.table('data/order_items.parquet') extend {
 }
 ```
 
-- `to=<slug>` navigates to that dashboard with the clicked value written into the named given.
+- `to=<slug>` navigates to that dashboard with the clicked value written into the named given. The
+  value is written as **filter syntax**, because a click cannot know what it is aiming at, so the
+  destination's given should be a `filter<…>` one. Seeding a plain `string` given across dashboards
+  delivers the escaped spelling (`Ben\ &\ Jerry` for a cell reading `Ben & Jerry`), which matches
+  nothing. `to=self` is exempt: there the surface knows the declared type and re-encodes for it.
 - `to=self` filters wherever the click came from, without leaving the page.
 - More than one destination pops a menu, because a choice is not a guess.
 - `given=` names the given to seed. **Write it.** Without it the given is the dimension name
@@ -437,8 +441,11 @@ import { Dashboard, encodeResourceUri } from "@malloy-publisher/sdk";
 
 Without `onNavigate`, drilling to another dashboard is inert — and, by the rule above, those cells do
 not read as clickable either, so a host that has not wired navigation shows no affordance rather than
-a dead one. `to=self` still works, since it never leaves the component. [`examples/data-app`](../examples/data-app) is a running standalone app that
-does this.
+a dead one. `to=self` still works, since it never leaves the component. The Console's own
+`DashboardPage` (`packages/app/src/components/pages/DashboardPage/DashboardPage.tsx`) is the worked
+example of both handlers; [`examples/data-app`](../examples/data-app) is a standalone SDK app, but it
+predates this component and builds its pages from `EmbeddedQueryResult` rather than rendering
+`<Dashboard>`.
 
 Embedding into a **non-React** host page is a follow-up
 ([#931](https://github.com/malloydata/publisher/issues/931)); `Publisher.embed` cannot usefully

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -147,10 +147,14 @@ model.
 
 All of this applies equally to a `# dashboard` **view** run in a notebook cell — the two surfaces
 render through the same code, so a view laid out with these tags looks the same in a cell as on a
-dashboard page. The storefront model's `business_overview` view is the worked case, and the notebook's
-first cell is that view. Height is the one thing the surface decides rather than the tags: a dashboard
-renders at its natural height, while a notebook caps a chart cell and lets a table cell hug its rows,
-so one long result cannot push the prose off the page.
+dashboard page. The storefront model's `business_overview` view is the shipped `# dashboard` view,
+and the notebook's first cell is that view — read it as a working example of the two surfaces
+agreeing, not of the layout recipe above, which it predates: it carries no `columns=`, no colspans,
+and it nests a `# big_value` for its KPIs, which is the one thing this page says not to do. Height
+is the one thing the surface decides rather than the tags: a single-query dashboard renders at its
+natural height, a composite caps each tile so one long table cannot set its row's height, and a
+notebook caps a chart cell and lets a table cell hug its rows so one long result cannot push the
+prose off the page.
 
 ### Tag reference
 
@@ -324,9 +328,13 @@ source: order_items is duckdb.table('data/order_items.parquet') extend {
   given.** Without it the given is the dimension name exactly as the model spells it, so
   `dimension: brand_name` looks for a given called `brand_name` and a model declaring `BRAND` does
   not match. The failure is quiet on the dashboard side: the cell still reads as clickable and the
-  click lands on an unfiltered page. A difference of CASE alone is forgiven, since both surfaces
-  fold case when they look the name up, and the load-time lint reports the rest: a `to=self` drill
-  seeding a given no model in the package declares is an error at load.
+  click lands on an unfiltered page. A difference of CASE alone is forgiven **only for `to=self`**,
+  where the surface resolves the name against the givens it declares and folds case doing it; a
+  notebook and a dashboard fold it the same way. A `to=<slug>` drill has no such lookup: the name
+  goes into the destination's URL exactly as the tag spells it, and the destination binds only the
+  parameters it declares, spelled identically. So `given=brand` into a dashboard declaring `BRAND`
+  opens it unfiltered. The load-time lint reports the case it can see: a `to=self` drill seeding a
+  given no model in the package declares is an error at load.
 
 **What a reader sees.** Cells in a drillable column take a pointer cursor, and turn blue and
 underlined under the pointer: plain text at rest, a link when you reach for them. They are also in

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -320,12 +320,13 @@ source: order_items is duckdb.table('data/order_items.parquet') extend {
   nothing. `to=self` is exempt: there the surface knows the declared type and re-encodes for it.
 - `to=self` filters wherever the click came from, without leaving the page.
 - More than one destination pops a menu, because a choice is not a guess.
-- `given=` names the given to seed. **Write it.** Without it the given is the dimension name
-  exactly as the model spells it, so a lowercase `dimension: category` looks for a given called
-  `category`. A dashboard whose model declares `CATEGORY` does not match it, and the failure is
-  quiet: the cell still reads as clickable, and the click lands on an unfiltered page with an
-  empty control. Note the load-time lint does not catch this, because it upper-cases the
-  dimension name before checking while the click does not.
+- `given=` names the given to seed. **Write it whenever the dimension is not named after the
+  given.** Without it the given is the dimension name exactly as the model spells it, so
+  `dimension: brand_name` looks for a given called `brand_name` and a model declaring `BRAND` does
+  not match. The failure is quiet on the dashboard side: the cell still reads as clickable and the
+  click lands on an unfiltered page. A difference of CASE alone is forgiven, since both surfaces
+  fold case when they look the name up, and the load-time lint reports the rest: a `to=self` drill
+  seeding a given no model in the package declares is an error at load.
 
 **What a reader sees.** Cells in a drillable column take a pointer cursor, and turn blue and
 underlined under the pointer: plain text at rest, a link when you reach for them. They are also in

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -1,7 +1,7 @@
 # Dashboards
 
-> **What this is:** how to write a `dashboards/*.malloy` file — a filterable, clickable, grid-laid-out
-> dashboard declared entirely in Malloy tags, with no code and no build step.
+> **What this is:** how to write a `dashboards/*.malloy` file (a filterable, clickable, grid-laid-out
+> dashboard declared entirely in Malloy tags, with no code and no build step).
 
 A dashboard is a self-contained `.malloy` file in a package's `dashboards/` directory. The file _is_
 the dashboard: it imports the model parts it needs, declares its query, applies its filtering, and
@@ -25,7 +25,7 @@ a model repo with a `dashboards/` directory works unchanged in either.
 storefront/
   publisher.json           # package manifest
   storefront.malloy        # sources, measures, reusable views, # drill tags
-  givens.malloy            # given: declarations — the filter controls
+  givens.malloy            # given: declarations, the filter controls
   dashboards/
     overview.malloy        # a dashboard: imports the model, declares its query
     category.malloy
@@ -38,7 +38,7 @@ Two conventions carry most of the weight:
 
 - **The filename is the dashboard's name.** `overview.malloy` is the slug in its URL, the name in
   the package listing, and what a `# drill { to=overview }` elsewhere in the model points at. The
-  query inside it can be called anything — `regions.malloy` names its query `regional_sales`,
+  query inside it can be called anything. `regions.malloy` names its query `regional_sales`,
   because the `regions` source it imports already owns that name in the file.
 - **A file in `dashboards/` with no `# artifact` tag is a shared include.** Discovery skips it. It
   is where to put anything more than one dashboard needs.
@@ -95,7 +95,7 @@ query: overview is order_items -> {
 
 - `# artifact { … }` is what makes the file a dashboard. `title=` names it; without one the title
   falls back to the `#"` doc comment above, then to the slug.
-- `# dashboard { columns=N }` is the renderer's grid — a standard `@malloydata/render` tag, not a
+- `# dashboard { columns=N }` is the renderer's grid: a standard `@malloydata/render` tag, not a
   Publisher one.
 - `where:` naming a given is what puts a control on the page. Two names here, so two controls.
 - In a `# dashboard` view, fields render **by role**: a top-level `aggregate:` measure becomes a KPI
@@ -111,19 +111,19 @@ across a package's dashboards is what makes them read as one product rather than
 - **A colspan on every card and every tile, summing to `columns` per row.** Four cards at 3, three at
   4, two tiles at 6, a full-width table at 12. Leave them off and each item takes its natural width,
   which is how a page ends up looking accidental. A `# colspan` without `columns=` on the
-  `# dashboard` tag is ignored with a warning — the usual reason a grid comes out as one column.
+  `# dashboard` tag is ignored with a warning, the usual reason a grid comes out as one column.
 - **`# break` on the first tile after the cards.** Without it the first tile flows into whatever
   columns are left beside the cards and the next one wraps. A break is for interrupting a row that
   would otherwise be shared, not for every new row: once a row's colspans sum to `columns`, the next
   item wraps on its own with the same gap.
-- **`# label="…"` on every nest.** The tile's heading is otherwise the view's name —
+- **`# label="…"` on every nest.** The tile's heading is otherwise the view's name:
   `sales_by_month` over a chart, which reads like a database column. Labelling on the nest rather
   than the view lets the same view carry different words on different pages.
 
 Two things about cards specifically. A top-level `aggregate:` measure _is_ the card, so do not nest a
 `# big_value` view to get one: nested in a dashboard it renders embedded, and each measure becomes a
 full-width bar inside a single tile instead of a row of cards. And a card's label is one line that
-ellipses rather than wrapping, so a narrow card truncates it silently — "Orders / customer" reads as
+ellipses rather than wrapping, so a narrow card truncates it silently: "Orders / customer" reads as
 "ORDERS / CUSTOMEI" at 1 column of 6.
 
 Tiles size themselves to the width their colspan gives them, so leave `# size=fill` off. Inside a
@@ -136,7 +136,7 @@ Two places read a field's **name** rather than its `# label`, so a labelled mode
 `total_sales` on the page:
 
 - **A `# shape_map`'s color legend** is titled with the measure's field name. Rename the measure in
-  the view — `aggregate: revenue is total_sales` — rather than only labelling it.
+  the view (`aggregate: revenue is total_sales`) rather than only labelling it.
 - **A chart's series legend** reserves its width from the longer of the series label and its widest
   value, then truncates both to fit. A 4-character label over 4-digit years clips to `20…`; naming
   the series `# label="Order year"` instead of `"Year"` buys the column enough room. A legend showing
@@ -145,10 +145,10 @@ Two places read a field's **name** rather than its `# label`, so a labelled mode
 Both are upstream renderer behavior, not Publisher's, and both are cheap to work around in the
 model.
 
-All of this applies equally to a `# dashboard` **view** run in a notebook cell — the two surfaces
+All of this applies equally to a `# dashboard` **view** run in a notebook cell: the two surfaces
 render through the same code, so a view laid out with these tags looks the same in a cell as on a
 dashboard page. The storefront model's `business_overview` view is the shipped `# dashboard` view,
-and the notebook's first cell is that view — read it as a working example of the two surfaces
+and the notebook's first cell is that view. Read it as a working example of the two surfaces
 agreeing, not of the layout recipe above, which it predates: it carries no `columns=`, no colspans,
 and it nests a `# big_value` for its KPIs, which is the one thing this page says not to do. Height
 is the one thing the surface decides rather than the tags: a single-query dashboard renders at its
@@ -158,14 +158,14 @@ prose off the page.
 
 ### Tag reference
 
-| Construct                                                        | What it does                                                                                                                   |
-| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `# artifact { title= givens{…} autorun= }` on a `query:`                | Declares the dashboard. `title` falls back to the `#"` doc comment; `givens` sets starting control values; see [Apply](#apply) |
-| `## artifact { title= tiles=[…] dashboard_columns=N }`           | Declares a **composite** — model-level, because there is no query of its own to hang a `#` tag on                              |
-| `# dashboard { columns=N }`, `# colspan=K`, `# break`            | The renderer grid — see [Laying out the grid](#laying-out-the-grid). `# colspan` does nothing without `columns=`               |
-| `# label="…"` on an aggregate                                    | What the KPI card is headed. Without it a card reads `total_sales`, which is a column name, not a number a reader came for     |
-| `# drill { to=[…] given=… }` on a source `dimension:`            | Makes cells that group by it clickable — see [Drill](#drill)                                                                   |
-| A `dashboards/*.malloy` with **no** artifact tag                 | A shared include, skipped by discovery                                                                                         |
+| Construct                                                | What it does                                                                                                                   |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `# artifact { title= givens{…} autorun= }` on a `query:` | Declares the dashboard. `title` falls back to the `#"` doc comment; `givens` sets starting control values; see [Apply](#apply) |
+| `## artifact { title= tiles=[…] dashboard_columns=N }`   | Declares a **composite**, model-level because there is no query of its own to hang a `#` tag on                                |
+| `# dashboard { columns=N }`, `# colspan=K`, `# break`    | The renderer grid, see [Laying out the grid](#laying-out-the-grid). `# colspan` does nothing without `columns=`                |
+| `# label="…"` on an aggregate                            | What the KPI card is headed. Without it a card reads `total_sales`, which is a column name, not a number a reader came for     |
+| `# drill { to=[…] given=… }` on a source `dimension:`    | Makes cells that group by it clickable, see [Drill](#drill)                                                                    |
+| A `dashboards/*.malloy` with **no** artifact tag         | A shared include, skipped by discovery                                                                                         |
 
 Two spellings that bite:
 
@@ -206,7 +206,7 @@ given: SINCE :: date is @2023-01-01
 
 A `suggest` reads either a `source=` and `dimension=` pair, or a named `query=` when the option list
 needs its own ordering or filtering. **The source or query has to resolve in the dashboard file**,
-so import it there — a dashboard that surfaces a given whose suggest names something it cannot see
+so import it there: a dashboard that surfaces a given whose suggest names something it cannot see
 is a package warning at load, not a surprise when someone opens the dropdown.
 
 In a package that [curates its surface](discovery-and-access.md) (`explores` plus
@@ -230,8 +230,8 @@ dashboard and margin on another without either redeclaring it.
 **Importing a given is what makes it bindable.** Malloy's given namespace is per-file, so a
 dashboard can only be _run_ with the givens its own file imports, even when the `where:` that
 references one lives up an import chain. A given the file does not import gets no control, and
-sending it at run time fails with "unknown given". Everything about givens themselves —
-declaration, types, defaults, access control — is in [givens.md](givens.md).
+sending it at run time fails with "unknown given". Everything about givens themselves
+(declaration, types, defaults, access control) is in [givens.md](givens.md).
 
 <a id="apply"></a>
 
@@ -252,8 +252,8 @@ query: regional_sales is order_items -> { … }
 - **Control state lives in the URL**, so a filtered dashboard is a shareable link. A URL parameter
   beats the dashboard's own starting values.
 
-All three behave identically in a notebook, which spells them at the file level — `## autorun=false`
-and `## givens { REGION=f'West' }` — and gets the same controls, the same URL state, and the same
+All three behave identically in a notebook, which spells them at the file level (`## autorun=false`
+and `## givens { REGION=f'West' }`) and gets the same controls, the same URL state, and the same
 Apply button from the same code.
 
 ## Composite dashboards
@@ -274,17 +274,17 @@ Each tile runs as its own query, which means a broken tile shows its error in pl
 blanking the page, and a control change re-runs only the tiles that reference it. The control row is
 the union across the tiles.
 
-A composite's tiles are equal-width — `dashboard_columns` is the whole layout, and there is no
+A composite's tiles are equal-width: `dashboard_columns` is the whole layout, and there is no
 per-tile colspan, since each tile is a separate result rather than a field in one. So choose a column
 count the tile list divides evenly (three tiles at 3, four at 2 or 4), and expect each chart to have
 `1/N` of the page: a monthly trend at a third of the width gets crowded x labels, which is a reason
 to prefer the single-query form when one tile deserves more room than the others.
 
 A composite has no query of its own, so the filtering it applies has to live in what it composes.
-That is the job the shared include does here — `_shared.malloy` scopes the source once:
+That is the job the shared include does here. `_shared.malloy` scopes the source once:
 
 ```malloy
-// dashboards/_shared.malloy — no artifact tag, so an include rather than a dashboard.
+// dashboards/_shared.malloy: no artifact tag, so an include rather than a dashboard.
 ##! experimental.givens
 import { order_items } from '../storefront.malloy'
 import { CATEGORY, SINCE } from '../givens.malloy'
@@ -294,8 +294,8 @@ source: scoped_sales is order_items extend {
 }
 ```
 
-Note the imports in the composite itself. Nothing in that file mentions `CATEGORY` or `SINCE` — the
-`where:` that does is one file over — but the given namespace is per-file, so without importing them
+Note the imports in the composite itself. Nothing in that file mentions `CATEGORY` or `SINCE` (the
+`where:` that does is one file over), but the given namespace is per-file, so without importing them
 the control row would be empty and the tiles would silently run at their defaults.
 
 <a id="drill"></a>
@@ -354,7 +354,7 @@ wiring. A notebook cell grouping by a tagged dimension is clickable for exactly 
 says nothing about drill itself: it imports the given for its own Parameters panel, which is all
 `to=self` needs. Both surfaces run the same
 implementation, down to the hover styling and the menu, so a reader cannot tell from the
-interaction which kind of document they are in — only the menu's `to=self` entry names it ("Filter
+interaction which kind of document they are in. Only the menu's `to=self` entry names it ("Filter
 this notebook" against "Filter this dashboard").
 
 A drill only lands somewhere useful if the destination declares a control for the given being
@@ -374,7 +374,7 @@ field names and identical numbers.
 ## What Publisher checks at load
 
 Every package load lints the dashboards and reports findings as package warnings, visible on the
-package page and in the server log. They catch the failures that are otherwise silent — a control
+package page and in the server log. They catch the failures that are otherwise silent: a control
 that never appears, a click that goes nowhere. Broadly, they cover:
 
 - **Drill targets.** A `# drill { to=… }` naming a dashboard that does not exist in the package, or
@@ -410,12 +410,12 @@ the file, reload again.
 | Path                                                       | What it is                                                  |
 | ---------------------------------------------------------- | ----------------------------------------------------------- |
 | `/<env>/<pkg>/dashboards/<name>`                           | The Console page                                            |
-| `/<env>/<pkg>/dashboards/<name>?CATEGORY=Outerwear`        | The same page, filtered — control state is URL state        |
+| `/<env>/<pkg>/dashboards/<name>?CATEGORY=Outerwear`        | The same page, filtered: control state is URL state         |
 | `GET /api/v0/environments/<env>/packages/<pkg>/dashboards` | List them                                                   |
 | `GET …/dashboards/<name>`                                  | The manifest: title, autorun, columns, control specs, tiles |
 
 A dashboard's query runs through the ordinary query endpoint against
-`dashboards/<name>.malloy`, with givens in the request body — there is no dashboard-specific
+`dashboards/<name>.malloy`, with givens in the request body. There is no dashboard-specific
 execution path, so authorization, row limits, and query caps behave exactly as they do everywhere
 else. [ai-agents.md](ai-agents.md) has the REST playbook.
 
@@ -448,7 +448,7 @@ import { Dashboard, encodeResourceUri } from "@malloy-publisher/sdk";
 />;
 ```
 
-Without `onNavigate`, drilling to another dashboard is inert — and, by the rule above, those cells do
+Without `onNavigate`, drilling to another dashboard is inert, and by the rule above those cells do
 not read as clickable either, so a host that has not wired navigation shows no affordance rather than
 a dead one. `to=self` still works, since it never leaves the component. The Console's own
 `DashboardPage` (`packages/app/src/components/pages/DashboardPage/DashboardPage.tsx`) is the worked
@@ -463,8 +463,8 @@ complete embedding story.
 
 ## Where dashboards stop
 
-Whatever renderer tags can express is the ceiling. There is deliberately no code escape hatch — no
-custom component, no authored JavaScript — because a page that needs to go past the tags is an
+Whatever renderer tags can express is the ceiling. There is deliberately no code escape hatch (no
+custom component, no authored JavaScript) because a page that needs to go past the tags is an
 [HTML data app](html-data-apps.md), which already does that job at whole-page scope with a real
 runtime and a real embedding story. The reasoning, including why the sandboxed-component approach
 was built and then cut, is in
@@ -472,7 +472,7 @@ was built and then cut, is in
 
 ## See also
 
-- [givens.md](givens.md) — the parameter mechanism the controls are built on
-- [malloyyo-dashboards-design.md](malloyyo-dashboards-design.md) — the design, and the grammar's provenance
-- [console.md](console.md) — the rest of the Publisher Console
+- [givens.md](givens.md): the parameter mechanism the controls are built on
+- [malloyyo-dashboards-design.md](malloyyo-dashboards-design.md): the design, and the grammar's provenance
+- [console.md](console.md): the rest of the Publisher Console
 - [`examples/storefront`](../examples/storefront), the ecommerce model this page's examples build on

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -324,12 +324,16 @@ source: order_items is duckdb.table('data/order_items.parquet') extend {
   dimension name before checking while the click does not.
 
 **What a reader sees.** Cells in a drillable column take a pointer cursor, and turn blue and
-underlined under the pointer — plain text at rest, a link when you reach for them. That is the only
-signal a cell does anything, so it is worth knowing what turns it off: a destination the surface
-cannot reach is not offered and not marked, deliberately, since a dead link is worse than none. A
-`to=self` drill read in a document that declares no control for its given is the usual case, and it
-stays plain text rather than swallowing the click. The same rule decides the menu, so what looks
-clickable and what a click does can't drift apart.
+underlined under the pointer: plain text at rest, a link when you reach for them. They are also in
+the tab order and carry a button role, so a keyboard reaches them and Enter or Space fires the drill,
+with focus styled the way hover is. That matters because a pointer cursor and a hover colour are the
+two things a keyboard or touch user can never produce.
+
+Those signals are the only thing saying a cell does anything, so it is worth knowing what turns them
+off: a destination the surface cannot reach is not offered and not marked, deliberately, since a dead
+link is worse than none. A `to=self` drill read in a document that declares no control for its given
+is the usual case, and it stays plain text rather than swallowing the click. The same rule decides
+the menu, so what looks clickable and what a click does cannot drift apart.
 
 Declaring it on the dimension is what makes it work everywhere: any result that groups by that
 dimension is clickable, in a dashboard tile and in a **notebook cell** alike, with no per-document

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -355,7 +355,15 @@ keyboard or touch user can never produce.
 order, not one per row, so Tab does not walk a reader through a thousand cells to reach whatever
 follows the result. From a cell in the column, ArrowDown and ArrowUp step a row, Home and End jump to
 the ends, and the movement stops at the ends rather than wrapping. The tab stop follows the focused
-row, so leaving the result and tabbing back returns to the row you were on.
+row however you got there, clicking included, so leaving the result and tabbing back returns to the
+row you were on.
+
+That is one stop per TABLE, which is not the same as one per result when a drill sits inside a
+`nest:`. The renderer draws a nested table per parent row, each with its own columns, so a drillable
+dimension inside a nest still contributes a stop per parent row: measured 2 parent rows, 2 stops,
+against 1 for the same dimension grouped flat. Sharing a stop across those tables needs the marking
+to match on field identity rather than on a rendered column, which is the same limitation noted in
+`markDrillableCells`.
 
 Those signals are the only thing saying a cell does anything, so it is worth knowing what turns them
 off: a destination the surface cannot reach is not offered and not marked, deliberately, since a dead

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -148,10 +148,10 @@ model.
 All of this applies equally to a `# dashboard` **view** run in a notebook cell: the two surfaces
 render through the same code, so a view laid out with these tags looks the same in a cell as on a
 dashboard page. The storefront model's `business_overview` view is the shipped `# dashboard` view,
-and the notebook's first cell is that view. Read it as a working example of the two surfaces
-agreeing, not of the layout recipe above, which it predates: it carries no `columns=`, no colspans,
-and it nests a `# big_value` for its KPIs, which is the one thing this page says not to do. Height
-is the one thing the surface decides rather than the tags: a single-query dashboard renders at its
+and the notebook's Business overview cell runs that view. Read it as a working example of the two
+surfaces agreeing, not of the layout recipe above, which it predates: it carries no `columns=`, no
+colspans, and it nests a `# big_value` for its KPIs, which is the one thing this page says not to do.
+Height is the one thing the surface decides rather than the tags: a single-query dashboard renders at its
 natural height when the result reports one, which a `# dashboard` grid does, a composite caps each
 tile so one long table cannot set its row's height, and a notebook caps a chart cell and lets a table
 cell hug its rows so one long result cannot push the prose off the page.

--- a/packages/app/src/components/pages/DashboardPage/DashboardPage.tsx
+++ b/packages/app/src/components/pages/DashboardPage/DashboardPage.tsx
@@ -11,7 +11,7 @@ import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 export interface DashboardPageProps {
    environmentName: string;
    packageName: string;
-   /** The dashboard's slug — `overview`, not `dashboards/overview.malloy`. */
+   /** The dashboard's slug: `overview`, not `dashboards/overview.malloy`. */
    dashboardName: string;
 }
 

--- a/packages/app/src/components/pages/DashboardPage/DashboardPage.tsx
+++ b/packages/app/src/components/pages/DashboardPage/DashboardPage.tsx
@@ -6,7 +6,7 @@ import {
 } from "@malloy-publisher/sdk";
 import { Box } from "@mui/material";
 import { useCallback, useMemo } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
 export interface DashboardPageProps {
    environmentName: string;
@@ -28,8 +28,16 @@ export default function DashboardPage({
    packageName,
    dashboardName,
 }: DashboardPageProps) {
-   const [searchParams, setSearchParams] = useSearchParams();
+   const [searchParams] = useSearchParams();
    const navigate = useRouterClickHandler();
+
+   // `setSearchParams` is deliberately not used to WRITE, for the reason
+   // NotebookPage documents: it navigates to a search-only target, and a target
+   // carrying no fragment resolves to an empty one, so changing a control
+   // dropped whatever anchor the reader had arrived on. Navigating with an
+   // explicit `hash` keeps it.
+   const routerNavigate = useNavigate();
+   const location = useLocation();
 
    // Control values ride in the query string, so a link reproduces the view.
    const givens = useMemo(
@@ -39,11 +47,27 @@ export default function DashboardPage({
 
    const onGivensChange = useCallback(
       (next: Record<string, string>) => {
-         // Filtering is not a navigation step: Back should leave the
-         // dashboard, not walk back through every filter the user tried.
-         setSearchParams(next, { replace: true });
+         // KNOWN GAP, unlike NotebookPage: the applied values REPLACE the query
+         // string rather than merging into it, so an unrelated parameter on a
+         // dashboard URL (a tracking tag, say) is dropped on the first control
+         // change. Merging needs to know which names are the dashboard's to take
+         // back out, and `Dashboard`'s `onGivensChange` hands over values only,
+         // where `Notebook`'s hands over the managed names alongside them, which
+         // is what lets NotebookPage merge. Guessing is worse than replacing:
+         // without that list, a control the reader CLEARS cannot be told from a
+         // parameter that was never ours, so its value would stay in the address
+         // bar while the page ran without it.
+         routerNavigate(
+            // Filtering is not a navigation step: Back should leave the
+            // dashboard, not walk back through every filter the user tried.
+            {
+               search: new URLSearchParams(next).toString(),
+               hash: location.hash,
+            },
+            { replace: true },
+         );
       },
-      [setSearchParams],
+      [routerNavigate, location],
    );
 
    // A drill IS a navigation step, so unlike filtering it pushes history: Back

--- a/packages/app/src/components/pages/DashboardPage/DashboardPage.tsx
+++ b/packages/app/src/components/pages/DashboardPage/DashboardPage.tsx
@@ -1,0 +1,85 @@
+import {
+   Dashboard,
+   encodeResourceUri,
+   useRouterClickHandler,
+   type DrillNavigation,
+} from "@malloy-publisher/sdk";
+import { Box } from "@mui/material";
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+
+export interface DashboardPageProps {
+   environmentName: string;
+   packageName: string;
+   /** The dashboard's slug — `overview`, not `dashboards/overview.malloy`. */
+   dashboardName: string;
+}
+
+/**
+ * The Console's host for the SDK `Dashboard`.
+ *
+ * Everything the component externalizes on purpose lands here: the URL sync that
+ * makes a filtered dashboard a shareable link, and the drill navigation that
+ * turns a slug and a seeded given into a route. The component itself reads
+ * nothing from the router.
+ */
+export default function DashboardPage({
+   environmentName,
+   packageName,
+   dashboardName,
+}: DashboardPageProps) {
+   const [searchParams, setSearchParams] = useSearchParams();
+   const navigate = useRouterClickHandler();
+
+   // Control values ride in the query string, so a link reproduces the view.
+   const givens = useMemo(
+      () => Object.fromEntries(searchParams.entries()),
+      [searchParams],
+   );
+
+   const onGivensChange = useCallback(
+      (next: Record<string, string>) => {
+         // Filtering is not a navigation step: Back should leave the
+         // dashboard, not walk back through every filter the user tried.
+         setSearchParams(next, { replace: true });
+      },
+      [setSearchParams],
+   );
+
+   // A drill IS a navigation step, so unlike filtering it pushes history: Back
+   // returns to the dashboard the user drilled from. `navigate` also honours
+   // cmd/ctrl-click by opening the destination in a new tab.
+   const onNavigate = useCallback(
+      (target: DrillNavigation, event?: MouseEvent) => {
+         const query = new URLSearchParams(target.givens).toString();
+         // Every segment encoded. The destination slug comes from a `# drill`
+         // tag naming a filename, so it can hold a character that would read as
+         // structure in a path or start the query string early; the server
+         // percent-encodes the same name when it publishes a dashboard's own
+         // URL. The environment and package names are validated on the way in
+         // and hold nothing worth encoding, but they are encoded on the same
+         // principle as the `pages/` redirect in ModelPage.
+         const env = encodeURIComponent(environmentName);
+         const pkg = encodeURIComponent(packageName);
+         const slug = encodeURIComponent(target.dashboard);
+         navigate(
+            `/${env}/${pkg}/dashboards/${slug}` + (query ? `?${query}` : ""),
+            event,
+         );
+      },
+      [navigate, environmentName, packageName],
+   );
+
+   return (
+      <Box sx={{ p: 3, maxWidth: 1600, mx: "auto" }}>
+         <Dashboard
+            resourceUri={encodeResourceUri({ environmentName, packageName })}
+            dashboard={dashboardName}
+            givens={givens}
+            onGivensChange={onGivensChange}
+            onNavigate={onNavigate}
+            maxResultSize={1024 * 1024}
+         />
+      </Box>
+   );
+}

--- a/packages/app/src/components/pages/DashboardPage/DashboardPage.tsx
+++ b/packages/app/src/components/pages/DashboardPage/DashboardPage.tsx
@@ -5,7 +5,7 @@ import {
    type DrillNavigation,
 } from "@malloy-publisher/sdk";
 import { Box } from "@mui/material";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
 export interface DashboardPageProps {
@@ -45,25 +45,49 @@ export default function DashboardPage({
       [searchParams],
    );
 
+   // Names this page has written into the query string, so a control cleared
+   // after the dashboard stopped declaring it still gets cleaned up. Same device
+   // NotebookPage uses, for the same reason.
+   const writtenRef = useRef<Set<string>>(new Set());
+
    const onGivensChange = useCallback(
-      (next: Record<string, string>) => {
-         // KNOWN GAP, unlike NotebookPage: the applied values REPLACE the query
-         // string rather than merging into it, so an unrelated parameter on a
-         // dashboard URL (a tracking tag, say) is dropped on the first control
-         // change. Merging needs to know which names are the dashboard's to take
-         // back out, and `Dashboard`'s `onGivensChange` hands over values only,
-         // where `Notebook`'s hands over the managed names alongside them, which
-         // is what lets NotebookPage merge. Guessing is worse than replacing:
-         // without that list, a control the reader CLEARS cannot be told from a
-         // parameter that was never ours, so its value would stay in the address
-         // bar while the page ran without it.
+      (next: Record<string, string>, managed: readonly string[]) => {
+         const ours = new Set([...managed, ...writtenRef.current]);
+         writtenRef.current = new Set([
+            ...writtenRef.current,
+            ...Object.keys(next),
+            ...managed,
+         ]);
+         // Merged into what is already there, not written over it. The query
+         // string is not this page's alone: a tracking tag or any other unrelated
+         // parameter shares it, and replacing the whole string dropped it, not on
+         // the first control change as this comment used to claim, but on LOAD,
+         // as soon as a manifest carrying a declared given arrived. It was also
+         // inconsistent: on a warm react-query cache the first report never fired
+         // and the parameter survived, so whether a link kept its tracking tag
+         // depended on whether the reader had opened that dashboard before.
+         //
+         // Merging is possible here now because `Dashboard` hands over the names
+         // it manages alongside the values, the way `Notebook` does. Without that
+         // list a host cannot tell a control the reader CLEARED from a parameter
+         // that was never its business, which is why this used to replace.
+         const merged = new URLSearchParams(location.search);
+         for (const name of ours) {
+            // `hasOwnProperty`, not `in`: `next` is a plain object literal, so
+            // `in` walks its prototype and reports `constructor`, `toString` and
+            // friends as present, which would leave a given with one of those
+            // names stuck in the address bar after its control was cleared.
+            if (!Object.prototype.hasOwnProperty.call(next, name)) {
+               merged.delete(name);
+            }
+         }
+         for (const [name, value] of Object.entries(next)) {
+            merged.set(name, value);
+         }
          routerNavigate(
             // Filtering is not a navigation step: Back should leave the
             // dashboard, not walk back through every filter the user tried.
-            {
-               search: new URLSearchParams(next).toString(),
-               hash: location.hash,
-            },
+            { search: merged.toString(), hash: location.hash },
             { replace: true },
          );
       },

--- a/packages/app/src/components/pages/ModelPage/ModelPage.tsx
+++ b/packages/app/src/components/pages/ModelPage/ModelPage.tsx
@@ -82,6 +82,17 @@ function ModelPage() {
    // is what keeps those two apart: a route param matches any single segment,
    // dots included, so the literal route would have swallowed the file path
    // too. Same reasoning as the `data-apps/` branch below.
+   //
+   // The cost, stated the way `spa_fallback.ts` states its own: a slug is a
+   // filename with `.malloy` removed, so `dashboards/report.malloy.malloy`
+   // publishes the slug `report.malloy`, and this branch sends that URL to the
+   // Model viewer instead of the dashboard, which then finds no such file. That
+   // dashboard is listed and served by the API but has no working address here.
+   // Unhandled deliberately: `/{env}/{pkg}/dashboards/report.malloy` is
+   // genuinely ambiguous between the dashboard and a real model file of that
+   // path, and guessing would break the author's "view the Malloy" path, which
+   // is the commoner case by far. `report.csv` has no such ambiguity, which is
+   // why the server-side entry in SPA_OWNED_SEGMENTS can fix that one.
    if (
       modelPath?.startsWith("dashboards/") &&
       !modelPath.endsWith(".malloy") &&

--- a/packages/app/src/components/pages/ModelPage/ModelPage.tsx
+++ b/packages/app/src/components/pages/ModelPage/ModelPage.tsx
@@ -10,6 +10,7 @@ import Link from "@mui/material/Link";
 import Typography from "@mui/material/Typography";
 import { Navigate, useLocation, useParams } from "react-router-dom";
 import { MONO_FONT_FAMILY } from "../../../theme/colors";
+import DashboardPage from "../DashboardPage/DashboardPage";
 import NotebookPage from "../NotebookPage/NotebookPage";
 
 function ModelPage() {
@@ -73,6 +74,27 @@ function ModelPage() {
    }
 
    const wrapperSx = { p: 3, maxWidth: 1200, mx: "auto" } as const;
+
+   // Dashboard viewer. `dashboards/overview` is the dashboard; the file it is
+   // declared in, `dashboards/overview.malloy`, keeps opening in the Model
+   // view, which is the author's "view the Malloy" path. Branching on the
+   // extension here rather than declaring a literal `dashboards/:name` route
+   // is what keeps those two apart: a route param matches any single segment,
+   // dots included, so the literal route would have swallowed the file path
+   // too. Same reasoning as the `data-apps/` branch below.
+   if (
+      modelPath?.startsWith("dashboards/") &&
+      !modelPath.endsWith(".malloy") &&
+      !modelPath.endsWith(".malloynb")
+   ) {
+      return (
+         <DashboardPage
+            environmentName={params.environmentName}
+            packageName={params.packageName}
+            dashboardName={modelPath.slice("dashboards/".length)}
+         />
+      );
+   }
 
    // In-package HTML data app (embedded view). The Data Apps section in
    // <Package> routes clicks to `data-apps/<file>` so this branch picks them

--- a/packages/app/src/components/pages/NotebookPage/NotebookPage.tsx
+++ b/packages/app/src/components/pages/NotebookPage/NotebookPage.tsx
@@ -2,6 +2,7 @@ import {
    encodeResourceUri,
    Notebook,
    useRouterClickHandler,
+   type DrillNavigation,
 } from "@malloy-publisher/sdk";
 import Box from "@mui/material/Box";
 import { useCallback, useMemo, useRef } from "react";
@@ -128,6 +129,25 @@ export default function NotebookPage({
       [routerNavigate, location],
    );
 
+   // A `# drill` naming a dashboard leaves the notebook, so unlike a filter
+   // change it pushes history: Back returns to the notebook the reader drilled
+   // from. `navigate` also honours cmd/ctrl-click by opening a new tab. Every
+   // segment is encoded, since the destination slug comes from a tag naming a
+   // filename and can hold characters that would read as structure in a path.
+   const onDrillNavigate = useCallback(
+      (target: DrillNavigation, event?: MouseEvent) => {
+         const query = new URLSearchParams(target.givens).toString();
+         const env = encodeURIComponent(environmentName);
+         const pkg = encodeURIComponent(packageName);
+         const slug = encodeURIComponent(target.dashboard);
+         navigate(
+            `/${env}/${pkg}/dashboards/${slug}` + (query ? `?${query}` : ""),
+            event,
+         );
+      },
+      [navigate, environmentName, packageName],
+   );
+
    return (
       <Box sx={{ p: 3, maxWidth: 1200, mx: "auto" }}>
          <Notebook
@@ -140,6 +160,7 @@ export default function NotebookPage({
             givens={givens}
             onGivensChange={onGivensChange}
             onNavigate={navigate}
+            onDrillNavigate={onDrillNavigate}
          />
       </Box>
    );

--- a/packages/app/src/components/pages/index.ts
+++ b/packages/app/src/components/pages/index.ts
@@ -1,3 +1,4 @@
+export { default as DashboardPage } from "./DashboardPage/DashboardPage";
 export { default as EnvironmentPage } from "./EnvironmentPage/EnvironmentPage";
 export { default as HomePage } from "./HomePage/HomePage";
 export { default as ModelPage } from "./ModelPage/ModelPage";

--- a/packages/app/tests/playwright/package-dashboards.spec.ts
+++ b/packages/app/tests/playwright/package-dashboards.spec.ts
@@ -744,6 +744,30 @@ test.describe("package-dashboards", () => {
       await expect(page.getByRole("menuitem")).toHaveCount(2);
    });
 
+   test("clicking a cell moves the tab stop to it", async ({ page }) => {
+      await openDashboard(page, "combined");
+      const tile = page.locator(".MuiPaper-root").filter({
+         has: page.locator('[title="orders -> by_region"]'),
+      });
+      const cells = tile.locator(".publisher-drill");
+      await expect(cells.first()).toBeVisible({ timeout: 30_000 });
+      await expect(cells.nth(0)).toHaveAttribute("tabindex", "0");
+      await expect(cells.nth(1)).toHaveAttribute("tabindex", "-1");
+
+      // A `tabindex="-1"` cell is still click-focusable, so focus can arrive
+      // without going through the arrow handler that moves the stop. Before the
+      // focusin handler, clicking row 2 then tabbing away and back returned the
+      // reader to row 1.
+      await cells.nth(1).click();
+      await page.keyboard.press("Escape");
+
+      await expect(cells.nth(1)).toHaveAttribute("tabindex", "0");
+      await expect(cells.nth(0)).toHaveAttribute("tabindex", "-1");
+      await expect(tile.locator('.publisher-drill[tabindex="0"]')).toHaveCount(
+         1,
+      );
+   });
+
    test("Space opens the drill menu without choosing from it", async ({
       page,
    }) => {

--- a/packages/app/tests/playwright/package-dashboards.spec.ts
+++ b/packages/app/tests/playwright/package-dashboards.spec.ts
@@ -255,6 +255,34 @@ test.describe("package-dashboards", () => {
       await expect(page).toHaveURL(/[?&]utm_campaign=spring/);
    });
 
+   test("clearing a control removes only its own parameter", async ({
+      page,
+   }) => {
+      // The DELETE half of the merge, which had no test at all: every other
+      // dashboard test only ever ADDS or changes a value, and a merge that never
+      // deletes passes all of them while leaving a cleared control's parameter
+      // stuck in the address bar, silently re-applying to anyone opening the
+      // link.
+      await page.goto(
+         `/${env}/${PKG}/dashboards/overview?BRAND=Nike&utm_campaign=spring`,
+      );
+      await expect(
+         page.getByRole("heading", { name: "Business Overview" }),
+      ).toBeVisible({ timeout: 30_000 });
+      await expect(page).toHaveURL(/[?&]BRAND=Nike/);
+
+      const brand = page.locator(".MuiAutocomplete-root", {
+         has: page.getByRole("combobox", { name: "Brand" }),
+      });
+      await brand.hover();
+      await brand.getByRole("button", { name: "Clear" }).click();
+
+      // Its own parameter goes...
+      await expect(page).not.toHaveURL(/[?&]BRAND=/);
+      // ...and the one that was never the dashboard's stays.
+      await expect(page).toHaveURL(/[?&]utm_campaign=spring/);
+   });
+
    test("autorun=false gets an Apply button and its starting values", async ({
       page,
    }) => {

--- a/packages/app/tests/playwright/package-dashboards.spec.ts
+++ b/packages/app/tests/playwright/package-dashboards.spec.ts
@@ -118,6 +118,60 @@ test.describe("package-dashboards", () => {
       );
    });
 
+   test("both lists are ordered by the name they show", async ({ page }) => {
+      await gotoHome(page);
+      await openEnvironment(page, env);
+      await openPackage(page, env, PKG);
+      await expect(
+         page.getByRole("heading", { name: "Dashboards", level: 6 }),
+      ).toBeVisible({ timeout: 60_000 });
+
+      // Polled rather than snapshotted once: the rows arrive after the section
+      // heading does, and a single `allTextContents()` read them mid-render and
+      // reported a row as missing rather than as out of order.
+      const positions = async (names: string[]) => {
+         const labels = await page.getByRole("button").allTextContents();
+         return names.map((name) => labels.findIndex((l) => l.includes(name)));
+      };
+      const ascending = (xs: number[]) =>
+         xs.every((x, i) => x >= 0 && (i === 0 || x > xs[i - 1]));
+
+      // Sorted by the string on screen, not by the slug underneath it. By slug
+      // this reads Combined, Grid, Business Overview, Orders by region, which
+      // looks unsorted to anyone reading the titles.
+      await expect
+         .poll(
+            async () =>
+               ascending(
+                  await positions([
+                     "Business Overview",
+                     "Combined",
+                     "Grid",
+                     "Orders by region",
+                  ]),
+               ),
+            { timeout: 30_000 },
+         )
+         .toBe(true);
+
+      // Same for notebooks, which this release started labelling by title while
+      // still ordering them by filename: by path `orders-since` precedes
+      // `orders-start`, but "Orders from a start" precedes "Orders in a window".
+      await expect
+         .poll(
+            async () =>
+               ascending(
+                  await positions([
+                     "Brands",
+                     "Orders from a start",
+                     "Orders in a window",
+                  ]),
+               ),
+            { timeout: 30_000 },
+         )
+         .toBe(true);
+   });
+
    test("renders the title and the control row its given specs describe", async ({
       page,
    }) => {

--- a/packages/app/tests/playwright/package-dashboards.spec.ts
+++ b/packages/app/tests/playwright/package-dashboards.spec.ts
@@ -682,15 +682,65 @@ test.describe("package-dashboards", () => {
       const target = cell(page, "orders -> by_region", "US").locator("..");
       await expect(target).toBeVisible({ timeout: 30_000 });
 
-      // Marked cells are in the tab order and announce themselves, which is the
-      // whole difference between a drill a keyboard user can find and one only
-      // a mouse can reach.
-      await expect(target).toHaveAttribute("tabindex", "0");
+      // Marked cells are reachable and announce themselves, which is the whole
+      // difference between a drill a keyboard user can find and one only a mouse
+      // can reach.
       await expect(target).toHaveAttribute("role", "button");
+      // Focusable, but not necessarily the column's tab stop: a drillable column
+      // gets ONE stop and the arrow keys move within it. Marking every cell
+      // tabbable instead put a whole result column in the tab order, which at the
+      // server's row cap is hundreds of presses to reach the next tile.
+      await expect(target).toHaveAttribute("tabindex", /^(0|-1)$/);
+      const tile = page.locator(".MuiPaper-root").filter({
+         has: page.locator('[title="orders -> by_region"]'),
+      });
+      await expect(tile.locator('.publisher-drill[tabindex="0"]')).toHaveCount(
+         1,
+      );
 
       await target.focus();
       await page.keyboard.press("Enter");
       // Two honorable destinations, so Enter opens the menu rather than acting.
+      await expect(page.getByRole("menuitem")).toHaveCount(2);
+   });
+
+   test("arrow keys move within a drillable column and the stop follows", async ({
+      page,
+   }) => {
+      await openDashboard(page, "combined");
+      const tile = page.locator(".MuiPaper-root").filter({
+         has: page.locator('[title="orders -> by_region"]'),
+      });
+      const drillCells = tile.locator(".publisher-drill");
+      await expect(drillCells.first()).toBeVisible({ timeout: 30_000 });
+      const total = await drillCells.count();
+      expect(total).toBeGreaterThan(1);
+
+      // The stop starts on the first row, which is what Tab reaches.
+      await expect(drillCells.nth(0)).toHaveAttribute("tabindex", "0");
+      await drillCells.nth(0).focus();
+
+      await page.keyboard.press("ArrowDown");
+      // Focus AND the stop move together, so tabbing away and back returns to the
+      // row the reader was on rather than to the top of the column.
+      await expect(drillCells.nth(1)).toBeFocused();
+      await expect(drillCells.nth(1)).toHaveAttribute("tabindex", "0");
+      await expect(drillCells.nth(0)).toHaveAttribute("tabindex", "-1");
+      // Still exactly one stop: the point of the change.
+      await expect(tile.locator('.publisher-drill[tabindex="0"]')).toHaveCount(
+         1,
+      );
+
+      // Clamped rather than wrapping, which is how a table's rows read.
+      await page.keyboard.press("ArrowUp");
+      await expect(drillCells.nth(0)).toBeFocused();
+      await page.keyboard.press("ArrowUp");
+      await expect(drillCells.nth(0)).toBeFocused();
+
+      // End jumps to the last row, and the drill still fires from there.
+      await page.keyboard.press("End");
+      await expect(drillCells.nth(total - 1)).toBeFocused();
+      await page.keyboard.press("Enter");
       await expect(page.getByRole("menuitem")).toHaveCount(2);
    });
 

--- a/packages/app/tests/playwright/package-dashboards.spec.ts
+++ b/packages/app/tests/playwright/package-dashboards.spec.ts
@@ -226,6 +226,35 @@ test.describe("package-dashboards", () => {
       );
    });
 
+   test("an unrelated query parameter survives load and a control change", async ({
+      page,
+   }) => {
+      // The page's query string is not the dashboard's alone. Replacing it
+      // wholesale dropped anything else on LOAD, as soon as a manifest carrying a
+      // declared given arrived, and did it inconsistently: on a warm cache the
+      // first report never fired and the parameter survived, so whether a shared
+      // link kept its tracking tag depended on whether the reader had opened that
+      // dashboard before.
+      await page.goto(
+         `/${env}/${PKG}/dashboards/overview?BRAND=Nike&utm_campaign=spring`,
+      );
+      await expect(
+         page.getByRole("heading", { name: "Business Overview" }),
+      ).toBeVisible({ timeout: 30_000 });
+
+      await expect(page).toHaveURL(/[?&]utm_campaign=spring/);
+      await expect(page).toHaveURL(/[?&]BRAND=Nike/);
+
+      // And it still survives once a control writes to the query string.
+      const brand = page.getByRole("combobox", { name: "Brand" });
+      await brand.click();
+      await page.getByRole("option", { name: "Levi's" }).click({
+         timeout: 30_000,
+      });
+      await expect(page).toHaveURL(/[?&]BRAND=Levi/);
+      await expect(page).toHaveURL(/[?&]utm_campaign=spring/);
+   });
+
    test("autorun=false gets an Apply button and its starting values", async ({
       page,
    }) => {

--- a/packages/app/tests/playwright/package-dashboards.spec.ts
+++ b/packages/app/tests/playwright/package-dashboards.spec.ts
@@ -598,6 +598,46 @@ test.describe("package-dashboards", () => {
       });
    });
 
+   test("a drillable cell is reachable and firable from the keyboard", async ({
+      page,
+   }) => {
+      await openDashboard(page, "combined");
+      // `cell` resolves the inner `.cell-content`; the affordance attributes and
+      // the focus live on the cell that WRAPS it, which is the element the
+      // marking pass writes to.
+      const target = cell(page, "orders -> by_region", "US").locator("..");
+      await expect(target).toBeVisible({ timeout: 30_000 });
+
+      // Marked cells are in the tab order and announce themselves, which is the
+      // whole difference between a drill a keyboard user can find and one only
+      // a mouse can reach.
+      await expect(target).toHaveAttribute("tabindex", "0");
+      await expect(target).toHaveAttribute("role", "button");
+
+      await target.focus();
+      await page.keyboard.press("Enter");
+      // Two honorable destinations, so Enter opens the menu rather than acting.
+      await expect(page.getByRole("menuitem")).toHaveCount(2);
+   });
+
+   test("Space opens the drill menu without choosing from it", async ({
+      page,
+   }) => {
+      await openDashboard(page, "combined");
+      const target = cell(page, "orders -> by_region", "US").locator("..");
+      await expect(target).toBeVisible({ timeout: 30_000 });
+
+      // Space activates on keyUP, the native button rule. Firing it on keydown
+      // instead left the same keypress's keyup landing on the freshly-focused
+      // first menu item, so a Space drill chose a destination it never showed
+      // the reader. The URL check is what catches that regressing.
+      const before = page.url();
+      await target.focus();
+      await page.keyboard.press("Space");
+      await expect(page.getByRole("menuitem")).toHaveCount(2);
+      expect(page.url()).toBe(before);
+   });
+
    test("a cell with no drill tag is not clickable", async ({ page }) => {
       await openDashboard(page, "combined");
       await expect(page.getByRole("heading", { name: "Combined" })).toBeVisible(

--- a/packages/app/tests/playwright/package-dashboards.spec.ts
+++ b/packages/app/tests/playwright/package-dashboards.spec.ts
@@ -323,7 +323,7 @@ test.describe("package-dashboards", () => {
 
    /**
     * A clicked cell in the rendered result. The renderer owns this DOM, so
-    * there is no test id to hang onto — the cell's own text is the handle, and
+    * there is no test id to hang onto: the cell's own text is the handle, and
     * it is scoped to the tile so a value appearing in two tiles is unambiguous.
     * The tile is named by its run expression, which the panel keeps as its
     * heading's tooltip once the heading itself is humanized.
@@ -336,7 +336,7 @@ test.describe("package-dashboards", () => {
          .first();
 
    /**
-    * The table cell containing `text` — the element the affordance is marked on,
+    * The table cell containing `text`, the element the affordance is marked on,
     * one level up from the text node `cell()` returns.
     */
    const valueCell = (page: Page, text: string) =>
@@ -365,7 +365,7 @@ test.describe("package-dashboards", () => {
    // The affordance, which is what tells a reader a cell does anything at all.
    // Asserted on both surfaces because a drill's whole premise is that the tag
    // is declared once on a dimension and behaves the same wherever it is
-   // grouped — a notebook cell that navigates but doesn't say so is the same
+   // grouped: a notebook cell that navigates but doesn't say so is the same
    // feature only in principle.
    for (const surface of [
       {
@@ -399,8 +399,8 @@ test.describe("package-dashboards", () => {
          await expect(drillable).toHaveClass(/publisher-drill/);
 
          const drill = await readsAs(drillable);
-         // Ordinary text at rest — a column painted like a link competes with
-         // the data — and a link on hover.
+         // Ordinary text at rest (a column painted like a link competes with
+         // the data), and a link on hover.
          expect(drill.resting.cursor).toBe("pointer");
          expect(drill.resting.underlined).toBe(false);
          expect(drill.hovered.underlined).toBe(true);
@@ -427,7 +427,7 @@ test.describe("package-dashboards", () => {
       );
 
       // `# drill { to=overview given=BRAND }` on the brand_name dimension, which
-      // no dashboard declares — the tile is clickable because it groups by it.
+      // no dashboard declares: the tile is clickable because it groups by it.
       await cell(page, "orders -> by_brand", "Nike").click({ timeout: 30_000 });
 
       // One destination acts immediately: the slug becomes the route and the
@@ -501,6 +501,49 @@ test.describe("package-dashboards", () => {
       await expect(page.getByRole("button", { name: "Apply" })).toBeDisabled();
    });
 
+   // Distinct from the test above, which drills with nothing applied. That case
+   // cannot show this bug: the hook suppresses a report that repeats what it last
+   // reported, and with no given applied both are empty. With one applied, the
+   // destination's manifest is briefly undefined, so the hook reports "no values"
+   // while still holding the PREVIOUS dashboard's record, and a host that trusts
+   // that report clears the given the drill just seeded.
+   test("a drill keeps its seeded given when one was already applied", async ({
+      page,
+   }) => {
+      await openDashboard(page, "combined");
+
+      const brand = page.getByRole("combobox", { name: "Brand" });
+      await expect(brand).toBeVisible({ timeout: 30_000 });
+      await brand.click();
+      await page
+         .getByRole("option", { name: "Nike" })
+         .click({ timeout: 30_000 });
+      await expect(page).toHaveURL(/[?&]BRAND=Nike/);
+
+      await cell(page, "orders -> by_region", "EU").click({ timeout: 30_000 });
+      await page.getByRole("menuitem", { name: "Regions" }).click();
+
+      const seeded = new RegExp(
+         `/${env}/${PKG}/dashboards/regions\\?REGION=EU$`,
+      );
+      await expect(page).toHaveURL(seeded);
+      // Asserted again AFTER the destination has rendered, because the first
+      // assertion can pass on the pushed URL and `toHaveURL` stops looking once
+      // it matches. The wipe lands a commit later, so only a check past the
+      // destination's own paint can see it.
+      await expect(
+         page.getByRole("heading", { name: "Orders by region" }),
+      ).toBeVisible({ timeout: 30_000 });
+      await expect(page).toHaveURL(seeded);
+      // The value has to reach the control too, not just survive in the URL.
+      const region = page.locator(".MuiAutocomplete-root", {
+         has: page.getByRole("combobox", { name: "Region" }),
+      });
+      await expect(region.getByText("EU", { exact: true })).toBeVisible({
+         timeout: 30_000,
+      });
+   });
+
    test("a notebook cell drills into a dashboard", async ({ page }) => {
       // The payoff of declaring drill on the dimension: `brands.malloynb` says
       // nothing about drill, but its cell groups by `brand_name`, so the same
@@ -542,7 +585,7 @@ test.describe("package-dashboards", () => {
       await expect(applyButton).toBeDisabled();
 
       // The notebook's one cell counts orders on or after SINCE, which defaults
-      // to 2024-01-01 — all six of them. Deliberately not `.first()`: the count
+      // to 2024-01-01, all six of them. Deliberately not `.first()`: the count
       // is the only bare number on the page, so a second match means this is
       // matching something other than the result, and should fail.
       const count = (n: string) => page.getByText(n, { exact: true });
@@ -686,8 +729,8 @@ test.describe("package-dashboards", () => {
    });
 
    // A dashboard renders from its tags, in the page. Publisher runs no
-   // author-written dashboard component, so nothing here should ever be framed
-   // — see docs/malloyyo-dashboards-design.md §"Custom JSX components".
+   // author-written dashboard component, so nothing here should ever be framed.
+   // See docs/malloyyo-dashboards-design.md §"Custom JSX components".
    test("renders in the page, with no iframe", async ({ page }) => {
       await openDashboard(page, "overview");
       await expect(

--- a/packages/app/tests/playwright/package-dashboards.spec.ts
+++ b/packages/app/tests/playwright/package-dashboards.spec.ts
@@ -243,7 +243,7 @@ test.describe("package-dashboards", () => {
       }
    });
 
-   test("the grid lines up: colspans that sum, and a break between the rows", async ({
+   test("the grid lines up: two rows of two, each pair equal and flush", async ({
       page,
    }) => {
       await openDashboard(page, "grid");
@@ -254,40 +254,71 @@ test.describe("package-dashboards", () => {
       // Cards and tiles are the same kind of grid item, which is the point: two
       // cards at 6 and two tiles at 6 have to come out as two rows that end in
       // the same place. What "the dashboard looks janky" reduces to is this
-      // failing — a KPI card at its natural width, or a tile flowing in beside
-      // the cards because the break is missing.
+      // failing, a KPI card at its natural width or a row that does not reach
+      // the same edge as the one above it.
+      //
+      // It does NOT pin the `# break`, despite what this test used to be called.
+      // Measured: removing the break from the fixture changes nothing, because
+      // two cards at 6 already fill a 12-column row and the next item wraps on
+      // its own. That is the documented rule ("a break is for interrupting a row
+      // that would otherwise be shared"), so pinning the break needs a fixture
+      // whose first row does not fill, which this one deliberately is not.
       const items = page.locator(".dashboard-item");
-      await expect(items).toHaveCount(4, { timeout: 30_000 });
-      const boxes = await items.evaluateAll((elements) =>
-         elements.map((element) => {
-            const rect = element.getBoundingClientRect();
-            return {
-               left: Math.round(rect.left),
-               right: Math.round(rect.right),
-               top: Math.round(rect.top),
-               width: Math.round(rect.width),
-            };
-         }),
-      );
 
-      const rows = [...new Set(boxes.map((box) => box.top))].sort(
-         (a, b) => a - b,
-      );
-      expect(rows).toHaveLength(2);
-      for (const top of rows) {
-         const row = boxes.filter((box) => box.top === top);
-         expect(row).toHaveLength(2);
-         // Half the grid each, so the seam between them is in the same place on
-         // both rows.
-         expect(Math.abs(row[0].width - row[1].width)).toBeLessThanOrEqual(1);
-      }
-      const [cards, tiles] = rows.map((top) =>
-         boxes.filter((box) => box.top === top),
-      );
-      expect(Math.abs(cards[0].left - tiles[0].left)).toBeLessThanOrEqual(1);
-      expect(
-         Math.abs(cards.at(-1)!.right - tiles.at(-1)!.right),
-      ).toBeLessThanOrEqual(1);
+      // Retried as a block, because waiting for the four items to EXIST is not
+      // waiting for them to be laid out. The grid items are in the DOM before
+      // their results render, and in that window all four report `top: 0`, so a
+      // measurement taken then sees one row rather than two and the test fails
+      // against a page that is about to be correct. Observed at roughly one run
+      // in four by the slice stacked on this one, whose failure output showed
+      // exactly that: four items, every top zero.
+      //
+      // `toPass` rather than a sleep or a height gate: the assertions below are
+      // unchanged and still have to hold, so a genuinely broken grid still
+      // fails, it just gets the layout a chance to settle first. A height gate
+      // would be a second rule about when the grid is ready, and this file
+      // would then own two of them.
+      await expect(async () => {
+         await expect(items).toHaveCount(4);
+         const boxes = await items.evaluateAll((elements) =>
+            elements.map((element) => {
+               const rect = element.getBoundingClientRect();
+               return {
+                  left: Math.round(rect.left),
+                  right: Math.round(rect.right),
+                  top: Math.round(rect.top),
+                  width: Math.round(rect.width),
+                  height: Math.round(rect.height),
+               };
+            }),
+         );
+
+         // The precondition the old version left implicit. A collapsed item has
+         // no height, and its top is whatever the container's edge happens to
+         // be, which is what made every row look like row one.
+         for (const box of boxes) expect(box.height).toBeGreaterThan(0);
+
+         const rows = [...new Set(boxes.map((box) => box.top))].sort(
+            (a, b) => a - b,
+         );
+         expect(rows).toHaveLength(2);
+         for (const top of rows) {
+            const row = boxes.filter((box) => box.top === top);
+            expect(row).toHaveLength(2);
+            // Half the grid each, so the seam between them is in the same place
+            // on both rows.
+            expect(Math.abs(row[0].width - row[1].width)).toBeLessThanOrEqual(
+               1,
+            );
+         }
+         const [cards, tiles] = rows.map((top) =>
+            boxes.filter((box) => box.top === top),
+         );
+         expect(Math.abs(cards[0].left - tiles[0].left)).toBeLessThanOrEqual(1);
+         expect(
+            Math.abs(cards.at(-1)!.right - tiles.at(-1)!.right),
+         ).toBeLessThanOrEqual(1);
+      }).toPass({ timeout: 30_000 });
    });
 
    /**

--- a/packages/app/tests/playwright/package-dashboards.spec.ts
+++ b/packages/app/tests/playwright/package-dashboards.spec.ts
@@ -1,0 +1,627 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import path from "path";
+import { fileURLToPath } from "url";
+import { tmpName } from "./helpers/fixtures";
+import { gotoHome, openEnvironment, openPackage } from "./helpers/navigation";
+
+/**
+ * The dashboard viewer, end to end in a browser: the Dashboards section on the
+ * package page, the control row the manifest's given specs produce, URL-carried
+ * filter state, Apply mode, and the composite tile grid.
+ *
+ * Runs against its own environment built from the server's dashboards fixture
+ * rather than the bundled examples, which declare no dashboards. Registered in
+ * `beforeAll` through the same REST call a user would make and removed after,
+ * so the suite leaves the server as it found it.
+ */
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.resolve(
+   __dirname,
+   "../../../server/tests/fixtures/dashboards-test",
+);
+const PKG = "dashboards-test";
+
+let env: string;
+let baseURL: string;
+
+test.describe("package-dashboards", () => {
+   // Playwright requires the first argument to be a destructuring pattern even
+   // when no fixture is wanted, so the empty pattern is load-bearing here.
+   // eslint-disable-next-line no-empty-pattern
+   test.beforeAll(async ({}, testInfo) => {
+      baseURL = testInfo.project.use.baseURL ?? "http://localhost:4000";
+      env = tmpName("dashboards");
+      const res = await fetch(`${baseURL}/api/v0/environments`, {
+         method: "POST",
+         headers: { "Content-Type": "application/json" },
+         body: JSON.stringify({
+            name: env,
+            packages: [{ name: PKG, location: FIXTURE }],
+            connections: [],
+         }),
+      });
+      test.skip(
+         res.status === 405 || res.status === 403,
+         "publisher is read-only",
+      );
+      expect(res.ok, await res.text()).toBe(true);
+   });
+
+   test.afterAll(async () => {
+      if (!env || !baseURL) return;
+      await fetch(`${baseURL}/api/v0/environments/${env}`, {
+         method: "DELETE",
+      }).catch(() => undefined);
+   });
+
+   const openDashboard = async (page: Page, slug: string) => {
+      await page.goto(`/${env}/${PKG}/dashboards/${slug}`);
+   };
+
+   test("the package page lists dashboards and lists them only once", async ({
+      page,
+   }) => {
+      await gotoHome(page);
+      await openEnvironment(page, env);
+      await openPackage(page, env, PKG);
+
+      await expect(
+         page.getByRole("heading", { name: "Dashboards", level: 6 }),
+      ).toBeVisible({ timeout: 60_000 });
+      await expect(
+         page.getByRole("button", { name: /Business Overview/ }),
+      ).toBeVisible();
+
+      // A dashboard belongs in the Dashboards section, not a second time under
+      // Semantic Models where clicking it would open the Explorer instead.
+      await expect(
+         page.getByRole("button", { name: /dashboards\/overview\.malloy/ }),
+      ).toHaveCount(0);
+      // An untagged include in dashboards/ is not a dashboard and stays a model.
+      await expect(
+         page.getByRole("button", { name: /dashboards\/_shared\.malloy/ }),
+      ).toBeVisible();
+
+      await page.getByRole("button", { name: /Business Overview/ }).click();
+      await expect(page).toHaveURL(
+         new RegExp(`/${env}/${PKG}/dashboards/overview$`),
+      );
+   });
+
+   test("lists notebooks by title, the way it lists dashboards", async ({
+      page,
+   }) => {
+      await gotoHome(page);
+      await openEnvironment(page, env);
+      await openPackage(page, env, PKG);
+
+      await expect(
+         page.getByRole("heading", { name: "Notebooks", level: 6 }),
+      ).toBeVisible({ timeout: 60_000 });
+
+      // An explicit `## title=`, and a title read from the first markdown
+      // heading. Both rows keep the filename as the secondary label, so the
+      // path a reader needs in order to find the file is never lost.
+      const titled = page.getByRole("button", {
+         name: /Orders in a window/,
+      });
+      await expect(titled).toBeVisible();
+      await expect(titled).toContainText("orders-since.malloynb");
+      await expect(page.getByRole("button", { name: /Brands/ })).toContainText(
+         "brands.malloynb",
+      );
+
+      await titled.click();
+      await expect(page).toHaveURL(
+         new RegExp(`/${env}/${PKG}/orders-since.malloynb$`),
+      );
+   });
+
+   test("renders the title and the control row its given specs describe", async ({
+      page,
+   }) => {
+      await openDashboard(page, "overview");
+
+      await expect(
+         page.getByRole("heading", { name: "Business Overview" }),
+      ).toBeVisible({ timeout: 30_000 });
+      await expect(page.getByText("Order health at a glance.")).toBeVisible();
+
+      // `control=select` becomes a combobox, labelled by `# label=` rather than
+      // by the given's name.
+      await expect(page.getByRole("combobox", { name: "Brand" })).toBeVisible();
+      // `range_min`/`range_max` become a slider, and no control appears for the
+      // givens this dashboard's query does not reference.
+      await expect(
+         page.getByRole("slider", { name: "Minimum amount" }),
+      ).toBeVisible();
+      await expect(page.getByRole("combobox", { name: "Region" })).toHaveCount(
+         0,
+      );
+
+      await expect(page.locator("canvas, svg, table").first()).toBeVisible({
+         timeout: 30_000,
+      });
+   });
+
+   test("a select is populated by its suggest query and lands in the URL", async ({
+      page,
+   }) => {
+      await openDashboard(page, "overview");
+
+      const brand = page.getByRole("combobox", { name: "Brand" });
+      await expect(brand).toBeVisible({ timeout: 30_000 });
+      await brand.click();
+
+      // Options come from `suggest { source=orders dimension=brand }`, run
+      // through the ordinary query endpoint.
+      await expect(page.getByRole("option", { name: "Nike" })).toBeVisible({
+         timeout: 30_000,
+      });
+      await page.getByRole("option", { name: "Nike" }).click();
+
+      // Applied values are URL state, so this view is a shareable link.
+      await expect(page).toHaveURL(/[?&]BRAND=Nike/);
+
+      // And that link restores the control on a cold load.
+      await page.goto(`/${env}/${PKG}/dashboards/overview?BRAND=Nike`);
+      await expect(page.getByRole("combobox", { name: "Brand" })).toHaveValue(
+         "Nike",
+         { timeout: 30_000 },
+      );
+   });
+
+   test("autorun=false gets an Apply button and its starting values", async ({
+      page,
+   }) => {
+      await openDashboard(page, "regions");
+
+      await expect(
+         page.getByRole("heading", { name: "Orders by region" }),
+      ).toBeVisible({ timeout: 30_000 });
+
+      // `# artifact { givens { REGION=f'US' } }` is where the control starts.
+      // A multiselect holds its selection as chips, so the input itself stays
+      // empty and the chip is what to look for.
+      const region = page.locator(".MuiAutocomplete-root", {
+         has: page.getByRole("combobox", { name: "Region" }),
+      });
+      await expect(region.getByText("US", { exact: true })).toBeVisible({
+         timeout: 30_000,
+      });
+
+      // Nothing to apply until something changes.
+      const applyButton = page.getByRole("button", { name: "Apply" });
+      await expect(applyButton).toBeVisible();
+      await expect(applyButton).toBeDisabled();
+   });
+
+   test("a multiselect keeps its list open across picks", async ({ page }) => {
+      await openDashboard(page, "regions");
+
+      const region = page.getByRole("combobox", { name: "Region" });
+      await expect(region).toBeVisible({ timeout: 30_000 });
+      await region.click();
+      const options = page.getByRole("option");
+      await expect(options.first()).toBeVisible({ timeout: 30_000 });
+      const offered = await options.count();
+
+      // Picking a second value should not cost a second click to reopen. MUI's
+      // Autocomplete closes on select by default, which is right for the
+      // single-value picker next to this one and wrong for this one.
+      await options.first().click();
+      await expect(page.getByRole("option")).toHaveCount(offered);
+   });
+
+   test("a composite dashboard renders one panel per tile", async ({
+      page,
+   }) => {
+      await openDashboard(page, "combined");
+
+      await expect(page.getByRole("heading", { name: "Combined" })).toBeVisible(
+         { timeout: 30_000 },
+      );
+
+      // The control row is the union across tiles; `orders -> totals`
+      // references nothing and so contributes none.
+      await expect(page.getByRole("combobox", { name: "Brand" })).toBeVisible();
+      await expect(
+         page.getByRole("combobox", { name: "Region" }),
+      ).toBeVisible();
+
+      // One panel per tile, headed by the humanized view name rather than the
+      // run expression from `tiles=[…]`, which stays as the heading's tooltip.
+      for (const [tile, heading] of [
+         ["orders -> by_brand", "By brand"],
+         ["orders -> by_region", "By region"],
+         ["orders -> totals", "Totals"],
+      ]) {
+         const title = page.getByText(heading, { exact: true });
+         await expect(title).toBeVisible({ timeout: 30_000 });
+         await expect(title).toHaveAttribute("title", tile);
+      }
+   });
+
+   test("the grid lines up: colspans that sum, and a break between the rows", async ({
+      page,
+   }) => {
+      await openDashboard(page, "grid");
+      await expect(page.getByRole("heading", { name: "Grid" })).toBeVisible({
+         timeout: 30_000,
+      });
+
+      // Cards and tiles are the same kind of grid item, which is the point: two
+      // cards at 6 and two tiles at 6 have to come out as two rows that end in
+      // the same place. What "the dashboard looks janky" reduces to is this
+      // failing — a KPI card at its natural width, or a tile flowing in beside
+      // the cards because the break is missing.
+      const items = page.locator(".dashboard-item");
+      await expect(items).toHaveCount(4, { timeout: 30_000 });
+      const boxes = await items.evaluateAll((elements) =>
+         elements.map((element) => {
+            const rect = element.getBoundingClientRect();
+            return {
+               left: Math.round(rect.left),
+               right: Math.round(rect.right),
+               top: Math.round(rect.top),
+               width: Math.round(rect.width),
+            };
+         }),
+      );
+
+      const rows = [...new Set(boxes.map((box) => box.top))].sort(
+         (a, b) => a - b,
+      );
+      expect(rows).toHaveLength(2);
+      for (const top of rows) {
+         const row = boxes.filter((box) => box.top === top);
+         expect(row).toHaveLength(2);
+         // Half the grid each, so the seam between them is in the same place on
+         // both rows.
+         expect(Math.abs(row[0].width - row[1].width)).toBeLessThanOrEqual(1);
+      }
+      const [cards, tiles] = rows.map((top) =>
+         boxes.filter((box) => box.top === top),
+      );
+      expect(Math.abs(cards[0].left - tiles[0].left)).toBeLessThanOrEqual(1);
+      expect(
+         Math.abs(cards.at(-1)!.right - tiles.at(-1)!.right),
+      ).toBeLessThanOrEqual(1);
+   });
+
+   /**
+    * A clicked cell in the rendered result. The renderer owns this DOM, so
+    * there is no test id to hang onto — the cell's own text is the handle, and
+    * it is scoped to the tile so a value appearing in two tiles is unambiguous.
+    * The tile is named by its run expression, which the panel keeps as its
+    * heading's tooltip once the heading itself is humanized.
+    */
+   const cell = (page: Page, tile: string, text: string) =>
+      page
+         .locator(".MuiPaper-root")
+         .filter({ has: page.locator(`[title="${tile}"]`) })
+         .getByText(text, { exact: true })
+         .first();
+
+   /**
+    * The table cell containing `text` — the element the affordance is marked on,
+    * one level up from the text node `cell()` returns.
+    */
+   const valueCell = (page: Page, text: string) =>
+      page.locator(".column-cell.td").filter({ hasText: text }).first();
+
+   /** How a cell reads to a user: at rest, and under the pointer. */
+   async function readsAs(target: Locator) {
+      const at = (locator: Locator) =>
+         locator.evaluate((element) => {
+            const content = element.querySelector(".cell-content");
+            return {
+               cursor: getComputedStyle(element).cursor,
+               color: content ? getComputedStyle(content).color : "",
+               underlined: content
+                  ? getComputedStyle(content).textDecorationLine === "underline"
+                  : false,
+            };
+         });
+      const resting = await at(target);
+      await target.hover();
+      // The hover rule is CSS, so it lands on the next style recalculation.
+      await target.page().waitForTimeout(250);
+      return { resting, hovered: await at(target) };
+   }
+
+   // The affordance, which is what tells a reader a cell does anything at all.
+   // Asserted on both surfaces because a drill's whole premise is that the tag
+   // is declared once on a dimension and behaves the same wherever it is
+   // grouped — a notebook cell that navigates but doesn't say so is the same
+   // feature only in principle.
+   for (const surface of [
+      {
+         name: "dashboard",
+         open: async (page: Page) => {
+            await openDashboard(page, "combined");
+            await expect(
+               page.getByRole("heading", { name: "Combined" }),
+            ).toBeVisible({ timeout: 30_000 });
+         },
+      },
+      {
+         name: "notebook",
+         open: async (page: Page) => {
+            await page.goto(`/${env}/${PKG}/brands.malloynb`);
+            await expect(
+               page.getByRole("heading", { name: "Brands" }),
+            ).toBeVisible({ timeout: 60_000 });
+         },
+      },
+   ]) {
+      test(`a drillable cell reads as a link in a ${surface.name}, and its neighbours do not`, async ({
+         page,
+      }) => {
+         await surface.open(page);
+
+         // `brand_name` carries `# drill`; `total_amount`, beside it in the same
+         // table, does not.
+         const drillable = valueCell(page, "Nike");
+         await expect(drillable).toBeVisible({ timeout: 30_000 });
+         await expect(drillable).toHaveClass(/publisher-drill/);
+
+         const drill = await readsAs(drillable);
+         // Ordinary text at rest — a column painted like a link competes with
+         // the data — and a link on hover.
+         expect(drill.resting.cursor).toBe("pointer");
+         expect(drill.resting.underlined).toBe(false);
+         expect(drill.hovered.underlined).toBe(true);
+         expect(drill.hovered.color).not.toBe(drill.resting.color);
+
+         // The aggregate beside it: same table, same row height, no drill.
+         const measure = page.locator(".column-cell.td.numeric").first();
+         await expect(measure).not.toHaveClass(/publisher-drill/);
+         const plain = await readsAs(measure);
+         expect(plain.resting.cursor).not.toBe("pointer");
+         expect(plain.hovered.underlined).toBe(false);
+         expect(plain.hovered.color).toBe(plain.resting.color);
+      });
+   }
+
+   test("a single-destination drill navigates with the clicked value seeded", async ({
+      page,
+   }) => {
+      await openDashboard(page, "combined");
+      await expect(page.getByRole("heading", { name: "Combined" })).toBeVisible(
+         {
+            timeout: 30_000,
+         },
+      );
+
+      // `# drill { to=overview given=BRAND }` on the brand_name dimension, which
+      // no dashboard declares — the tile is clickable because it groups by it.
+      await cell(page, "orders -> by_brand", "Nike").click({ timeout: 30_000 });
+
+      // One destination acts immediately: the slug becomes the route and the
+      // clicked value becomes the given.
+      await expect(page).toHaveURL(
+         new RegExp(`/${env}/${PKG}/dashboards/overview\\?BRAND=Nike$`),
+      );
+      // Arriving seeded means arriving filtered, so the destination's control
+      // shows the drilled value.
+      await expect(page.getByRole("combobox", { name: "Brand" })).toHaveValue(
+         "Nike",
+         { timeout: 30_000 },
+      );
+   });
+
+   test("a two-destination drill offers a menu, and `self` filters in place", async ({
+      page,
+   }) => {
+      await openDashboard(page, "combined");
+      await expect(page.getByRole("heading", { name: "Combined" })).toBeVisible(
+         {
+            timeout: 30_000,
+         },
+      );
+
+      // `# drill { to=["regions", "self"] given=REGION }`: more than one
+      // destination is a choice, not a guess.
+      await cell(page, "orders -> by_region", "EU").click({ timeout: 30_000 });
+      // The destination reads as a sentence rather than as a filename, which is
+      // how Malloyyo labels the same menu.
+      await expect(page.getByRole("menuitem", { name: "Regions" })).toBeVisible(
+         {
+            timeout: 30_000,
+         },
+      );
+
+      // `self` never leaves the page; it sets the control instead.
+      await page
+         .getByRole("menuitem", { name: "Filter this dashboard" })
+         .click();
+      await expect(page).toHaveURL(/[?&]REGION=EU/);
+      const region = page.locator(".MuiAutocomplete-root", {
+         has: page.getByRole("combobox", { name: "Region" }),
+      });
+      await expect(region.getByText("EU", { exact: true })).toBeVisible({
+         timeout: 30_000,
+      });
+   });
+
+   test("the other menu destination navigates to that dashboard", async ({
+      page,
+   }) => {
+      await openDashboard(page, "combined");
+      await expect(page.getByRole("heading", { name: "Combined" })).toBeVisible(
+         {
+            timeout: 30_000,
+         },
+      );
+
+      await cell(page, "orders -> by_region", "EU").click({ timeout: 30_000 });
+      await page.getByRole("menuitem", { name: "Regions" }).click();
+
+      await expect(page).toHaveURL(
+         new RegExp(`/${env}/${PKG}/dashboards/regions\\?REGION=EU$`),
+      );
+      // regions is autorun=false, and a drill arrives applied rather than
+      // pending: the point of a drill is to land on the filtered view.
+      await expect(
+         page.getByRole("heading", { name: "Orders by region" }),
+      ).toBeVisible({ timeout: 30_000 });
+      await expect(page.getByRole("button", { name: "Apply" })).toBeDisabled();
+   });
+
+   test("a notebook cell drills into a dashboard", async ({ page }) => {
+      // The payoff of declaring drill on the dimension: `brands.malloynb` says
+      // nothing about drill, but its cell groups by `brand_name`, so the same
+      // click path works with no notebook-specific code.
+      await page.goto(`/${env}/${PKG}/brands.malloynb`);
+      await expect(page.getByRole("heading", { name: "Brands" })).toBeVisible({
+         timeout: 60_000,
+      });
+
+      await page
+         .getByText("Nike", { exact: true })
+         .first()
+         .click({ timeout: 60_000 });
+
+      await expect(page).toHaveURL(
+         new RegExp(`/${env}/${PKG}/dashboards/overview\\?BRAND=Nike$`),
+      );
+      await expect(
+         page.getByRole("heading", { name: "Business Overview" }),
+      ).toBeVisible({ timeout: 30_000 });
+   });
+
+   // A notebook and a dashboard run the same givens state, the same controls,
+   // and the same drill, so the interactivity a reader gets should not depend on
+   // which of the two an author reached for. These are the dashboard tests
+   // above, aimed at a notebook.
+   test("a notebook's parameters are URL state, batched behind Apply", async ({
+      page,
+   }) => {
+      // `orders-since.malloynb` carries `## autorun=false`, the notebook
+      // spelling of the dashboard's `# artifact { autorun=false }`.
+      await page.goto(`/${env}/${PKG}/orders-since.malloynb`);
+      await expect(
+         page.getByRole("heading", { name: "Orders since" }),
+      ).toBeVisible({ timeout: 60_000 });
+
+      const applyButton = page.getByRole("button", { name: "Apply" });
+      await expect(applyButton).toBeVisible();
+      await expect(applyButton).toBeDisabled();
+
+      // The notebook's one cell counts orders on or after SINCE, which defaults
+      // to 2024-01-01 — all six of them. Deliberately not `.first()`: the count
+      // is the only bare number on the page, so a second match means this is
+      // matching something other than the result, and should fail.
+      const count = (n: string) => page.getByText(n, { exact: true });
+      await expect(count("6")).toBeVisible({ timeout: 30_000 });
+
+      // The control's label comes from the given declaration, which is where a
+      // dashboard's comes from too.
+      await page
+         .getByRole("textbox", { name: "Ordered since" })
+         .fill("03/01/2024");
+
+      // Pending, not applied: the URL is untouched and the cell has not re-run,
+      // which is the whole point of batching.
+      await expect(applyButton).toBeEnabled();
+      expect(page.url()).not.toContain("SINCE");
+      await expect(count("6")).toBeVisible();
+
+      await applyButton.click();
+      await expect(page).toHaveURL(/[?&]SINCE=2024-03-01/);
+      // Two of the six are on or after 2024-03-01. Getting here at all is the
+      // date codec working: a full ISO timestamp is rejected with a 400.
+      await expect(count("2")).toBeVisible({ timeout: 30_000 });
+      await expect(count("6")).toBeHidden();
+
+      // And the link restores the value on a cold load.
+      await page.goto(`/${env}/${PKG}/orders-since.malloynb?SINCE=2024-03-01`);
+      await expect(
+         page.getByRole("textbox", { name: "Ordered since" }),
+      ).toHaveValue("03/01/2024", { timeout: 30_000 });
+   });
+
+   test("a notebook starts where `## givens` says, and a URL beats it", async ({
+      page,
+   }) => {
+      // `orders-start.malloynb` carries `## givens { SINCE="2024-03-01" }`, the
+      // notebook spelling of a dashboard's `# artifact { givens { … } }`.
+      await page.goto(`/${env}/${PKG}/orders-start.malloynb`);
+      const since = page.getByRole("textbox", { name: "Ordered since" });
+      await expect(since).toHaveValue("03/01/2024", { timeout: 60_000 });
+
+      // Applied, not merely displayed: two of the six orders are in the window.
+      const count = (n: string) => page.getByText(n, { exact: true });
+      await expect(count("2")).toBeVisible({ timeout: 30_000 });
+
+      // And written into the URL, so what a reader copies out of the address bar
+      // is what they are looking at. A dashboard's starting values do the same
+      // (`dashboards/regions?REGION=US`).
+      await expect(page).toHaveURL(/[?&]SINCE=2024-03-01/);
+
+      // A link overrides the file, so a shared URL shows the sender's view.
+      await page.goto(`/${env}/${PKG}/orders-start.malloynb?SINCE=2024-01-01`);
+      await expect(since).toHaveValue("01/01/2024", { timeout: 60_000 });
+      await expect(count("6")).toBeVisible({ timeout: 30_000 });
+   });
+
+   test("a notebook cell drills into the notebook itself", async ({ page }) => {
+      await page.goto(`/${env}/${PKG}/brands.malloynb`);
+      await expect(page.getByRole("heading", { name: "Brands" })).toBeVisible({
+         timeout: 60_000,
+      });
+
+      // Same tag, same menu as on the `combined` dashboard: `to=["regions",
+      // "self"]`, where self means this document.
+      await page
+         .getByText("EU", { exact: true })
+         .first()
+         .click({ timeout: 60_000 });
+      // The surface names itself: a notebook filtering itself is not "this
+      // dashboard", though the tag it came from is the same one.
+      await page
+         .getByRole("menuitem", { name: "Filter this notebook" })
+         .click();
+
+      // Filtering in place is a URL change, not a navigation: still the
+      // notebook, now with the given set.
+      await expect(page).toHaveURL(
+         new RegExp(`/${env}/${PKG}/brands\\.malloynb\\?REGION=EU$`),
+      );
+      const region = page.locator(".MuiAutocomplete-root", {
+         has: page.getByRole("combobox", { name: "Region" }),
+      });
+      await expect(region.getByText("EU", { exact: true })).toBeVisible({
+         timeout: 30_000,
+      });
+   });
+
+   test("a cell with no drill tag is not clickable", async ({ page }) => {
+      await openDashboard(page, "combined");
+      await expect(page.getByRole("heading", { name: "Combined" })).toBeVisible(
+         {
+            timeout: 30_000,
+         },
+      );
+
+      // `orders -> totals` groups by nothing, so its measures carry no drill
+      // tag. Clicking one must leave the page exactly where it was.
+      const before = page.url();
+      await cell(page, "orders -> totals", "6").click({ timeout: 30_000 });
+      await expect(page.getByRole("menuitem")).toHaveCount(0);
+      expect(page.url()).toBe(before);
+   });
+
+   // A dashboard renders from its tags, in the page. Publisher runs no
+   // author-written dashboard component, so nothing here should ever be framed
+   // — see docs/malloyyo-dashboards-design.md §"Custom JSX components".
+   test("renders in the page, with no iframe", async ({ page }) => {
+      await openDashboard(page, "overview");
+      await expect(
+         page.getByRole("heading", { name: "Business Overview" }),
+      ).toBeVisible({ timeout: 30_000 });
+      await expect(page.locator("iframe")).toHaveCount(0);
+   });
+});

--- a/packages/app/tests/playwright/package-dashboards.spec.ts
+++ b/packages/app/tests/playwright/package-dashboards.spec.ts
@@ -283,6 +283,23 @@ test.describe("package-dashboards", () => {
       await expect(page).toHaveURL(/[?&]utm_campaign=spring/);
    });
 
+   test("a select control looks like one", async ({ page }) => {
+      // MUI hides the dropdown arrow whenever `freeSolo` is set, which every
+      // given control needs so a reader can type a value the suggest query did
+      // not offer. Without `forcePopupIcon` the control renders as a bare text
+      // box, so nothing says it has options: a reader-reported complaint, and it
+      // had no test until a mutation sweep pointed out that both select tests
+      // click the control directly and would pass with the arrow gone.
+      await openDashboard(page, "overview");
+      const brand = page.locator(".MuiAutocomplete-root", {
+         has: page.getByRole("combobox", { name: "Brand" }),
+      });
+      await expect(brand).toBeVisible({ timeout: 30_000 });
+      await expect(
+         brand.locator(".MuiAutocomplete-popupIndicator"),
+      ).toHaveCount(1);
+   });
+
    test("autorun=false gets an Apply button and its starting values", async ({
       page,
    }) => {

--- a/packages/sdk/src/components/Dashboard/Dashboard.tsx
+++ b/packages/sdk/src/components/Dashboard/Dashboard.tsx
@@ -194,8 +194,21 @@ export function Dashboard({
          // milliseconds and a filter value went unescaped. Set under the name
          // the MODEL declares, so the value reaches the URL and the request
          // under the one name the server knows.
-         const value = encodeDrillValue(rawValue, declaredTypes.get(declared));
-         if (value === undefined) return;
+         const declaredType = declaredTypes.get(declared);
+         const value = encodeDrillValue(rawValue, declaredType);
+         if (value === undefined) {
+            // Say so, the way the notebook does. `canSelf` only checks that the
+            // NAME resolves, so a `given=` naming a type the clicked value
+            // cannot become still paints the whole column as clickable and then
+            // drops every click. That is an authoring mistake with no other
+            // symptom, and this is the likelier surface for it, because the
+            // givens are the dashboard's own.
+            console.warn(
+               `Drill declined: ${JSON.stringify(rawValue)} cannot be a value for given "${declared}"` +
+                  (declaredType ? ` of type ${declaredType}` : ""),
+            );
+            return;
+         }
          setGiven(declared, value);
       },
       [declaredTypes, resolveGiven, setGiven],

--- a/packages/sdk/src/components/Dashboard/Dashboard.tsx
+++ b/packages/sdk/src/components/Dashboard/Dashboard.tsx
@@ -1,0 +1,272 @@
+import { Alert, Box, Stack, Typography } from "@mui/material";
+import { useCallback, useMemo } from "react";
+import type { DashboardManifest } from "../../client";
+import { useGivensState } from "../../hooks/useGivensState";
+import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
+import { useSuggestOptions } from "../../hooks/useSuggestOptions";
+import { parseResourceUri } from "../../utils/formatting";
+import { ApiErrorDisplay } from "../ApiErrorDisplay";
+import { useDrill, type DrillNavigation } from "../drill";
+import { GivensPanel } from "../given";
+import { Loading } from "../Loading";
+import { useServer } from "../ServerProvider";
+import { DashboardTile } from "./DashboardTile";
+
+export interface DashboardProps {
+   /** `publisher://environments/{env}/packages/{pkg}` — env and package only. */
+   resourceUri: string;
+   /** The dashboard's slug, as listed by the dashboards endpoint. */
+   dashboard: string;
+   /**
+    * Control values from the host, typically its URL query parameters. These
+    * beat the dashboard's own starting values, so a shared link shows what the
+    * sender was looking at.
+    */
+   givens?: Record<string, string>;
+   /**
+    * Applied control values, for a host that wants them in its URL. Fires with
+    * what the results reflect, not with every keystroke.
+    */
+   onGivensChange?: (givens: Record<string, string>) => void;
+   /**
+    * Where to go when a `# drill` cell is clicked. Without it, drilling to
+    * another dashboard is inert — `to=self` still filters in place, since that
+    * never leaves the component.
+    */
+   onNavigate?: (target: DrillNavigation, event?: MouseEvent) => void;
+   /**
+    * Height cap for a result panel. Left unset, each form gets the cap that
+    * suits its shape — see {@link TILE_HEIGHT} and {@link WHOLE_PAGE_HEIGHT}.
+    * Set it to hold a dashboard to a fixed box, as an embedding host might.
+    */
+   height?: number;
+   maxResultSize?: number;
+}
+
+/**
+ * Per-tile cap for the composite form. A tile is one panel among several, so
+ * capping them keeps the grid even instead of letting one long table set the
+ * height of its whole row.
+ */
+const TILE_HEIGHT = 400;
+
+/**
+ * Cap for the single-query form, where the one result *is* the dashboard and a
+ * cap would clip the page rather than tidy it. High enough to be no cap in
+ * practice, and still a guard against a pathological result; the result renders
+ * at its natural height and the page scrolls, which is what a reader expects of
+ * a dashboard.
+ */
+const WHOLE_PAGE_HEIGHT = 20000;
+
+/**
+ * A Malloyyo-style dashboard: a control row over one or more query results,
+ * declared entirely by tags in a package's `dashboards/*.malloy`.
+ *
+ * Host-agnostic on purpose. It takes props rather than reading a router, and
+ * hands navigation and URL state back to whoever mounted it, so the Publisher
+ * Console and an external React app render the same component and differ only
+ * in what they do with `onNavigate` and `onGivensChange`.
+ */
+export function Dashboard({
+   resourceUri,
+   dashboard,
+   givens,
+   onGivensChange,
+   onNavigate,
+   height,
+   maxResultSize,
+}: DashboardProps) {
+   const { environmentName, packageName } = parseResourceUri(resourceUri);
+   const { apiClients } = useServer();
+
+   if (!environmentName || !packageName) {
+      throw new Error(
+         "A Dashboard resource URI must name an environment and a package.",
+      );
+   }
+
+   const {
+      data: manifestResponse,
+      isSuccess,
+      isError,
+      error,
+   } = useQueryWithApiError({
+      queryKey: ["dashboard", environmentName, packageName, dashboard],
+      queryFn: () =>
+         apiClients.dashboards.getDashboard(
+            environmentName,
+            packageName,
+            dashboard,
+         ),
+   });
+   const manifest = manifestResponse?.data;
+
+   const specs = useMemo(() => manifest?.givens ?? [], [manifest]);
+   const declaredTypes = useMemo(
+      () =>
+         new Map(
+            specs
+               .filter((spec) => spec.name !== undefined)
+               .map((spec) => [spec.name as string, spec.type]),
+         ),
+      [specs],
+   );
+
+   const { draft, applied, setGiven, reset, apply, pending } = useGivensState({
+      declaredTypes,
+      startingValues: manifest?.startingGivens,
+      params: givens,
+      onParamsChange: onGivensChange,
+      // Which document these edits belong to. Without it the edits are keyed by
+      // their starting VALUES alone, so two dashboards whose starting values
+      // coincide (the common case: both empty) look like one document, and the
+      // one you came from keeps filtering the one you drilled into.
+      documentKey: `${environmentName}/${packageName}/${dashboard}`,
+      // Absent means autorun; only an explicit `autorun=false` batches.
+      autorun: manifest?.autorun !== false,
+   });
+
+   const {
+      options,
+      isLoading: optionsLoading,
+      failed: optionsFailed,
+   } = useSuggestOptions(environmentName, packageName, manifest?.path, specs);
+
+   // `to=self` filters in place, which only works for a given this dashboard
+   // actually surfaces: sending one it cannot bind would fail every tile's
+   // query. Asked here rather than checked after the click, so a cell that
+   // cannot be honoured is never painted as clickable in the first place.
+   const canSelf = useCallback(
+      (given: string) => declaredTypes.has(given),
+      [declaredTypes],
+   );
+   const { drill, drillMenu } = useDrill({
+      onNavigate,
+      onSelf: setGiven,
+      canSelf,
+      selfLabel: "Filter this dashboard",
+   });
+
+   if (isError) {
+      return (
+         <ApiErrorDisplay
+            context={`${environmentName} > ${packageName} > ${dashboard}`}
+            error={error}
+         />
+      );
+   }
+   if (!isSuccess || !manifest) {
+      return <Loading text="Loading dashboard…" />;
+   }
+
+   // A dashboard whose file failed to compile still lists and still resolves,
+   // so say why rather than rendering an empty frame.
+   if (manifest.error) {
+      return (
+         <Stack spacing={2}>
+            <DashboardHeader manifest={manifest} />
+            <Alert severity="error">{manifest.error}</Alert>
+         </Stack>
+      );
+   }
+
+   const modelPath = manifest.path;
+   const tiles = manifest.tiles ?? [];
+
+   return (
+      <Stack spacing={2}>
+         <DashboardHeader manifest={manifest} />
+
+         <GivensPanel
+            givens={specs}
+            values={draft}
+            onChange={setGiven}
+            onReset={reset}
+            layout="bar"
+            options={options}
+            optionsLoading={optionsLoading}
+            optionsFailed={optionsFailed}
+            apply={
+               manifest.autorun === false
+                  ? { onApply: apply, pending }
+                  : undefined
+            }
+         />
+
+         {modelPath === undefined ? (
+            <Alert severity="error">
+               This dashboard has no model path, so there is nothing to run.
+            </Alert>
+         ) : manifest.query !== undefined ? (
+            // Single-query form: one query whose result IS the dashboard. Its
+            // `# dashboard {columns=N}` tag is the renderer's business, so no
+            // grid is imposed here — doing so would nest a grid in a grid.
+            <DashboardTile
+               environmentName={environmentName}
+               packageName={packageName}
+               modelPath={modelPath}
+               queryName={manifest.query}
+               givens={applied}
+               declaredTypes={declaredTypes}
+               height={height ?? WHOLE_PAGE_HEIGHT}
+               maxResultSize={maxResultSize}
+               drill={drill}
+            />
+         ) : tiles.length > 0 ? (
+            // Composite form: each tile runs on its own and the results are
+            // combined into one grid here, since no single Malloy result spans
+            // them.
+            <Box
+               sx={{
+                  display: "grid",
+                  gridTemplateColumns: {
+                     xs: "1fr",
+                     md: `repeat(${manifest.dashboardColumns ?? 2}, minmax(0, 1fr))`,
+                  },
+                  gap: 2,
+               }}
+            >
+               {tiles.map((tile) => (
+                  <DashboardTile
+                     key={tile.query}
+                     environmentName={environmentName}
+                     packageName={packageName}
+                     modelPath={modelPath}
+                     tile={tile.query}
+                     givens={applied}
+                     declaredTypes={declaredTypes}
+                     givenNames={tile.givenNames}
+                     height={height ?? TILE_HEIGHT}
+                     maxResultSize={maxResultSize}
+                     drill={drill}
+                  />
+               ))}
+            </Box>
+         ) : (
+            <Alert severity="warning">
+               This dashboard names neither a query nor any tiles.
+            </Alert>
+         )}
+
+         {drillMenu}
+      </Stack>
+   );
+}
+
+function DashboardHeader({ manifest }: { manifest: DashboardManifest }) {
+   return (
+      <Box>
+         <Typography variant="h5" sx={{ fontWeight: 600 }}>
+            {manifest.title ?? manifest.name}
+         </Typography>
+         {manifest.description && (
+            <Typography variant="body2" color="text.secondary">
+               {manifest.description}
+            </Typography>
+         )}
+      </Box>
+   );
+}
+
+export default Dashboard;

--- a/packages/sdk/src/components/Dashboard/Dashboard.tsx
+++ b/packages/sdk/src/components/Dashboard/Dashboard.tsx
@@ -26,8 +26,18 @@ export interface DashboardProps {
    /**
     * Applied control values, for a host that wants them in its URL. Fires with
     * what the results reflect, not with every keystroke.
+    *
+    * `managed` is every given this dashboard declares, whether or not it
+    * currently holds a value, and a host writing to a shared query string needs
+    * it. `givens` alone says which parameters to write but not which to REMOVE,
+    * so a host that guesses by deleting everything it did not just receive
+    * deletes the unrelated parameters it has no business touching. Same contract
+    * as `Notebook`, so a host can treat the two surfaces alike.
     */
-   onGivensChange?: (givens: Record<string, string>) => void;
+   onGivensChange?: (
+      givens: Record<string, string>,
+      managed: readonly string[],
+   ) => void;
    /**
     * Where to go when a `# drill` cell is clicked. Without it, drilling to
     * another dashboard is inert: `to=self` still filters in place, since that
@@ -121,6 +131,18 @@ export function Dashboard({
       [specs],
    );
 
+   // Hands the host the names this dashboard MANAGES alongside the values, so it
+   // can merge into a shared query string instead of replacing it. Guarded on
+   // `isSuccess` as well as at the call site, since an empty declared set before
+   // the manifest lands is the absence of an answer rather than the answer.
+   const reportGivens = useCallback(
+      (next: Record<string, string>) => {
+         if (!isSuccess) return;
+         onGivensChange?.(next, Array.from(declaredTypes.keys()));
+      },
+      [isSuccess, onGivensChange, declaredTypes],
+   );
+
    const { draft, applied, setGiven, reset, apply, pending } = useGivensState({
       declaredTypes,
       startingValues: manifest?.startingGivens,
@@ -134,7 +156,7 @@ export function Dashboard({
       // PREVIOUS dashboard's values and does not suppress that report as a
       // repeat. The host reasonably clears its query string, which is exactly the
       // givens the drill just seeded for the dashboard now arriving.
-      onParamsChange: isSuccess ? onGivensChange : undefined,
+      onParamsChange: isSuccess ? reportGivens : undefined,
       // Which document these edits belong to. Without it the edits are keyed by
       // their starting VALUES alone, so two dashboards whose starting values
       // coincide (the common case: both empty) look like one document, and the

--- a/packages/sdk/src/components/Dashboard/Dashboard.tsx
+++ b/packages/sdk/src/components/Dashboard/Dashboard.tsx
@@ -13,7 +13,7 @@ import { useServer } from "../ServerProvider";
 import { DashboardTile } from "./DashboardTile";
 
 export interface DashboardProps {
-   /** `publisher://environments/{env}/packages/{pkg}` — env and package only. */
+   /** `publisher://environments/{env}/packages/{pkg}`, env and package only. */
    resourceUri: string;
    /** The dashboard's slug, as listed by the dashboards endpoint. */
    dashboard: string;
@@ -30,13 +30,13 @@ export interface DashboardProps {
    onGivensChange?: (givens: Record<string, string>) => void;
    /**
     * Where to go when a `# drill` cell is clicked. Without it, drilling to
-    * another dashboard is inert — `to=self` still filters in place, since that
+    * another dashboard is inert: `to=self` still filters in place, since that
     * never leaves the component.
     */
    onNavigate?: (target: DrillNavigation, event?: MouseEvent) => void;
    /**
     * Height cap for a result panel. Left unset, each form gets the cap that
-    * suits its shape — see {@link TILE_HEIGHT} and {@link WHOLE_PAGE_HEIGHT}.
+    * suits its shape, see {@link TILE_HEIGHT} and {@link WHOLE_PAGE_HEIGHT}.
     * Set it to hold a dashboard to a fixed box, as an embedding host might.
     */
    height?: number;
@@ -117,7 +117,16 @@ export function Dashboard({
       declaredTypes,
       startingValues: manifest?.startingGivens,
       params: givens,
-      onParamsChange: onGivensChange,
+      // Withheld until the manifest has loaded, for the same reason the notebook
+      // withholds it. Changing `dashboard` changes the query key, so `data` is
+      // undefined for one commit and `declaredTypes` is empty; `applied` prunes
+      // to nothing and the hook reports "no values, and I manage nothing". This
+      // component is reconciled rather than remounted on a dashboard-to-dashboard
+      // drill, so the hook's record of what it last reported still holds the
+      // PREVIOUS dashboard's values and does not suppress that report as a
+      // repeat. The host reasonably clears its query string, which is exactly the
+      // givens the drill just seeded for the dashboard now arriving.
+      onParamsChange: isSuccess ? onGivensChange : undefined,
       // Which document these edits belong to. Without it the edits are keyed by
       // their starting VALUES alone, so two dashboards whose starting values
       // coincide (the common case: both empty) look like one document, and the
@@ -244,7 +253,7 @@ export function Dashboard({
          ) : manifest.query !== undefined ? (
             // Single-query form: one query whose result IS the dashboard. Its
             // `# dashboard {columns=N}` tag is the renderer's business, so no
-            // grid is imposed here — doing so would nest a grid in a grid.
+            // grid is imposed here: doing so would nest a grid in a grid.
             <DashboardTile
                environmentName={environmentName}
                packageName={packageName}

--- a/packages/sdk/src/components/Dashboard/Dashboard.tsx
+++ b/packages/sdk/src/components/Dashboard/Dashboard.tsx
@@ -95,14 +95,19 @@ export function Dashboard({
    height,
    maxResultSize,
 }: DashboardProps) {
-   const { environmentName, packageName } = parseResourceUri(resourceUri);
+   const parsed = parseResourceUri(resourceUri);
    const { apiClients } = useServer();
 
-   if (!environmentName || !packageName) {
-      throw new Error(
-         "A Dashboard resource URI must name an environment and a package.",
-      );
-   }
+   // Degraded, not thrown. `Notebook`, `Model` and `Package` all let a bad URI
+   // fail into an error display; a throw in the render body takes the host's
+   // whole tree down with it instead, which is a white screen rather than a
+   // message. The Console cannot reach this, because `DashboardPage` builds the
+   // URI from params `ModelPage` has already guarded, so the only caller a throw
+   // could punish is the embedding host the docs invite. Reported below rather
+   // than here, so every hook still runs in the same order.
+   const environmentName = parsed.environmentName ?? "";
+   const packageName = parsed.packageName ?? "";
+   const uriNamesBoth = !!parsed.environmentName && !!parsed.packageName;
 
    const {
       data: manifestResponse,
@@ -117,6 +122,8 @@ export function Dashboard({
             packageName,
             dashboard,
          ),
+      // No point asking for a dashboard under a name the URI never carried.
+      enabled: uriNamesBoth,
    });
    const manifest = manifestResponse?.data;
 
@@ -242,6 +249,16 @@ export function Dashboard({
       canSelf,
       selfLabel: "Filter this dashboard",
    });
+
+   // After every hook, so the hook order does not depend on the URI.
+   if (!uriNamesBoth) {
+      return (
+         <Alert severity="error">
+            A dashboard resource URI must name an environment and a package.
+            Received: {resourceUri}
+         </Alert>
+      );
+   }
 
    if (isError) {
       return (

--- a/packages/sdk/src/components/Dashboard/Dashboard.tsx
+++ b/packages/sdk/src/components/Dashboard/Dashboard.tsx
@@ -6,7 +6,7 @@ import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
 import { useSuggestOptions } from "../../hooks/useSuggestOptions";
 import { parseResourceUri } from "../../utils/formatting";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
-import { useDrill, type DrillNavigation } from "../drill";
+import { encodeDrillValue, useDrill, type DrillNavigation } from "../drill";
 import { GivensPanel } from "../given";
 import { Loading } from "../Loading";
 import { useServer } from "../ServerProvider";
@@ -133,17 +133,60 @@ export function Dashboard({
       failed: optionsFailed,
    } = useSuggestOptions(environmentName, packageName, manifest?.path, specs);
 
+   // A drill tag names its given as the model spells it, and `# drill` with no
+   // `given=` falls back to the DIMENSION's spelling, which need not match. The
+   // notebook folds case rather than picking a side, and this folds it the same
+   // way so one tag behaves identically on both surfaces.
+   const givenNamesByFold = useMemo(() => {
+      const byFold = new Map<string, string>();
+      for (const name of declaredTypes.keys()) {
+         // First declaration wins, so a model with `REGION` and `region` keeps
+         // the one it declared first rather than silently flipping.
+         if (!byFold.has(name.toLowerCase()))
+            byFold.set(name.toLowerCase(), name);
+      }
+      return byFold;
+   }, [declaredTypes]);
+
+   /** The declared given a drill tag's name refers to, or undefined. */
+   const resolveGiven = useCallback(
+      (given: string) =>
+         declaredTypes.has(given)
+            ? given
+            : givenNamesByFold.get(given.toLowerCase()),
+      [declaredTypes, givenNamesByFold],
+   );
+
    // `to=self` filters in place, which only works for a given this dashboard
    // actually surfaces: sending one it cannot bind would fail every tile's
    // query. Asked here rather than checked after the click, so a cell that
    // cannot be honoured is never painted as clickable in the first place.
    const canSelf = useCallback(
-      (given: string) => declaredTypes.has(given),
-      [declaredTypes],
+      (given: string) => resolveGiven(given) !== undefined,
+      [resolveGiven],
    );
+
+   const onSelf = useCallback(
+      (given: string, rawValue: unknown) => {
+         const declared = resolveGiven(given);
+         if (declared === undefined) return;
+         // Encoded against the DECLARED type, which is knowable here and is not
+         // knowable at the click: `useDrill` hands over the raw cell value for
+         // exactly this reason. Passing it straight to `setGiven` skipped the
+         // encoder, so a clicked date reached a `number` given as epoch
+         // milliseconds and a filter value went unescaped. Set under the name
+         // the MODEL declares, so the value reaches the URL and the request
+         // under the one name the server knows.
+         const value = encodeDrillValue(rawValue, declaredTypes.get(declared));
+         if (value === undefined) return;
+         setGiven(declared, value);
+      },
+      [declaredTypes, resolveGiven, setGiven],
+   );
+
    const { drill, drillMenu } = useDrill({
       onNavigate,
-      onSelf: setGiven,
+      onSelf,
       canSelf,
       selfLabel: "Filter this dashboard",
    });

--- a/packages/sdk/src/components/Dashboard/Dashboard.tsx
+++ b/packages/sdk/src/components/Dashboard/Dashboard.tsx
@@ -270,9 +270,13 @@ export function Dashboard({
                   gap: 2,
                }}
             >
-               {tiles.map((tile) => (
+               {tiles.map((tile, index) => (
                   <DashboardTile
-                     key={tile.query}
+                     // Position too, not the expression alone: `tiles=[…]` can
+                     // repeat one, which is a typo rather than a request for two
+                     // identical panels, and keying on the expression made the
+                     // duplicate warn and reconcile onto its twin.
+                     key={`${index}:${tile.query}`}
                      environmentName={environmentName}
                      packageName={packageName}
                      modelPath={modelPath}

--- a/packages/sdk/src/components/Dashboard/Dashboard.tsx
+++ b/packages/sdk/src/components/Dashboard/Dashboard.tsx
@@ -53,9 +53,17 @@ const TILE_HEIGHT = 400;
 /**
  * Cap for the single-query form, where the one result *is* the dashboard and a
  * cap would clip the page rather than tidy it. High enough to be no cap in
- * practice, and still a guard against a pathological result; the result renders
- * at its natural height and the page scrolls, which is what a reader expects of
- * a dashboard.
+ * practice, and still a guard against a pathological result.
+ *
+ * A result that REPORTS its own height, which a `# dashboard` grid does, renders
+ * at that height and the page scrolls, which is what a reader expects. A result
+ * that sizes to its CONTAINER instead, which a bare `# bar_chart` does, has no
+ * height to report and keeps whatever first-paint height it was handed, so it
+ * stretches: measured 1992px for a two-row bar chart against 227px for the same
+ * query under a grid tag. `INITIAL_RENDER_HEIGHT` bounds that near 2000 rather
+ * than removing it, and lowering the bound is NOT the fix, because the same seed
+ * sizes a notebook's chart cells (measured 700px there). Telling the two kinds of
+ * result apart needs something the renderer does not expose here.
  */
 const WHOLE_PAGE_HEIGHT = 20000;
 
@@ -212,8 +220,15 @@ export function Dashboard({
       return <Loading text="Loading dashboard…" />;
    }
 
-   // A dashboard whose file failed to compile still lists and still resolves,
-   // so say why rather than rendering an empty frame.
+   // Reachable on the in-process load path only. Production loads a package
+   // through the worker pool, which aborts the package on the first compile
+   // error, so an uncompilable file answers 424 everywhere rather than serving a
+   // per-file error. Measured on this base with one bad file: the package
+   // endpoint, the dashboards listing, and the manifest of a dashboard that was
+   // FINE all answered 424. The earlier note here said such a dashboard "still
+   // lists and still resolves", which contradicted this repo's own docs and was
+   // the wrong half of the pair. Kept because the per-file error manifest still
+   // exists and an empty frame would be worse than saying why.
    if (manifest.error) {
       return (
          <Stack spacing={2}>

--- a/packages/sdk/src/components/Dashboard/DashboardTile.tsx
+++ b/packages/sdk/src/components/Dashboard/DashboardTile.tsx
@@ -1,0 +1,145 @@
+import { Box, Paper, Typography } from "@mui/material";
+import { useQueryWithApiError } from "../../hooks/useQueryWithApiError";
+import type { GivenValue } from "../../hooks/givenValue";
+import { CHART_RESULT_QUERY_OPTIONS } from "../../utils/queryClient";
+import { ApiErrorDisplay } from "../ApiErrorDisplay";
+import { humanizeSlug, type DrillBinding } from "../drill";
+import { givensToRequest } from "../given/paramCodec";
+import { Loading } from "../Loading";
+import ResultContainer from "../RenderedResult/ResultContainer";
+import { useServer } from "../ServerProvider";
+
+export interface DashboardTileProps {
+   environmentName: string;
+   packageName: string;
+   modelPath: string;
+   /** A named query (the single-query form). */
+   queryName?: string;
+   /** A run expression (a composite tile). */
+   tile?: string;
+   /** Control values to run with, already narrowed to this tile's givens. */
+   givens: Map<string, GivenValue>;
+   /** Declared type per given name, which decides how a value is encoded. */
+   declaredTypes: ReadonlyMap<string, string | undefined>;
+   /**
+    * Given names this tile references, or undefined when discovery could not
+    * resolve the tile. Undefined means "send the whole control row", which the
+    * server accepts — a surfaced given a query does not reference is ignored.
+    */
+   givenNames?: string[];
+   height: number;
+   maxResultSize?: number;
+   /** Cell clicks and their affordance, for the dashboard's `# drill`. */
+   drill?: DrillBinding;
+}
+
+/**
+ * A composite tile's heading, read off its run expression: the last step's name
+ * as a sentence, so `scoped_sales -> sales_by_month` is titled "Sales by month".
+ *
+ * A tile in the single-query form gets its heading from a `# label` on the nest,
+ * and a composite tile has no nest to label — the entry is a string in
+ * `tiles=[…]`. Deriving it keeps the two forms reading alike instead of one
+ * showing titles and the other showing code.
+ */
+export function tileTitle(tile: string): string {
+   const lastStep = tile.split("->").at(-1)?.trim() ?? tile;
+   // Anything that is not a bare name (an inline `{ … }` stage, say) has no
+   // sensible title to derive, so it keeps the expression as written.
+   return /^[A-Za-z_][\w-]*$/.test(lastStep) ? humanizeSlug(lastStep) : tile;
+}
+
+/**
+ * One result panel: run it, render it, and keep its failure to itself.
+ *
+ * A tile owning its own query is what lets a composite dashboard survive a bad
+ * tile — the broken one shows its error in place and the rest of the grid still
+ * renders, rather than one failure blanking the page.
+ */
+export function DashboardTile({
+   environmentName,
+   packageName,
+   modelPath,
+   queryName,
+   tile,
+   givens,
+   declaredTypes,
+   givenNames,
+   height,
+   maxResultSize,
+   drill,
+}: DashboardTileProps) {
+   const { apiClients } = useServer();
+   const requestGivens = givensToRequest(givens, declaredTypes, givenNames);
+
+   const { data, isSuccess, isError, error } = useQueryWithApiError({
+      queryKey: [
+         "dashboardTile",
+         environmentName,
+         packageName,
+         modelPath,
+         queryName,
+         tile,
+         // Re-runs when the applied values change, which is the whole point of
+         // the control row.
+         JSON.stringify(requestGivens),
+      ],
+      queryFn: () =>
+         apiClients.models.executeQueryModel(
+            environmentName,
+            packageName,
+            modelPath,
+            {
+               queryName,
+               query: tile !== undefined ? `run: ${tile}` : undefined,
+               givens: requestGivens,
+            },
+         ),
+      ...CHART_RESULT_QUERY_OPTIONS,
+   });
+
+   return (
+      <Paper
+         elevation={0}
+         sx={{
+            border: 1,
+            borderColor: "divider",
+            borderRadius: 1,
+            overflow: "hidden",
+            minHeight: 120,
+         }}
+      >
+         {tile !== undefined && (
+            <Box sx={{ px: 2.5, pt: 2 }}>
+               <Typography
+                  variant="subtitle2"
+                  sx={{ fontWeight: 500, color: "text.secondary" }}
+                  // The expression is what actually ran, so it stays reachable
+                  // — as a tooltip rather than as the heading.
+                  title={tile}
+               >
+                  {tileTitle(tile)}
+               </Typography>
+            </Box>
+         )}
+         {!isSuccess && !isError && <Loading text="Running…" />}
+         {isSuccess && (
+            <ResultContainer
+               result={data.data.result}
+               maxHeight={height}
+               maxResultSize={maxResultSize}
+               renderLogs={data.data.renderLogs}
+               drill={drill}
+            />
+         )}
+         {isError && (
+            <Box sx={{ p: 2 }}>
+               <ApiErrorDisplay
+                  context={tile ?? queryName ?? modelPath}
+                  error={error}
+               />
+            </Box>
+         )}
+      </Paper>
+   );
+}

--- a/packages/sdk/src/components/Dashboard/DashboardTile.tsx
+++ b/packages/sdk/src/components/Dashboard/DashboardTile.tsx
@@ -17,7 +17,12 @@ export interface DashboardTileProps {
    queryName?: string;
    /** A run expression (a composite tile). */
    tile?: string;
-   /** Control values to run with, already narrowed to this tile's givens. */
+   /**
+    * The whole applied control row, NOT this tile's share of it. The narrowing
+    * happens here, in `givensToRequest` below, using {@link givenNames}: the
+    * caller does not know which givens a tile references and this component
+    * does.
+    */
    givens: Map<string, GivenValue>;
    /** Declared type per given name, which decides how a value is encoded. */
    declaredTypes: ReadonlyMap<string, string | undefined>;

--- a/packages/sdk/src/components/Dashboard/DashboardTile.tsx
+++ b/packages/sdk/src/components/Dashboard/DashboardTile.tsx
@@ -24,7 +24,7 @@ export interface DashboardTileProps {
    /**
     * Given names this tile references, or undefined when discovery could not
     * resolve the tile. Undefined means "send the whole control row", which the
-    * server accepts — a surfaced given a query does not reference is ignored.
+    * server accepts: a surfaced given a query does not reference is ignored.
     */
    givenNames?: string[];
    height: number;
@@ -38,7 +38,7 @@ export interface DashboardTileProps {
  * as a sentence, so `scoped_sales -> sales_by_month` is titled "Sales by month".
  *
  * A tile in the single-query form gets its heading from a `# label` on the nest,
- * and a composite tile has no nest to label — the entry is a string in
+ * and a composite tile has no nest to label: the entry is a string in
  * `tiles=[…]`. Deriving it keeps the two forms reading alike instead of one
  * showing titles and the other showing code.
  */
@@ -53,7 +53,7 @@ export function tileTitle(tile: string): string {
  * One result panel: run it, render it, and keep its failure to itself.
  *
  * A tile owning its own query is what lets a composite dashboard survive a bad
- * tile — the broken one shows its error in place and the rest of the grid still
+ * tile: the broken one shows its error in place and the rest of the grid still
  * renders, rather than one failure blanking the page.
  */
 export function DashboardTile({
@@ -115,7 +115,7 @@ export function DashboardTile({
                   variant="subtitle2"
                   sx={{ fontWeight: 500, color: "text.secondary" }}
                   // The expression is what actually ran, so it stays reachable
-                  // — as a tooltip rather than as the heading.
+                  // as a tooltip rather than as the heading.
                   title={tile}
                >
                   {tileTitle(tile)}

--- a/packages/sdk/src/components/Dashboard/index.ts
+++ b/packages/sdk/src/components/Dashboard/index.ts
@@ -1,0 +1,2 @@
+export { Dashboard, type DashboardProps } from "./Dashboard";
+export { DashboardTile, type DashboardTileProps } from "./DashboardTile";

--- a/packages/sdk/src/components/Notebook/Notebook.tsx
+++ b/packages/sdk/src/components/Notebook/Notebook.tsx
@@ -67,10 +67,10 @@ interface NotebookProps {
     * with what the cells actually ran with, which is what makes the URL a link
     * that reproduces the view.
     *
-    * That is every committed change, and today every change is committed: the
-    * Apply batching `useGivensState` implements is not reachable here while
-    * `autorun` is hardcoded true, so typing in a text control reports per
-    * keystroke. It does NOT run per keystroke: a changed value waits
+    * That is every committed change. Under `## autorun=false` a change is
+    * committed on Apply, so reports are batched; otherwise every change is
+    * committed and typing in a text control reports per keystroke. It does NOT
+    * run per keystroke: a changed value waits
     * `GIVEN_SETTLE_MS` before anything is dispatched, so a burst of typing
     * produces one run. A run that does start supersedes and aborts the one
     * before it. The REPORTS are still per keystroke, so a host doing something
@@ -185,14 +185,17 @@ export default function Notebook({
       [isSuccess, onGivensChange, declaredTypes],
    );
 
-   // Always on for now, and deliberately not read off the notebook. Batching
+   // Read off the notebook now that the server derives it: a file-level
+   // `## autorun=false` arrives as `RawNotebook.autorun`, the same field with
+   // the same default that a dashboard's `# artifact { autorun=false }`
+   // produces. This was hardcoded true while nothing populated the field, on
+   // the grounds that a spec declaring one nothing produces is a spec that
+   // lies; the reader has landed, so this is the follow-up that comment named.
+   //
+   // Absent means autorun, so only an explicit `false` batches. Batching
    // matters more here than on a dashboard: one control change re-runs every
-   // cell in the document, and `useGivensState` implements it, but the
-   // file-level `## autorun=false` that would turn it off has no reader on the
-   // server yet, so `RawNotebook` carries no `autorun` field. Declaring one
-   // nothing produces would be a spec that lies. When the reader lands, this
-   // becomes `notebook?.autorun !== false` and the Apply button appears.
-   const autorun = true;
+   // cell in the document.
+   const autorun = notebook?.autorun !== false;
    const { draft, applied, setGiven, reset, apply, pending } = useGivensState({
       declaredTypes,
       // Where the controls start, from a file-level `## givens { … }`. A URL

--- a/packages/sdk/src/components/Notebook/Notebook.tsx
+++ b/packages/sdk/src/components/Notebook/Notebook.tsx
@@ -11,7 +11,7 @@ import { useSuggestOptions } from "../../hooks/useSuggestOptions";
 import { parseResourceUri } from "../../utils/formatting";
 import { ApiErrorDisplay } from "../ApiErrorDisplay";
 import type { NavigationClick } from "../click_helper";
-import { encodeDrillValue } from "../drill";
+import { encodeDrillValue, type DrillNavigation } from "../drill";
 import { GivensPanel } from "../given";
 import { givensToRequest } from "../given/paramCodec";
 import { Loading } from "../Loading";
@@ -92,11 +92,17 @@ interface NotebookProps {
     * react-router context is required to render a notebook.
     *
     * It does NOT carry drill. A `# drill { to=self }` filters this notebook
-    * through `given:` state and works with or without this handler, and a drill
-    * naming a dashboard is not wired at all yet: see the note in
-    * `NotebookCell` for why.
+    * through `given:` state and needs no handler at all, and a drill naming a
+    * dashboard goes through {@link onDrillNavigate}, which takes a destination
+    * rather than a URL.
     */
    onNavigate?: (to: string, event?: NavigationClick) => void;
+   /**
+    * Opens a `# drill { to=<dashboard> }` from a cell, seeded with the clicked
+    * value. Omitted on a host with no dashboard route, which leaves those
+    * destinations inert AND unmarked rather than painting a dead link.
+    */
+   onDrillNavigate?: (target: DrillNavigation, event?: MouseEvent) => void;
 }
 
 // Requires PackageProvider
@@ -106,6 +112,7 @@ export default function Notebook({
    givens,
    onGivensChange,
    onNavigate,
+   onDrillNavigate,
 }: NotebookProps) {
    const { apiClients } = useServer();
    const {
@@ -645,6 +652,7 @@ export default function Notebook({
                         // the settle window has to signal.
                         pendingRerun={runScheduled}
                         onNavigate={onNavigate}
+                        onDrillNavigate={onDrillNavigate}
                         onDrillSelf={
                            declaredGivens.length > 0 ? onDrillSelf : undefined
                         }

--- a/packages/sdk/src/components/Notebook/NotebookCell.tsx
+++ b/packages/sdk/src/components/Notebook/NotebookCell.tsx
@@ -23,7 +23,7 @@ import { parseResourceUri } from "../../utils/formatting";
 import { highlight } from "../highlighter";
 import { ModelExplorerDialog } from "../Model/ModelExplorerDialog";
 import type { NavigationClick } from "../click_helper";
-import { useDrill } from "../drill";
+import { useDrill, type DrillNavigation } from "../drill";
 import { createEmbeddedQueryResult } from "../QueryResult/QueryResult";
 import ResultContainer from "../RenderedResult/ResultContainer";
 import ResultsDialog from "../ResultsDialog";
@@ -74,6 +74,16 @@ interface NotebookCellProps {
     * refusal only shows up in the console.
     */
    canDrillSelf?: (given: string) => boolean;
+   /**
+    * Opens a `# drill { to=<dashboard> }` destination, seeded with the clicked
+    * value. Distinct from {@link onNavigate}, which routes a markdown link and
+    * takes a URL: this one takes a destination and the givens to seed, and only
+    * the host knows how to turn those into a route.
+    *
+    * Omitted on a host with no dashboard route, which makes a cross-dashboard
+    * drill inert rather than dead-ended, and removes the affordance with it.
+    */
+   onDrillNavigate?: (target: DrillNavigation, event?: MouseEvent) => void;
 }
 
 interface NotebookMarkdownLinkProps {
@@ -164,6 +174,7 @@ export function NotebookCell({
    onNavigate,
    onDrillSelf,
    canDrillSelf,
+   onDrillNavigate,
 }: NotebookCellProps) {
    const [codeDialogOpen, setCodeDialogOpen] = React.useState<boolean>(false);
    const [embeddingDialogOpen, setEmbeddingDialogOpen] =
@@ -186,22 +197,22 @@ export function NotebookCell({
    // by that dimension is clickable for free: the same resolution, and the
    // same hook, the dashboard viewer uses.
    const { drill, drillMenu } = useDrill({
-      // No `onNavigate` yet, deliberately: a `# drill { to=<dashboard> }` would
-      // route to `/{env}/{pkg}/dashboards/<slug>`, and no such route exists.
-      // The Console's catch-all sends it to `ModelPage`, which answers "Nothing
-      // to open at this path". Wiring it now would paint those cells as links to a
-      // dead page, and `markDrillableCells` exists on the opposite principle:
-      // "a destination the surface cannot reach never becomes a link: a dead
-      // link is worse than none." Omitting it makes a named destination
-      // non-honorable, which removes the affordance as well as the navigation,
-      // so a `to=self` drill still works and a cross-dashboard one is simply
-      // inert until the slice that adds the route also passes this handler.
+      // The dashboards route now exists, so a `# drill { to=<dashboard> }` from
+      // a notebook cell is honoured: the host turns the destination and its
+      // seeded givens into `/{env}/{pkg}/dashboards/<slug>?GIVEN=value`. Passed
+      // through rather than built here, because only the host knows its routing.
       //
-      // One consequence to know rather than rediscover: `drillMenu` below is
-      // therefore unreachable for now. A menu only opens for two or more
-      // honorable destinations, and `self` is the only honorable one, so a
-      // drillable cell applies its filter on the first click. The menu comes
-      // back with the navigation handler.
+      // Still optional, and the reason matters: a host without a dashboard
+      // route omits it, which makes a named destination non-honorable and
+      // removes the AFFORDANCE along with the navigation. That is
+      // `markDrillableCells`'s principle, that a destination the surface cannot
+      // reach never becomes a link, and it is why this is a prop rather than
+      // something the cell assumes.
+      //
+      // Wiring it also makes `drillMenu` reachable for the first time: a menu
+      // opens only for two or more honorable destinations, so until there was a
+      // second one every drillable cell applied its filter on the first click.
+      onNavigate: onDrillNavigate,
       onSelf: onDrillSelf,
       // Only the notebook knows which givens it declares, and a self-drill onto
       // one it does not is refused. Asking here keeps the affordance honest

--- a/packages/sdk/src/components/Package/ContentTypeIcon.tsx
+++ b/packages/sdk/src/components/Package/ContentTypeIcon.tsx
@@ -98,9 +98,14 @@ function StackPath() {
 }
 
 /**
- * Panels of unequal size in one frame: the grid of tiles a dashboard lays out,
- * and deliberately not the browser window a data app gets, since the two sit
- * next to each other in the package list.
+ * Panels of unequal size in one frame: the grid of tiles a dashboard lays out.
+ *
+ * The neighbour to stay distinct from is the TABLE glyph, not the data app's
+ * browser window. Both this and the table are a rounded rect with the same
+ * `M3.5 9.5` divider, so with only the one vertical stroke the two differed by
+ * that stroke's position alone and read as the same icon at 18px, with the
+ * Dashboards and Databases sections on one page. The second divider is what
+ * makes this one read as a grid rather than as columns.
  */
 function DashboardGridPath() {
    return (
@@ -108,6 +113,7 @@ function DashboardGridPath() {
          <rect x="3.5" y="3.5" width="17" height="17" rx="2" />
          <path d="M3.5 9.5 H20.5" />
          <path d="M12 9.5 V20.5" />
+         <path d="M12 15 H20.5" />
       </>
    );
 }

--- a/packages/sdk/src/components/Package/ContentTypeIcon.tsx
+++ b/packages/sdk/src/components/Package/ContentTypeIcon.tsx
@@ -1,6 +1,12 @@
 import SvgIcon, { SvgIconProps } from "@mui/material/SvgIcon";
 
-type ContentType = "report" | "model" | "data" | "materialization" | "dataApp";
+type ContentType =
+   | "report"
+   | "model"
+   | "data"
+   | "materialization"
+   | "dataApp"
+   | "dashboard";
 
 interface ContentTypeIconProps extends Omit<SvgIconProps, "fontSize"> {
    type: ContentType;
@@ -40,6 +46,7 @@ export default function ContentTypeIcon({
          {type === "data" && <TablePath />}
          {type === "materialization" && <StackPath />}
          {type === "dataApp" && <BrowserWindowPath />}
+         {type === "dashboard" && <DashboardGridPath />}
       </SvgIcon>
    );
 }
@@ -86,6 +93,21 @@ function StackPath() {
          <path d="M12 3 L21 7.5 L12 12 L3 7.5 Z" />
          <path d="M3 12 L12 16.5 L21 12" />
          <path d="M3 16.5 L12 21 L21 16.5" />
+      </>
+   );
+}
+
+/**
+ * Panels of unequal size in one frame: the grid of tiles a dashboard lays out,
+ * and deliberately not the browser window a data app gets, since the two sit
+ * next to each other in the package list.
+ */
+function DashboardGridPath() {
+   return (
+      <>
+         <rect x="3.5" y="3.5" width="17" height="17" rx="2" />
+         <path d="M3.5 9.5 H20.5" />
+         <path d="M12 9.5 V20.5" />
       </>
    );
 }

--- a/packages/sdk/src/components/Package/Package.tsx
+++ b/packages/sdk/src/components/Package/Package.tsx
@@ -124,11 +124,51 @@ export default function Package({
    });
    const dataApps = dataAppsQuery.data?.data ?? [];
 
+   // No versionId, for the same reason as data apps: the dashboards endpoint
+   // takes only env + package.
+   const dashboardsQuery = useQueryWithApiError({
+      queryKey: ["dashboards", environmentName, packageName],
+      queryFn: async () => {
+         try {
+            return await apiClients.dashboards.listDashboards(
+               environmentName,
+               packageName,
+            );
+         } catch (e) {
+            // Non-fatal for the same reasons as the data-apps list above: an
+            // older Publisher without the route should render a package page
+            // without a Dashboards section, not an error.
+            const status = (e as { response?: { status?: number } })?.response
+               ?.status;
+            if (status === 404 || status === undefined) {
+               return { data: [] } as Awaited<
+                  ReturnType<typeof apiClients.dashboards.listDashboards>
+               >;
+            }
+            throw e;
+         }
+      },
+   });
+   const dashboards = (dashboardsQuery.data?.data ?? [])
+      .slice()
+      .sort((a, b) => (a.name ?? "").localeCompare(b.name ?? ""));
+
    const notebooks = (notebooksQuery.data?.data ?? [])
       .slice()
       .sort((a, b) => a.path.localeCompare(b.path));
+   // A dashboard is listed once, under Dashboards. Its file is a model like any
+   // other, so it would otherwise appear a second time under Semantic Models
+   // where clicking it opens the Explorer rather than the dashboard. Untagged
+   // shared includes in `dashboards/` are not dashboards and stay in the model
+   // list, which is where they belong.
+   const dashboardPaths = new Set(
+      dashboards
+         .map((dashboard) => dashboard.path)
+         .filter((path): path is string => path !== undefined),
+   );
    const models = (modelsQuery.data?.data ?? [])
       .slice()
+      .filter((model) => !dashboardPaths.has(model.path))
       .sort((a, b) => a.path.localeCompare(b.path));
    const databases = (databasesQuery.data?.data ?? [])
       .slice()
@@ -201,6 +241,44 @@ export default function Package({
 
          {!isLoading && (
             <>
+               {/* First: the at-a-glance artifact a visitor most likely wants,
+                   ahead of the notebooks and models it is built on. Hidden when
+                   empty, like Data Apps. */}
+               {dashboards.length > 0 && (
+                  <PackageSection title="Dashboards" count={dashboards.length}>
+                     {dashboards.map((dashboard) => {
+                        // A title equal to the slug is what the server falls
+                        // back to when the file names itself neither way, so
+                        // showing both would print the same word twice.
+                        const hasTitle =
+                           !!dashboard.title &&
+                           dashboard.title !== dashboard.name;
+                        return (
+                           <PackageItemRow
+                              key={dashboard.name}
+                              icon={<ContentTypeIcon type="dashboard" />}
+                              tint={MALLOY_BRAND.teal}
+                              label={
+                                 hasTitle ? dashboard.title! : dashboard.name!
+                              }
+                              rightLabel={hasTitle ? dashboard.name : undefined}
+                              onClick={(event) =>
+                                 onClick(
+                                    `/${environmentName}/${packageName}/dashboards/` +
+                                       // The slug comes from a filename, which
+                                       // can hold characters that would read as
+                                       // structure in a path. The server encodes
+                                       // it in `resource` for the same reason.
+                                       encodeURIComponent(dashboard.name ?? ""),
+                                    event,
+                                 )
+                              }
+                           />
+                        );
+                     })}
+                  </PackageSection>
+               )}
+
                <PackageSection title="Notebooks" count={notebooks.length}>
                   {notebooks.map((notebook) => (
                      <PackageItemRow

--- a/packages/sdk/src/components/Package/Package.tsx
+++ b/packages/sdk/src/components/Package/Package.tsx
@@ -187,7 +187,7 @@ export default function Package({
    // because the models list is FILTERED by it. Gated on notebooks alone, a
    // dashboards call that resolves after the models call rendered the sections
    // with an empty `dashboardPaths`, so `dashboards/overview.malloy` appeared
-   // under Semantic Models and then vanished — the double listing the filter
+   // under Semantic Models and then vanished: the double listing the filter
    // exists to prevent, briefly on screen. It cannot hang the page: the query
    // above turns a 404 or a transport failure into an empty list.
    const isLoading =
@@ -347,7 +347,7 @@ export default function Package({
                                        event,
                                     );
                                  } else {
-                                    // No host app — navigate to standalone HTML.
+                                    // No host app: navigate to standalone HTML.
                                     if (
                                        event &&
                                        (event.metaKey || event.ctrlKey)

--- a/packages/sdk/src/components/Package/Package.tsx
+++ b/packages/sdk/src/components/Package/Package.tsx
@@ -183,7 +183,16 @@ export default function Package({
       modelPath: README_NOTEBOOK,
    });
 
-   const isLoading = !notebooksQuery.isSuccess && !notebooksQuery.isError;
+   // The dashboards list is part of the gate, not just the notebooks one,
+   // because the models list is FILTERED by it. Gated on notebooks alone, a
+   // dashboards call that resolves after the models call rendered the sections
+   // with an empty `dashboardPaths`, so `dashboards/overview.malloy` appeared
+   // under Semantic Models and then vanished — the double listing the filter
+   // exists to prevent, briefly on screen. It cannot hang the page: the query
+   // above turns a 404 or a transport failure into an empty list.
+   const isLoading =
+      (!notebooksQuery.isSuccess && !notebooksQuery.isError) ||
+      (!dashboardsQuery.isSuccess && !dashboardsQuery.isError);
 
    if (pkgQuery.isError) {
       return (

--- a/packages/sdk/src/components/Package/Package.tsx
+++ b/packages/sdk/src/components/Package/Package.tsx
@@ -280,20 +280,29 @@ export default function Package({
                )}
 
                <PackageSection title="Notebooks" count={notebooks.length}>
-                  {notebooks.map((notebook) => (
-                     <PackageItemRow
-                        key={notebook.path}
-                        icon={<ContentTypeIcon type="report" />}
-                        tint={MALLOY_BRAND.teal}
-                        label={notebook.path}
-                        onClick={(event) =>
-                           onClick(
-                              `/${environmentName}/${packageName}/${notebook.path}`,
-                              event,
-                           )
-                        }
-                     />
-                  ))}
+                  {notebooks.map((notebook) => {
+                     // Named the way dashboards and data apps are: a notebook
+                     // that titles itself is listed by that title, with the
+                     // filename kept as the secondary label so the path a
+                     // reader needs to find the file is never lost.
+                     const hasTitle =
+                        !!notebook.title && notebook.title !== notebook.path;
+                     return (
+                        <PackageItemRow
+                           key={notebook.path}
+                           icon={<ContentTypeIcon type="report" />}
+                           tint={MALLOY_BRAND.teal}
+                           label={hasTitle ? notebook.title! : notebook.path}
+                           rightLabel={hasTitle ? notebook.path : undefined}
+                           onClick={(event) =>
+                              onClick(
+                                 `/${environmentName}/${packageName}/${notebook.path}`,
+                                 event,
+                              )
+                           }
+                        />
+                     );
+                  })}
                   {notebooks.length === 0 && <EmptyRow label="No notebooks" />}
                </PackageSection>
 

--- a/packages/sdk/src/components/Package/Package.tsx
+++ b/packages/sdk/src/components/Package/Package.tsx
@@ -149,13 +149,27 @@ export default function Package({
          }
       },
    });
+   // Sorted by the string the row actually SHOWS, not by the slug or the path
+   // underneath it. A list labelled by title and ordered by filename reads as
+   // unsorted: `overview` titled "Business Overview" sorts ahead of `regions`
+   // titled "Regional Sales". Notebooks acquired that mismatch here too, when
+   // they started being listed by title while still being ordered by path.
+   const dashboardLabel = (dashboard: { name?: string; title?: string }) =>
+      dashboard.title && dashboard.title !== dashboard.name
+         ? dashboard.title
+         : (dashboard.name ?? "");
+   const notebookLabel = (notebook: { path?: string; title?: string }) =>
+      notebook.title && notebook.title !== notebook.path
+         ? notebook.title
+         : (notebook.path ?? "");
+
    const dashboards = (dashboardsQuery.data?.data ?? [])
       .slice()
-      .sort((a, b) => (a.name ?? "").localeCompare(b.name ?? ""));
+      .sort((a, b) => dashboardLabel(a).localeCompare(dashboardLabel(b)));
 
    const notebooks = (notebooksQuery.data?.data ?? [])
       .slice()
-      .sort((a, b) => a.path.localeCompare(b.path));
+      .sort((a, b) => notebookLabel(a).localeCompare(notebookLabel(b)));
    // A dashboard is listed once, under Dashboards. Its file is a model like any
    // other, so it would otherwise appear a second time under Semantic Models
    // where clicking it opens the Explorer rather than the dashboard. Untagged

--- a/packages/sdk/src/components/RenderedResult/RenderedResult.tsx
+++ b/packages/sdk/src/components/RenderedResult/RenderedResult.tsx
@@ -254,6 +254,18 @@ div.malloy-render .malloy-dashboard .dashboard-row-header {
    color: var(--publisher-drill-link) !important;
    text-decoration: underline;
 }
+/* Keyboard focus reads the same as hover, plus a ring: a hover colour is not
+   something a keyboard user can produce, and a focus ring is not something a
+   mouse user sees. focus-visible rather than focus, so a click does not leave a
+   ring behind it. (No backticks in here: this is inside a template literal.) */
+.malloy-render .${DRILL_CELL_CLASS}:focus-visible {
+   outline: 2px solid var(--publisher-drill-link);
+   outline-offset: -2px;
+}
+.malloy-render .${DRILL_CELL_CLASS}:focus-visible > .cell-content {
+   color: var(--publisher-drill-link) !important;
+   text-decoration: underline;
+}
 `;
 
 /**
@@ -351,6 +363,8 @@ function RenderedResultInner({
       let viz: MalloyVizHandle | undefined;
       let drillObserver: MutationObserver | null = null;
       let drillFrame = 0;
+      let drillKeydown: ((event: KeyboardEvent) => void) | null = null;
+      let drillKeyup: ((event: KeyboardEvent) => void) | null = null;
       let observer: MutationObserver | null = null;
       let measureTimeout: NodeJS.Timeout | null = null;
       // Safety net so a render that never signals ready (an async renderer
@@ -518,6 +532,68 @@ function RenderedResultInner({
                      }
                   };
                   mark();
+                  // Enter and Space fire the drill for a focused cell. Delegated
+                  // on the stage rather than bound per cell, because the
+                  // renderer rebuilds cells as a dashboard's cards arrive and a
+                  // per-cell listener would be lost with them; this one outlives
+                  // every re-mark.
+                  //
+                  // It synthesises a CLICK rather than calling the drill handler
+                  // directly, so the payload comes from the renderer's own click
+                  // path. Building one here would mean re-deriving which field
+                  // and value a cell represents, which is exactly the mapping
+                  // this module has no access to and the reason the affordance
+                  // is matched on rendered text in the first place.
+                  //
+                  // The click goes to the cell's INNER `.cell-content`, not to
+                  // the cell. Measured, because dispatching on the cell looked
+                  // right and silently did nothing: a real mouse click lands on
+                  // `.cell-content` and the renderer reads the event target to
+                  // identify the field, so a click on the outer cell reaches the
+                  // handler with a target it does not recognise and is dropped
+                  // without a sound. Falls back to the cell for a shape that has
+                  // no inner content node.
+                  //
+                  // Enter fires on keydown and Space on keyUP, which is the
+                  // native button rule and is load-bearing here rather than
+                  // pedantry. Firing Space on keydown opened the drill menu and
+                  // then the SAME keypress's keyup landed on the now-focused
+                  // first menu item and chose it, so a Space drill navigated
+                  // straight past the menu it had just opened. Measured: the
+                  // menu was visible while the key was held and gone, with the
+                  // URL already changed, once it was released.
+                  const fire = (cell: Element) => {
+                     const content =
+                        cell.querySelector<HTMLElement>(".cell-content");
+                     (content ?? (cell as HTMLElement)).click();
+                  };
+                  const drillCell = (event: KeyboardEvent) =>
+                     (event.target as HTMLElement | null)?.closest?.(
+                        `.${DRILL_CELL_CLASS}`,
+                     ) ?? null;
+                  drillKeydown = (event: KeyboardEvent) => {
+                     const cell = drillCell(event);
+                     if (!cell) return;
+                     if (event.key === "Enter") {
+                        // Otherwise Enter submits an enclosing form on an
+                        // embedding host.
+                        event.preventDefault();
+                        fire(cell);
+                     } else if (event.key === " ") {
+                        // Held Space scrolls the page; the activation itself
+                        // waits for keyup.
+                        event.preventDefault();
+                     }
+                  };
+                  drillKeyup = (event: KeyboardEvent) => {
+                     if (event.key !== " ") return;
+                     const cell = drillCell(event);
+                     if (!cell) return;
+                     event.preventDefault();
+                     fire(cell);
+                  };
+                  stageNode.addEventListener("keydown", drillKeydown);
+                  stageNode.addEventListener("keyup", drillKeyup);
                   if (
                      names.size > 0 &&
                      typeof MutationObserver !== "undefined"
@@ -562,6 +638,8 @@ function RenderedResultInner({
          cancelled = true;
          observer?.disconnect();
          drillObserver?.disconnect();
+         if (drillKeydown) stage?.removeEventListener("keydown", drillKeydown);
+         if (drillKeyup) stage?.removeEventListener("keyup", drillKeyup);
          cancelAnimationFrame(drillFrame);
          if (measureTimeout) clearTimeout(measureTimeout);
          if (readyFallback) clearTimeout(readyFallback);

--- a/packages/sdk/src/components/RenderedResult/RenderedResult.tsx
+++ b/packages/sdk/src/components/RenderedResult/RenderedResult.tsx
@@ -562,10 +562,27 @@ function RenderedResultInner({
                   // straight past the menu it had just opened. Measured: the
                   // menu was visible while the key was held and gone, with the
                   // URL already changed, once it was released.
+                  //
+                  // Dispatched with the cell's own coordinates rather than
+                  // through `HTMLElement.click()`, which reports `clientX/Y` as
+                  // 0. A drill offering two destinations anchors its menu on
+                  // those numbers (`useDrill` holds no ref into the renderer's
+                  // DOM), so a keyboard-opened menu appeared in the corner of
+                  // the viewport instead of beside the cell it came from.
                   const fire = (cell: Element) => {
                      const content =
                         cell.querySelector<HTMLElement>(".cell-content");
-                     (content ?? (cell as HTMLElement)).click();
+                     const target = content ?? (cell as HTMLElement);
+                     const rect = target.getBoundingClientRect();
+                     target.dispatchEvent(
+                        new MouseEvent("click", {
+                           bubbles: true,
+                           cancelable: true,
+                           view: target.ownerDocument.defaultView,
+                           clientX: Math.round(rect.left + rect.width / 2),
+                           clientY: Math.round(rect.bottom),
+                        }),
+                     );
                   };
                   const drillCell = (event: KeyboardEvent) =>
                      (event.target as HTMLElement | null)?.closest?.(

--- a/packages/sdk/src/components/RenderedResult/RenderedResult.tsx
+++ b/packages/sdk/src/components/RenderedResult/RenderedResult.tsx
@@ -655,8 +655,6 @@ function RenderedResultInner({
          cancelled = true;
          observer?.disconnect();
          drillObserver?.disconnect();
-         if (drillKeydown) stage?.removeEventListener("keydown", drillKeydown);
-         if (drillKeyup) stage?.removeEventListener("keyup", drillKeyup);
          cancelAnimationFrame(drillFrame);
          if (measureTimeout) clearTimeout(measureTimeout);
          if (readyFallback) clearTimeout(readyFallback);
@@ -664,6 +662,20 @@ function RenderedResultInner({
          // (superseded, or unmounted mid-render), tear it down so it can't
          // leak a viz or leave an orphan node behind.
          if (stage && liveRef.current?.node !== stage) {
+            // The keyboard listeners go with the stage, and ONLY with the
+            // stage. Removing them unconditionally tied their lifetime to the
+            // effect RUN instead, while the stage's is tied to `liveRef`: a
+            // re-run tore them off the chart that is still on screen, which
+            // keeps its `tabindex` and `role="button"` and so still says Enter
+            // and Space do something. Usually that window closes when the new
+            // render promotes, but a render that never gets that far (a parse
+            // failure, a renderer that throws) leaves the visible chart
+            // permanently keyboard-dead while still advertising otherwise.
+            // Left on a promoted stage they are collected with the node when
+            // `promote` removes it, so nothing leaks by keeping them.
+            if (drillKeydown)
+               stage.removeEventListener("keydown", drillKeydown);
+            if (drillKeyup) stage.removeEventListener("keyup", drillKeyup);
             viz?.remove();
             if (stage.parentNode === element) {
                element.removeChild(stage);

--- a/packages/sdk/src/components/RenderedResult/RenderedResult.tsx
+++ b/packages/sdk/src/components/RenderedResult/RenderedResult.tsx
@@ -366,6 +366,7 @@ function RenderedResultInner({
       let drillFrame = 0;
       let drillKeydown: ((event: KeyboardEvent) => void) | null = null;
       let drillKeyup: ((event: KeyboardEvent) => void) | null = null;
+      let drillFocusIn: ((event: FocusEvent) => void) | null = null;
       let observer: MutationObserver | null = null;
       let measureTimeout: NodeJS.Timeout | null = null;
       // Safety net so a render that never signals ready (an async renderer
@@ -645,8 +646,23 @@ function RenderedResultInner({
                      event.preventDefault();
                      fire(cell);
                   };
+                  // Focus and the tab stop have to agree however focus got
+                  // there. The arrow handler moves the stop, but a
+                  // `tabindex="-1"` cell is still CLICK-focusable, so without
+                  // this a reader who clicked row 5, tabbed away and tabbed back
+                  // landed on row 0. That is the same asymmetry the arrow path
+                  // already fixes, for the one way of arriving that does not go
+                  // through it. `moveDrillStop(cell, 0)` resolves to the cell
+                  // itself, so it just makes that cell the column's stop.
+                  drillFocusIn = (event: FocusEvent) => {
+                     const cell = (
+                        event.target as HTMLElement | null
+                     )?.closest?.<HTMLElement>(`.${DRILL_CELL_CLASS}`);
+                     if (cell) moveDrillStop(cell, 0);
+                  };
                   stageNode.addEventListener("keydown", drillKeydown);
                   stageNode.addEventListener("keyup", drillKeyup);
+                  stageNode.addEventListener("focusin", drillFocusIn);
                   if (
                      names.size > 0 &&
                      typeof MutationObserver !== "undefined"
@@ -710,6 +726,8 @@ function RenderedResultInner({
             if (drillKeydown)
                stage.removeEventListener("keydown", drillKeydown);
             if (drillKeyup) stage.removeEventListener("keyup", drillKeyup);
+            if (drillFocusIn)
+               stage.removeEventListener("focusin", drillFocusIn);
             // The re-marker is scoped the same way, and for the same reason.
             // Disconnecting it unconditionally tied it to the effect RUN: a
             // re-run while a `# dashboard` was still building its cards stopped

--- a/packages/sdk/src/components/RenderedResult/RenderedResult.tsx
+++ b/packages/sdk/src/components/RenderedResult/RenderedResult.tsx
@@ -15,7 +15,7 @@ import { usePublisherTheme } from "../../theme/ThemeContext";
 import type { ResolvedTheme } from "../../theme/types";
 import {
    DRILL_CELL_CLASS,
-   drillColumnSiblings,
+   moveDrillStop,
    drillableFieldNames,
    markDrillableCells,
    type DrillMetadataSource,
@@ -599,27 +599,12 @@ function RenderedResultInner({
                      cell: HTMLElement,
                      to: number | "first" | "last",
                   ) => {
-                     const siblings = drillColumnSiblings(cell);
-                     const at = siblings.indexOf(cell);
-                     if (at === -1) return false;
-                     const next =
-                        to === "first"
-                           ? siblings[0]
-                           : to === "last"
-                             ? siblings[siblings.length - 1]
-                             : siblings[
-                                  Math.min(
-                                     Math.max(at + to, 0),
-                                     siblings.length - 1,
-                                  )
-                               ];
-                     if (!next || next === cell) return false;
-                     // The stop moves with focus, so tabbing away and back
-                     // returns to the row the reader was on.
-                     cell.tabIndex = -1;
-                     next.tabIndex = 0;
-                     next.focus();
-                     return true;
+                     // The move lives in `markDrillableCells` beside the column
+                     // rule, because it has to hold the same invariant the
+                     // marking does: exactly one stop per column. Doing it here
+                     // by clearing the focused cell assumed that cell HELD the
+                     // stop, which a click-focused `tabindex="-1"` cell does not.
+                     moveDrillStop(cell, to)?.focus();
                   };
                   drillKeydown = (event: KeyboardEvent) => {
                      const cell = drillCell(event) as HTMLElement | null;
@@ -705,8 +690,6 @@ function RenderedResultInner({
       return () => {
          cancelled = true;
          observer?.disconnect();
-         drillObserver?.disconnect();
-         cancelAnimationFrame(drillFrame);
          if (measureTimeout) clearTimeout(measureTimeout);
          if (readyFallback) clearTimeout(readyFallback);
          // If this render built a stage but never swapped it into `liveRef`
@@ -727,6 +710,14 @@ function RenderedResultInner({
             if (drillKeydown)
                stage.removeEventListener("keydown", drillKeydown);
             if (drillKeyup) stage.removeEventListener("keyup", drillKeyup);
+            // The re-marker is scoped the same way, and for the same reason.
+            // Disconnecting it unconditionally tied it to the effect RUN: a
+            // re-run while a `# dashboard` was still building its cards stopped
+            // the LIVE stage being re-marked, so cards arriving after that point
+            // never became drillable. Like the listeners, it is collected with
+            // the node once a promoted stage is dropped.
+            drillObserver?.disconnect();
+            cancelAnimationFrame(drillFrame);
             viz?.remove();
             if (stage.parentNode === element) {
                element.removeChild(stage);

--- a/packages/sdk/src/components/RenderedResult/RenderedResult.tsx
+++ b/packages/sdk/src/components/RenderedResult/RenderedResult.tsx
@@ -15,6 +15,7 @@ import { usePublisherTheme } from "../../theme/ThemeContext";
 import type { ResolvedTheme } from "../../theme/types";
 import {
    DRILL_CELL_CLASS,
+   drillColumnSiblings,
    drillableFieldNames,
    markDrillableCells,
    type DrillMetadataSource,
@@ -585,12 +586,62 @@ function RenderedResultInner({
                      );
                   };
                   const drillCell = (event: KeyboardEvent) =>
-                     (event.target as HTMLElement | null)?.closest?.(
-                        `.${DRILL_CELL_CLASS}`,
-                     ) ?? null;
+                     (
+                        event.target as HTMLElement | null
+                     )?.closest?.<HTMLElement>(`.${DRILL_CELL_CLASS}`) ?? null;
+                  // Move the single tab stop within a drillable column.
+                  // `markDrillableCells` gives a column one stop rather than one
+                  // per cell, so these keys are how a reader reaches the other
+                  // rows; without them the affordance would only ever fire on
+                  // whichever row held the stop. Clamped rather than wrapping,
+                  // which is what a table's rows read as.
+                  const rove = (
+                     cell: HTMLElement,
+                     to: number | "first" | "last",
+                  ) => {
+                     const siblings = drillColumnSiblings(cell);
+                     const at = siblings.indexOf(cell);
+                     if (at === -1) return false;
+                     const next =
+                        to === "first"
+                           ? siblings[0]
+                           : to === "last"
+                             ? siblings[siblings.length - 1]
+                             : siblings[
+                                  Math.min(
+                                     Math.max(at + to, 0),
+                                     siblings.length - 1,
+                                  )
+                               ];
+                     if (!next || next === cell) return false;
+                     // The stop moves with focus, so tabbing away and back
+                     // returns to the row the reader was on.
+                     cell.tabIndex = -1;
+                     next.tabIndex = 0;
+                     next.focus();
+                     return true;
+                  };
                   drillKeydown = (event: KeyboardEvent) => {
-                     const cell = drillCell(event);
+                     const cell = drillCell(event) as HTMLElement | null;
                      if (!cell) return;
+                     const roveKey =
+                        event.key === "ArrowDown"
+                           ? 1
+                           : event.key === "ArrowUp"
+                             ? -1
+                             : event.key === "Home"
+                               ? ("first" as const)
+                               : event.key === "End"
+                                 ? ("last" as const)
+                                 : undefined;
+                     if (roveKey !== undefined) {
+                        // Prevented whether or not the move happened, so the
+                        // first and last rows do not scroll the page out from
+                        // under a reader who is still inside the column.
+                        event.preventDefault();
+                        rove(cell, roveKey);
+                        return;
+                     }
                      if (event.key === "Enter") {
                         // Otherwise Enter submits an enclosing form on an
                         // embedding host.

--- a/packages/sdk/src/components/RenderedResult/ResultContainer.tsx
+++ b/packages/sdk/src/components/RenderedResult/ResultContainer.tsx
@@ -25,6 +25,24 @@ interface ResultContainerProps {
    drill?: DrillBinding;
 }
 
+/**
+ * Height to paint at before the result has been measured.
+ *
+ * `maxHeight` is a CAP, but it was also the first paint's height, because the
+ * measured height starts out equal to it. That was harmless while every caller
+ * passed something viewport-sized (400 to 800). A caller that means "no cap"
+ * passes a number that is not a height anyone wants to see: the dashboard
+ * viewer's whole-page form passes 20000, so the panel painted twenty thousand
+ * pixels tall until the measurement landed, and a result the renderer sizes to
+ * its CONTAINER (a top-level chart, as opposed to a `# dashboard` grid, which
+ * reports its own height) measured that back and kept it.
+ *
+ * Bounded here rather than by lowering the cap, so "no cap" stays expressible.
+ * Above the cap it does nothing, which is every caller that passes a real
+ * height, so this changes nothing for them.
+ */
+const INITIAL_RENDER_HEIGHT = 2000;
+
 // ResultContainer is a component that renders a result, with a toggle button to expand/collapse the result.
 // For fill-elements, the result is rendered at minHeight, and the toggle button is shown to scale up to maxHeight.
 // For non-fill-elements, the result is rendered at explicitHeight, with a small window (minHeight) that can be expanded to maxHeight.
@@ -37,7 +55,9 @@ export default function ResultContainer({
    drill,
 }: ResultContainerProps) {
    const containerRef = useRef<HTMLDivElement>(null);
-   const [measuredHeight, setMeasuredHeight] = useState(maxHeight);
+   const [measuredHeight, setMeasuredHeight] = useState(
+      Math.min(maxHeight, INITIAL_RENDER_HEIGHT),
+   );
    const [userAcknowledged, setUserAcknowledged] = useState(false);
    const renderLogSummary = summarizeRenderLogs(renderLogs);
 

--- a/packages/sdk/src/components/ServerProvider.tsx
+++ b/packages/sdk/src/components/ServerProvider.tsx
@@ -11,6 +11,7 @@ import React, {
 } from "react";
 import {
    ConnectionsApi,
+   DashboardsApi,
    DataAppsApi,
    DatabasesApi,
    EnvironmentsApi,
@@ -138,6 +139,7 @@ const getApiClients = (
       publisher: new PublisherApi(config, basePath, axiosInstance),
       environments: new EnvironmentsApi(config, basePath, axiosInstance),
       packages: new PackagesApi(config, basePath, axiosInstance),
+      dashboards: new DashboardsApi(config, basePath, axiosInstance),
       dataApps: new DataAppsApi(config, basePath, axiosInstance),
       notebooks: new NotebooksApi(config, basePath, axiosInstance),
       connections: new ConnectionsApi(config, basePath, axiosInstance),

--- a/packages/sdk/src/components/drill/index.ts
+++ b/packages/sdk/src/components/drill/index.ts
@@ -1,6 +1,7 @@
 export {
    DRILL_CELL_CLASS,
    drillableFieldNames,
+   drillColumnSiblings,
    markDrillableCells,
    type DrillMetadataSource,
 } from "./markDrillableCells";

--- a/packages/sdk/src/components/drill/index.ts
+++ b/packages/sdk/src/components/drill/index.ts
@@ -1,7 +1,6 @@
 export {
    DRILL_CELL_CLASS,
    drillableFieldNames,
-   drillColumnSiblings,
    markDrillableCells,
    type DrillMetadataSource,
 } from "./markDrillableCells";

--- a/packages/sdk/src/components/drill/markDrillableCells.dom.spec.ts
+++ b/packages/sdk/src/components/drill/markDrillableCells.dom.spec.ts
@@ -120,6 +120,38 @@ describe("markDrillableCells and the tab order", () => {
    });
 });
 
+describe("markDrillableCells across two drillable columns", () => {
+   // The stop is per drillable COLUMN, scoped to its table, not per table. The
+   // guide said "one stop per TABLE" for two rounds, which is wrong the moment a
+   // dashboard groups by two drilled dimensions.
+   it("gives each drillable column its own stop", () => {
+      const root = document.createElement("div");
+      root.innerHTML = `
+         <div class="malloy-table">
+            <div class="column-cell th" style="grid-column: 1 / 2;">category</div>
+            <div class="column-cell th" style="grid-column: 2 / 3;">brand</div>
+            <div class="column-cell th" style="grid-column: 3 / 4;">sales</div>
+            <div class="column-cell td" style="grid-column: 1 / 2;">c0</div>
+            <div class="column-cell td" style="grid-column: 2 / 3;">b0</div>
+            <div class="column-cell td" style="grid-column: 3 / 4;">1</div>
+            <div class="column-cell td" style="grid-column: 1 / 2;">c1</div>
+            <div class="column-cell td" style="grid-column: 2 / 3;">b1</div>
+            <div class="column-cell td" style="grid-column: 3 / 4;">2</div>
+         </div>`;
+      markDrillableCells(root, new Set(["category", "brand"]));
+
+      const stops = Array.from(
+         root.querySelectorAll<HTMLElement>(`.${DRILL_CELL_CLASS}`),
+      )
+         .filter((n) => n.getAttribute("tabindex") === "0")
+         .map((n) => n.textContent);
+      // One per column, both on the first row, and the undrilled column
+      // contributes none.
+      expect(stops).toEqual(["c0", "b0"]);
+      expect(root.querySelectorAll(`.${DRILL_CELL_CLASS}`).length).toBe(4);
+   });
+});
+
 describe("moveDrillStop keeps a column to exactly one tab stop", () => {
    const table = (rows: number) => {
       const root = document.createElement("div");

--- a/packages/sdk/src/components/drill/markDrillableCells.dom.spec.ts
+++ b/packages/sdk/src/components/drill/markDrillableCells.dom.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
    DRILL_CELL_CLASS,
    drillColumnSiblings,
+   moveDrillStop,
    markDrillableCells,
 } from "./markDrillableCells";
 
@@ -116,5 +117,83 @@ describe("markDrillableCells and the tab order", () => {
       const orphan = document.createElement("div");
       orphan.className = DRILL_CELL_CLASS;
       expect(drillColumnSiblings(orphan)).toEqual([]);
+   });
+});
+
+describe("moveDrillStop keeps a column to exactly one tab stop", () => {
+   const table = (rows: number) => {
+      const root = document.createElement("div");
+      const cells = Array.from(
+         { length: rows },
+         (_unused, index) =>
+            `<div class="column-cell td" style="grid-column: 1 / 2;">v${index}</div>`,
+      ).join("");
+      root.innerHTML = `
+         <div class="malloy-table">
+            <div class="column-cell th" style="grid-column: 1 / 2;">region</div>
+            ${cells}
+         </div>`;
+      markDrillableCells(root, new Set(["region"]));
+      return root;
+   };
+   const marked = (root: HTMLElement) =>
+      Array.from(root.querySelectorAll<HTMLElement>(`.${DRILL_CELL_CLASS}`));
+   const stops = (root: HTMLElement) =>
+      marked(root)
+         .filter((n) => n.getAttribute("tabindex") === "0")
+         .map((n) => n.textContent);
+
+   // The case both earlier tests missed, because each simulated the move by
+   // hand-setting tabIndex on the cell that already held the stop. A cell with
+   // `tabindex="-1"` is still CLICK-focusable, so the cell an arrow moves from
+   // is frequently not the one holding the stop.
+   it("moves from a click-focused cell without leaving a second stop", () => {
+      const root = table(6);
+      const cells = marked(root);
+      expect(stops(root)).toEqual(["v0"]);
+
+      // The reader clicks row 3. Focus is there; the stop is still on row 0.
+      const next = moveDrillStop(cells[3], 1);
+
+      expect(next?.textContent).toBe("v4");
+      expect(stops(root)).toEqual(["v4"]);
+   });
+
+   it("repeating that gesture cannot accumulate stops", () => {
+      const root = table(6);
+      const cells = marked(root);
+      moveDrillStop(cells[3], 1);
+      moveDrillStop(cells[1], 1);
+      moveDrillStop(cells[5], -1);
+      expect(stops(root)).toEqual(["v4"]);
+   });
+
+   it("a clamped move at the end repairs a column rather than doing nothing", () => {
+      const root = table(4);
+      const cells = marked(root);
+      // Drift the column into two stops by hand, the state the old move left.
+      cells[2].tabIndex = 0;
+      expect(stops(root)).toEqual(["v0", "v2"]);
+
+      moveDrillStop(cells[3], 1); // already last, so it clamps to itself
+      expect(stops(root)).toEqual(["v3"]);
+   });
+
+   it("reports nothing for a cell outside a table", () => {
+      const orphan = document.createElement("div");
+      orphan.className = DRILL_CELL_CLASS;
+      expect(moveDrillStop(orphan, 1)).toBeUndefined();
+   });
+
+   // Belt and braces: even if some other path drifts a column, the next mark
+   // pass demotes the extra rather than preserving both for good.
+   it("a re-mark demotes a duplicate stop instead of keeping it", () => {
+      const root = table(4);
+      const cells = marked(root);
+      cells[2].tabIndex = 0;
+      expect(stops(root)).toEqual(["v0", "v2"]);
+
+      markDrillableCells(root, new Set(["region"]));
+      expect(stops(root)).toEqual(["v0"]);
    });
 });

--- a/packages/sdk/src/components/drill/markDrillableCells.dom.spec.ts
+++ b/packages/sdk/src/components/drill/markDrillableCells.dom.spec.ts
@@ -217,6 +217,73 @@ describe("moveDrillStop keeps a column to exactly one tab stop", () => {
       expect(moveDrillStop(orphan, 1)).toBeUndefined();
    });
 
+   // Home and End. Untested until a mutation sweep showed that making "first"
+   // resolve to the LAST cell kept every other test green, so Home would have
+   // jumped a reader to the bottom row with nothing to catch it.
+   it("Home goes to the first row and End to the last", () => {
+      const root = table(5);
+      const cells = marked(root);
+
+      expect(moveDrillStop(cells[2], "first")?.textContent).toBe("v0");
+      expect(stops(root)).toEqual(["v0"]);
+
+      expect(moveDrillStop(cells[2], "last")?.textContent).toBe("v4");
+      expect(stops(root)).toEqual(["v4"]);
+   });
+
+   // A nested table has its own grid and its own column numbering. Untested
+   // until a mutation sweep showed that dropping the own-table filter kept
+   // everything green, because no fixture anywhere had a nested table: arrow
+   // keys would have walked out of the outer column into the inner one and
+   // stripped the outer column's stop on the way.
+   it("does not walk into a nested table that shares a column number", () => {
+      const root = document.createElement("div");
+      root.innerHTML = `
+         <div class="malloy-table">
+            <div class="column-cell th" style="grid-column: 1 / 2;">region</div>
+            <div class="column-cell td" style="grid-column: 1 / 2;">outer0</div>
+            <div class="column-cell td" style="grid-column: 1 / 2;">outer1</div>
+            <div class="column-cell td" style="grid-column: 1 / 2;">
+               <div class="malloy-table">
+                  <div class="column-cell th" style="grid-column: 1 / 2;">region</div>
+                  <div class="column-cell td" style="grid-column: 1 / 2;">inner0</div>
+                  <div class="column-cell td" style="grid-column: 1 / 2;">inner1</div>
+               </div>
+            </div>
+         </div>`;
+      markDrillableCells(root, new Set(["region"]));
+
+      const outer = Array.from(
+         root.querySelectorAll<HTMLElement>(`.${DRILL_CELL_CLASS}`),
+      ).filter((n) => n.textContent === "outer0");
+      expect(outer).toHaveLength(1);
+
+      // The outer column's siblings are its own rows only. The cell wrapping the
+      // nested table is not marked at all, so it is not among them either.
+      expect(
+         drillColumnSiblings(outer[0]).map((n) => n.textContent?.trim()),
+      ).toEqual(["outer0", "outer1"]);
+
+      // Each table keeps its own stop, so the nested one does not steal the
+      // outer one's.
+      const inner = Array.from(
+         root.querySelectorAll<HTMLElement>(`.${DRILL_CELL_CLASS}`),
+      ).filter((n) => n.textContent === "inner0");
+      expect(inner).toHaveLength(1);
+      expect(outer[0].getAttribute("tabindex")).toBe("0");
+      expect(inner[0].getAttribute("tabindex")).toBe("0");
+
+      // The RE-MARK is the case that matters, and a fresh mark cannot show it.
+      // The outer table's pre-scan queries its own subtree, which CONTAINS the
+      // nested table, so without the own-table filter it sees the inner table's
+      // stop as a duplicate of the outer column's and demotes it. The inner
+      // table would lose its only tab stop on every re-mark, and a settling
+      // `# dashboard` re-marks repeatedly.
+      markDrillableCells(root, new Set(["region"]));
+      expect(outer[0].getAttribute("tabindex")).toBe("0");
+      expect(inner[0].getAttribute("tabindex")).toBe("0");
+   });
+
    // Belt and braces: even if some other path drifts a column, the next mark
    // pass demotes the extra rather than preserving both for good.
    it("a re-mark demotes a duplicate stop instead of keeping it", () => {

--- a/packages/sdk/src/components/drill/markDrillableCells.dom.spec.ts
+++ b/packages/sdk/src/components/drill/markDrillableCells.dom.spec.ts
@@ -273,15 +273,27 @@ describe("moveDrillStop keeps a column to exactly one tab stop", () => {
       expect(outer[0].getAttribute("tabindex")).toBe("0");
       expect(inner[0].getAttribute("tabindex")).toBe("0");
 
-      // The RE-MARK is the case that matters, and a fresh mark cannot show it.
-      // The outer table's pre-scan queries its own subtree, which CONTAINS the
-      // nested table, so without the own-table filter it sees the inner table's
-      // stop as a duplicate of the outer column's and demotes it. The inner
-      // table would lose its only tab stop on every re-mark, and a settling
-      // `# dashboard` re-marks repeatedly.
+      // The case that matters is a re-mark with the nested stop MOVED OFF row
+      // zero. Asserting only that `inner0` still holds it proves nothing: that
+      // is where the fallback promotion lands anyway, so the assertion passes
+      // with the guard deleted. This is the shape that fails without it.
+      const inner1 = Array.from(
+         root.querySelectorAll<HTMLElement>(`.${DRILL_CELL_CLASS}`),
+      ).find((n) => n.textContent === "inner1");
+      expect(inner1).toBeDefined();
+      inner[0].tabIndex = -1;
+      (inner1 as HTMLElement).tabIndex = 0;
+
       markDrillableCells(root, new Set(["region"]));
+
+      // The outer pass sees the nested stop as a duplicate of its own column and
+      // demotes it; the nested pass then re-promotes the FIRST row rather than
+      // the roved one, so a reader who had arrowed down inside a nested table
+      // would be thrown back to its top on every re-mark, and a settling
+      // `# dashboard` re-marks repeatedly.
       expect(outer[0].getAttribute("tabindex")).toBe("0");
-      expect(inner[0].getAttribute("tabindex")).toBe("0");
+      expect(inner[0].getAttribute("tabindex")).toBe("-1");
+      expect((inner1 as HTMLElement).getAttribute("tabindex")).toBe("0");
    });
 
    // Belt and braces: even if some other path drifts a column, the next mark

--- a/packages/sdk/src/components/drill/markDrillableCells.dom.spec.ts
+++ b/packages/sdk/src/components/drill/markDrillableCells.dom.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { DRILL_CELL_CLASS, markDrillableCells } from "./markDrillableCells";
+import {
+   DRILL_CELL_CLASS,
+   drillColumnSiblings,
+   markDrillableCells,
+} from "./markDrillableCells";
 
 /**
  * The DOM half of the marking, which the sibling spec deliberately does not
@@ -36,5 +40,81 @@ describe("markDrillableCells and cells with no value", () => {
       ).map((node) => node.classList.contains(DRILL_CELL_CLASS));
       // West and 0 are values; the null glyph and the empty cell are not.
       expect(marked).toEqual([true, false, false, true]);
+   });
+});
+
+describe("markDrillableCells and the tab order", () => {
+   const table = (rows: number) => {
+      const root = document.createElement("div");
+      const cells = Array.from(
+         { length: rows },
+         (_unused, index) =>
+            `<div class="column-cell td" style="grid-column: 1 / 2;">v${index}</div>` +
+            `<div class="column-cell td" style="grid-column: 2 / 3;">n${index}</div>`,
+      ).join("");
+      root.innerHTML = `
+         <div class="malloy-table">
+            <div class="column-cell th" style="grid-column: 1 / 2;">region</div>
+            <div class="column-cell th" style="grid-column: 2 / 3;">sales</div>
+            ${cells}
+         </div>`;
+      return root;
+   };
+   const stops = (root: HTMLElement) =>
+      Array.from(root.querySelectorAll<HTMLElement>(`.${DRILL_CELL_CLASS}`))
+         .filter((node) => node.getAttribute("tabindex") === "0")
+         .map((node) => node.textContent);
+
+   // Marking every cell tabbable put a whole column in the tab order, so a
+   // result at the row cap cost a keyboard reader hundreds of presses to get
+   // past it. One stop per column, arrow keys within.
+   it("gives a drillable column one tab stop, not one per cell", () => {
+      const root = table(12);
+      markDrillableCells(root, new Set(["region"]));
+
+      const marked = root.querySelectorAll(`.${DRILL_CELL_CLASS}`);
+      expect(marked.length).toBe(12);
+      expect(stops(root)).toEqual(["v0"]);
+      // The rest are reachable by arrow key, so they are focusable but skipped.
+      const rest = Array.from(marked).slice(1);
+      expect(rest.every((n) => n.getAttribute("tabindex") === "-1")).toBe(true);
+      // The non-drillable column is left alone entirely.
+      expect(
+         root.querySelectorAll('[style*="grid-column: 2"][tabindex]').length,
+      ).toBe(0);
+   });
+
+   // A `# dashboard` settles over several frames, so the caller re-runs the
+   // marking. Rebuilding the stop from scratch each pass would snap it back to
+   // the first row under a reader who had arrowed down.
+   it("keeps the roving position across a re-run", () => {
+      const root = table(5);
+      markDrillableCells(root, new Set(["region"]));
+
+      const cells = Array.from(
+         root.querySelectorAll<HTMLElement>(`.${DRILL_CELL_CLASS}`),
+      );
+      // Move the stop the way the arrow handler does.
+      cells[0].tabIndex = -1;
+      cells[3].tabIndex = 0;
+
+      markDrillableCells(root, new Set(["region"]));
+      expect(stops(root)).toEqual(["v3"]);
+   });
+
+   it("reports a column's marked cells in row order", () => {
+      const root = table(4);
+      markDrillableCells(root, new Set(["region"]));
+      const first = root.querySelector<HTMLElement>(`.${DRILL_CELL_CLASS}`);
+      expect(first).not.toBeNull();
+      expect(
+         drillColumnSiblings(first as HTMLElement).map((n) => n.textContent),
+      ).toEqual(["v0", "v1", "v2", "v3"]);
+   });
+
+   it("reports nothing for a cell that is not in a table", () => {
+      const orphan = document.createElement("div");
+      orphan.className = DRILL_CELL_CLASS;
+      expect(drillColumnSiblings(orphan)).toEqual([]);
    });
 });

--- a/packages/sdk/src/components/drill/markDrillableCells.ts
+++ b/packages/sdk/src/components/drill/markDrillableCells.ts
@@ -151,6 +151,19 @@ export function markDrillableCells(
       }
       if (columns.size === 0) continue;
 
+      // Which columns already own their single tab stop. Read off the DOM first
+      // so the roving position survives the re-runs a settling `# dashboard`
+      // triggers; rebuilding it from scratch each pass would snap the stop back
+      // to the first row under a reader who had arrowed down.
+      const hasStop = new Set<string>();
+      for (const marked of table.querySelectorAll<HTMLElement>(
+         `.${DRILL_CELL_CLASS}[tabindex="0"]`,
+      )) {
+         if (!ownedByTable(marked)) continue;
+         const column = gridColumnStart(marked);
+         if (column) hasStop.add(column);
+      }
+
       for (const cell of table.querySelectorAll<HTMLElement>(
          ".column-cell.td",
       )) {
@@ -196,9 +209,48 @@ export function markDrillableCells(
             // role is the one that promises less. Set alongside the class and
             // never separately, so the three can never disagree about which
             // cells are actionable.
-            cell.tabIndex = 0;
+            // ONE tab stop per drillable column, not one per cell. Making every
+            // cell tabbable put the whole column in the tab order, so a result at
+            // the server's row cap cost a reader hundreds of presses to reach the
+            // next tile, and a composite grid multiplied that by its tiles. That
+            // traded one accessibility problem for another. Arrow keys move
+            // within the column instead (see `drillColumnSiblings`, driven from
+            // RenderedResult), which is the ordinary pattern for a grid.
+            //
+            // A cell already holding the stop keeps it, so a re-run does not move
+            // focus out from under the reader.
+            if (cell.tabIndex === 0) {
+               hasStop.add(column);
+            } else {
+               const owned = hasStop.has(column);
+               if (!owned) hasStop.add(column);
+               cell.tabIndex = owned ? -1 : 0;
+            }
             cell.setAttribute("role", "button");
          }
       }
    }
+}
+
+/**
+ * The drillable cells sharing `cell`'s column, in row order, or an empty array
+ * when `cell` is not a marked cell.
+ *
+ * Lives here rather than in the keyboard handler that calls it because the
+ * column identity is this module's rule: a cell's column is its inline
+ * `grid-column` start, scoped to its own `.malloy-table` so a nested table's
+ * numbering never matches the parent's. Two sites deciding that separately is
+ * how they come to disagree, so the handler asks this one.
+ */
+export function drillColumnSiblings(cell: HTMLElement): HTMLElement[] {
+   const table = cell.closest<HTMLElement>(".malloy-table");
+   const column = gridColumnStart(cell);
+   if (!table || !column) return [];
+   return Array.from(
+      table.querySelectorAll<HTMLElement>(`.${DRILL_CELL_CLASS}`),
+   ).filter(
+      (sibling) =>
+         sibling.closest(".malloy-table") === table &&
+         gridColumnStart(sibling) === column,
+   );
 }

--- a/packages/sdk/src/components/drill/markDrillableCells.ts
+++ b/packages/sdk/src/components/drill/markDrillableCells.ts
@@ -183,6 +183,21 @@ export function markDrillableCells(
             !cell.querySelector(".malloy-table")
          ) {
             cell.classList.add(DRILL_CELL_CLASS);
+            // Reachable without a mouse. The class alone gave a pointer cursor
+            // and a hover colour, both of which a keyboard user never sees and
+            // a touch user cannot produce, so the drill was discoverable only
+            // by clicking at random. `tabindex` puts the cell in the tab order
+            // and `role` tells a screen reader it does something; the cell's
+            // own text is its accessible name, which is the value that gets
+            // drilled on, so no `aria-label` is invented here.
+            //
+            // `button` rather than `link`: a `to=self` drill filters in place
+            // and does not navigate, and one tag can offer both, so the honest
+            // role is the one that promises less. Set alongside the class and
+            // never separately, so the three can never disagree about which
+            // cells are actionable.
+            cell.tabIndex = 0;
+            cell.setAttribute("role", "button");
          }
       }
    }

--- a/packages/sdk/src/components/drill/markDrillableCells.ts
+++ b/packages/sdk/src/components/drill/markDrillableCells.ts
@@ -159,6 +159,15 @@ export function markDrillableCells(
       for (const marked of table.querySelectorAll<HTMLElement>(
          `.${DRILL_CELL_CLASS}[tabindex="0"]`,
       )) {
+         // Belt and braces, NOT load-bearing, and measured as such: this query
+         // is scoped to `table`, whose subtree contains any nested table, so
+         // without this line an outer pass can see a nested table's stop and
+         // demote it. It is then restored when that nested table is processed
+         // moments later, because tables are walked in document order and each
+         // repairs its own columns. Compared the full tabindex map with and
+         // without the line across a fresh mark, a re-mark, and a re-mark after
+         // the stop was moved: identical every time. Kept for symmetry with the
+         // marking loop below, which needs its own `ownedByTable` guard.
          if (!ownedByTable(marked)) continue;
          const column = gridColumnStart(marked);
          if (!column) continue;

--- a/packages/sdk/src/components/drill/markDrillableCells.ts
+++ b/packages/sdk/src/components/drill/markDrillableCells.ts
@@ -159,15 +159,19 @@ export function markDrillableCells(
       for (const marked of table.querySelectorAll<HTMLElement>(
          `.${DRILL_CELL_CLASS}[tabindex="0"]`,
       )) {
-         // Belt and braces, NOT load-bearing, and measured as such: this query
-         // is scoped to `table`, whose subtree contains any nested table, so
-         // without this line an outer pass can see a nested table's stop and
-         // demote it. It is then restored when that nested table is processed
-         // moments later, because tables are walked in document order and each
-         // repairs its own columns. Compared the full tabindex map with and
-         // without the line across a fresh mark, a re-mark, and a re-mark after
-         // the stop was moved: identical every time. Kept for symmetry with the
-         // marking loop below, which needs its own `ownedByTable` guard.
+         // LOAD-BEARING, and a previous comment here claimed the opposite on
+         // the strength of a measurement that missed the case. This query is
+         // scoped to `table`, whose subtree contains any nested table, so
+         // without this line an outer pass sees a nested table's stop and
+         // demotes it as a duplicate of its own column. The nested pass then
+         // re-promotes, but it promotes the FIRST row, not the one the reader
+         // had roved to, so the restoration is not position-preserving.
+         //
+         // Measured both ways. Move the stop to the nested table's second row
+         // and re-mark: with this line, the stop stays there; without it, the
+         // stop is back on the nested table's first row. The earlier
+         // measurement moved the stop in the OUTER table, where the fallback
+         // lands on the same cell and the two are indistinguishable.
          if (!ownedByTable(marked)) continue;
          const column = gridColumnStart(marked);
          if (!column) continue;

--- a/packages/sdk/src/components/drill/markDrillableCells.ts
+++ b/packages/sdk/src/components/drill/markDrillableCells.ts
@@ -161,7 +161,13 @@ export function markDrillableCells(
       )) {
          if (!ownedByTable(marked)) continue;
          const column = gridColumnStart(marked);
-         if (column) hasStop.add(column);
+         if (!column) continue;
+         // The first one keeps the stop and a duplicate is DEMOTED, not left
+         // alone. Preserving every `tabindex="0"` it found meant a column that
+         // had somehow gained a second stop kept both through every re-mark,
+         // which is the accumulation this whole scheme exists to prevent.
+         if (hasStop.has(column)) marked.tabIndex = -1;
+         else hasStop.add(column);
       }
 
       for (const cell of table.querySelectorAll<HTMLElement>(
@@ -253,4 +259,40 @@ export function drillColumnSiblings(cell: HTMLElement): HTMLElement[] {
          sibling.closest(".malloy-table") === table &&
          gridColumnStart(sibling) === column,
    );
+}
+
+/**
+ * Move a drillable column's single tab stop `to` rows from `from`, or to the
+ * first or last cell, and return the cell that should now take focus.
+ *
+ * Lives beside {@link drillColumnSiblings} because it enforces the same
+ * invariant the marking does: exactly one cell per column carries
+ * `tabindex="0"`.
+ */
+export function moveDrillStop(
+   from: HTMLElement,
+   to: number | "first" | "last",
+): HTMLElement | undefined {
+   const siblings = drillColumnSiblings(from);
+   const at = siblings.indexOf(from);
+   if (at === -1) return undefined;
+   const next =
+      to === "first"
+         ? siblings[0]
+         : to === "last"
+           ? siblings[siblings.length - 1]
+           : siblings[Math.min(Math.max(at + to, 0), siblings.length - 1)];
+   if (!next) return undefined;
+   // EVERY sibling is rewritten, not just `from`. A cell with `tabindex="-1"`
+   // is still click-focusable, so `from` is frequently NOT the cell holding the
+   // stop: clicking a cell mid-column and then pressing an arrow used to clear
+   // `from` (already -1, a no-op) and promote its neighbour, leaving the column
+   // with two stops. The marking pass then preserved both, so it stuck, and
+   // repeating the gesture accumulated more.
+   //
+   // Rewriting all of them also means a clamped move at either end, where
+   // `next === from`, repairs a column that had drifted rather than doing
+   // nothing.
+   for (const sibling of siblings) sibling.tabIndex = sibling === next ? 0 : -1;
+   return next;
 }

--- a/packages/sdk/src/components/given/GivenInput.tsx
+++ b/packages/sdk/src/components/given/GivenInput.tsx
@@ -299,6 +299,16 @@ export function GivenInput({
             // Free text keeps the control from being a cage: the suggest query
             // returns the common values, not necessarily every legal one.
             freeSolo
+            // MUI hides the dropdown arrow whenever `freeSolo` is set, which
+            // left a control that HAS a list of values looking exactly like a
+            // plain text box: nothing on it said the list existed, so the only
+            // way to find the options was to guess that clicking would reveal
+            // them. Reported independently by a reader as "the controls render
+            // as text boxes rather than dropdowns"; the options were being
+            // fetched and offered correctly the whole time, and only the
+            // affordance was missing. Same principle as `markDrillableCells`:
+            // something you can act on has to look like it.
+            forcePopupIcon
             // Keeps text the reader typed but did not pick from the list. A
             // `freeSolo` Autocomplete without this discards it on blur, so a
             // value that is legal but absent from `suggest` could be typed and

--- a/packages/sdk/src/components/given/GivenInput.tsx
+++ b/packages/sdk/src/components/given/GivenInput.tsx
@@ -169,9 +169,8 @@ export function GivenInput({
    // `date` or `boolean` given would receive a string that `givensToRequest`
    // forwards verbatim for Malloy to refuse. Falling through gives the given the
    // widget its type implies, which is the behaviour before `control=` existed.
-   // No picker renders unless a given carries `control`, so this closes the hole
-   // before the slice
-   // that opens it rather than after.
+   // `control=` IS populated now, by `readGivenControlSpec` on the server, so
+   // this guard is live rather than pre-emptive.
    const pickableType = type === "string" || filterInnerType(type) === "string";
    const filterIsPickable =
       !isFilterType(type) ||
@@ -275,10 +274,10 @@ export function GivenInput({
             //
             // FORECLOSED by choosing revert: a reader cannot override a
             // DECLARED default with "match everything", because the only
-            // gesture for it now means revert. Unreachable today (nothing
-            // carries `control`, so no picker renders here), and the honest fix is
-            // a separate affordance rather than two meanings for one ×. Worth
-            // settling before `control=` is wired up server-side.
+            // gesture for it now means revert. The honest fix is a separate
+            // affordance rather than two meanings for one ×. This is now
+            // REACHABLE: `control=` is populated server-side and pickers render,
+            // so a given with a declared default and a picker hits it.
             onChange(null);
             return;
          }
@@ -413,8 +412,8 @@ export function GivenInput({
            : undefined;
       // Same hazard as the number and date branches: a value that cannot be
       // placed on the track would otherwise read as "Any" while still being
-      // sent. Unreachable without `rangeMin`/`rangeMax` on the given,
-      // which is exactly why it is worth closing before anything does.
+      // sent. Live rather than latent: `readGivenControlSpec` populates
+      // `rangeMin`/`rangeMax` from the declaration's own tags.
       if (
          current === undefined &&
          value !== undefined &&

--- a/packages/sdk/src/components/index.ts
+++ b/packages/sdk/src/components/index.ts
@@ -1,5 +1,6 @@
 export { AnalyzePackageButton } from "./AnalyzePackageButton";
 export { useRouterClickHandler, type NavigationClick } from "./click_helper";
+export * from "./Dashboard";
 export * from "./DataAppViewer";
 export * from "./drill";
 export * from "./Environment";

--- a/packages/server/src/spa_fallback.spec.ts
+++ b/packages/server/src/spa_fallback.spec.ts
@@ -46,6 +46,26 @@ describe("classifySpaFallback", () => {
          });
       });
 
+      it("keeps a dashboard whose slug ends in an asset extension", () => {
+         // A slug is a FILENAME with `.malloy` removed, so
+         // `dashboards/report.csv.malloy` publishes the slug `report.csv`
+         // through no choice of the reader's. Measured before this entry
+         // existed: that dashboard was listed on the package page, served by
+         // the API, and reachable by in-app navigation, while a deep link or a
+         // refresh 302d to the static route and answered 404.
+         expect(classify("/examples/storefront/dashboards/report.csv")).toEqual(
+            {
+               kind: "spa",
+            },
+         );
+         // The ordinary shape reaches the app without needing this set at all,
+         // asserted so a regression that removes the entry is distinguishable
+         // from one that breaks the whole route.
+         expect(classify("/examples/storefront/dashboards/overview")).toEqual({
+            kind: "spa",
+         });
+      });
+
       it("still claims the OLD `pages` segment, which the app redirects", () => {
          // Kept deliberately, and load-bearing for the deprecation: an old
          // bookmark has to REACH the app, because the app is what rewrites it to

--- a/packages/server/src/spa_fallback.ts
+++ b/packages/server/src/spa_fallback.ts
@@ -75,7 +75,15 @@ const ASSET_EXTENSIONS = new Set([
  * Third segments that belong to the app rather than to a package's `public/`
  * directory, so `/<env>/<pkg>/<here>/...` must keep reaching the SPA even when
  * the path ends in an asset extension. `data-apps/<file>.html` is the in-app
- * embedded data app viewer and `workbook/...` is the workbook route.
+ * embedded data app viewer, `workbook/...` is the workbook route, and
+ * `dashboards/<slug>` is the dashboard viewer.
+ *
+ * `dashboards` is here because a slug is a FILENAME with its `.malloy` suffix
+ * removed, so `dashboards/report.csv.malloy` publishes the slug `report.csv`,
+ * which ends in an asset extension through no choice of the reader's. Without
+ * this entry that dashboard is listed on the package page, served by the API,
+ * and reachable by in-app navigation, but a deep link or a refresh 302s to the
+ * static route and answers 404. Measured before adding it.
  *
  * `pages` is the OLD spelling of `data-apps`, kept only so an existing bookmark
  * reaches the app and the app can redirect it to the new URL. Without it here the
@@ -87,7 +95,12 @@ const ASSET_EXTENSIONS = new Set([
  * together with the redirect in ModelPage.tsx that depends on it. The newest tag
  * when this was written was v0.0.240.
  */
-const SPA_OWNED_SEGMENTS = new Set(["data-apps", "pages", "workbook"]);
+const SPA_OWNED_SEGMENTS = new Set([
+   "dashboards",
+   "data-apps",
+   "pages",
+   "workbook",
+]);
 
 export type SpaFallbackAction =
    /** Serve the app shell, as before. */

--- a/packages/server/src/spa_fallback.ts
+++ b/packages/server/src/spa_fallback.ts
@@ -88,7 +88,8 @@ const ASSET_EXTENSIONS = new Set([
  * The cost, which `pages` pays too and is worth stating for this one: a package
  * that ships a `public/dashboards/` directory can no longer address those files
  * as `/<env>/<pkg>/dashboards/<file>`, since that shape now opens the dashboard
- * viewer, which answers "no such dashboard". `data-apps` has a viewer one
+ * viewer, which reports that the package has no dashboard by that name.
+ * `data-apps` has a viewer one
  * segment down that catches its own collision; this route has no equivalent, so
  * those files are reachable only on the static URL
  * `/environments/<env>/packages/<pkg>/dashboards/<file>`.

--- a/packages/server/src/spa_fallback.ts
+++ b/packages/server/src/spa_fallback.ts
@@ -85,6 +85,14 @@ const ASSET_EXTENSIONS = new Set([
  * and reachable by in-app navigation, but a deep link or a refresh 302s to the
  * static route and answers 404. Measured before adding it.
  *
+ * The cost, which `pages` pays too and is worth stating for this one: a package
+ * that ships a `public/dashboards/` directory can no longer address those files
+ * as `/<env>/<pkg>/dashboards/<file>`, since that shape now opens the dashboard
+ * viewer, which answers "no such dashboard". `data-apps` has a viewer one
+ * segment down that catches its own collision; this route has no equivalent, so
+ * those files are reachable only on the static URL
+ * `/environments/<env>/packages/<pkg>/dashboards/<file>`.
+ *
  * `pages` is the OLD spelling of `data-apps`, kept only so an existing bookmark
  * reaches the app and the app can redirect it to the new URL. Without it here the
  * old link is diverted to the static route and 404s, which is a worse answer than

--- a/packages/server/tests/fixtures/dashboards-test/dashboards/grid.malloy
+++ b/packages/server/tests/fixtures/dashboards-test/dashboards/grid.malloy
@@ -1,9 +1,14 @@
 // The layout recipe as a fixture: `columns=12`, colspans summing to 12 on each
 // row, and a `# break` so the tiles get a row of their own instead of flowing in
-// beside the KPI cards. Nothing here measures the rendered result: this slice
-// ships no UI, so what is pinned is only that the manifest carries the numbers
-// through. "The cards and the tiles line up" is a claim about pixels and belongs
-// to whichever slice builds the browser surface.
+// beside the KPI cards. The manifest half pins that the numbers carry through;
+// the pixels are pinned by the browser suite, which is where "the cards and the
+// tiles line up" belongs.
+//
+// One tile is a `# bar_chart` and one is a table, deliberately. A row of two
+// tables lines up for free, because two tables of the same data are the same
+// height; a chart beside a table is the case where a layout bug actually shows,
+// and it is also the only place these fixtures exercise the renderer's chart
+// path (vega, async ready, measured height) rather than its table path.
 //
 // The tiles are inline rather than the model's `by_brand` / `by_region`, whose
 // own `where:` clauses would add controls this page is not about.
@@ -32,6 +37,7 @@ query: grid is orders -> {
          group_by: brand_name
          aggregate: total_amount
       }
+      # bar_chart
       # colspan=6
       # label="By region"
       region_tile is {


### PR DESCRIPTION
Slice 8 of the ten-way split of #935, and the piece that makes dashboards visible. Slices 1 through 7 are on `main`; #987 landed the server side (discovery, lint, the manifest and the REST surface) and this renders it: a `Dashboard` component, a route to it from the Console, and a notebook cell that can drill into one.

Base is `main`. 16 commits, 24 files, +2266/-64. This branch was previously stacked on slice 6 with slice 7 merged in, and read 120 files against that base; rebased onto `main` now that both are landed it reads its own 24. Every earlier shape of it was unreviewable for that reason, which is why this PR is opening only now.

## What it adds

`packages/sdk/src/components/Dashboard/` is the renderer: `Dashboard.tsx` lays out the grid from the manifest #987 publishes, `DashboardTile.tsx` renders one tile. `DashboardPage.tsx` routes to it from the Console, and `ContentTypeIcon`/`Package.tsx` give dashboards their own signal in the package listing rather than borrowing a notebook's.

Two things beyond the renderer. A notebook cell can drill into a dashboard, which is `markDrillableCells.ts` plus the `Notebook`/`NotebookCell` and `RenderedResult` changes, and it is reachable from the keyboard rather than mouse-only. And `## autorun=false` is honoured in a notebook, with notebooks listed by title.

## The one server file, and why it is here

`spa_fallback.ts` gains a `dashboards` entry. A slug is a filename with its `.malloy` suffix removed, so `dashboards/report.csv.malloy` publishes the slug `report.csv`, which ends in an asset extension through no choice of the reader's. Without the entry that dashboard is listed on the package page, served by the API and reachable by in-app navigation, but a deep link or a refresh 302s to the static route and answers 404. Measured before adding it, not inferred.

The cost is stated in the docblock rather than left implicit: a package shipping a `public/dashboards/` directory can no longer address those files through that path. `pages` already pays the same cost.

## Tests

`package-dashboards.spec.ts` drives the viewer end to end in a browser. The grid fixture now puts a chart beside a table, because a grid of one content type does not exercise layout. One earlier version of the grid test raced the layout and passed for the wrong reason; it now names what it pins.

## Docs

`docs/dashboards.md` is new here and is the guide the feature needed. Worth flagging for sequencing: #1020's authoring skill links it at `SKILL.md:373` as "the full guide this skill condenses", so **#1020 cannot merge until this does**. #1026 is also based on this branch and becomes reviewable once this PR exists.

## Review history

Fourteen of the sixteen commits are review-driven, and the subjects say which: "seven findings from the code review, four of them defects", "four review fixes, two of them in code this branch just added", and three separate commits correcting claims in prose rather than code (four in the dashboards guide, three about drill, one release-note claim found false). That ratio is the honest summary of how this branch got here: the recurring defect class was a claim that was true when written and false when read, not a logic error.

## Verification worth knowing about

The rebase onto `main` was built in a throwaway worktree first and then applied to the branch, and both produced the identical tree. Of the twelve files this branch overlaps with slice 7, eleven are byte-identical to what it had already merged, so only `RELEASE_NOTES.md` conflicted. The stale "file's own `export {}` closure" phrasing that slice 6 corrected is absent here and the corrected "union of every listed file" phrasing is present, checked with a positive control rather than a bare grep.
