### PR TITLE
docs: stamp the release notes shipped in 0.0.250

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,7 +31,7 @@ One behaviour change to know about: `skills-npm.yml` now publishes only from `ma
 
 ---
 
-## [Unreleased] — opt-in request rate limiting
+## [0.0.250] — opt-in request rate limiting
 
 The REST server can now cap how many requests one client makes per minute: set `PUBLISHER_RATE_LIMIT=<n>` and the `n+1`th request in a minute from the same peer address gets a `429` with standard `RateLimit-*` headers. It is off unless set, so nothing changes for an existing deployment. Health probes and `/metrics` are exempt, and the MCP port is not covered. Behind a reverse proxy every client arrives from the proxy's address and would share one bucket, so rate-limit at the proxy in that deployment instead. See [docs/configuration.md](docs/configuration.md).
 
@@ -231,7 +231,7 @@ A `storage=` build reads its source through DuckDB's native query-passthrough, w
 
 ---
 
-## [Unreleased]: an incremental refresh can advance a `storage=` table
+## [0.0.250]: an incremental refresh can advance a `storage=` table
 
 `refresh="incremental"` alongside `storage=` was a publish rejection. It is now supported, with the
 same declarations and the same guarantees as a colocated incremental source: the table is advanced by


### PR DESCRIPTION
Opened from the branch `gh-release` pushed during the 0.0.250 release — the flow #1056 introduced, on its first live run. The job summary printed the compare link and this is it.

Both sections are on [the 0.0.250 release page](https://github.com/malloydata/publisher/releases/tag/v0.0.250); this restamps their headings so the **next** release doesn't re-append them to its own page.

- `opt-in request rate limiting`
- `an incremental refresh can advance a storage= table`

Two lines, `[Unreleased]` → `[0.0.250]`, and nothing else.

Worth noting the mechanism worked exactly as designed: the release stopped at pushing the branch rather than opening this itself, so the checks below actually run and any maintainer can merge — where a bot-authored PR would have left them at `expected` with an admin as the only possible merger. Which is also the failure this replaced: 0.0.249 put all six of its sections on its release page and stamped none of them, because the step still pushed straight to a protected `main` and was rejected with `GH006` every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)