### PR TITLE
feat(server): read ClickHouse from a Malloy model via DuckDB

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -4875,6 +4875,71 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AttachedDatabase"
+        clickhouseServers:
+          type: array
+          description: >
+            ClickHouse servers this DuckDB connection can read. Each entry
+            registers a table macro named after the server, so a model calls
+            `<name>('SELECT ...')` and gets the result set back as a DuckDB
+            table. Publisher owns the transport: it reads ClickHouse's HTTP
+            interface with `default_format=Parquet`, URL-encodes the query, and
+            keeps credentials in a scoped DuckDB secret rather than in the URL
+            or the macro body.
+
+            The macro argument is sent to ClickHouse verbatim and is NOT pushed
+            down or rewritten -- whatever it selects is what crosses the wire.
+            Aggregate inside the macro argument and let Malloy roll up from
+            there; a bare `SELECT * FROM tbl` extracts the whole table on every
+            query.
+          items:
+            $ref: "#/components/schemas/ClickhouseServer"
+
+    ClickhouseServer:
+      type: object
+      description: >
+        A remote ClickHouse server reachable over its HTTP interface, exposed to
+        Malloy models as a DuckDB table macro.
+      required: [name, host]
+      properties:
+        name:
+          type: string
+          description: >
+            Macro name models call, e.g. `events` makes `events('SELECT ...')`
+            resolvable. Must be a valid SQL identifier, and must not collide
+            with an existing DuckDB function.
+          pattern: "^[a-zA-Z_][a-zA-Z0-9_]*$"
+          example: "events"
+        host:
+          type: string
+          description: Hostname or IP of the ClickHouse HTTP interface.
+          example: "localhost"
+        port:
+          type: integer
+          description: Port of the ClickHouse HTTP interface.
+          default: 8123
+          example: 8123
+        database:
+          type: string
+          description: >
+            Default database for unqualified table names in the macro argument.
+            Omit to use the server's default.
+          example: "demo"
+        user:
+          type: string
+          description: ClickHouse user. Omit for a server that allows anonymous access.
+          example: "default"
+        password:
+          type: string
+          description: >
+            ClickHouse password. Supports `${ENV_VAR}` substitution so the
+            secret stays out of the config file. Sent as an HTTP Basic
+            Authorization header held in a scoped DuckDB secret, never in the
+            query URL.
+          example: "${CLICKHOUSE_PASSWORD}"
+        useSsl:
+          type: boolean
+          description: Use https instead of http for the HTTP interface.
+          default: false
 
     AttachedDatabase:
       type: object

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
 
 ## Examples
 
-Three runnable packages ship in the default `examples` environment, plus one standalone React app —
+Three runnable packages ship in the default `examples` environment, plus one standalone React app and one opt-in package —
 every doc below points back to one of them, and each example's README points back to the docs.
 
 | Example                                              | What it shows                                                                                                                     |
@@ -15,6 +15,7 @@ every doc below points back to one of them, and each example's README points bac
 | [governed-analytics](../examples/governed-analytics) | Givens, `#(authorize)`, row-level access, and discovery curation in one small package.                                            |
 | [html-data-app](../examples/html-data-app)           | A no-build SaaS-subscriptions dashboard served from a package's `public/` directory.                                              |
 | [data-app](../examples/data-app)                     | _Advanced/internal:_ a standalone React app built on the SDK, reading from `storefront`. Not a served package — run it with Vite. |
+| [clickhouse](../examples/clickhouse)                 | A model over a remote ClickHouse server. Not in the default environment — it needs a running ClickHouse (a `docker-compose.yml` is included). |
 
 ## Concepts
 
@@ -55,6 +56,7 @@ there for the primitive, then follow the application you need.
 | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [deployment.md](deployment.md)                             | Run a built server via npx, Docker, or Docker Compose.                                                                                              |
 | [connections.md](connections.md)                           | Connect BigQuery, Snowflake, Postgres, DuckDB, and more.                                                                                            |
+| [clickhouse.md](clickhouse.md)                             | Query a remote ClickHouse server from a model — the config, the aggregate-server-side rule, and the type mapping.                                   |
 | [materialization.md](materialization.md)                   | Persist Malloy sources into tables — the publish-gate rules, on-demand + scheduled builds, the `malloy-pub` CLI, and standalone-vs-hosted behavior. |
 | [preaggregation.md](preaggregation.md)                     | Roll a measure up to a coarse grain with `#@ preaggregate` so covered queries read a small table — what can be pre-aggregated, what routes, and what it costs. |
 | [query-metadata.md](query-metadata.md)                     | Tag the statements Publisher sends so the backend's own reporting can attribute them — layers, the contract, and correlating an API call with a backend query. Off unless `PUBLISHER_QUERY_METADATA=on`. |

--- a/docs/clickhouse.md
+++ b/docs/clickhouse.md
@@ -1,0 +1,138 @@
+# ClickHouse
+
+> What this is: how to query a remote ClickHouse server from a Malloy model. For connections in
+> general, see [connections.md](connections.md); for the config file, see
+> [configuration.md](configuration.md).
+
+Publisher reads ClickHouse through DuckDB. You declare the server once under a DuckDB connection,
+and Publisher registers a **table macro** named after it. A model calls that macro with a ClickHouse
+SQL string and gets the result set back as a table it can build a source on.
+
+There is no ClickHouse driver and no Malloy ClickHouse dialect involved. ClickHouse's HTTP interface
+can return Parquet, and DuckDB can read Parquet over HTTP — that is the whole mechanism.
+
+## Set it up
+
+Declare the server on an environment-level DuckDB connection in `publisher.config.json`:
+
+```json
+{
+  "name": "clickhouse",
+  "type": "duckdb",
+  "duckdbConnection": {
+    "clickhouseServers": [
+      {
+        "name": "demo",
+        "host": "localhost",
+        "port": 8123,
+        "database": "demo",
+        "user": "malloy",
+        "password": "${CLICKHOUSE_PASSWORD}"
+      }
+    ]
+  }
+}
+```
+
+`port` defaults to `8123` (ClickHouse's HTTP port, **not** the native 9000 port). Set
+`"useSsl": true` for https. `password` goes through the usual `${ENV_VAR}` substitution, so the
+secret stays out of the config file — see [configuration.md](configuration.md).
+
+Then write a model against it. The connection name (`clickhouse`) picks the connection; the macro
+name (`demo`) picks the server:
+
+```malloy
+source: orders is clickhouse.sql("""
+  SELECT * FROM demo('
+    SELECT region, order_date, count() AS order_count, sum(amount) AS revenue
+    FROM demo.orders
+    GROUP BY region, order_date
+  ')
+""") extend {
+  measure:
+    total_orders is order_count.sum()
+    total_revenue is revenue.sum()
+
+  view: by_region is {
+    group_by: region
+    aggregate: total_orders, total_revenue
+  }
+}
+```
+
+A runnable version is in [examples/clickhouse](../examples/clickhouse), with a
+`docker-compose.yml` that starts a seeded ClickHouse.
+
+## Aggregate on the ClickHouse side
+
+**Nothing is pushed down.** Whatever SQL you put in the macro string is exactly what ClickHouse runs.
+Malloy's own filters, `group_by`, and measures are applied by DuckDB to the rows the macro already
+returned.
+
+So this is the shape to avoid:
+
+```malloy
+// Every query re-extracts the whole table over HTTP.
+source: orders is clickhouse.sql("""SELECT * FROM demo('SELECT * FROM demo.orders')""")
+```
+
+and this is the shape that works — aggregate or filter inside the string, and let Malloy roll up the
+partials:
+
+```malloy
+source: orders is clickhouse.sql("""
+  SELECT * FROM demo('
+    SELECT region, order_date, count() AS order_count, sum(amount) AS revenue
+    FROM demo.orders GROUP BY region, order_date
+  ')
+""")
+```
+
+On a 5M-row table, the difference measured 1961 ms against 156 ms, and 1.63 MiB across the wire
+against 3 KiB — same answers. The gap grows with the table.
+
+Treat the macro as a **parameterized extract**, not as a pushdown connector. Good sources are a
+pre-aggregated rollup, a date-bounded slice, or a small dimension table.
+
+## What Publisher handles
+
+- **URL encoding.** The query string is `url_encode`d, so a `+`, `&`, or `#` in your SQL survives.
+- **Authentication.** Credentials become an HTTP Basic header stored in a DuckDB secret scoped to the
+  server's base URL. They are deliberately kept out of the query URL (ClickHouse logs URLs in
+  `system.query_log`) and out of the macro body (any model author can read that via
+  `duckdb_functions()`).
+- **`httpfs`.** Loaded automatically. It is baked into the Publisher image, so this works under
+  `EXTENSION_FETCH_POLICY=local-only`.
+- **Name validation.** A macro name must be a SQL identifier and must not be a reserved word —
+  `"name": "primary"` is rejected at startup with a suggested fix, rather than registering a macro
+  no model can call.
+
+## Types
+
+ClickHouse types arrive through Parquet, so the mapping is Parquet's:
+
+| ClickHouse                | DuckDB / Malloy            |
+| ------------------------- | -------------------------- |
+| `Date`                    | `DATE`                     |
+| `DateTime`                | `TIMESTAMP WITH TIME ZONE` |
+| `Decimal(p, s)`           | `DECIMAL(p, s)`            |
+| `Enum8` / `Enum16`        | `VARCHAR`                  |
+| `LowCardinality(String)`  | `VARCHAR`                  |
+| `Nullable(T)`             | nullable `T`               |
+| `UInt8` … `UInt64`        | `UTINYINT` … `UBIGINT`     |
+
+`DateTime` is stored UTC and comes back as a timezone-aware timestamp, so it renders in the server's
+local zone. That is invisible at date grain and visible at hour grain — if you group by hour, convert
+explicitly in the ClickHouse query (`toTimeZone(created_at, 'UTC')`) rather than relying on the
+default.
+
+## Notes
+
+- **The macro argument is trusted input.** It is your model's SQL, sent verbatim. Publisher does not
+  parse or rewrite it. Give the ClickHouse user read-only grants on just the tables you intend to
+  expose.
+- **The `chsql` community extension is not used and not needed.** Its `ch_scan` is a SQL macro over
+  `read_parquet` — the same idea — but it has no build for the DuckDB version Malloy embeds
+  (community builds stop at DuckDB 1.3.2), and its macro neither URL-encodes the query nor supports
+  password authentication.
+- **Writes are not supported.** This is a read path.

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -17,9 +17,12 @@ package format, see [packages.md](packages.md).
 
 ## Environment-level DuckDB connections
 
-You can also declare a top-level DuckDB connection at the environment level. Publisher intentionally exposes only data-source intent for these — database files, working directories, filesystem/network policy, extension loading, temp directories, and resource knobs are all owned by Publisher. The only configuration available is **attached databases**, where you declare foreign databases (BigQuery, Snowflake, Postgres, GCS, S3, Azure) that the DuckDB instance should `ATTACH` so queries can reference them.
+You can also declare a top-level DuckDB connection at the environment level. Publisher intentionally exposes only data-source intent for these — database files, working directories, filesystem/network policy, extension loading, setup SQL, temp directories, and resource knobs are all owned by Publisher. Two kinds of data source are available:
 
-An env-level DuckDB connection must declare at least one attached database. If you don't need to attach any foreign databases, you don't need to declare an env-level DuckDB connection at all — each loaded package already gets a per-package `duckdb` sandbox automatically (see above), which covers the plain in-memory use case.
+- **`attachedDatabases`** — foreign databases (BigQuery, Snowflake, Postgres, GCS, S3, Azure) that the DuckDB instance should `ATTACH` so queries can reference them.
+- **`clickhouseServers`** — remote ClickHouse servers read over their HTTP interface. Each entry registers a table macro a model calls as `<name>('SELECT …')`. See **[clickhouse.md](clickhouse.md)**.
+
+An env-level DuckDB connection must declare at least one of the two. If you need neither, you don't need to declare an env-level DuckDB connection at all — each loaded package already gets a per-package `duckdb` sandbox automatically (see above), which covers the plain in-memory use case.
 
 ## DuckLake connections (`type: "ducklake"`)
 

--- a/examples/clickhouse/README.md
+++ b/examples/clickhouse/README.md
@@ -1,0 +1,89 @@
+# clickhouse
+
+A Malloy model over a remote **ClickHouse** server, reached through DuckDB's HTTP reader.
+
+Unlike the other bundled examples, this one needs a running ClickHouse, so it is **not** in the
+default `examples` environment — you add it to your config after starting the server below.
+
+See [docs/clickhouse.md](../../docs/clickhouse.md) for the full reference.
+
+## 1. Start ClickHouse
+
+```bash
+docker compose -f examples/clickhouse/docker-compose.yml up -d
+```
+
+That seeds `demo.orders` (50,000 rows) from [seed.sql](seed.sql) and exposes ClickHouse's HTTP
+interface on port 8123. Wait for it to answer:
+
+```bash
+curl -s http://localhost:8123/ping   # -> Ok.
+```
+
+## 2. Declare the server and the package
+
+Add both to your `publisher.config.json`:
+
+```json
+{
+  "environments": [
+    {
+      "name": "examples",
+      "packages": [{ "name": "clickhouse", "location": "../../examples/clickhouse" }],
+      "connections": [
+        {
+          "name": "clickhouse",
+          "type": "duckdb",
+          "duckdbConnection": {
+            "clickhouseServers": [
+              {
+                "name": "demo",
+                "host": "localhost",
+                "port": 8123,
+                "database": "demo",
+                "user": "malloy",
+                "password": "${CLICKHOUSE_PASSWORD}"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+## 3. Run Publisher
+
+Connections are read from the config on a re-initializing boot, so pass `--init` the first time:
+
+```bash
+CLICKHOUSE_PASSWORD=malloy bun run build && CLICKHOUSE_PASSWORD=malloy bun run start:init
+```
+
+Open http://localhost:4000 and pick the `clickhouse` package, or query it directly:
+
+```bash
+curl -s -X POST \
+  http://localhost:4000/api/v0/environments/examples/packages/clickhouse/models/clickhouse.malloy/query \
+  -H 'Content-Type: application/json' \
+  -d '{"sourceName":"orders","queryName":"revenue_by_region","compactJson":true}'
+```
+
+## What's in the model
+
+[clickhouse.malloy](clickhouse.malloy) has two sources, showing both shapes:
+
+| Source       | Shape                                                                                       |
+| ------------ | ------------------------------------------------------------------------------------------- |
+| `orders`     | Pre-aggregated in ClickHouse to region/day/status. Malloy sums the partials. **Do this.**   |
+| `order_rows` | Row grain, date-filtered in ClickHouse. Fine at this size; the shape to avoid on big tables. |
+
+The rule to remember: **nothing is pushed down.** Whatever SQL sits inside `demo('…')` is what
+ClickHouse runs, and Malloy aggregates whatever came back. Filter and aggregate inside the string.
+
+## Tear down
+
+```bash
+docker compose -f examples/clickhouse/docker-compose.yml down -v
+```

--- a/examples/clickhouse/clickhouse.malloy
+++ b/examples/clickhouse/clickhouse.malloy
@@ -1,0 +1,92 @@
+// Malloy over a remote ClickHouse server.
+//
+// The `demo(...)` macro comes from the `clickhouseServers` entry on this
+// environment's DuckDB connection (see the environment's publisher.config.json).
+// Publisher registers one macro per configured server; the string you pass is
+// sent to ClickHouse as-is and the result set comes back as a DuckDB table.
+//
+// THE ONE RULE: nothing is pushed down. Malloy's filters and GROUP BY are
+// applied by DuckDB to whatever the macro returned, so aggregate or filter
+// inside the macro string and let Malloy roll up from there. A bare
+// `SELECT * FROM demo.orders` re-extracts the whole table on every query.
+
+// Pre-aggregated in ClickHouse to one row per region, day, and status. Malloy
+// sums those partials, so every view below is a rollup of a rollup.
+source: orders is clickhouse.sql("""
+  SELECT * FROM demo('
+    SELECT region, order_date, status,
+           count()      AS order_count,
+           sum(amount)  AS revenue,
+           sum(item_count) AS items
+    FROM demo.orders
+    GROUP BY region, order_date, status
+  ')
+""") extend {
+  # description = "Daily orders by region and status, pre-aggregated in ClickHouse."
+
+  measure:
+    total_orders is order_count.sum()
+    total_revenue is revenue.sum()
+    total_items is items.sum()
+    avg_order_value is total_revenue / nullif(total_orders, 0)
+
+  dimension:
+    order_year is order_date.year
+
+  # bar_chart
+  view: revenue_by_region is {
+    group_by: region
+    aggregate: total_orders, total_revenue
+    order_by: total_revenue desc
+  }
+
+  # line_chart
+  view: revenue_trend is {
+    group_by: order_month is order_date.month
+    aggregate: total_revenue
+    order_by: order_month asc
+  }
+
+  view: status_mix is {
+    group_by: status
+    aggregate: total_orders, total_revenue
+    order_by: total_orders desc
+  }
+
+  view: region_detail is {
+    group_by: region
+    aggregate: total_orders, total_revenue, avg_order_value
+    nest: status_mix
+    order_by: total_revenue desc
+  }
+}
+
+// Row grain, for the cases that genuinely need it. Fine at 50k rows; at 50M
+// this is the shape to avoid -- prefer aggregating inside the macro as above.
+source: order_rows is clickhouse.sql("""
+  SELECT * FROM demo('
+    SELECT order_id, customer_id, order_date, status, region, item_count, amount, discount
+    FROM demo.orders
+    WHERE order_date >= ''2025-06-01''
+  ')
+""") extend {
+  # description = "Individual orders from 2025-06-01 onward. Filtered in ClickHouse, not by Malloy."
+
+  measure:
+    order_count is count()
+    customer_count is count(customer_id)
+    total_revenue is amount.sum()
+    avg_order_value is amount.avg()
+
+  view: biggest_orders is {
+    select: order_id, order_date, region, status, amount
+    order_by: amount desc
+    limit: 20
+  }
+
+  view: by_region is {
+    group_by: region
+    aggregate: order_count, customer_count, avg_order_value
+    order_by: avg_order_value desc
+  }
+}

--- a/examples/clickhouse/docker-compose.yml
+++ b/examples/clickhouse/docker-compose.yml
@@ -1,0 +1,27 @@
+# Local ClickHouse for the `clickhouse` example package.
+#
+#   docker compose -f examples/clickhouse/docker-compose.yml up -d
+#
+# Seeds demo.orders on first start from seed.sql. Port 8123 is ClickHouse's
+# HTTP interface, which is the one Publisher reads.
+services:
+  clickhouse:
+    image: clickhouse/clickhouse-server:latest
+    container_name: malloy-clickhouse
+    ports:
+      - "8123:8123"
+    environment:
+      CLICKHOUSE_DB: demo
+      CLICKHOUSE_USER: malloy
+      CLICKHOUSE_PASSWORD: malloy
+    volumes:
+      - ./seed.sql:/docker-entrypoint-initdb.d/seed.sql:ro
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8123/ping"]
+      interval: 2s
+      timeout: 2s
+      retries: 30

--- a/examples/clickhouse/publisher.json
+++ b/examples/clickhouse/publisher.json
@@ -1,0 +1,5 @@
+{
+  "name": "clickhouse",
+  "version": "1.0.0",
+  "description": "A Malloy model over a remote ClickHouse server, reached through DuckDB's HTTP reader."
+}

--- a/examples/clickhouse/seed.sql
+++ b/examples/clickhouse/seed.sql
@@ -1,0 +1,26 @@
+-- Seed data for the `clickhouse` example package. Run automatically by
+-- docker-compose on first start.
+CREATE DATABASE IF NOT EXISTS demo;
+
+CREATE TABLE IF NOT EXISTS demo.orders (
+   order_id UInt64,
+   customer_id UInt32,
+   order_date Date,
+   status Enum8('pending' = 1, 'shipped' = 2, 'delivered' = 3, 'cancelled' = 4),
+   region LowCardinality(String),
+   item_count UInt8,
+   amount Decimal(10, 2),
+   discount Nullable(Float64)
+) ENGINE = MergeTree ORDER BY (order_date, order_id);
+
+INSERT INTO demo.orders
+SELECT
+   number + 1,
+   toUInt32(1 + (number * 7919) % 500),
+   toDate('2025-01-01') + toIntervalDay((number * 13) % 400),
+   CAST(1 + (number % 4) AS Enum8('pending' = 1, 'shipped' = 2, 'delivered' = 3, 'cancelled' = 4)),
+   ['north', 'south', 'east', 'west', 'central'][1 + (number % 5)],
+   toUInt8(1 + (number % 9)),
+   toDecimal64(round(10 + (number * 17 % 4900) / 10.0, 2), 2),
+   if(number % 6 = 0, NULL, round((number % 30) / 100.0, 4))
+FROM numbers(50000);

--- a/packages/server/src/service/clickhouse_servers.integration.spec.ts
+++ b/packages/server/src/service/clickhouse_servers.integration.spec.ts
@@ -1,0 +1,98 @@
+import { DuckDBConnection } from "@malloydata/db-duckdb";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { components } from "../api";
+import { registerClickhouseServers } from "./connection";
+
+type ClickhouseServer = components["schemas"]["ClickhouseServer"];
+
+/**
+ * Exercises the macro against a real ClickHouse server, which is the only thing
+ * that can prove the URL, the Parquet format negotiation, and the Basic-auth
+ * secret actually line up. Skipped unless CLICKHOUSE_TEST_HOST is set.
+ *
+ *   docker run -d --name malloy-ch -p 8123:8123 \
+ *     -e CLICKHOUSE_USER=malloy -e CLICKHOUSE_PASSWORD=malloy \
+ *     clickhouse/clickhouse-server:latest
+ *   CLICKHOUSE_TEST_HOST=localhost CLICKHOUSE_TEST_USER=malloy \
+ *     CLICKHOUSE_TEST_PASSWORD=malloy bun test clickhouse_servers.integration
+ */
+const host = process.env.CLICKHOUSE_TEST_HOST;
+const port = Number(process.env.CLICKHOUSE_TEST_PORT ?? 8123);
+const user = process.env.CLICKHOUSE_TEST_USER;
+const password = process.env.CLICKHOUSE_TEST_PASSWORD;
+
+const describeIfClickhouse = host ? describe : describe.skip;
+
+describeIfClickhouse("registerClickhouseServers against a live server", () => {
+   let connection: DuckDBConnection;
+
+   const server = (
+      overrides: Partial<ClickhouseServer> = {},
+   ): ClickhouseServer =>
+      ({
+         name: "ch",
+         host,
+         port,
+         user,
+         password,
+         ...overrides,
+      }) as ClickhouseServer;
+
+   beforeAll(async () => {
+      connection = new DuckDBConnection("duckdb", ":memory:");
+      await registerClickhouseServers(connection, [server()]);
+   });
+
+   afterAll(async () => {
+      await connection?.close();
+   });
+
+   it("round-trips a scalar through the HTTP interface", async () => {
+      const result = await connection.runSQL(
+         `SELECT * FROM ch('SELECT 42 AS answer')`,
+      );
+      expect(Number(result.rows[0]!["answer"])).toBe(42);
+   });
+
+   it("URL-encodes a query containing characters that break a raw query string", async () => {
+      // '+' and '&' are exactly what the chsql ch_scan macro corrupts.
+      const result = await connection.runSQL(
+         `SELECT * FROM ch('SELECT 1 + 1 AS sum_value, ''a&b'' AS amp')`,
+      );
+      expect(Number(result.rows[0]!["sum_value"])).toBe(2);
+      expect(String(result.rows[0]!["amp"])).toBe("a&b");
+   });
+
+   it("preserves ClickHouse types through Parquet", async () => {
+      const result = await connection.runSQL(
+         `SELECT * FROM ch('SELECT toDate(''2025-01-15'') AS d,
+                                   toDecimal64(12.34, 2) AS amount,
+                                   CAST(NULL AS Nullable(Float64)) AS missing')`,
+      );
+      const row = result.rows[0]!;
+      expect(String(row["d"])).toContain("2025-01-15");
+      expect(Number(row["amount"])).toBeCloseTo(12.34, 2);
+      expect(row["missing"]).toBeNull();
+   });
+
+   it("aggregates server-side so only the rollup crosses the wire", async () => {
+      const result = await connection.runSQL(
+         `SELECT * FROM ch('SELECT count() AS n FROM numbers(100000)')`,
+      );
+      expect(Number(result.rows[0]!["n"])).toBe(100000);
+   });
+
+   it("rejects a bad password rather than silently returning nothing", async () => {
+      const bad = new DuckDBConnection("duckdb", ":memory:");
+      try {
+         await registerClickhouseServers(bad, [
+            server({ name: "bad", password: "definitely-not-the-password" }),
+         ]);
+         await expect(
+            bad.runSQL(`SELECT * FROM bad('SELECT 1 AS x')`),
+         ).rejects.toThrow();
+      } finally {
+         await bad.close();
+      }
+   });
+});

--- a/packages/server/src/service/clickhouse_servers.spec.ts
+++ b/packages/server/src/service/clickhouse_servers.spec.ts
@@ -1,0 +1,265 @@
+import { DuckDBConnection } from "@malloydata/db-duckdb";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { components } from "../api";
+import { registerClickhouseServers } from "./connection";
+import { assembleEnvironmentConnections } from "./connection_config";
+
+type ClickhouseServer = components["schemas"]["ClickhouseServer"];
+type ApiConnection = components["schemas"]["Connection"];
+
+/**
+ * These run against a real in-memory DuckDB rather than asserting on generated
+ * SQL strings: DuckDB's own parser and secret manager are the oracle for
+ * "is this valid", and a hand-written matcher would happily pass on SQL DuckDB
+ * rejects. Registering a macro never contacts ClickHouse, so no server is
+ * needed here -- the gated integration test below covers the wire.
+ */
+describe("registerClickhouseServers", () => {
+   let connection: DuckDBConnection;
+   let databaseDir: string;
+
+   // Each test gets its own database file rather than ":memory:". Malloy shares
+   // a single DuckDB instance between connections whose config hashes equal, so
+   // every ":memory:" connection in the process -- including other spec files
+   // running alongside this one -- would otherwise see each other's macros and
+   // secrets, and the absence assertions below would depend on test ordering.
+   beforeEach(async () => {
+      databaseDir = await fs.mkdtemp(
+         path.join(os.tmpdir(), "publisher-clickhouse-"),
+      );
+      connection = new DuckDBConnection(
+         "duckdb",
+         path.join(databaseDir, "test.duckdb"),
+      );
+   });
+
+   afterEach(async () => {
+      await connection.close();
+      await fs.rm(databaseDir, { recursive: true, force: true });
+   });
+
+   const server = (
+      overrides: Partial<ClickhouseServer> = {},
+   ): ClickhouseServer =>
+      ({
+         name: "ch",
+         host: "localhost",
+         port: 18123,
+         ...overrides,
+      }) as ClickhouseServer;
+
+   const macroBody = async (name: string): Promise<string> => {
+      const result = await connection.runSQL(
+         `SELECT macro_definition FROM duckdb_functions() WHERE function_name = '${name}'`,
+      );
+      const rows = result.rows ?? [];
+      expect(rows.length).toBeGreaterThan(0);
+      return String(rows[0]!["macro_definition"]);
+   };
+
+   it("registers a callable table macro named after the server", async () => {
+      await registerClickhouseServers(connection, [server({ name: "events" })]);
+
+      const result = await connection.runSQL(
+         `SELECT count(*) AS n FROM duckdb_functions()
+          WHERE function_name = 'events' AND function_type = 'table_macro'`,
+      );
+      expect(Number(result.rows[0]!["n"])).toBe(1);
+   });
+
+   it("URL-encodes the query argument", async () => {
+      // The chsql ch_scan macro concatenates the query raw, so a '+' or '&' in
+      // the query silently corrupts the request. Pin that we encode.
+      await registerClickhouseServers(connection, [server()]);
+      expect(await macroBody("ch")).toContain("url_encode");
+   });
+
+   it("keeps credentials out of the macro body", async () => {
+      await registerClickhouseServers(connection, [
+         server({ user: "malloy", password: "sup3rsecret" }),
+      ]);
+
+      const body = await macroBody("ch");
+      expect(body).not.toContain("sup3rsecret");
+      expect(body).not.toContain("password");
+      // ...and out of the URL the macro builds, since ClickHouse logs URLs.
+      expect(body).not.toContain("malloy");
+   });
+
+   it("stores credentials in a DuckDB secret scoped to the server", async () => {
+      await registerClickhouseServers(connection, [
+         server({ user: "malloy", password: "sup3rsecret" }),
+      ]);
+
+      const secrets = await connection.runSQL(
+         `SELECT name, type, scope FROM duckdb_secrets()
+          WHERE name = 'secret_clickhouse_ch'`,
+      );
+      expect(secrets.rows).toHaveLength(1);
+      expect(String(secrets.rows[0]!["type"])).toBe("http");
+      expect(String(secrets.rows[0]!["scope"])).toContain(
+         "http://localhost:18123",
+      );
+   });
+
+   it("creates no secret for an anonymous server", async () => {
+      await registerClickhouseServers(connection, [server()]);
+      // Scoped to this server's secret name: DuckDB's secret manager is shared
+      // process-wide, so a global count would pick up other specs' secrets.
+      const secrets = await connection.runSQL(
+         `SELECT name FROM duckdb_secrets() WHERE name = 'secret_clickhouse_ch'`,
+      );
+      expect(secrets.rows).toHaveLength(0);
+   });
+
+   it("uses https and the configured port when useSsl is set", async () => {
+      await registerClickhouseServers(connection, [
+         server({
+            name: "secure",
+            host: "ch.example.com",
+            port: 8443,
+            useSsl: true,
+         }),
+      ]);
+      expect(await macroBody("secure")).toContain(
+         "https://ch.example.com:8443/",
+      );
+   });
+
+   it("defaults to port 8123", async () => {
+      await registerClickhouseServers(connection, [
+         { name: "defaulted", host: "ch.example.com" } as ClickhouseServer,
+      ]);
+      expect(await macroBody("defaulted")).toContain("ch.example.com:8123");
+   });
+
+   it("passes the default database through as a URL parameter", async () => {
+      await registerClickhouseServers(connection, [
+         server({ database: "demo" }),
+      ]);
+      expect(await macroBody("ch")).toContain("database=demo");
+   });
+
+   it("omits the database parameter when unset", async () => {
+      await registerClickhouseServers(connection, [server()]);
+      expect(await macroBody("ch")).not.toContain("database=");
+   });
+
+   it("registers each server independently", async () => {
+      await registerClickhouseServers(connection, [
+         server({ name: "warm", host: "a.example.com" }),
+         server({ name: "replica", host: "b.example.com" }),
+      ]);
+      expect(await macroBody("warm")).toContain("a.example.com");
+      expect(await macroBody("replica")).toContain("b.example.com");
+   });
+
+   it("rejects a reserved SQL word as a name", async () => {
+      // `primary` matches the identifier pattern but a model calling
+      // primary('SELECT ...') would not parse, so fail at config time instead.
+      await expect(
+         registerClickhouseServers(connection, [server({ name: "primary" })]),
+      ).rejects.toThrow(/reserved SQL word in DuckDB/);
+   });
+
+   it("rejects a name that is not a SQL identifier", async () => {
+      // Without this the name is interpolated straight into DDL.
+      await expect(
+         registerClickhouseServers(connection, [
+            server({ name: "ch; DROP TABLE users; --" }),
+         ]),
+      ).rejects.toThrow(/expected a SQL identifier/);
+   });
+
+   it("rejects duplicate names instead of silently overwriting", async () => {
+      await expect(
+         registerClickhouseServers(connection, [
+            server({ name: "dup", host: "a.example.com" }),
+            server({ name: "dup", host: "b.example.com" }),
+         ]),
+      ).rejects.toThrow(/Duplicate clickhouseServers\[\]\.name 'dup'/);
+   });
+
+   it("rejects a missing host", async () => {
+      await expect(
+         registerClickhouseServers(connection, [
+            { name: "nohost", host: "" } as ClickhouseServer,
+         ]),
+      ).rejects.toThrow(/Missing clickhouseServers\[\]\.host/);
+   });
+
+   it("escapes single quotes in configured values", async () => {
+      // A quote in a host would otherwise terminate the SQL literal.
+      await registerClickhouseServers(connection, [
+         server({ name: "quoted", host: "it's.example.com" }),
+      ]);
+      expect(await macroBody("quoted")).toContain("it''s.example.com");
+   });
+
+   it("is idempotent across repeated registration", async () => {
+      await registerClickhouseServers(connection, [server()]);
+      await registerClickhouseServers(connection, [server()]);
+      const result = await connection.runSQL(
+         `SELECT count(*) AS n FROM duckdb_functions() WHERE function_name = 'ch'`,
+      );
+      expect(Number(result.rows[0]!["n"])).toBe(1);
+   });
+
+   it("does nothing when no servers are configured", async () => {
+      await registerClickhouseServers(connection, []);
+      const result = await connection.runSQL(
+         `SELECT count(*) AS n FROM duckdb_functions()
+          WHERE function_type = 'table_macro' AND function_name = 'ch'`,
+      );
+      expect(Number(result.rows[0]!["n"])).toBe(0);
+   });
+});
+
+describe("clickhouseServers config validation", () => {
+   const assemble = (connection: ApiConnection) =>
+      assembleEnvironmentConnections(
+         [connection],
+         "/tmp/publisher-clickhouse-spec",
+      );
+
+   it("accepts a DuckDB connection carrying only clickhouseServers", () => {
+      const assembled = assemble({
+         name: "ch_only",
+         type: "duckdb",
+         duckdbConnection: {
+            clickhouseServers: [{ name: "ch", host: "localhost" }],
+         },
+      } as ApiConnection);
+
+      expect(assembled.metadata.get("ch_only")?.clickhouseServers).toHaveLength(
+         1,
+      );
+   });
+
+   it("still rejects a DuckDB connection with no data sources at all", () => {
+      expect(() =>
+         assemble({
+            name: "empty",
+            type: "duckdb",
+            duckdbConnection: {},
+         } as ApiConnection),
+      ).toThrow(/has no data sources/);
+   });
+
+   it("rejects unsupported DuckDB fields such as setupSQL", () => {
+      // clickhouseServers widened the surface deliberately; setupSQL must stay out.
+      expect(() =>
+         assemble({
+            name: "sneaky",
+            type: "duckdb",
+            duckdbConnection: {
+               clickhouseServers: [{ name: "ch", host: "localhost" }],
+               setupSQL: "ATTACH 'x'",
+            },
+         } as unknown as ApiConnection),
+      ).toThrow(/Unsupported DuckDB connection field\(s\): setupSQL/);
+   });
+});

--- a/packages/server/src/service/connection.spec.ts
+++ b/packages/server/src/service/connection.spec.ts
@@ -1750,11 +1750,11 @@ describe("connection integration tests", () => {
             ).rejects.toThrow(/'duckdb' is reserved/);
          });
 
-         it("should reject DuckDB connections with no attachments", async () => {
-            // Env-level DuckDB connections must declare at least one
-            // attached foreign database; the empty-array case is operator
-            // confusion (the per-package "duckdb" sandbox already covers
-            // the plain-in-memory use case).
+         it("should reject DuckDB connections with no data sources", async () => {
+            // Env-level DuckDB connections must declare at least one data
+            // source -- an attached foreign database or a ClickHouse server;
+            // the empty case is operator confusion (the per-package "duckdb"
+            // sandbox already covers the plain-in-memory use case).
             await expect(
                createEnvironmentConnections(
                   [
@@ -1766,7 +1766,43 @@ describe("connection integration tests", () => {
                   ],
                   testEnvironmentPath,
                ),
-            ).rejects.toThrow(/has no attached databases/);
+            ).rejects.toThrow(/has no data sources/);
+         });
+
+         it("should accept a DuckDB connection with only clickhouseServers", async () => {
+            // clickhouseServers is the second kind of data source, so it alone
+            // makes an env-level DuckDB connection well-formed.
+            const connections = await createEnvironmentConnections(
+               [
+                  {
+                     name: "ch_only",
+                     type: "duckdb",
+                     duckdbConnection: {
+                        clickhouseServers: [
+                           { name: "events", host: "localhost", port: 8123 },
+                        ],
+                     },
+                  },
+               ],
+               testEnvironmentPath,
+            );
+
+            try {
+               const connection = connections.malloyConnections.get("ch_only");
+               expect(connection).toBeDefined();
+
+               // The macro is the whole point of the connection, so assert it
+               // is actually callable rather than that the build returned.
+               const result = await (
+                  connection as unknown as DuckDBConnection
+               ).runSQL(
+                  `SELECT count(*) AS n FROM duckdb_functions()
+                   WHERE function_name = 'events' AND function_type = 'table_macro'`,
+               );
+               expect(Number(result.rows[0]!["n"])).toBe(1);
+            } finally {
+               await connections.releaseConnections();
+            }
          });
 
          it("should reject unsupported DuckDB connector fields", async () => {

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -58,6 +58,7 @@ import { openProxy, type ProxyEndpoint } from "./proxy";
 import { quoteIdentifier } from "./quoting";
 
 type AttachedDatabase = components["schemas"]["AttachedDatabase"];
+type ClickhouseServer = components["schemas"]["ClickhouseServer"];
 type ApiConnection = components["schemas"]["Connection"];
 type ApiConnectionAttributes = components["schemas"]["ConnectionAttributes"];
 type ApiConnectionStatus = components["schemas"]["ConnectionStatus"];
@@ -1289,6 +1290,152 @@ async function attachDatabasesToDuckDB(
    }
 }
 
+/**
+ * Shape a macro name must have. The name is quoted in the DDL below, so this
+ * is not the injection guard on its own -- it is what keeps a name callable
+ * from a model, where Malloy writes it bare.
+ */
+const CLICKHOUSE_MACRO_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+/** Default port of the ClickHouse HTTP interface. */
+const CLICKHOUSE_DEFAULT_HTTP_PORT = 8123;
+
+/**
+ * Base URL of a ClickHouse server's HTTP interface, with no query string.
+ *
+ * Doubles as the DuckDB secret SCOPE, so it must be the exact prefix of the
+ * URLs the macro builds -- a mismatch silently drops the Authorization header
+ * and the server answers 403.
+ */
+function buildClickhouseBaseUrl(server: ClickhouseServer): string {
+   const scheme = server.useSsl ? "https" : "http";
+   const port = server.port ?? CLICKHOUSE_DEFAULT_HTTP_PORT;
+   return `${scheme}://${server.host}:${port}`;
+}
+
+/**
+ * Whether DuckDB's parser treats `name` as a reserved word. Read from
+ * `duckdb_keywords()` so the answer comes from the running parser rather than a
+ * list we would have to keep in sync across DuckDB upgrades.
+ */
+async function isReservedDuckDBKeyword(
+   connection: DuckDBConnection,
+   name: string,
+): Promise<boolean> {
+   const result = await connection.runSQL(
+      `SELECT count(*) AS reserved FROM duckdb_keywords()
+       WHERE keyword_category = 'reserved'
+         AND lower(keyword_name) = lower('${escapeSQL(name)}')`,
+   );
+   return Number(result.rows?.[0]?.["reserved"] ?? 0) > 0;
+}
+
+/**
+ * Register one table macro per configured ClickHouse server.
+ *
+ * ClickHouse's HTTP interface can emit Parquet, so `read_parquet()` over
+ * `?default_format=Parquet` streams a result set straight into DuckDB. The
+ * macro is the whole integration: there is no ClickHouse extension involved.
+ * (The `chsql` community extension ships the same idea as `ch_scan`, but it has
+ * no build for the DuckDB that Malloy embeds, and its macro neither URL-encodes
+ * the query nor supports password auth. Both are fixed here.)
+ *
+ * Credentials go into a DuckDB secret scoped to the server's base URL and are
+ * sent as an HTTP Basic header. They are deliberately kept out of the URL and
+ * out of the macro body: a macro definition is readable by any model author via
+ * `duckdb_functions()`, and query URLs show up in ClickHouse's `system.query_log`.
+ *
+ * NOTE: the macro argument is forwarded to ClickHouse verbatim. Nothing is
+ * pushed down, and Malloy's own filters and GROUP BY are applied by DuckDB to
+ * whatever the macro returns. Aggregate inside the argument for anything large.
+ */
+export async function registerClickhouseServers(
+   duckdbConnection: DuckDBConnection,
+   clickhouseServers: ClickhouseServer[],
+): Promise<void> {
+   if (clickhouseServers.length === 0) return;
+
+   await applyExtensionSessionSettings(duckdbConnection);
+   // read_parquet() over http:// needs httpfs, and the secret manager needs it
+   // loaded before `CREATE SECRET (TYPE http, ...)` will validate.
+   await installAndLoadExtension(duckdbConnection, "httpfs");
+
+   const seen = new Set<string>();
+   for (const server of clickhouseServers) {
+      const name = server.name;
+      if (!CLICKHOUSE_MACRO_NAME.test(name)) {
+         throw new Error(
+            `Invalid clickhouseServers[].name '${name}': expected a SQL identifier ` +
+               `matching ${CLICKHOUSE_MACRO_NAME.source}. Fix: "name": "events"`,
+         );
+      }
+      if (seen.has(name)) {
+         throw new Error(
+            `Duplicate clickhouseServers[].name '${name}': each server needs its own ` +
+               `macro name, because the last one registered would silently win. ` +
+               `Fix: rename one, e.g. "name": "${name}_replica"`,
+         );
+      }
+      seen.add(name);
+
+      if (!server.host) {
+         throw new Error(
+            `Missing clickhouseServers[].host on '${name}'. Fix: "host": "localhost"`,
+         );
+      }
+
+      // A reserved word parses as syntax, not as a name, so `primary(...)` in a
+      // model is a compile error however the macro was declared. Reject it here
+      // -- where we can say what to do -- rather than leaving a registered macro
+      // nobody can call. DuckDB's own keyword table is the source of truth, so
+      // this never drifts from the parser.
+      if (await isReservedDuckDBKeyword(duckdbConnection, name)) {
+         throw new Error(
+            `Invalid clickhouseServers[].name '${name}': that is a reserved SQL word ` +
+               `in DuckDB, so a model could not call ${name}('SELECT ...'). ` +
+               `Fix: pick a non-reserved name, e.g. "name": "${name}_ch"`,
+         );
+      }
+
+      const baseUrl = buildClickhouseBaseUrl(server);
+
+      // Auth first: the macro is useless without it, and creating the macro
+      // first would leave a working-looking macro behind on a bad credential.
+      if (server.user) {
+         const basic = Buffer.from(
+            `${server.user}:${server.password ?? ""}`,
+            "utf8",
+         ).toString("base64");
+         await duckdbConnection.runSQL(
+            `CREATE OR REPLACE SECRET ${sanitizeSecretName(`clickhouse_${name}`)} (
+               TYPE http,
+               EXTRA_HTTP_HEADERS MAP{'Authorization': 'Basic ${escapeSQL(basic)}'},
+               SCOPE '${escapeSQL(baseUrl)}'
+            );`,
+         );
+      }
+
+      // `database=` sets the default for unqualified names in the argument;
+      // an argument that fully qualifies its tables ignores it.
+      const databaseParam = server.database
+         ? `&database=${encodeURIComponent(server.database)}`
+         : "";
+      const urlPrefix = `${baseUrl}/?default_format=Parquet${databaseParam}&query=`;
+
+      await duckdbConnection.runSQL(
+         `CREATE OR REPLACE MACRO ${quoteIdentifier(name, "duckdb")}("query") AS TABLE
+             SELECT * FROM read_parquet('${escapeSQL(urlPrefix)}' || url_encode("query"));`,
+      );
+
+      logger.info("connection.duckdb.clickhouse.registered", {
+         macro: name,
+         url: baseUrl,
+         database: server.database,
+         authenticated: Boolean(server.user),
+      });
+   }
+}
+
 type ApiAzureConnection = components["schemas"]["AzureConnection"];
 
 /**
@@ -1816,7 +1963,8 @@ export function buildEnvironmentMalloyConfig(
       metadata: EnvironmentConnectionMetadata,
    ): Promise<void> {
       if (
-         metadata.attachedDatabases.length === 0 ||
+         (metadata.attachedDatabases.length === 0 &&
+            metadata.clickhouseServers.length === 0) ||
          !isDuckDBConnection(connection)
       ) {
          return;
@@ -1824,11 +1972,21 @@ export function buildEnvironmentMalloyConfig(
 
       let attachPromise = attachPromises.get(connection);
       if (!attachPromise) {
-         // One ATTACH run per connection object per config generation.
-         attachPromise = attachDatabasesToDuckDB(
-            connection,
-            metadata.attachedDatabases,
-         );
+         // One ATTACH + macro-registration run per connection object per config
+         // generation. Both share the promise so a caller that awaits the
+         // connection is guaranteed the macros exist before it compiles a model.
+         attachPromise = (async () => {
+            if (metadata.attachedDatabases.length > 0) {
+               await attachDatabasesToDuckDB(
+                  connection,
+                  metadata.attachedDatabases,
+               );
+            }
+            await registerClickhouseServers(
+               connection,
+               metadata.clickhouseServers,
+            );
+         })();
          attachPromises.set(connection, attachPromise);
       }
       await attachPromise;

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -13,6 +13,7 @@ import {
 
 type ApiConnection = components["schemas"]["Connection"];
 type AttachedDatabase = components["schemas"]["AttachedDatabase"];
+type ClickhouseServer = components["schemas"]["ClickhouseServer"];
 
 // TLS modes accepted on a proxied postgres connection. Canonical here (rather
 // than in connection.ts, which imports this module) so both the config-load
@@ -37,6 +38,7 @@ export type CoreConnectionsPojo = {
 export type EnvironmentConnectionMetadata = {
    apiConnection: ApiConnection;
    attachedDatabases: AttachedDatabase[];
+   clickhouseServers: ClickhouseServer[];
    hasAzureAttachment: boolean;
    hasSnowflakePrivateKey: boolean;
    isDuckLake: boolean;
@@ -51,7 +53,10 @@ export type AssembledEnvironmentConnections = {
    apiConnections: ApiConnection[];
 };
 
-const PUBLISHER_DUCKDB_API_FIELDS = new Set<string>(["attachedDatabases"]);
+const PUBLISHER_DUCKDB_API_FIELDS = new Set<string>([
+   "attachedDatabases",
+   "clickhouseServers",
+]);
 
 /**
  * Collapse `null` to `undefined` for an optional connection field.
@@ -473,9 +478,11 @@ function validateConnectionShape(connection: ApiConnection): void {
          {
             const attached =
                connection.duckdbConnection.attachedDatabases ?? [];
-            if (attached.length === 0) {
+            const clickhouse =
+               connection.duckdbConnection.clickhouseServers ?? [];
+            if (attached.length === 0 && clickhouse.length === 0) {
                throw new Error(
-                  `DuckDB connection "${connection.name}" has no attached databases. Add at least one foreign database (BigQuery, Snowflake, Postgres, GCS, S3, Azure) to attachedDatabases, or remove this connection entirely — each package already gets a per-package DuckDB sandbox named "duckdb" automatically.`,
+                  `DuckDB connection "${connection.name}" has no data sources. Add at least one foreign database (BigQuery, Snowflake, Postgres, GCS, S3, Azure) to attachedDatabases, or a ClickHouse server to clickhouseServers, or remove this connection entirely — each package already gets a per-package DuckDB sandbox named "duckdb" automatically.`,
                );
             }
          }
@@ -938,6 +945,8 @@ export function assembleEnvironmentConnections(
       apiConnection.attributes = getStaticConnectionAttributes(connection.type);
       const attachedDatabases =
          connection.duckdbConnection?.attachedDatabases ?? [];
+      const clickhouseServers =
+         connection.duckdbConnection?.clickhouseServers ?? [];
       const isDuckLake = connection.type === "ducklake";
       const isDuckdb = connection.type === "duckdb";
       const databasePath = isDuckLake
@@ -949,6 +958,7 @@ export function assembleEnvironmentConnections(
       metadata.set(connection.name, {
          apiConnection,
          attachedDatabases,
+         clickhouseServers,
          hasAzureAttachment: attachedDatabases.some(
             (database) => database.type === "azure",
          ),

--- a/packages/server/tests/unit/duckdb/attached_databases.test.ts
+++ b/packages/server/tests/unit/duckdb/attached_databases.test.ts
@@ -999,9 +999,10 @@ describe("createEnvironmentConnections - DuckDB", () => {
          ).rejects.toThrow(/'duckdb' is reserved/);
       });
 
-      it("should throw when DuckDB connection has no attached databases", async () => {
-         // Env-level DuckDB requires at least one attached foreign db;
-         // the per-package "duckdb" sandbox covers the plain-in-memory case.
+      it("should throw when DuckDB connection has no data sources", async () => {
+         // Env-level DuckDB requires at least one data source -- an attached
+         // foreign db or a ClickHouse server; the per-package "duckdb" sandbox
+         // covers the plain-in-memory case.
          const connections: ApiConnection[] = [
             {
                name: "no_attached_db",
@@ -1014,7 +1015,33 @@ describe("createEnvironmentConnections - DuckDB", () => {
 
          await expect(
             createEnvironmentConnections(connections, PROJECT_TEST_DIR),
-         ).rejects.toThrow(/has no attached databases/);
+         ).rejects.toThrow(/has no data sources/);
+      });
+
+      it("should accept a DuckDB connection with only clickhouseServers", async () => {
+         const connections: ApiConnection[] = [
+            {
+               name: "clickhouse_only",
+               type: "duckdb",
+               duckdbConnection: {
+                  clickhouseServers: [
+                     { name: "events", host: "localhost", port: 8123 },
+                  ],
+               },
+            },
+         ];
+
+         const created = await createEnvironmentConnections(
+            connections,
+            PROJECT_TEST_DIR,
+         );
+         try {
+            expect(
+               created.malloyConnections.get("clickhouse_only"),
+            ).toBeDefined();
+         } finally {
+            await created.releaseConnections();
+         }
       });
 
       it("should throw on unsupported connection type", async () => {


### PR DESCRIPTION
## What

Adds `clickhouseServers` to the environment-level DuckDB connection, so a Malloy model can query a remote ClickHouse server:

```json
{
  "name": "clickhouse",
  "type": "duckdb",
  "duckdbConnection": {
    "clickhouseServers": [
      {
        "name": "demo",
        "host": "localhost",
        "port": 8123,
        "database": "demo",
        "user": "malloy",
        "password": "${CLICKHOUSE_PASSWORD}"
      }
    ]
  }
}
```

Each entry registers a DuckDB table macro named after the server:

```malloy
source: orders is clickhouse.sql("""
  SELECT * FROM demo('
    SELECT region, order_date, count() AS order_count, sum(amount) AS revenue
    FROM demo.orders GROUP BY region, order_date
  ')
""") extend {
  measure: total_revenue is revenue.sum()
  view: by_region is { group_by: region; aggregate: total_revenue }
}
```

## Why this shape

ClickHouse's HTTP interface returns Parquet and DuckDB reads Parquet over HTTP, so a table macro is the entire integration — no driver, no Malloy dialect, no ClickHouse extension.

The `chsql` community extension packages the same idea as `ch_scan`, and it is worth saying why it is not used: its builds stop at DuckDB 1.3.2 while Malloy embeds 1.5.3 (`INSTALL chsql FROM community` 404s), and dumping its macro shows it concatenates the query without `url_encode` and takes a `user` but no password. So `SELECT 1 + 1` returns HTTP 400 and any password-protected server returns 403. Both are fixed here.

Config declares only data-source intent, matching the existing `attachedDatabases` contract — Publisher owns the URL, the encoding, and the credentials.

## Credential handling

Credentials become an HTTP Basic header stored in a DuckDB secret scoped to the server's base URL. They are deliberately kept out of two places:

- **the query URL** — ClickHouse records URLs in `system.query_log`
- **the macro body** — any model author can read that via `duckdb_functions()`

`password` goes through the existing `${ENV_VAR}` substitution, so it need not sit in the config file. Tests assert the password appears in neither place, and that a wrong password fails rather than silently returning nothing.

## The caveat, stated up front

**Nothing is pushed down.** The macro argument is exactly what ClickHouse runs; Malloy's filters and `group_by` are applied by DuckDB to the rows that came back. Aggregate inside the argument.

Measured on a 5M-row table, same results both ways:

| | wall clock | over the wire |
| --- | --- | --- |
| `SELECT *`, aggregate in DuckDB | 1961 ms | 1.63 MiB |
| aggregate in the ClickHouse query | 156 ms | 3.02 KiB |

The docs, the example model, and the schema description all lead with this rather than leaving it to be discovered.

## Behaviour change

An env-level DuckDB connection previously had to declare at least one attached database. It now requires at least one of `attachedDatabases` or `clickhouseServers`, and the error message names both. Two existing tests asserted the old wording and were updated (one in `test:unit`, one in `tests/unit/duckdb`, which is run by `test:integration`).

## Validation

Bad config fails at startup with an actionable message rather than registering a macro nobody can call:

- name is not a SQL identifier → rejected (it is interpolated into DDL)
- name is a reserved word (`primary`) → rejected, since a model calling `primary('…')` would not parse. Checked against DuckDB's own `duckdb_keywords()` so it cannot drift from the parser across upgrades.
- duplicate names → rejected instead of the last one silently winning
- missing host → rejected

## Testing

- **`clickhouse_servers.spec.ts`** (20 tests, always run) — exercises a **real in-memory DuckDB** rather than asserting on generated SQL strings, so DuckDB's parser and secret manager are the oracle. This caught a real bug during development: `primary` matched the identifier regex but failed to parse as DDL, which is what prompted the reserved-word check.
- **`clickhouse_servers.integration.spec.ts`** (5 tests, gated on `CLICKHOUSE_TEST_HOST`) — runs against a live ClickHouse: scalar round-trip, `+`/`&` survival, type mapping, server-side aggregation, and bad-password rejection.
- Full server unit suite: 3018 pass, 0 fail.
- Verified end to end through a running Publisher against ClickHouse 26.7.4 — REST query results match ClickHouse ground truth exactly.

Each unit test gets its own DuckDB database file. Malloy shares one DuckDB instance across `:memory:` connections whose config hashes match, so with `:memory:` the absence assertions passed alone and failed in the full suite as other spec files leaked macros and secrets in.

## Docs & example

- `docs/clickhouse.md` — config, the aggregate-server-side rule with the measurements, the ClickHouse→DuckDB type mapping, and the `DateTime` timezone gotcha.
- `examples/clickhouse/` — runnable package with a `docker-compose.yml` that seeds 50k rows, and two sources contrasting the pre-aggregated shape against the row-grain shape. Not in the default environment, since it needs a running ClickHouse.
- `docs/connections.md` updated — it stated that attached databases were the only configuration available and that one was required. Both are now false.

## Notes for review

- **The macro argument is trusted input.** It is the model author's SQL, forwarded verbatim; Publisher does not parse or rewrite it. The intended posture is a read-only ClickHouse user granted only the tables you mean to expose, which the docs say.
- `httpfs` is already baked into the Publisher image (8/8 extensions), so this works under `EXTENSION_FETCH_POLICY=local-only`.
- Read path only; no writes.
- The generated API clients are gitignored, so `api-doc.yaml` is the only tracked source for the new schema.
