### PR TITLE
feat(server): BigQuery per-connection service-account impersonation via Malloy's authClient overlay

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -4366,7 +4366,12 @@ components:
             actually changes; consumers should treat it as an opaque token and
             use the supplied value verbatim rather than deriving their own. This
             field is optional — when omitted, a connection identity is derived
-            locally instead.
+            locally instead. Because the fingerprint replaces the derived digest
+            verbatim, it must vary with anything that changes which data the
+            connection can reach — including the impersonated identity: two
+            environments on the same project with different
+            impersonateServiceAccount values but the same fingerprint would
+            share persisted-table ids.
         queryMetadata:
           $ref: "#/components/schemas/QueryMetadata"
           description: >-
@@ -4730,6 +4735,19 @@ components:
         serviceAccountKeyJson:
           type: string
           description: JSON string containing Google Cloud service account credentials
+        impersonateServiceAccount:
+          type: string
+          description: >-
+            Email of a Google Cloud service account this connection impersonates
+            for every BigQuery call, via short-lived tokens from the IAM Service
+            Account Credentials API. The publisher's own credential (ADC) must
+            hold roles/iam.serviceAccountTokenCreator on the target service
+            account, and iamcredentials.googleapis.com must be enabled in the
+            calling project. Mutually exclusive with serviceAccountKeyJson; set
+            billingProjectId explicitly, since project auto-detection resolves
+            through the impersonated credential. Not supported on DuckDB
+            attachedDatabases entries or federated builds from a BigQuery
+            source through DuckDB, which require a service account key.
         maximumBytesBilled:
           type: string
           description: Maximum bytes to bill for query execution (prevents runaway costs)

--- a/bun.lock
+++ b/bun.lock
@@ -209,6 +209,7 @@
         "express-rate-limit": "^8",
         "extract-zip": "^2.0.1",
         "globals": "^15.9.0",
+        "google-auth-library": "^9.15.1",
         "handlebars": "^4.7.8",
         "http-proxy-middleware": "^3.0.5",
         "lunr": "^2.3.6",

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -13,6 +13,56 @@ Publisher uses **connections** to reach databases and query engines. Connections
 
 For full setup details per connection type, see [docs.malloydata.dev/documentation/user_guides/publishing/connections](https://docs.malloydata.dev/documentation/user_guides/publishing/connections).
 
+## BigQuery service-account impersonation
+
+A BigQuery connection can run as a dedicated service account without holding any key
+material, by naming the account to impersonate:
+
+```json
+{
+  "name": "bigquery",
+  "type": "bigquery",
+  "bigqueryConnection": {
+    "defaultProjectId": "tenant-project",
+    "billingProjectId": "tenant-project",
+    "impersonateServiceAccount": "sa-viewer@tenant-project.iam.gserviceaccount.com"
+  }
+}
+```
+
+Every BigQuery call the connection makes — query execution **and** schema discovery
+(`/schemas`, `/tables`, `malloy_searchDatabaseSchema`) — then runs as that account, using
+short-lived tokens minted through the IAM Service Account Credentials API. Publisher's own
+credential (ambient ADC) is only the token minter, so in a multi-environment deployment each
+environment can be pinned to an identity that can read only its own data: cross-environment
+access fails at the IAM layer regardless of what the compiled query asks for, per-environment
+access is revocable with a single IAM binding, and BigQuery Cloud Audit Logs record both
+identities (`serviceAccountDelegationInfo`).
+
+Operator prerequisites:
+
+- `iamcredentials.googleapis.com` enabled in the project Publisher's credential belongs to.
+- Publisher's credential granted `roles/iam.serviceAccountTokenCreator` **on each target
+  service account** (a resource-level grant — no project-wide role needed).
+- The target account holds the data-access roles (e.g. `roles/bigquery.dataViewer` plus
+  `roles/bigquery.jobUser` in its project).
+
+Constraints:
+
+- Mutually exclusive with `serviceAccountKeyJson` — an auth client replaces the credential
+  entirely, so a key alongside it would be silently ignored; Publisher rejects the
+  combination at config load.
+- `billingProjectId` is required: with an impersonated credential the SDK resolves the
+  project through that credential, so the project that runs (and is billed for) jobs must be
+  named explicitly.
+- Not supported on DuckDB `attachedDatabases` entries or on federated materialization builds
+  that read a BigQuery source through DuckDB — DuckDB's `BIGQUERY` secret authenticates with
+  a service account key, not a token. Both cases are rejected with an explicit error.
+- If you also set the connection-level `fingerprint`, make it vary with the impersonated
+  identity: the fingerprint replaces the derived connection digest verbatim, and the derived
+  digest already incorporates the impersonation reference precisely so that two environments
+  with different identities never share persisted-table ids.
+
 ## Per-package DuckDB sandboxes
 
 Each loaded package automatically gets its own DuckDB connection named `duckdb`. These per-package sandboxes are how the bundled examples (`storefront`, `governed-analytics`, `html-data-app`) query the data files in each package without needing any user-defined connection. DuckDB reads Parquet, CSV, and Excel files in place, so `duckdb.table('data/customers.parquet')`, `duckdb.table('data/regions.csv')`, and `duckdb.table('data/budget.xlsx')` all work with no conversion step (`storefront` uses the first two). To select a sheet or pass other `read_xlsx` options, use a SQL source instead: `duckdb.sql("SELECT * FROM read_xlsx('data/budget.xlsx', sheet = 'Q2')")`.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -73,6 +73,7 @@
       "express-rate-limit": "^8",
       "extract-zip": "^2.0.1",
       "globals": "^15.9.0",
+      "google-auth-library": "^9.15.1",
       "handlebars": "^4.7.8",
       "http-proxy-middleware": "^3.0.5",
       "lunr": "^2.3.6",

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -56,6 +56,7 @@ import {
    EnvironmentConnectionMetadata,
    normalizeSnowflakePrivateKey,
 } from "./connection_config";
+import { gcpImpersonationOverlay } from "./gcp_impersonation";
 import { CloudStorageCredentials } from "./gcs_s3_utils";
 import { openProxy, type ProxyEndpoint } from "./proxy";
 import { quoteIdentifier } from "./quoting";
@@ -843,6 +844,20 @@ async function federateBigQuery(
       );
    }
 
+   // Config-load validation rejects impersonateServiceAccount on attached
+   // databases, but a materialization build federating from a BigQuery SOURCE
+   // connection arrives here with that connection's own config — which may
+   // legitimately carry impersonation for the serve path. The DuckDB BIGQUERY
+   // secret takes a key, not a token, so name the limitation instead of
+   // falling through to the generic "service account key required".
+   if (bq.impersonateServiceAccount) {
+      throw new Error(
+         `BigQuery connection '${config.name}' uses impersonateServiceAccount, ` +
+            `which cannot federate through DuckDB: the DuckDB BIGQUERY secret ` +
+            `authenticates with a service account key, not a token. Federated ` +
+            `builds from this source require serviceAccountKeyJson.`,
+      );
+   }
    let projectId = bq.defaultProjectId;
    let serviceAccountJson: string | undefined;
    if (bq.serviceAccountKeyJson) {
@@ -1812,6 +1827,11 @@ export function buildEnvironmentMalloyConfig(
 
    const malloyConfig = new MalloyConfig(assembled.pojo, {
       config: contextOverlay({ rootDirectory: environmentPath }),
+      // Resolves `authClient: {gcpImpersonation: "<sa-email>"}` references on
+      // bigquery connections to live Impersonated clients (see
+      // gcp_impersonation.ts). Registered unconditionally: the overlay is only
+      // consulted when a connection actually carries the reference.
+      gcpImpersonation: gcpImpersonationOverlay(),
    });
 
    async function attachOnce(

--- a/packages/server/src/service/connection_config.spec.ts
+++ b/packages/server/src/service/connection_config.spec.ts
@@ -801,3 +801,94 @@ describe("ducklake shape validation", () => {
       }
    });
 });
+
+describe("assembleEnvironmentConnections — bigquery impersonation", () => {
+   const impersonated: ApiConnection = {
+      name: "bigquery",
+      type: "bigquery",
+      bigqueryConnection: {
+         defaultProjectId: "tenant-project",
+         billingProjectId: "tenant-project",
+         impersonateServiceAccount:
+            "sa-viewer@tenant-project.iam.gserviceaccount.com",
+      },
+   };
+
+   it("emits an authClient overlay reference and no key material", () => {
+      const { pojo } = assembleEnvironmentConnections([impersonated]);
+      const entry = pojo.connections["bigquery"];
+      expect(entry.is).toBe("bigquery");
+      expect(entry.authClient).toEqual({
+         gcpImpersonation: "sa-viewer@tenant-project.iam.gserviceaccount.com",
+      });
+      expect(entry.serviceAccountKey).toBeUndefined();
+      expect(entry.projectId).toBe("tenant-project");
+      expect(entry.billingProjectId).toBe("tenant-project");
+   });
+
+   it("emits no authClient when impersonation is not configured", () => {
+      const plain: ApiConnection = {
+         name: "bigquery",
+         type: "bigquery",
+         bigqueryConnection: { defaultProjectId: "tenant-project" },
+      };
+      const { pojo } = assembleEnvironmentConnections([plain]);
+      // The KEY must be absent, not merely undefined: authClient is
+      // mustHaveValue in core, and a present-but-undefined property fails the
+      // connection with "no value arrived".
+      expect("authClient" in pojo.connections["bigquery"]).toBe(false);
+   });
+
+   it("rejects impersonation combined with a service account key", () => {
+      const both: ApiConnection = {
+         ...impersonated,
+         bigqueryConnection: {
+            ...impersonated.bigqueryConnection,
+            serviceAccountKeyJson: JSON.stringify({
+               type: "service_account",
+               project_id: "tenant-project",
+            }),
+         },
+      };
+      expect(() => assembleEnvironmentConnections([both])).toThrow(
+         /impersonateServiceAccount and serviceAccountKeyJson/,
+      );
+   });
+
+   it("rejects impersonation without an explicit billingProjectId", () => {
+      const noBilling: ApiConnection = {
+         ...impersonated,
+         bigqueryConnection: {
+            defaultProjectId: "tenant-project",
+            impersonateServiceAccount:
+               "sa-viewer@tenant-project.iam.gserviceaccount.com",
+         },
+      };
+      expect(() => assembleEnvironmentConnections([noBilling])).toThrow(
+         /no billingProjectId/,
+      );
+   });
+
+   it("rejects impersonation on a DuckDB attached database", () => {
+      const duckdb: ApiConnection = {
+         name: "duck",
+         type: "duckdb",
+         duckdbConnection: {
+            attachedDatabases: [
+               {
+                  name: "bq_attached",
+                  type: "bigquery",
+                  bigqueryConnection: {
+                     defaultProjectId: "tenant-project",
+                     impersonateServiceAccount:
+                        "sa-viewer@tenant-project.iam.gserviceaccount.com",
+                  },
+               },
+            ],
+         },
+      };
+      expect(() => assembleEnvironmentConnections([duckdb])).toThrow(
+         /not supported on attached databases/,
+      );
+   });
+});

--- a/packages/server/src/service/connection_config.ts
+++ b/packages/server/src/service/connection_config.ts
@@ -467,8 +467,38 @@ function validateConnectionShape(connection: ApiConnection): void {
    switch (connection.type) {
       case "postgres":
       case "mysql":
-      case "bigquery":
          break;
+      case "bigquery": {
+         const bigquery = connection.bigqueryConnection;
+         if (bigquery?.impersonateServiceAccount) {
+            // An authClient replaces the credential entirely in the SDK, so a
+            // key alongside it would sit there looking live while the
+            // impersonated identity executes every query. Core refuses the
+            // combination at construction too; refusing here surfaces it as a
+            // config error at load instead of a connection error at first use.
+            if (bigquery.serviceAccountKeyJson) {
+               throw new Error(
+                  `Connection '${connection.name}' sets impersonateServiceAccount ` +
+                     `and serviceAccountKeyJson. Impersonation replaces the ` +
+                     `credential entirely — the key would be ignored — so supply ` +
+                     `one or the other.`,
+               );
+            }
+            // With an authClient the SDK resolves the project id through the
+            // impersonated credential, not ambient ADC, so auto-detection is
+            // not a meaningful fallback for the job project. Require it named.
+            if (!bigquery.billingProjectId) {
+               throw new Error(
+                  `Connection '${connection.name}' sets impersonateServiceAccount ` +
+                     `but no billingProjectId. Impersonated connections resolve ` +
+                     `the project through the impersonated credential, so the ` +
+                     `project that runs (and is billed for) jobs must be named ` +
+                     `explicitly.`,
+               );
+            }
+         }
+         break;
+      }
       case "duckdb":
          if (!connection.duckdbConnection) {
             throw new Error("DuckDB connection configuration is missing.");
@@ -476,6 +506,27 @@ function validateConnectionShape(connection: ApiConnection): void {
          {
             const attached =
                connection.duckdbConnection.attachedDatabases ?? [];
+            // AttachedDatabase reuses the BigqueryConnection schema, but the
+            // ATTACH path builds a DuckDB BIGQUERY secret from key JSON — the
+            // DuckDB extension takes a key, not a token — so an impersonation
+            // request here would be accepted and silently ignored. Refuse it
+            // with the limitation named, rather than the generic "service
+            // account key required" it would otherwise hit later.
+            for (const attachedDb of attached) {
+               if (
+                  attachedDb.type === "bigquery" &&
+                  attachedDb.bigqueryConnection?.impersonateServiceAccount
+               ) {
+                  throw new Error(
+                     `Attached database '${attachedDb.name}' on DuckDB connection ` +
+                        `'${connection.name}' sets impersonateServiceAccount, which ` +
+                        `is not supported on attached databases: DuckDB's BIGQUERY ` +
+                        `secret authenticates with a service account key, not a ` +
+                        `token. Use serviceAccountKeyJson for attached BigQuery ` +
+                        `databases.`,
+                  );
+               }
+            }
             if (attached.length === 0) {
                throw new Error(
                   `DuckDB connection "${connection.name}" has no attached databases. Add at least one foreign database (BigQuery, Snowflake, Postgres, GCS, S3, Azure) to attachedDatabases, or remove this connection entirely — each package already gets a per-package DuckDB sandbox named "duckdb" automatically.`,
@@ -999,12 +1050,34 @@ export function assembleEnvironmentConnections(
                   | string
                   | undefined,
             );
+            // Impersonation rides the config-overlay mechanism: the pojo
+            // carries a plain-JSON reference, and buildEnvironmentMalloyConfig
+            // registers the `gcpImpersonation` overlay that resolves it to a
+            // live Impersonated auth client. The property is opaque +
+            // overlay-sourced + mustHaveValue on the bigquery type, so a
+            // literal can never satisfy it and an unresolved reference errors
+            // instead of falling back to ambient ADC. The raw reference (which
+            // embeds the SA email) is also what core folds into the connection
+            // digest, giving per-identity BuildIDs.
+            const impersonateServiceAccount =
+               connection.bigqueryConnection?.impersonateServiceAccount;
             pojo.connections[connection.name] = {
                is: "bigquery",
                projectId:
                   connection.bigqueryConnection?.defaultProjectId ??
                   serviceAccountKey?.environment_id,
                serviceAccountKey,
+               // Spread rather than `authClient: x ?? undefined`: the property
+               // is mustHaveValue, and core keys off the property being SET —
+               // an `authClient: undefined` entry still counts as set and
+               // fails every plain connection with "no value arrived".
+               ...(impersonateServiceAccount
+                  ? {
+                       authClient: {
+                          gcpImpersonation: impersonateServiceAccount,
+                       },
+                    }
+                  : {}),
                location: connection.bigqueryConnection?.location,
                maximumBytesBilled:
                   connection.bigqueryConnection?.maximumBytesBilled,

--- a/packages/server/src/service/db_utils.ts
+++ b/packages/server/src/service/db_utils.ts
@@ -4,6 +4,7 @@
 import { ClientSecretCredential } from "@azure/identity";
 import { ContainerClient } from "@azure/storage-blob";
 import { BigQuery } from "@google-cloud/bigquery";
+import { Impersonated } from "google-auth-library";
 import { Connection, TableSourceDef } from "@malloydata/malloy";
 import { components } from "../api";
 import { BadRequestError, InvalidArgumentError } from "../errors";
@@ -17,6 +18,7 @@ import {
    parseCloudUri,
    s3ConnectionToCredentials,
 } from "./gcs_s3_utils";
+import { getImpersonatedAuthClient } from "./gcp_impersonation";
 import { ApiConnection } from "./model";
 import { runIntrospectionSQL, sqlLiteral } from "./introspection_sql";
 
@@ -111,7 +113,9 @@ function groupColumnRowsIntoTables(
    return tables;
 }
 
-function createBigQueryClient(connection: ApiConnection): BigQuery {
+async function createBigQueryClient(
+   connection: ApiConnection,
+): Promise<BigQuery> {
    if (!connection.bigqueryConnection) {
       throw new Error("BigQuery connection is required");
    }
@@ -120,12 +124,26 @@ function createBigQueryClient(connection: ApiConnection): BigQuery {
       projectId: string;
       credentials?: object;
       keyFilename?: string;
+      authClient?: Impersonated;
    } = {
       projectId: connection.bigqueryConnection.defaultProjectId || "",
    };
 
-   // Add service account key if provided
-   if (connection.bigqueryConnection.serviceAccountKeyJson) {
+   // Discovery must run as the same identity as query execution. For an
+   // impersonated connection that means the shared Impersonated client from
+   // gcp_impersonation.ts — falling through to ambient ADC here would silently
+   // read schemas as the publisher's own (broad) credential, the exact
+   // identity impersonation exists to stop using.
+   if (connection.bigqueryConnection.impersonateServiceAccount) {
+      config.authClient = await getImpersonatedAuthClient(
+         connection.bigqueryConnection.impersonateServiceAccount,
+      );
+      if (!config.projectId) {
+         throw new Error(
+            "BigQuery project ID is required. Set defaultProjectId on the connection when using impersonateServiceAccount.",
+         );
+      }
+   } else if (connection.bigqueryConnection.serviceAccountKeyJson) {
       let credentials: Record<string, unknown>;
       try {
          credentials = JSON.parse(
@@ -199,7 +217,7 @@ async function getSchemasForBigQuery(
       throw new Error("BigQuery connection is required");
    }
    try {
-      const bigquery = createBigQueryClient(connection);
+      const bigquery = await createBigQueryClient(connection);
       const [datasets] = await bigquery.getDatasets();
 
       return await Promise.all(
@@ -1362,7 +1380,7 @@ async function listTablesForBigQuery(
    tableNames?: string[],
 ): Promise<ApiTable[]> {
    try {
-      const bigquery = createBigQueryClient(connection);
+      const bigquery = await createBigQueryClient(connection);
       // A 3-segment table reference ("project.dataset.table") reaches here with a
       // project-qualified schema ("project.dataset"). bigquery.dataset() takes a
       // BARE dataset id plus an optional projectId, so passing "project.dataset" as

--- a/packages/server/src/service/gcp_impersonation.ts
+++ b/packages/server/src/service/gcp_impersonation.ts
@@ -1,0 +1,108 @@
+// Copyright (c) Credible Data Inc.
+// SPDX-License-Identifier: MIT
+
+import { AuthClient, GoogleAuth, Impersonated } from "google-auth-library";
+
+/**
+ * Google Cloud service-account impersonation for BigQuery connections.
+ *
+ * A connection that sets `impersonateServiceAccount` runs every BigQuery call
+ * as that service account, using short-lived tokens minted through the IAM
+ * Service Account Credentials API (`generateAccessToken`) — no exportable key
+ * material anywhere. The publisher's own credential (ambient ADC) is only the
+ * token *minter*: it needs `roles/iam.serviceAccountTokenCreator` on each
+ * target service account, and the data-access roles live on the target instead.
+ *
+ * Two consumers share the clients built here, deliberately:
+ *  - Malloy query execution, via the `gcpImpersonation` config overlay that
+ *    `buildEnvironmentMalloyConfig` registers (the connection pojo carries
+ *    `authClient: {gcpImpersonation: "<sa-email>"}`), and
+ *  - schema discovery (`db_utils.ts` `createBigQueryClient`), which passes the
+ *    same client as `ServiceOptions.authClient` to `new BigQuery(...)`.
+ * If discovery built its own client from ADC it would silently read as the
+ * publisher's broad identity — exactly what impersonation exists to prevent.
+ */
+
+const CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
+
+/**
+ * The publisher's ambient credential, fetched once per process and shared by
+ * every impersonated connection. `GoogleAuth.getClient()` resolves ADC (a
+ * mounted credentials file, workload identity, or the metadata server); the
+ * promise is cached rather than the client so concurrent first callers share
+ * one resolution. A failed resolution is NOT cached — the next call retries —
+ * so a transient metadata-server hiccup at boot doesn't wedge the process.
+ */
+let sourceClientPromise: Promise<AuthClient> | undefined;
+
+function getSourceClient(): Promise<AuthClient> {
+   if (!sourceClientPromise) {
+      sourceClientPromise = new GoogleAuth({
+         scopes: [CLOUD_PLATFORM_SCOPE],
+      })
+         .getClient()
+         .catch((error) => {
+            sourceClientPromise = undefined;
+            throw error;
+         });
+   }
+   return sourceClientPromise;
+}
+
+/**
+ * One `Impersonated` client per target service account. The client refreshes
+ * its own short-lived tokens (default lifetime 3600s) for the process
+ * lifetime, so callers never see an expired credential, and one entry per
+ * distinct target keeps the `generateAccessToken` call volume at
+ * one-mint-per-hour per tenant rather than per query.
+ */
+const impersonatedClients = new Map<string, Promise<Impersonated>>();
+
+export async function getImpersonatedAuthClient(
+   targetPrincipal: string,
+): Promise<Impersonated> {
+   let clientPromise = impersonatedClients.get(targetPrincipal);
+   if (!clientPromise) {
+      clientPromise = getSourceClient().then(
+         (sourceClient) =>
+            new Impersonated({
+               sourceClient,
+               targetPrincipal,
+               targetScopes: [CLOUD_PLATFORM_SCOPE],
+               delegates: [],
+            }),
+      );
+      // Don't cache a failed source-credential resolution against this target.
+      clientPromise.catch(() => impersonatedClients.delete(targetPrincipal));
+      impersonatedClients.set(targetPrincipal, clientPromise);
+   }
+   return clientPromise;
+}
+
+/**
+ * The `gcpImpersonation` config overlay. A connection pojo referencing
+ * `authClient: {gcpImpersonation: "sa@project.iam.gserviceaccount.com"}`
+ * resolves through this to a live `Impersonated` client. The property is
+ * declared `opaque` + `source: 'overlay'` + `mustHaveValue` on the bigquery
+ * connection type, so the reference can only be filled by this registration —
+ * never by a config literal — and a failure to resolve errors instead of
+ * silently falling back to ambient ADC.
+ *
+ * The overlay resolver awaits async overlays, so returning the promise is
+ * fine. An empty path means a malformed reference; refuse it rather than
+ * letting `Impersonated` target `undefined`.
+ */
+export function gcpImpersonationOverlay(): (
+   path: string[],
+) => Promise<Impersonated> {
+   return (path: string[]) => {
+      const targetPrincipal = path[0];
+      if (!targetPrincipal) {
+         throw new Error(
+            "gcpImpersonation overlay reference is missing the target " +
+               "service account email.",
+         );
+      }
+      return getImpersonatedAuthClient(targetPrincipal);
+   };
+}


### PR DESCRIPTION
Implements #1055 (approved in principle there), including all three maintainer asks from the review comment. **Stacked on #1063** (the `@malloydata/*` 0.0.432 bump) — the first commit here is that PR; I'll rebase once it merges, keeping this a one-commit feature diff. Draft until then.

## What

A `BigqueryConnection` may set `impersonateServiceAccount`: every BigQuery call the connection makes then runs as that service account through short-lived IAM Credentials tokens — no key material anywhere. `authClient` rides malloy 0.0.432's overlay mechanism: the pojo carries `authClient: {gcpImpersonation: "<sa-email>"}` and the server registers the `gcpImpersonation` overlay beside `contextOverlay` in `buildEnvironmentMalloyConfig` (environment load and test-connection both flow through it).

- `gcp_impersonation.ts` (new): one ADC source client per process, one `Impersonated` client per target SA, and the overlay. `google-auth-library` added as a direct server dep.
- **Schema discovery runs as the impersonated identity** (review ask 1): `db_utils.ts` `createBigQueryClient` passes the same `Impersonated` client as `ServiceOptions.authClient`, so `malloy_searchDatabaseSchema` and the `/schemas`/`/tables` endpoints share the query identity instead of falling through to ambient ADC.
- **Load-time validation** (review ask 2), in the `connection_config.ts` per-type switch: rejects `impersonateServiceAccount` + `serviceAccountKeyJson`; rejects it without an explicit `billingProjectId` (with an auth client the SDK resolves the project through the impersonated credential); rejects it on DuckDB `attachedDatabases` entries, and `federateBigQuery` names the limitation for federated materialization builds — DuckDB's BIGQUERY secret takes a key, not a token.
- **Docs** (review ask 3): `docs/connections.md` section (operator prerequisites: `iamcredentials.googleapis.com`, resource-level `roles/iam.serviceAccountTokenCreator`; constraints), and the `fingerprint` description in `api-doc.yaml` now warns that a verbatim fingerprint must vary with the impersonated identity or environments share persisted-table ids.

One subtlety worth flagging for review: the pojo mapping spreads `authClient` in conditionally rather than assigning `authClient: x ?? undefined` — the property is `mustHaveValue`, and a present-but-`undefined` key counts as set, failing every *plain* connection with "no value arrived". There's a unit test asserting the key is absent.

## Validation

Unit: config-mapping + all three validation rejections covered in `connection_config.spec.ts`; full server suite green (3047 pass / 0 fail); `tsc --noEmit` and eslint clean.

Live (multi-tenant deployment, Docker image from this branch): an impersonated environment compiled (schema fetched as the impersonated SA), queried, and its BigQuery jobs appear in Cloud Audit Logs as the impersonated principal with `serviceAccountDelegationInfo` naming the source credential; a cross-project read from that environment failed with `Access Denied` at the IAM layer *while the ambient ADC could read that project* — i.e. no silent ADC fallback, for discovery or query. A plain (non-impersonating) environment in the same deployment behaved byte-identically to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Zb6YvbDh4Fr6PdZnvEstW