### PR TITLE
docs(skills): tell agents how malloy-config.json must be set for local data

### DIFF
--- a/skills/malloy-debug/SKILL.md
+++ b/skills/malloy-debug/SKILL.md
@@ -33,6 +33,7 @@ description: Fix Malloy compile errors and understand error messages. Use when e
 | "Aggregate not allowed in where" | Use `having:` instead |
 | 20+ random errors | Backtick reserved word (`` `Date` ``, `` `Hour` ``, `` `number` ``) |
 | `Can't find field 'X' to set access modifier` | An `include {}` sits before the `extend { rename: }`. Rename first, then `include {}` naming the field by its new name (see `skill:malloy-gotchas-modeling` § Field Management) |
+| `IO Error: No files found that match the pattern "data/x.csv"` | Data-file path, not the model. Relative `duckdb.table()` paths resolve against the DuckDB `workingDirectory`; Publisher sets it to the package root, but a relative `workingDirectory` in `malloy-config.json` resolves against the process cwd. Make it absolute (see `skill:malloy-gotchas-modeling` § Relative Data-File Paths). The "not defined" errors under it are cascade, not real |
 | Import path errors | Check paths: `import "orders.malloy"`. All files should be in the same directory (flat layout) |
 | `from()` errors | Verify the source query returns the expected columns, check that imported sources are defined |
 | "Cannot redefine 'X'" | Field already exists from query-based source (`-> { group_by, aggregate }`). Remove the dimension, add only NEW derived fields in `extend {}`. Use `include {}` to add `#(doc)` tags to existing fields. |

--- a/skills/malloy-getting-started/SKILL.md
+++ b/skills/malloy-getting-started/SKILL.md
@@ -24,6 +24,56 @@ Two escape hatches worth knowing:
 
 When a user is present, do not route around it by calling the REST API with curl. It appears to work, so the user never learns their session is missing the tools, and you lose what they are for: grounded discovery instead of guessed names, `malloy_compile` instead of throwaway queries, and `malloy_reloadPackage` instead of a restart. Say the tools are missing and let the user fix it in five seconds. Running unattended, with nobody who can reconnect you, is different: there the REST API is the supported interface, not a workaround. Discovery, query, compile, and reload all have REST equivalents (`malloy_searchDocs` and `malloy_getContext`'s plain-English ranking do not; read the bundled skills for syntax and ground from model metadata instead); the running server serves the full spec at `http://localhost:4000/api-doc.yaml`, and AGENTS.md carries the endpoint map.
 
+## 0.5 Ask whether they also use the CLI or the VS Code extension
+
+Publisher is often not the only thing reading the model. The Malloy CLI (`malloy-cli`) and the VS
+Code extension compile the same files, and they do **not** get their connections from
+`publisher.config.json` - they read `malloy-config.json`, found by walking up from the file being
+compiled. So a package that Publisher serves correctly can fail to compile in the editor, on the
+same machine, from the same files.
+
+Ask before the user finds out the hard way:
+
+> Are you also using the Malloy CLI or the VS Code extension on this package?
+
+If yes, and the package reads **local data files**, it needs a `malloy-config.json`. Publisher
+resolves a relative `duckdb.table('data/x.csv')` against the package root on its own, so nothing is
+configured for it; the other two hosts resolve it against the DuckDB connection's
+`workingDirectory`, which has to be set.
+
+**Make that path absolute.** A relative `workingDirectory` is resolved against the process's current
+directory, not the config file's directory and not the VS Code workspace root, so the same config
+compiles from one directory and fails from another:
+
+```json
+// malloy-config.json, beside the model
+{
+  "connections": {
+    "duckdb": {
+      "is": "duckdb",
+      "workingDirectory": "/abs/path/to/package",
+      "securityPolicy": "none"
+    }
+  }
+}
+```
+
+Point it at the directory the model's table paths are written relative to - the one holding `data/`.
+Leave the model's own paths relative so Publisher still serves it; only the config carries the
+absolute path. When this is wrong the editor reports `IO Error: No files found that match the
+pattern "data/x.csv"` on the `source:` line, followed by a "not defined" error for every field of
+that source; those are cascade, not real. `skill:malloy-gotchas-modeling` § Relative Data-File Paths
+has the mechanism.
+
+**Remote Credible connections are a different case.** With the Credible extension running and signed
+in, the data is reached through a `publisher` proxy connection - the connection type that forwards
+SQL to a remote Publisher dataplane, and the same type the CLI and the VS Code extensions use - and
+the extension supplies it, so there is nothing to hand-write and no `workingDirectory` involved.
+`workingDirectory` only ever matters for local files that DuckDB opens itself. Worth knowing: those
+access tokens are user-scoped and short-lived, and nothing refreshes them mid-session, so queries
+that start failing auth after a long session mean the token expired, not that the model broke. See
+`docs/connections.md` § Publisher proxy connections.
+
 ## 1. Discover what exists (never guess names)
 
 `malloy_getContext` is progressive. Call it with as much as you know:

--- a/skills/malloy-gotchas-modeling/SKILL.md
+++ b/skills/malloy-gotchas-modeling/SKILL.md
@@ -277,6 +277,46 @@ source: facts is conn.table('orders') -> { group_by: user_id, aggregate: total i
 
 If a project's standards file specifies a stricter policy (e.g., a `search_malloy_docs` rationale comment requirement above every `conn.sql()` block), defer to that.
 
+## Relative Data-File Paths: Set an Absolute `workingDirectory`
+
+`duckdb.table('data/x.csv')` is resolved against the DuckDB connection's `workingDirectory`, not
+against the model file. Publisher sets that to the package root, so relative paths work there with
+no config at all. Every other host reads it from `malloy-config.json`, and **a relative value there
+is resolved against the process's current directory** - not the config file's directory, and not the
+VS Code workspace root. `canonicalizeConfigPath` in `malloy-db-duckdb/src/duckdb_config.ts` calls
+`canonicalizePath` with no `baseDirectory`, which is a bare `path.resolve(input)`.
+
+So the same config works or fails depending on which directory the editor or shell was launched
+from. That is why this breaks intermittently and appears to be a model bug.
+
+```json
+// WRONG: resolved against the process cwd, so it works from the repo root and
+// fails from anywhere else - including however your editor happened to launch
+{"connections": {"duckdb": {"is": "duckdb", "workingDirectory": "malloy"}}}
+
+// RIGHT: absolute, so the cwd cannot change the answer
+{"connections": {"duckdb": {"is": "duckdb", "workingDirectory": "/abs/path/to/pkg"}}}
+```
+
+Point it at the directory the model's table paths are written relative to - the package root, the
+one holding `data/`. Keep the model's paths relative (`data/x.csv`) so Publisher still serves it;
+only the config carries the absolute path.
+
+**The symptom, and the cascade.** One `IO Error` at the `source:` line, then a "not defined" error
+for every field of that source:
+
+```
+line 87: IO Error: No files found that match the pattern "data/product_usage.csv"
+line 91: 'org_slug' is not defined
+line 93: Reference to undefined value active_users
+```
+
+Those field errors are not real. Fix the first error and they all go. Do not start renaming
+columns.
+
+**Check the config before the model** when a source that Publisher queries fine fails in the editor
+or CLI with a missing-file error. The model is the same file; the resolution base is not.
+
 ## JSON Files: Read Them In Place Like CSV
 
 ```malloy


### PR DESCRIPTION
## The problem

A package Publisher serves correctly can fail to compile in the VS Code extension or the Malloy CLI, on the same machine, from the same files. Nothing in the skills said why, so an agent hitting it reads the cascade of `'org_slug' is not defined` errors and starts editing the model.

Two things combine:

1. **Different resolution base.** Publisher resolves a relative `duckdb.table('data/x.csv')` against the package root on its own. The CLI and the extension resolve it against the DuckDB connection's `workingDirectory`, read from `malloy-config.json` - a file no skill mentioned.
2. **A relative `workingDirectory` resolves against the process cwd.** `canonicalizeConfigPath` (`malloy-db-duckdb/src/duckdb_config.ts`) calls `canonicalizePath` with no `baseDirectory`, so it is a bare `path.resolve(input)`. Not the config file's directory, and not the VS Code workspace root.

So the same config compiles from one directory and fails from another. That is what makes this feel intermittent, and what makes it look like a model bug rather than a config one.

## Verified, not inferred

`malloy-cli` reads the same `malloy-config.json` the extension does, which makes it a real oracle. Against a package with the model in `pkg/` and data in `pkg/data/`:

| `workingDirectory` | cwd | result |
|---|---|---|
| `"malloy"` (relative) | repo root | compiles, returns rows |
| `"malloy"` (relative) | `/tmp` | `IO Error: No files found that match the pattern "data/product_usage.csv"`, then one "not defined" error per field |
| absolute | `/tmp` | compiles, returns rows |

The middle row is the reported symptom, reproduced.

## The change

Three files, one concept, no definition duplicated - the mechanism lives in one place and the other two point at it.

- **`malloy-getting-started`** gains a setup step that has the agent **ask** whether the CLI or the VS Code extension is also in use, then gives the config to write. Setup-time prevention, which is the only point where this is cheap.
- **`malloy-gotchas-modeling`** carries the mechanism, beside the existing read-a-file-in-place sections, because that is the file an agent reads before writing `duckdb.table(...)`.
- **`malloy-debug`** gets one quick-fix row mapping the error to the fix, and states that the field errors beneath it are cascade - so nobody starts renaming columns.

It also records what is **not** this case: a remote Credible connection arrives as a `publisher` proxy connection that the extension supplies, where no `workingDirectory` applies at all. Since that came up in the same breath, the note also mentions the documented token caveat - user-scoped, short-lived, unrefreshed - so auth failures late in a long session are not misread as a broken model.

## Notes for the reviewer

- Docs only. No code, no frontmatter, no `reference/` files, so `test:skills` (frontmatter stamping, name-matches-directory, reference shipping) is untouched.
- Dash style matches the three files, which use ` - ` and no em-dashes.
- The recommendation is "make it absolute" rather than teaching a relative form, because there is no relative form that survives a cwd change. If there is a host-injected `rootDirectory` default meant to cover this (`src/common/connections/CONTEXT.md` mentions `workingDirectory: {default: {config: 'rootDirectory'}}`), then the better fix is in the extension and this doc should say so instead - happy to change tack.