### PR TITLE
docs: retire the dormant next pre-release channel

### DIFF
--- a/.github/workflows/CONTEXT.md
+++ b/.github/workflows/CONTEXT.md
@@ -129,6 +129,31 @@ Prereleases keep the hyphen convention: `npm-sdk.yml` routes a hyphenated versio
 to the `next` dist-tag and `docker-image.yml` withholds `latest`, so a prerelease
 never takes over either.
 
+**The `next` dist-tag was retired on 2026-08-26, on npm and on Docker Hub.** It
+had pointed at `0.0.198-dev6` since 2026-05-21 while 51 stable versions shipped
+past it, because a dist-tag only moves when a publish uses it and no prerelease
+had been cut since. So `@malloy-publisher/server@next` silently installed a
+three-month-old build, and `ms2data/malloy-publisher:next` served the matching
+image. Nothing in this repo, in the Credible service, or in the published docs
+installed from either. Three consequences, and the first one decides what
+automation is possible here at all:
+
+- **npm OIDC cannot move a dist-tag.** Trusted publishing authenticates
+  `npm publish` and `npm stage publish` only; `npm dist-tag add|rm` needs a
+  granular token, which this repo deliberately does not have (see the OIDC note
+  below). So CI can move `next` only by publishing a real prerelease under it.
+  Re-pointing `next` at an existing stable release is not available without
+  reintroducing `NPM_TOKEN`, which is not a trade worth making for a tag nothing
+  reads. The same follows for any other dist-tag surgery: it is a human org
+  member acting by hand, never a workflow.
+- **The routing was left in place, so this is self-healing.** `npm-sdk.yml`
+  still sends any hyphenated version to `next`, and `docker-image.yml` still
+  tags `:next` on a prerelease. The first prerelease after this recreates both
+  tags, correctly, with no change here.
+- **`docs/deployment.md` now states there is no pre-release channel today.**
+  That sentence is true only while the above holds, so a release that cuts a
+  prerelease has to update it in the same PR.
+
 ### A forgotten bump is a red PR check
 
 It used to be invisible until release time — `publish-packages` skips a package

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -10,7 +10,7 @@
 # before bringing the stack up.
 #
 # REST is on :4000 and MCP is on :4040. See docs/deployment.md for
-# tag-scheme guidance (`:latest`, `:X.Y.Z`, `:next`).
+# tag-scheme guidance (`:latest`, `:X.Y.Z`).
 #
 # The `publisher_data` named volume persists the per-environment
 # package clones and DuckDB extension cache across container

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -127,13 +127,12 @@ docker run -d \
 
 **Tags:**
 
-- `:latest` — most recent stable release.
-- `:X.Y.Z` — pinned to a specific release; recommended for production.
-- `:next` — pre-release builds; not recommended for production.
+- `:latest`: most recent stable release.
+- `:X.Y.Z`: pinned to a specific release; recommended for production.
 
-`*-dev` tags (e.g. `:0.0.198-dev`) are frozen — no new ones are being published, and `:next` is the
-current pre-release channel. Existing `*-dev` tags still resolve in the registry; don't use them for
-new deployments.
+There is no pre-release channel today. The `*-dev` tags (e.g. `:0.0.198-dev`) are frozen at
+0.0.198-dev6 (May 2026) and the `:next` tag has been retired. Old `*-dev` tags still resolve in the
+registry, so an existing deployment pinned to one keeps working; don't use them for new deployments.
 
 ### Docker Compose
 

--- a/packages/server/README.docker.md
+++ b/packages/server/README.docker.md
@@ -37,7 +37,7 @@ docker run -d \
   ms2data/malloy-publisher
 ```
 
-See the [Docker Hub tags page](https://hub.docker.com/r/ms2data/malloy-publisher/tags) for available versions. Tag-scheme guidance (`:latest`, `:X.Y.Z`, `:next`) lives in the [deployment guide](../../docs/deployment.md).
+See the [Docker Hub tags page](https://hub.docker.com/r/ms2data/malloy-publisher/tags) for available versions. Tag-scheme guidance (`:latest`, `:X.Y.Z`) lives in the [deployment guide](../../docs/deployment.md).
 
 ## Runtime layout
 


### PR DESCRIPTION
## What this is

James asked why `@malloy-publisher/server`'s npm `next` tag points at something old. It turns out the tag was never pinned and nobody configured it specially: `npm-sdk.yml` derives the dist-tag from the version string alone, so any hyphenated version publishes under `next` and everything else under `latest`. `next` last moved on 2026-05-21 when `0.0.198-dev6` was published. Fifty-one stable versions have shipped since then and not one prerelease, so the pointer simply stayed where the last prerelease left it. Docker Hub's `:next` is frozen at the same date and resolves to the same image by digest.

That made our own documented tag scheme wrong in a way that mattered. `docs/deployment.md` told readers that `*-dev` tags were frozen and that `:next` was the current pre-release channel, when `:next` resolved to one of those very `*-dev` builds. Anyone who followed the docs to `:next` got a three-month-old image and had no way to tell from the tag name.

## What changes

`docs/deployment.md` drops `:next` from the tag list and replaces the paragraph that misdescribed it. The two sibling references that repeat the same inline list, `docker-compose.example.yml` and `packages/server/README.docker.md`, are updated to match so the three files agree. `.github/workflows/CONTEXT.md` records the decision, the constraint behind it, and what a future prerelease will do.

Docs only. No TypeScript, no workflow logic.

## Why retire rather than automate

Wiring this into the workflows is the obvious idea and it is not available in its obvious form. npm OIDC trusted publishing authenticates `npm publish` and `npm stage publish` only; `npm dist-tag add` and `npm dist-tag rm` need a granular token, and this repo deliberately has no `NPM_TOKEN` (`.github/workflows/CONTEXT.md` says so and says it should not be added back). So CI can move `next` only by publishing a real prerelease under it. Re-pointing the tag at an existing stable release would mean reintroducing a token, which is a poor trade for a channel nothing reads.

Removal is self-healing. The routing in `npm-sdk.yml` and `docker-image.yml` is untouched, so the first genuine prerelease recreates both tags with the correct meaning and no change here.

## Please read before merging

The docs describe the intended end state and say the tag "has been retired". At the time of writing the removals have not run yet: all three packages still show `next: 0.0.198-dev6` and Docker Hub still lists `:next`. The two registry actions cannot run from CI and are being done by hand. Either merge after they land, or accept a short window where the docs lead the registries.

## How it was verified

The diff is four files with zero TypeScript, so the typecheck, lint, and test legs cannot be affected by it and were not run. Saying that explicitly rather than implying a full gate. What was run: the enumeration was checked with `git grep ':next'` so the fix is not partial, and the only surviving hits are my own prose and the two intentional lines in `docker-image.yml` that recreate the tag on a prerelease; the relative link from `packages/server/README.docker.md` still resolves; `docs/deployment.md` is now prettier-conformant and the other three files were already non-conformant on `main` and sit outside CI's prettier glob, which passes clean; the branch is zero behind `origin/main` and merges clean by exit code.

Every number quoted above was measured against the live registries immediately before committing, not carried over from earlier in the investigation.

## Follow-up

Nothing blocking. If anyone does want a live pre-release channel, the shape that works with OIDC is publishing a prerelease from `main` on merge or nightly under `--tag next`. That is a real publish per merge on a package already at 192 versions, so it is worth doing only if someone actually wants to consume it.
