### PR TITLE
feat(server): let a build session opt out of preserve_insertion_order

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -274,6 +274,28 @@ export const getMemoryGovernorConfig = (): MemoryGovernorConfig | null => {
 };
 
 /**
+ * Resolve the materialization build session's `preserve_insertion_order`
+ * override from `PUBLISHER_BUILD_PRESERVE_INSERTION_ORDER`.
+ *
+ * `undefined` when unset — the default — and the build then issues no such
+ * statement at all, so DuckDB's own default stands and this knob cannot change
+ * an existing deployment until someone sets it. Opting in is the whole
+ * interface.
+ *
+ * Scoped to the build session on purpose. It is a global session setting, and a
+ * build session is the one place where the tradeoff is unambiguous: the
+ * pipeline is a single passthrough read written straight into a destination
+ * table, and nothing downstream depends on the order the rows were written in.
+ * See `applyBuildInsertionOrder` for why the buffer it governs is not bounded
+ * by batch size.
+ *
+ * Throws at startup on a malformed value, so a typo in a manifest is a loud
+ * failure rather than a silently ignored setting.
+ */
+export const getBuildPreserveInsertionOrder = (): boolean | undefined =>
+   parseBoolEnv("PUBLISHER_BUILD_PRESERVE_INSERTION_ORDER");
+
+/**
  * Settings for the optional embedding provider behind semantic
  * `malloy_getContext` retrieval. See {@link getEmbeddingConfig}.
  */

--- a/packages/server/src/service/materialization_build_session.spec.ts
+++ b/packages/server/src/service/materialization_build_session.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Credible Data Inc.
 // SPDX-License-Identifier: MIT
 
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { DuckDBConnection } from "@malloydata/db-duckdb";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -10,6 +10,7 @@ import { BadRequestError } from "../errors";
 import { storageDestinationRoot } from "./connection_config";
 import type { components } from "../api";
 import {
+   applyBuildInsertionOrder,
    assertStorageServeShapeCompiles,
    buildDownstreamIntoStorage,
    buildSourceIntoStorage,
@@ -442,5 +443,57 @@ describe("createTableAndDescribe (schema read-back window)", () => {
 
       expect(schema).toEqual([{ name: "a", type: "VARCHAR" }]);
       expect(issued.some((s) => /^DROP TABLE/i.test(s))).toBe(false);
+   });
+});
+
+describe("applyBuildInsertionOrder (opt-in preserve_insertion_order)", () => {
+   const ENV = "PUBLISHER_BUILD_PRESERVE_INSERTION_ORDER";
+   const original = process.env[ENV];
+
+   /** Records the SQL a session is asked to run, without opening a database. */
+   function recorder(): { session: DuckDBConnection; sql: string[] } {
+      const sql: string[] = [];
+      const session = {
+         runSQL: async (q: string) => {
+            sql.push(q);
+            return { rows: [], totalRows: 0, runStats: {} };
+         },
+         // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any as DuckDBConnection;
+      return { session, sql };
+   }
+
+   afterEach(() => {
+      if (original === undefined) delete process.env[ENV];
+      else process.env[ENV] = original;
+   });
+
+   it("issues nothing when unset, so DuckDB's own default stands", async () => {
+      delete process.env[ENV];
+      const { session, sql } = recorder();
+      await applyBuildInsertionOrder(session);
+      expect(sql).toEqual([]);
+   });
+
+   it("turns order preservation off when opted out", async () => {
+      process.env[ENV] = "false";
+      const { session, sql } = recorder();
+      await applyBuildInsertionOrder(session);
+      expect(sql).toEqual(["SET preserve_insertion_order = false"]);
+   });
+
+   it("honours an explicit opt-in, rather than treating it as unset", async () => {
+      process.env[ENV] = "true";
+      const { session, sql } = recorder();
+      await applyBuildInsertionOrder(session);
+      expect(sql).toEqual(["SET preserve_insertion_order = true"]);
+   });
+
+   it("throws on a malformed value rather than silently ignoring it", async () => {
+      process.env[ENV] = "maybe";
+      const { session } = recorder();
+      await expect(applyBuildInsertionOrder(session)).rejects.toThrow(
+         /expected a boolean/i,
+      );
    });
 });

--- a/packages/server/src/service/materialization_build_session.ts
+++ b/packages/server/src/service/materialization_build_session.ts
@@ -39,6 +39,7 @@ import {
    type FederatedSourceType,
 } from "./connection";
 import type { WatermarkBound } from "./incremental_apply";
+import { getBuildPreserveInsertionOrder } from "../config";
 import { storageDestinationRoot } from "./connection_config";
 import {
    assertServesInDuckDB,
@@ -657,6 +658,41 @@ export async function pinSessionToUTC(
    await session.runSQL("SET TimeZone='UTC'");
 }
 
+/**
+ * Apply the optional `preserve_insertion_order` override to a build session.
+ *
+ * A no-op unless `PUBLISHER_BUILD_PRESERVE_INSERTION_ORDER` is set: with it
+ * unset no statement is issued at all, so DuckDB's own default stands and an
+ * existing deployment's behaviour is unchanged. Opting in is the only way to
+ * move it.
+ *
+ * Why it is worth being able to move. A build's write is one pipeline — a
+ * passthrough SELECT the source engine executes, whose result is written
+ * straight into the destination — and DuckDB's execution is pull-based, so the
+ * writer paces the read. Order preservation sits outside that: to hand rows to
+ * the writer in input order, DuckDB buffers them between a parallel scan and
+ * the sink, and that buffer grows with how far out of order the pipeline runs
+ * rather than with any batch size. On a large enough result it is the
+ * difference between a bounded pipeline and one that outgrows its container,
+ * and no per-batch bound constrains it.
+ *
+ * A materialization has no insertion-order contract to keep — the built table
+ * is read back through the serve transform, which does not preserve or promise
+ * row order — so on this path the guarantee costs memory and buys nothing.
+ * Left opt-in regardless: this is a global session setting, and the blast
+ * radius of flipping it for every build is wider than the one build that
+ * needed it.
+ */
+export async function applyBuildInsertionOrder(
+   session: DuckDBConnection,
+): Promise<void> {
+   const preserve = getBuildPreserveInsertionOrder();
+   if (preserve === undefined) {
+      return;
+   }
+   await session.runSQL(`SET preserve_insertion_order = ${preserve}`);
+}
+
 /** Result of building one source into a storage destination. */
 export interface StorageBuildResult {
    /** The connection the physical table now lives in (the destination). */
@@ -823,6 +859,9 @@ export async function buildSourceIntoStorage(params: {
       // incremental refresh (a full CTAS issues none), but it is cheap and the
       // session it protects is this one — see pinSessionToUTC.
       await pinSessionToUTC(session);
+      // Before the write, since it governs how the write buffers. A no-op unless
+      // explicitly configured — see applyBuildInsertionOrder.
+      await applyBuildInsertionOrder(session);
 
       const federated = await federateSourceForPassthrough(
          session,
@@ -1006,6 +1045,9 @@ export async function buildDownstreamIntoStorage(params: {
       // this guards the case that lifting that exclusion creates, in the one
       // function where its absence would not be obvious.
       await pinSessionToUTC(session);
+      // Applied on both build-session paths for the same reason: this one also
+      // writes, so it also buffers.
+      await applyBuildInsertionOrder(session);
 
       // Compile the transient rebind model against the build session. Its only
       // connection is the attached destination; the upstream virtual sources


### PR DESCRIPTION
## What

Adds `PUBLISHER_BUILD_PRESERVE_INSERTION_ORDER`, an opt-in override for DuckDB's `preserve_insertion_order` on the materialization build session. **Unset — the default — issues no statement at all**, so DuckDB's own default stands and no existing deployment changes behaviour.

## Why

A storage build is one pipeline: a passthrough `SELECT` the source warehouse executes, whose result is written straight into the destination table. DuckDB's execution is pull-based, so the writer paces the read and the pipeline is naturally bounded — the write-side buffers are bounded too (`write_buffer_row_group_memory_limit`, `write_buffer_row_group_count`).

Order preservation sits outside that. To hand rows to the sink in input order, DuckDB buffers them between a parallel scan and the writer, and that buffer grows with **how far out of order the pipeline runs** — not with any batch size, and not under the per-batch bound that makes the rest of the pipeline safe. On a large result it is the one part of an otherwise-bounded pipeline that can outgrow the process.

And a materialization has no row-order contract to keep. The built table is read back through the serve transform, which neither preserves nor promises row order, so on this path the guarantee costs memory and buys nothing.

## Why opt-in rather than just turning it off

It is a global session setting, and the blast radius of flipping it for every build is wider than the one build that needs it. Leaving it off by default means:

- no behaviour change on upgrade,
- the value is a deployment decision rather than a code one, so tuning it needs no release,
- and an operator can turn it on for the environment that needs it without reasoning about every other build.

Scoped to the build session for the same reason — that is the one place the tradeoff is unambiguous.

## Shape

- `config.ts` — `getBuildPreserveInsertionOrder(): boolean | undefined`, via the existing `parseBoolEnv`, alongside the `PUBLISHER_MEMORY_*` family. Returns `undefined` when unset; throws on a malformed value so a typo in a manifest is a loud startup failure rather than a silently ignored setting.
- `materialization_build_session.ts` — `applyBuildInsertionOrder(session)`, a sibling to the existing `pinSessionToUTC`, called on both build-session paths (both write, so both buffer). Returns without issuing anything when unset.

## Test

Four cases in `materialization_build_session.spec.ts`, against a recording stub so they assert the SQL actually issued rather than the parse alone:

- unset → **no statement issued** (the default is genuinely a no-op)
- `false` → `SET preserve_insertion_order = false`
- `true` → honoured explicitly, not treated as unset
- malformed → throws

Verified red/green rather than just green: with the body of `applyBuildInsertionOrder` stubbed out, 3 of the 4 fail (the unset case correctly still passes, since a no-op satisfies it). With it in place the file is **31 pass / 0 fail / 36 expect() calls**. `tsc --noEmit` and `eslint` clean.

## What this does not do

It does not bound the pipeline's memory on its own. `memory_limit` is still DuckDB's default — 80% of the detected limit — which for an embedded engine sharing a process with a resident host is an overcommit before any query runs. That is a separate change; this one removes the unbounded buffer, it does not add a ceiling.
