### PR TITLE
chore(release): stamp 0.2.1 on main

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -74,7 +74,7 @@ One thing worth knowing before tuning: setting a `memory_limit` does **not** by 
 
 ---
 
-## [Unreleased] — a versioned dashboard URI is now honoured
+## [0.2.1] — a versioned dashboard URI is now honoured
 
 `<Dashboard>` accepted a `?versionId=` in its `resourceUri` and dropped it. It now sends it, on the
 manifest fetch, on each tile's query, and on each control's suggest query, and each is cached per
@@ -94,7 +94,7 @@ declares no `versionId`.
 
 ---
 
-## [Unreleased] — one way to build a dashboard, and per-tile layout for it (BREAKING)
+## [0.2.1] — one way to build a dashboard, and per-tile layout for it (BREAKING)
 
 A Publisher dashboard is `## artifact { tiles=[…] }`. The `# artifact` on a `query:` still works and
 is still served, but it is no longer offered as a second way to build one: it is a rendered Malloy

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/app",
    "description": "Malloy Publisher Console (the built-in web UI)",
-   "version": "0.2.0",
+   "version": "0.2.1",
    "type": "module",
    "main": "dist/index.cjs.js",
    "module": "dist/index.es.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/sdk",
    "description": "Malloy Publisher SDK",
-   "version": "0.2.0",
+   "version": "0.2.1",
    "type": "module",
    "main": "dist/index.cjs.js",
    "module": "dist/index.es.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/server",
    "description": "Malloy Publisher Server",
-   "version": "0.2.0",
+   "version": "0.2.1",
    "main": "dist/server.mjs",
    "bin": {
       "malloy-publisher": "dist/server.mjs"


### PR DESCRIPTION
Pushed by `gh-release` after v0.2.1 was cut. Stamps the two release-note headings that shipped on the release page with the version that shipped them, and resets the three lockstep manifests to `0.2.1`.

Until this lands the headings still read `[Unreleased]`, which is what the next release's `extract` matches — so 0.2.1's narrative would be appended to that release's page as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)