### PR TITLE
fix(create-malloy-package): unblock the scaffolder's publish, and the race that made it unfixable

### DIFF
--- a/.claude/skills/publisher-release/SKILL.md
+++ b/.claude/skills/publisher-release/SKILL.md
@@ -204,6 +204,31 @@ Any output there means bump `packages/skills/package.json`. Same shape for the
 scaffolder. This must be **merged to `main` before the dispatch**: the release
 reads `main`, not the release branch.
 
+#### The scaffolder also pins a server version, and it is checked
+
+`create-malloy-package` hard-pins the server its generated workspaces run
+(`SERVER_VERSION` in `packages/create-malloy-package/src/scaffold.ts`), and its
+publish workflow **refuses to ship unless that pin equals npm's `latest`**. A
+stale pin is therefore not a cosmetic lag; it fails the publish 25 minutes into a
+release, after `skills` has already gone out:
+
+```bash
+sed -n 's/^export const SERVER_VERSION = "\(.*\)";$/\1/p' \
+  packages/create-malloy-package/src/scaffold.ts
+npm view @malloy-publisher/server version
+```
+
+Set the pin to **the version this release is about to publish**, in the same
+pre-release PR, and confirm that version still honours `--host` (the guard's own
+instruction — check `--host` is still parsed in `packages/server/src/server.ts`).
+
+This works only because `publish-packages` waits for `publish-npm`. It did not
+until 0.0.250, and the two orderings made the pin unsatisfiable: the guard ran
+before the server reached npm, so pinning the outgoing version failed against a
+`latest` one release behind, and pinning the previous version failed once npm
+caught up. If that `needs:` is ever narrowed back to `prepare` alone, the
+scaffolder stops being publishable alongside a server bump at all.
+
 Do not skip the equality check and read the log alone. Anchored at the commit
 that set npm's version, the log still reports a bump that has already merged,
 and "any output means bump" then walks the version a second time for nothing.

--- a/.github/workflows/CONTEXT.md
+++ b/.github/workflows/CONTEXT.md
@@ -241,6 +241,20 @@ Read that summary rather than the run's green tick if you expected a publish.
    `gh-release` skips prereleases for the same reason. Publish these from an ordinary release, or
    dispatch their workflows on `main` directly.
 
+Those two are skips. The scaffolder has a third failure that is not a skip but a hard red, and it
+costs a full poll budget to discover: **`create-malloy-package` refuses to publish unless the
+`SERVER_VERSION` it pins in `src/scaffold.ts` equals `@malloy-publisher/server`'s npm `latest`.** The
+guard is deliberate — a scaffolder published ahead of its pinned server generates workspaces whose
+`npm start` cannot resolve — but nothing bumps that pin automatically, so a release that forgets it
+fails 25 minutes in, *after* `skills` has already published. Set the pin to the version the release is
+about to publish, in the pre-release PR.
+
+That only became possible in 0.0.250, when `publish-packages` gained `needs: publish-npm`. Before it,
+this job raced the server publish, and both pins failed: the outgoing version against an npm still a
+release behind, the previous one once npm caught up. 0.0.250 is the worked example — the guard ran at
+15:07:55 against a `latest` that did not become 0.0.250 until 15:09:13. Narrowing that `needs:` back
+to `prepare` alone re-breaks it.
+
 sdk/app/server are not re-runnable at the same version today. `prepare` walks the version forward
 whenever a release branch or tag exists, so a release that fails after `npm-sdk.yml` has published
 cannot be resumed and the retry burns three new versions. npm versions are immutable, so there is no

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,7 +227,19 @@ jobs:
     # publish anything. This job reads prepare's version solely for the
     # prerelease check below, and deliberately checks out main rather than the
     # release branch (see the checkout below).
-    needs: prepare
+    #
+    # `publish-npm` is in here for create-malloy-package's sake, and dropping it
+    # silently breaks that package's release. Its publish workflow refuses to
+    # ship unless the SERVER_VERSION it pins equals @malloy-publisher/server's
+    # npm `latest` — and on `needs: prepare` alone this job races publish-npm, so
+    # in 0.0.250 the scaffolder's guard ran at 15:07:55 against a `latest` that
+    # did not become 0.0.250 until 15:09:13. That is unwinnable rather than
+    # unlucky: pin the outgoing version and the guard fails because npm is still
+    # a release behind; pin the previous one and it fails once npm catches up. So
+    # the scaffolder could never publish in a release that bumped the server.
+    # Waiting for npm costs this job the few minutes publish-npm takes, against
+    # its own 25m-per-package poll budget.
+    needs: [ prepare, publish-npm ]
     runs-on: ubuntu-latest
     # Two full poll budgets (25m each, below) plus checkout and setup, with
     # margin. Keep this above 2 x POLL_BUDGET_SECONDS or a second package timing

--- a/packages/create-malloy-package/src/scaffold.spec.ts
+++ b/packages/create-malloy-package/src/scaffold.spec.ts
@@ -747,7 +747,8 @@ describe("scaffold: unservable workspace path", () => {
       // Not a DuckDB constraint, and not a cosmetic one: assertSafeEnvironmentPath
       // in the server's path_safety.ts tests an environment path against
       // /^(?:\/|[A-Za-z]:[\\/])[\x20-\x7E]*$/, so a package under a non-ASCII
-      // path never mounts. Measured against 0.0.244: the server answers
+      // path never mounts. Measured against 0.0.244 and still the same regex in
+      // 0.0.250, which is what SERVER_VERSION now pins: the server answers
       // `serving` with environments [], /environments/default/packages 400s,
       // and the only explanation is in status.loadErrors. Refusing here, before
       // anything is written, is what turns that into a message.

--- a/packages/create-malloy-package/src/scaffold.ts
+++ b/packages/create-malloy-package/src/scaffold.ts
@@ -279,7 +279,7 @@ const BIND_HOST = "127.0.0.1";
  * and confirm the new version still honours --host. A generated workspace can
  * move itself off it by editing the scripts in its own package.json.
  */
-export const SERVER_VERSION = "0.0.244";
+export const SERVER_VERSION = "0.0.250";
 
 function startCommandFor(envName: string): string {
    return (
@@ -379,7 +379,8 @@ function withAlternatePorts(command: string, viaNpmScript: boolean): string {
  * nothing. The server reports `serving` with the environment missing and names
  * the reason only in /api/v0/status loadErrors, so refusing here — before
  * anything is written — is the difference between a clear message and a
- * workspace that looks scaffolded and serves nothing. Measured against 0.0.244.
+ * workspace that looks scaffolded and serves nothing. Measured against 0.0.244,
+ * and `SAFE_ENVIRONMENT_PATH_RE` is unchanged in 0.0.250.
  *
  * Below U+0020 and DEL are refused for the separate reason that they corrupt
  * the shell commands and agent-briefing text this tool prints verbatim; being


### PR DESCRIPTION
0.0.250 published sdk/app/server, skills, Docker and its release page — then `publish-packages` went red. The scaffolder's own guard refused it:

```
SERVER_VERSION is 0.0.244 but @malloy-publisher/server latest is 0.0.250.
```

That pin is bumped by hand and nothing else validates it, so the release-prep PR simply missed it.

## Bumping it isn't the whole fix, because the pin was unsatisfiable

`publish-packages` needed only `prepare`, so it raced `publish-npm` — while the guard requires the pin to equal npm's `latest`:

- pin the **outgoing** version → fails, npm is still a release behind
- pin the **previous** version → fails once npm catches up

0.0.250 has the timestamps:

| Event | Time |
| --- | --- |
| Scaffolder guard ran | **15:07:55** |
| `server@0.0.250` reached npm | **15:09:13** |

So the scaffolder could not publish in *any* release that bumped the server. The two successful publishes before this won that race with a stale-but-still-`latest` pin.

## What's here

- **`SERVER_VERSION` 0.0.244 → 0.0.250.** Verified against the `v0.0.250` tag exactly what the guard's message asks: `--host` is still parsed (`server.ts:112`) and still documented (`:157`), and `SAFE_ENVIRONMENT_PATH_RE` is unchanged — which is what the two "measured against 0.0.244" notes rest on. Both notes now say they were re-checked, rather than being left to imply a measurement against a version the pin no longer names.
- **`publish-packages` gains `needs: publish-npm`**, so it's dispatched only once the server is actually on npm and a pin naming the outgoing version is satisfiable. Costs this job the few minutes `publish-npm` takes, against its own 25m-per-package poll budget. The comment explains why, because narrowing it back silently re-breaks the scaffolder.
- **The release skill's step 2 now checks the pin against npm** before dispatch. This cost 25 minutes to discover at release time, *after* `skills` had already published — the worst possible place to learn it.
- **`CONTEXT.md` records it** as a third failure mode alongside the two documented skips: not a skip but a hard red, and the only one that burns a full poll budget.

## Recovery for 0.0.250

The documented path, and explicitly **not** re-running the release (that walks the version forward and burns three npm versions): merge this, then dispatch `create-malloy-package-npm.yml` on `main`. Version `0.0.8` is still unpublished, so it goes out clean.

### Tested

- **The guard's own check, computed exactly as the workflow does it** (same `sed`, same `npm view | tail -n 1`): `0.0.250 == 0.0.250`, passes.
- Scaffolder suite: **389 pass**.
- `actionlint` unchanged at the baseline 9 pre-existing findings; `prettier` clean.
- One e2e case (`the MCP endpoint lists the malloy tools`) fails identically on unmodified `main` on macOS and is unaffected by this change — it's the Linux-only e2e suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)