### PR TITLE
fix(ci): stop the sdist guard failing on a tarball that contains the client

### DIFF
--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -421,8 +421,20 @@ jobs:
             echo "::error title=Publish::expected exactly one sdist in dist/, found ${#SDISTS[@]}"
             exit 1
           fi
-          if ! tar -tzf "${SDISTS[0]}" | grep -qE '/malloy_publisher_sdk/client\.py$'; then
-            tar -tzf "${SDISTS[0]}" | sed 's/^/[sdist] /'
+          # Listed ONCE into a variable rather than piped into `grep -q`, and
+          # that is not a style preference. `grep -q` exits on its first match;
+          # malloy_publisher_sdk/client.py is the SECOND of ~230 entries, so tar
+          # takes EPIPE on its next write, `pipefail` reports the pipeline as
+          # failed, and the check announces the file is missing WHILE LOGGING IT
+          # AS PRESENT. It is a race — whether tar has already emptied its
+          # listing into the pipe buffer decides it — which is why the harness
+          # for this step passed and the first real run failed with
+          # `tar: stdout: write error` above a listing containing client.py.
+          # Reading it once also makes the logged listing the same bytes the
+          # check ran against, rather than a second tar that could differ.
+          SDIST_LISTING="$(tar -tzf "${SDISTS[0]}")"
+          if ! grep -qE '/malloy_publisher_sdk/client\.py$' <<<"$SDIST_LISTING"; then
+            while IFS= read -r entry; do printf '[sdist] %s\n' "$entry"; done <<<"$SDIST_LISTING"
             echo "::error title=Publish::${SDISTS[0]} does not contain malloy_publisher_sdk/client.py, so the sdist is missing the generated client (logged above). NOTHING was uploaded."
             exit 1
           fi

--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -432,7 +432,15 @@ jobs:
           # `tar: stdout: write error` above a listing containing client.py.
           # Reading it once also makes the logged listing the same bytes the
           # check ran against, rather than a second tar that could differ.
-          SDIST_LISTING="$(tar -tzf "${SDISTS[0]}")"
+          # Captured through `if !` rather than left to `set -e`, so a tarball
+          # that cannot be read at all still gets an annotation naming what
+          # happened. Left bare, that case aborts the step with only tar's
+          # stderr, and "missing client" would have been the wrong diagnosis
+          # for it anyway.
+          if ! SDIST_LISTING="$(tar -tzf "${SDISTS[0]}")"; then
+            echo "::error title=Publish::${SDISTS[0]} could not be listed as a gzipped tarball, so the sdist that would be uploaded is unreadable. NOTHING was uploaded."
+            exit 1
+          fi
           if ! grep -qE '/malloy_publisher_sdk/client\.py$' <<<"$SDIST_LISTING"; then
             while IFS= read -r entry; do printf '[sdist] %s\n' "$entry"; done <<<"$SDIST_LISTING"
             echo "::error title=Publish::${SDISTS[0]} does not contain malloy_publisher_sdk/client.py, so the sdist is missing the generated client (logged above). NOTHING was uploaded."


### PR DESCRIPTION
The first-ever PyPI publish run failed, and the artifact was fine. The guard that
stopped it is the bug.

`grep -q` exits on its first match. `malloy_publisher_sdk/client.py` is the
**second of ~230 entries** in the sdist, so `tar` takes EPIPE on its next write,
`pipefail` reports the pipeline as failed, and the check announces the client is
missing — while logging a listing that contains it, two lines further down. Then
it skips twine.

[The run](https://github.com/malloydata/publisher/actions/runs/32860079238) says
so in one line, above its own listing:

```
tar: stdout: write error
[sdist] malloy_publisher_sdk-0.1.0/malloy_publisher_sdk/__init__.py
[sdist] malloy_publisher_sdk-0.1.0/malloy_publisher_sdk/client.py     <-- right there
...
##[error]dist/malloy_publisher_sdk-0.1.0.tar.gz does not contain malloy_publisher_sdk/client.py
```

Whether it fires is a **race**: if `tar` has already emptied the whole listing
into the pipe buffer, `grep` never short-circuits anything and the pipeline
succeeds. That is why the harness for this step passed 4/4 and the first real run
failed, and why re-running it might well have gone green and taught us the wrong
thing.

The fix reads the listing once into a variable, which removes the pipeline
entirely — no reader, nothing to short-circuit. It also makes the logged listing
the same bytes the check ran against, rather than a second `tar` that could
differ from the one that made the decision.

`grep -q` fed by a slow producer is the only instance of this shape in the
workflows; the other five are `echo | grep -q`, one line, no writer left to
signal.

That capture then goes through `if !` rather than being left to `set -e`, so a
tarball that cannot be listed at all still gets an annotation naming what
happened. Bare, that case aborted with only tar's stderr, and "missing client"
would have been the wrong diagnosis for it.

Nothing was uploaded and `0.1.0` is unspent, so the guard's own "NOTHING was
uploaded" claim was accurate — it just said it about the wrong thing. No version
bump here: `python-sdk.yml` is deliberately outside `check_version`'s scope,
since editing a publish workflow changes no published byte.

Worth noting the wheel-import half of this guard has still never run — it is the
step after the one that failed. If something lurks there it fails the same cheap
way, before twine.

### Tested

The changed `run:` body extracted from the YAML and executed against scratch
trees in `ubuntu:24.04` (GNU tar 1.35, `/usr/bin/bash`), old body vs new, with a
slow `tar` stub to make the race deterministic instead of hoping for it:

| Case | Old | New |
|---|---|---|
| `client.py` present, real tar | pass | pass |
| `client.py` present, slow writer | **fails — false negative** | pass |
| `client.py` genuinely absent | fails | fails |
| corrupt tarball | — | fails, with its own annotation |

The second row is the reported bug. The third is the one that matters for the fix
being worth anything: a sdist that really is missing the client still fails.

`shellcheck` clean on the extracted body — the first draft used
`sed 's/^/[sdist] /' <<<"$VAR"` and earned SC2001, so the logging uses the same
`printf '[...] %s\n'` shape as the two blocks above it. `actionlint` diffed
against the `origin/main` baseline: no new findings (the one `SC2086:info` at
line 257 is pre-existing, in the uv install step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
