### PR TITLE
test(app): pin that the instance theme's font reaches renderer-drawn text

### DIFF
--- a/packages/app/tests/playwright/package-dashboards.spec.ts
+++ b/packages/app/tests/playwright/package-dashboards.spec.ts
@@ -943,4 +943,94 @@ test.describe("package-dashboards", () => {
       ).toBeVisible({ timeout: 30_000 });
       await expect(page.locator("iframe")).toHaveCount(0);
    });
+
+   // REGRESSION GUARD, not a fix. The operator's font already reaches the text
+   // the renderer draws, and this pins that it keeps doing so.
+   //
+   // It is guarding a genuinely fragile arrangement. The renderer declares
+   // `font-family: var(--malloy-render--font-family)` on .malloy-render and then,
+   // in the same stylesheet, an `@supports (font-variation-settings: normal)`
+   // block re-declares `font-family: InterVariable, Inter, system-ui sans-serif`.
+   // That later rule would win on source order and pin every host to Inter. It
+   // does not, because `system-ui sans-serif` is an unquoted multi-word family
+   // name, and both `system-ui` and `sans-serif` are generic-family keywords, so
+   // the identifier sequence is invalid and the browser drops the whole
+   // declaration. Verified against `document.styleSheets`: the block declares
+   // `font-feature-settings: 'liga' 1, 'calt' 1` in source and computes to
+   // `font-feature-settings: "liga", "calt"`, with no `font-family` surviving.
+   //
+   // So a well-meaning upstream fix to that missing comma would silently pin
+   // every embedding host's dashboards to Inter, and nothing else in this repo
+   // would notice. This test is what notices.
+   //
+   // Asserted on the computed value rather than the emitted variable: the
+   // variable was always emitted correctly, so a test at that level passes
+   // whether or not the value reaches any text. The sentinel family need not
+   // exist on the machine, since getComputedStyle returns the specified
+   // font-family list rather than the face that resolved.
+   test("the instance theme's font reaches renderer-drawn text", async ({
+      page,
+   }) => {
+      const SENTINEL = "PublisherThemeProbe";
+      await page.route("**/api/v0/status", async (route) => {
+         const res = await route.fetch();
+         const body = await res.json();
+         await route.fulfill({
+            response: res,
+            json: {
+               ...body,
+               theme: {
+                  ...(body.theme ?? {}),
+                  font: {
+                     ...(body.theme?.font ?? {}),
+                     family: `"${SENTINEL}", monospace`,
+                  },
+               },
+            },
+         });
+      });
+
+      // `grid` is the single-query form, so every card and cell on it is the
+      // renderer's own output rather than the SDK's tile chrome.
+      await openDashboard(page, "grid");
+      // The renderer builds its tables from divs, not <table>, which is why the
+      // rest of this suite locates cells by .column-cell.
+      // 30s, not 60s: the per-test budget is 60s (playwright.config.ts) and the
+      // poll below needs 15s of it, so a 60s wait here could never be spent and
+      // would surface a cold-render failure as a bare test timeout naming no
+      // wait. 30s matches what this suite uses for a dashboard render.
+      await expect(
+         page.locator(".malloy-render .malloy-table").first(),
+      ).toBeVisible({
+         timeout: 30_000,
+      });
+
+      // The root the renderer pins its own family on.
+      await expect
+         .poll(
+            () =>
+               page
+                  .locator(".malloy-render")
+                  .first()
+                  .evaluate((el) => getComputedStyle(el).fontFamily),
+            { timeout: 15_000 },
+         )
+         .toContain(SENTINEL);
+
+      // And that it inherits all the way to a BODY cell, which is the text a
+      // reader actually sees. `.td` deliberately: header cells carry
+      // `column-cell` too and come first in DOM order, so a bare
+      // `.column-cell.first()` pins the `th` instead, and a future
+      // `font-family` on the header would let body text regress unnoticed.
+      // Explicit timeout because `actionTimeout` is unset, so a table that
+      // renders empty would otherwise hang to the test cap without naming the
+      // locator it could not find.
+      const cellFont = await page
+         .locator(".malloy-render .column-cell.td")
+         .first()
+         .evaluate((el) => getComputedStyle(el).fontFamily, undefined, {
+            timeout: 10_000,
+         });
+      expect(cellFont).toContain(SENTINEL);
+   });
 });

--- a/packages/app/tests/playwright/package-dashboards.spec.ts
+++ b/packages/app/tests/playwright/package-dashboards.spec.ts
@@ -993,12 +993,13 @@ test.describe("package-dashboards", () => {
       // `grid` is the single-query form, so every card and cell on it is the
       // renderer's own output rather than the SDK's tile chrome.
       await openDashboard(page, "grid");
-      // The renderer builds its tables from divs, not <table>, which is why the
-      // rest of this suite locates cells by .column-cell.
-      // 30s, not 60s: the per-test budget is 60s (playwright.config.ts) and the
-      // poll below needs 15s of it, so a 60s wait here could never be spent and
-      // would surface a cold-render failure as a bare test timeout naming no
-      // wait. 30s matches what this suite uses for a dashboard render.
+      // `.malloy-table`, not `table`: the renderer builds its tables from divs,
+      // which is why this suite addresses cells by class throughout.
+      //
+      // 30s, not 60s: the per-test budget is 60s (playwright.config.ts), and the
+      // two waits below claim 15s and 5s of it, so a 60s wait here could never
+      // be spent and a cold-render failure would surface as a bare test timeout
+      // naming no wait. 30 + 15 + 5 leaves headroom for the navigation.
       await expect(
          page.locator(".malloy-render .malloy-table").first(),
       ).toBeVisible({
@@ -1029,7 +1030,7 @@ test.describe("package-dashboards", () => {
          .locator(".malloy-render .column-cell.td")
          .first()
          .evaluate((el) => getComputedStyle(el).fontFamily, undefined, {
-            timeout: 10_000,
+            timeout: 5_000,
          });
       expect(cellFont).toContain(SENTINEL);
    });

--- a/packages/app/tests/playwright/package-dashboards.spec.ts
+++ b/packages/app/tests/playwright/package-dashboards.spec.ts
@@ -991,7 +991,12 @@ test.describe("package-dashboards", () => {
       });
 
       // `grid` is the single-query form, so every card and cell on it is the
-      // renderer's own output rather than the SDK's tile chrome.
+      // renderer's own output rather than the SDK's tile chrome. That split is
+      // also the limit of this guard: a composite's leaf cells ride the same
+      // `.malloy-render` cascade and would follow the sentinel too, but its tile
+      // titles are MUI `Typography` inheriting the app's own font and never read
+      // `theme.font.family`, so a themed instance can still ship Inter titles
+      // there and nothing here would catch it.
       await openDashboard(page, "grid");
       // `.malloy-table`, not `table`: the renderer builds its tables from divs,
       // which is why this suite addresses cells by class throughout.


### PR DESCRIPTION
Adds one Playwright test. No SDK, app or server source changes.

## Why

Nothing asserted that a host's `theme.font.family` actually affects the text the renderer draws. `buildTableCssVars.spec.ts:58` pins that `--malloy-render--font-family` is *emitted*, which is true regardless of how the cascade resolves, so emission and effect were never connected by a test.

That gap is currently hiding a trap, which is the real reason for this PR.

`@malloydata/render` declares `font-family: var(--malloy-render--font-family)` on `.malloy-render`, and then in the same stylesheet an `@supports (font-variation-settings: normal)` block re-declares `font-family: InterVariable, Inter, system-ui sans-serif`. That later rule is at equal specificity and would win, pinning every embedding host to Inter whatever it passes to `ServerProvider`.

It does not win, because the declaration is invalid CSS: `system-ui sans-serif` is an unquoted multi-word family name, and both `system-ui` and `sans-serif` are generic-family keywords, so the identifier sequence is invalid and the browser drops the whole declaration. Read back from `document.styleSheets`, that block computes to `font-feature-settings: "liga", "calt"` with no `font-family` surviving.

So host font theming currently works because of a missing comma. Adding the comma, which looks exactly like a typo worth tidying, would silently pin every host's dashboards to Inter, and nothing in this repo would fail. If anyone does touch that declaration upstream, the right change is to delete the `font-family` line and keep `font-feature-settings`, which is evidently what the block is for.

## What the test does

Serves an instance theme with a sentinel font family through `/api/v0/status`, opens the existing dashboards fixture's single-query `grid` dashboard (where the renderer draws the whole page rather than the SDK's tile chrome), and asserts the computed `font-family` on `.malloy-render` and on a `.column-cell.td` inside it follows the theme.

Three details that are deliberate:

- **Computed value, not the emitted variable.** That distinction is the whole point; a test at the variable level passes whichever way the cascade resolves.
- **`.column-cell.td`, not `.column-cell`.** Header cells carry `column-cell` too and come first in DOM order, so a bare selector pins the `th`. `.td` is the body text a reader actually sees, and matches this file's existing convention at :474 and :541.
- **The sentinel family need not exist on the machine.** `getComputedStyle` returns the specified font-family list rather than the face that resolved, so this checks the cascade and not the font inventory.

## Verification

Verified in both directions rather than only observed passing:

- Passes against unmodified `main`. It is a regression guard, so that is the correct result.
- Injecting the comma-corrected rule at runtime, which is what a tidy-up commit would produce, flips the computed font to `InterVariable, Inter, system-ui, sans-serif` and fails the assertion. So the guard discriminates on exactly the hazard it exists for.

Also measured, for the record, since it corrects something I got wrong on #1069: the operator's font reaches renderer tables, cells and chrome today. It is not confined to the Vega marks. Unthemed, the computed family is the SDK's `DEFAULT_FONT_FAMILY`.

Gate: lint, typecheck and prettier clean, server unit suite 3177 pass / 0 fail.

## Notes for review

Timeouts are sized against the 60s per-test budget on purpose: a 30s visibility wait plus a 15s poll fits, where the 60s wait I first wrote could never be spent and would have surfaced a cold-render failure as a bare test timeout naming no wait.

This may be worth landing alongside the Phase 3 assertion discussed in #1069 rather than separately, since it is the same shape of gap: something the theme is expected to control, with no test connecting the token to its effect.

Refs #1069
