### PR TITLE
fix(server): build each persist source once per run, not once per importing model

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -5498,7 +5498,11 @@ components:
       properties:
         graphs:
           type: array
-          description: Dependency-ordered build graphs, one per connection.
+          description: >-
+            Dependency-ordered build graphs. One per connection per model, not one
+            per connection: a model contributes a graph for each connection its ROOT
+            persist sources use, and a package's plan concatenates every model's, so
+            the same source appears in the graph of every model that imports it.
           items:
             $ref: "#/components/schemas/BuildGraph"
         sources:

--- a/packages/server/src/service/materialization_service.spec.ts
+++ b/packages/server/src/service/materialization_service.spec.ts
@@ -2664,6 +2664,84 @@ describe("executeInstructedBuild", () => {
       expect(rootIdx).toBeGreaterThan(midIdx);
    });
 
+   it("builds a source shared by two graphs exactly once", async () => {
+      // compilePackageBuildPlan pushes every model's graphs into one allGraphs
+      // list, so a persist source declared in one model and imported by another
+      // appears in BOTH models' graphs. iterGraphSources dedups per graph, so a
+      // shared source is yielded once per graph and built once per graph -- each
+      // a full reseed CTAS.
+      const runSQL = sinon.stub().resolves();
+      const connection = { runSQL } as unknown as MalloyConnection;
+      const shared = fakeSource({
+         name: "shared",
+         sourceEntityId: "bsharedaaaaaaaaa",
+      });
+      const consumer = fakeSource({
+         name: "consumer",
+         sourceEntityId: "bconsumerbbbbbbb",
+      });
+      const compiled = {
+         graphs: [
+            {
+               connectionName: "duckdb",
+               nodes: [[{ sourceID: "shared", dependsOn: [] }]],
+            },
+            {
+               connectionName: "duckdb",
+               nodes: [
+                  [
+                     {
+                        sourceID: "consumer",
+                        dependsOn: [{ sourceID: "shared", dependsOn: [] }],
+                     },
+                  ],
+               ],
+            },
+         ],
+         sources: { shared, consumer },
+         connectionDigests: { duckdb: "dig" },
+         connections: new Map([["duckdb", connection]]),
+      };
+
+      const { entries } = await callExecute(
+         compiled,
+         [
+            {
+               sourceEntityId: "bsharedaaaaaaaaa",
+               materializedTableId: "mt-s",
+               physicalTableName: "shared_v1",
+               realization: "COPY",
+            },
+            {
+               sourceEntityId: "bconsumerbbbbbbb",
+               materializedTableId: "mt-c",
+               physicalTableName: "consumer_v1",
+               realization: "COPY",
+            },
+         ],
+         {},
+      );
+
+      const creates = runSQL
+         .getCalls()
+         .map((c) => c.args[0] as string)
+         .filter((s) => s.startsWith("CREATE TABLE"));
+      // The shared source builds ONCE, not once per graph that reaches it.
+      expect(creates.filter((s) => s.includes("shared_v1")).length).toBe(1);
+      // And the dedup does not swallow the second graph's own work: the
+      // consumer still builds, and still after the upstream it reads.
+      expect(creates.filter((s) => s.includes("consumer_v1")).length).toBe(1);
+      expect(creates.findIndex((s) => s.includes("consumer_v1"))).toBeGreaterThan(
+         creates.findIndex((s) => s.includes("shared_v1")),
+      );
+      // Both are reported built, so an orchestrated caller settles neither as
+      // missing.
+      expect(Object.keys(entries).sort()).toEqual([
+         "bconsumerbbbbbbb",
+         "bsharedaaaaaaaaa",
+      ]);
+   });
+
    it("seeds a downstream build with the QUOTED upstream reference (case-folding dialect)", async () => {
       // A carried/seeded upstream (built in a prior run or unit, e.g. via
       // referenceManifest) must reach the downstream's SQL generation as the

--- a/packages/server/src/service/materialization_service.spec.ts
+++ b/packages/server/src/service/materialization_service.spec.ts
@@ -2742,6 +2742,114 @@ describe("executeInstructedBuild", () => {
       ]);
    });
 
+   it("builds two sources that share one content address, not just the first", async () => {
+      // Why the guard keys on sourceID and not sourceEntityId. Two DISTINCT sources can
+      // canonicalize to the same content address (identical SQL on one connection) while
+      // holding separate instructions that name separate physical tables. Keying on the
+      // address would build one and leave the other instructed table unbuilt — reported
+      // neither in entries nor in failures, which an orchestrated caller cannot settle.
+      const runSQL = sinon.stub().resolves();
+      const connection = { runSQL } as unknown as MalloyConnection;
+      const twinA = fakeSource({
+         name: "twin_a",
+         sourceEntityId: "btwinaaaaaaaaaaa",
+      });
+      const twinB = fakeSource({
+         name: "twin_b",
+         sourceEntityId: "btwinaaaaaaaaaaa",
+      });
+      const compiled = compiledWith(
+         { twin_a: twinA, twin_b: twinB },
+         [["twin_a"], ["twin_b"]],
+         new Map([["duckdb", connection]]),
+      );
+
+      const { entries } = await callExecute(
+         compiled,
+         [
+            {
+               sourceEntityId: "btwinaaaaaaaaaaa",
+               materializedTableId: "mt-a",
+               physicalTableName: "twin_a_v1",
+               realization: "COPY",
+               sourceID: "twin_a",
+            },
+            {
+               sourceEntityId: "btwinaaaaaaaaaaa",
+               materializedTableId: "mt-b",
+               physicalTableName: "twin_b_v1",
+               realization: "COPY",
+               sourceID: "twin_b",
+            },
+         ],
+         {},
+      );
+
+      const creates = runSQL
+         .getCalls()
+         .map((c) => c.args[0] as string)
+         .filter((s) => s.startsWith("CREATE TABLE"));
+      expect(creates.filter((s) => s.includes("twin_a_v1")).length).toBe(1);
+      expect(creates.filter((s) => s.includes("twin_b_v1")).length).toBe(1);
+      // Both were instructed, so both must be accounted for. They collide on one manifest
+      // key by construction — that collision is pre-existing and separately detected; what
+      // this pins is that the dedup did not swallow one of the BUILDS.
+      expect(Object.keys(entries)).toContain("btwinaaaaaaaaaaa");
+   });
+
+   it("does not collapse a source across two connections", async () => {
+      // buildOneSource executes on the connection resolved from graph.connectionName, and
+      // Malloy groups only ROOT nodes by connection — so the same declaration reached under
+      // two roots of different connections is two different builds today. The guard keys on
+      // the pair so it cannot silently decide otherwise; whether such a chain is reachable,
+      // and which connection is the right one, are pre-existing questions it leaves alone.
+      const runDuck = sinon.stub().resolves();
+      const runPg = sinon.stub().resolves();
+      const shared = fakeSource({
+         name: "shared",
+         sourceEntityId: "bsharedaaaaaaaaa",
+      });
+      const compiled = {
+         graphs: [
+            {
+               connectionName: "duckdb",
+               nodes: [[{ sourceID: "shared", dependsOn: [] }]],
+            },
+            {
+               connectionName: "postgres",
+               nodes: [[{ sourceID: "shared", dependsOn: [] }]],
+            },
+         ],
+         sources: { shared },
+         connectionDigests: { duckdb: "dig", postgres: "dig2" },
+         connections: new Map([
+            ["duckdb", { runSQL: runDuck } as unknown as MalloyConnection],
+            ["postgres", { runSQL: runPg } as unknown as MalloyConnection],
+         ]),
+      };
+
+      await callExecute(
+         compiled,
+         [
+            {
+               sourceEntityId: "bsharedaaaaaaaaa",
+               materializedTableId: "mt-s",
+               physicalTableName: "shared_v1",
+               realization: "COPY",
+            },
+         ],
+         {},
+      );
+
+      const creates = (stub: sinon.SinonStub) =>
+         stub
+            .getCalls()
+            .map((c) => c.args[0] as string)
+            .filter((s) => s.startsWith("CREATE TABLE")).length;
+      expect(creates(runDuck)).toBe(1);
+      expect(creates(runPg)).toBe(1);
+   });
+
    it("seeds a downstream build with the QUOTED upstream reference (case-folding dialect)", async () => {
       // A carried/seeded upstream (built in a prior run or unit, e.g. via
       // referenceManifest) must reach the downstream's SQL generation as the

--- a/packages/server/src/service/materialization_service.spec.ts
+++ b/packages/server/src/service/materialization_service.spec.ts
@@ -2731,9 +2731,9 @@ describe("executeInstructedBuild", () => {
       // And the dedup does not swallow the second graph's own work: the
       // consumer still builds, and still after the upstream it reads.
       expect(creates.filter((s) => s.includes("consumer_v1")).length).toBe(1);
-      expect(creates.findIndex((s) => s.includes("consumer_v1"))).toBeGreaterThan(
-         creates.findIndex((s) => s.includes("shared_v1")),
-      );
+      expect(
+         creates.findIndex((s) => s.includes("consumer_v1")),
+      ).toBeGreaterThan(creates.findIndex((s) => s.includes("shared_v1")));
       // Both are reported built, so an orchestrated caller settles neither as
       // missing.
       expect(Object.keys(entries).sort()).toEqual([

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -1796,6 +1796,9 @@ export class MaterializationService {
       const failures: Record<string, SourceFailure> = {};
       const failedReasons: string[] = [];
       const builtSources: string[] = [];
+      // Declared sources already visited this run, by `sourceID`, so a source
+      // shared by several graphs builds once. See the guard in the walk below.
+      const seenSources = new Set<string>();
       try {
          for (const graph of graphs) {
             const connection = connections.get(graph.connectionName);
@@ -1893,6 +1896,29 @@ export class MaterializationService {
                   persistSource,
                   connectionDigests,
                );
+
+               // One build per declared source per run, across every graph.
+               // `compilePackageBuildPlan` accumulates each model's graphs into a
+               // single list, and a source declared in one model appears again in the
+               // graph of every model that imports it -- so `graphs` legitimately
+               // holds several nodes for the same source. `iterGraphSources` dedups
+               // only WITHIN one graph, so without this the source is built once per
+               // importing model, each a full CTAS of identical content: a package
+               // whose persist source is imported by N models pays N times its build
+               // cost, and an orchestrated caller's run timeout is what surfaces it.
+               // `deriveSelfInstructions` applies the same guard across the same
+               // graph list; the auto-run path is why this never showed there.
+               //
+               // Keyed on `sourceID` -- the declaring model plus source name -- not
+               // on the content `sourceEntityId`: a revisit through another graph is
+               // always the same declaration, whereas two DISTINCT sources can share
+               // one content address (identical SQL on one connection), and those
+               // hold separate instructions naming separate physical tables.
+               // Collapsing them here would leave one instructed table unbuilt and
+               // reported neither built nor failed. That collision is real but
+               // separate, and it has its own detection.
+               if (seenSources.has(persistSource.sourceID)) continue;
+               seenSources.add(persistSource.sourceID);
 
                // A caller-instructed destination that cannot be honored REFUSES; it
                // never falls through to a colocated build. Auto-run already applies

--- a/packages/server/src/service/materialization_service.ts
+++ b/packages/server/src/service/materialization_service.ts
@@ -1796,8 +1796,8 @@ export class MaterializationService {
       const failures: Record<string, SourceFailure> = {};
       const failedReasons: string[] = [];
       const builtSources: string[] = [];
-      // Declared sources already visited this run, by `sourceID`, so a source
-      // shared by several graphs builds once. See the guard in the walk below.
+      // Builds already issued this run, keyed by the graph's connection and the source's
+      // `sourceID`, so a source shared by several graphs builds once. See the guard below.
       const seenSources = new Set<string>();
       try {
          for (const graph of graphs) {
@@ -1851,6 +1851,42 @@ export class MaterializationService {
                }
                if (!instruction) continue;
 
+               // One build per source per run, across every graph.
+               // `compilePackageBuildPlan` accumulates each model's graphs into a single
+               // list, and a source declared in one model appears again in the graph of
+               // every model that imports it -- so `graphs` legitimately holds several
+               // nodes for the same source. `iterGraphSources` dedups only WITHIN one
+               // graph, so without this the source is built once per importing model,
+               // each a full CTAS of identical content: a package whose persist source is
+               // imported by N models pays N times its build cost, and an orchestrated
+               // caller's run timeout is what surfaces it. `deriveSelfInstructions`
+               // applies the same guard across the same graph list; the auto-run path is
+               // why this never showed there.
+               //
+               // Placed before the eligibility asserts and the sourceEntityId hash on
+               // purpose: those are per-source and a repeat visit re-derives an answer the
+               // first visit already acted on, so skipping early is what makes a duplicate
+               // visit cost nothing rather than merely build nothing.
+               //
+               // Keyed on `sourceID` -- the declaring model plus source name -- and NOT on
+               // the content `sourceEntityId`: a revisit through another graph is always
+               // the same declaration, whereas two DISTINCT sources can share one content
+               // address (identical SQL on one connection) while holding separate
+               // instructions that name separate physical tables. Collapsing those would
+               // leave one instructed table unbuilt and reported neither built nor failed.
+               //
+               // The graph's connection is part of the key because it is part of what a
+               // build IS: `buildOneSource` below executes on the connection resolved from
+               // `graph.connectionName`, not from `persistSource.connectionName`. Malloy
+               // groups only ROOT nodes by connection, so a nested `dependsOn` source is
+               // yielded under a root of a different connection; whether such a chain is
+               // reachable, and whether the graph's connection is the right one to build
+               // it on, are pre-existing questions this guard deliberately does not
+               // answer. Keying on the pair keeps it from silently deciding them.
+               const buildKey = `${graph.connectionName}\u0000${persistSource.sourceID}`;
+               if (seenSources.has(buildKey)) continue;
+               seenSources.add(buildKey);
+
                // Enforce the eligibility gate for any storage-targeted build,
                // including orchestrated (host-supplied) instructions — the publisher
                // refuses an ineligible source into the tier itself, not on trust.
@@ -1896,29 +1932,6 @@ export class MaterializationService {
                   persistSource,
                   connectionDigests,
                );
-
-               // One build per declared source per run, across every graph.
-               // `compilePackageBuildPlan` accumulates each model's graphs into a
-               // single list, and a source declared in one model appears again in the
-               // graph of every model that imports it -- so `graphs` legitimately
-               // holds several nodes for the same source. `iterGraphSources` dedups
-               // only WITHIN one graph, so without this the source is built once per
-               // importing model, each a full CTAS of identical content: a package
-               // whose persist source is imported by N models pays N times its build
-               // cost, and an orchestrated caller's run timeout is what surfaces it.
-               // `deriveSelfInstructions` applies the same guard across the same
-               // graph list; the auto-run path is why this never showed there.
-               //
-               // Keyed on `sourceID` -- the declaring model plus source name -- not
-               // on the content `sourceEntityId`: a revisit through another graph is
-               // always the same declaration, whereas two DISTINCT sources can share
-               // one content address (identical SQL on one connection), and those
-               // hold separate instructions naming separate physical tables.
-               // Collapsing them here would leave one instructed table unbuilt and
-               // reported neither built nor failed. That collision is real but
-               // separate, and it has its own detection.
-               if (seenSources.has(persistSource.sourceID)) continue;
-               seenSources.add(persistSource.sourceID);
 
                // A caller-instructed destination that cannot be honored REFUSES; it
                // never falls through to a colocated build. Auto-run already applies


### PR DESCRIPTION
## The problem

`executeInstructedBuild` builds a persist source once for every graph that reaches it. A source imported by *N* models is therefore built *N* times in a single run, each time as a full reseed.

Two pieces combine, each correct on its own.

**1. The graph list holds one entry per model.** `compilePackageBuildPlan` accumulates every model's plan:

```ts
for (const modelPath of pkg.getModelPaths()) {
   const buildPlan = malloyModel.getBuildPlan();
   allGraphs.push(...buildPlan.graphs);        // wholesale, per model
   for (const [sourceID, source] of Object.entries(buildPlan.sources)) {
      allSources[sourceID] = source;           // keyed, so idempotent
   }
}
```

`allSources` is keyed and collapses a source seen twice; `allGraphs` is a list and does not. A source declared in one model appears in the build plan of every model that *imports* it — which the preaggregate branch a few lines up already documents: "a persist source declared there also appears in this plan — but under the SAME sourceID, since a sourceID embeds the model that DECLARES a source rather than the one importing it."

**2. The traversal dedups per graph, and is called per graph.**

```ts
export function* iterGraphSources(graph, sources) {
   const seen = new Set<string>();     // per call, i.e. per graph
   ...
}
```

Its doc is accurate as far as it goes — it deduplicates shared (diamond) dependencies "by sourceID so each is yielded once" — but only within one graph. The build walk needs that guarantee across the whole list:

```ts
for (const graph of graphs) {
   for (const persistSource of iterGraphSources(graph, sources)) {
```

`deriveSelfInstructions` walks the same list with its `seen` declared *outside* the graph loop, so the auto-run path has always been correct. Only orchestrated builds take the traversal without the guard, and every existing test of this loop constructs a single graph — so the cross-graph case was untested.

### What it costs

Measured on a package with three persist sources reachable across 21 models, in a run with no failures at all:

| # | Source | Duration | |
|---|---|---|---|
| 1 | A | 2m 54s | first build |
| 2 | B | 12m 36s | first build |
| 3 | A | 2m 52s | rebuild |
| 4 | B | 14m 45s | rebuild |
| 5 | C | 13s | first build |
| 6 | A | 2m 41s | rebuild |
| 7 | B | 10m 04s | rebuild |
| 8 | A | 3m 50s | rebuild |
| 9 | B | 10m 36s | rebuild |
| 10 | C | 15s | rebuild |
| 11 | A | 3m 58s | rebuild |

Eleven builds for three sources. All three had been built by visit 5, 33 minutes in; the run was still rebuilding them 32 minutes later — 15m 43s of necessary build time against 64m 44s spent, so **76% of the run was redundant**. Where a source takes ~24 minutes rather than three, four builds of it consume a two-hour run on their own, and an orchestrated caller that bounds a run never sees it finish.

Two further consequences worth naming, because neither looks like this bug from the outside:

- A run can build **every** instructed source successfully and still never finalize, because the traversal has not returned. The manifest is not published, so the caller sees no progress on a build that is complete and correct.
- With `strictUpstreams`, a source whose upstream failed on one visit reports "not found in manifest" — which reads as a dependency-ordering problem rather than a repeat visit.

## The fix

One build per declared source per run, in the build walk:

```ts
+ const seenSources = new Set<string>();      // hoisted above the graph loop

  for (const graph of graphs) {
     for (const persistSource of iterGraphSources(graph, sources)) {
        if (!instruction) continue;
+       const buildKey = `${graph.connectionName}\u0000${persistSource.sourceID}`;
+       if (seenSources.has(buildKey)) continue;
+       seenSources.add(buildKey);
```

**Keyed on `sourceID`, not `sourceEntityId`.** `deriveSelfInstructions` keys its guard on the content address, which is right for a path holding no caller instructions. It would not be right here: two *distinct* sources can share one content address — identical SQL on one connection — and each carries its own instruction naming its own physical table. Collapsing on the address would leave one instructed table unbuilt and reported as neither built nor failed. `sourceID` is the declaring model plus the source name, so a revisit through another graph is always genuinely the same declaration.

**And on the graph's connection, because that is part of what a build is.** `buildOneSource` executes on the connection resolved from `graph.connectionName`, not from `persistSource.connectionName`, and `getBuildPlan` groups only *root* nodes by connection (`collectSources` recurses into `dependsOn` regardless) — so a nested source can be yielded under a root of a different connection. Whether such a chain is reachable, and whether the graph's connection is the right one to build it on, are pre-existing questions; keying on the pair means this guard does not silently decide them by removing a build that happens today.

**Placed before the eligibility asserts and the content hash.** Those are per-source, so a repeat visit re-derives an answer the first visit already acted on. Skipping early is what makes a duplicate visit cost nothing rather than merely build nothing.

## Testing

`materialization_service.spec.ts` — **156 pass**. `build_plan.spec.ts`, `incremental_build.spec.ts` and `materialization_service.spec.ts` together — **208 pass, 0 fail**.

The new test builds one source reachable from two graphs and asserts a single `CREATE TABLE`. Against the unguarded traversal:

```
2730 |       expect(creates.filter((s) => s.includes("shared_v1")).length).toBe(1);
                                                                           ^
error: expect(received).toBe(expected)

Expected: 1
Received: 2

(fail) executeInstructedBuild > builds a source shared by two graphs exactly once
```

Revert-proved: with the added lines disabled, that is the only failure of the suite.

Both halves of the key are pinned by tests that discriminate, each failing alone under its own mutation:

| Mutation | Fails |
|---|---|
| key on `sourceEntityId` instead of `sourceID` | `builds two sources that share one content address, not just the first` |
| drop `graph.connectionName` from the key | `does not collapse a source across two connections` |

It also asserts the second graph's own work survives the dedup — the consumer still builds, still after the upstream it reads, and both appear in `entries` — so the guard cannot silently swallow work that a graph legitimately contributes.

**Not exercised:** no test builds the plan from real model files on disk, so the "one graph per importing model" shape is inferred from the observed visit sequence rather than asserted against `compilePackageBuildPlan` directly.

Also corrected: the `BuildPlan.graphs` description said "one per connection", where a package's plan holds one per connection *per model* — the fact this bug turns on.
