### PR TITLE
fix: measure a notebook table after it settles, not before

### DIFF
--- a/examples/storefront/storefront.malloynb
+++ b/examples/storefront/storefront.malloynb
@@ -61,3 +61,11 @@ run: order_items -> top_brands
 run: order_items -> top_products
 >>>malloy
 run: order_items -> top_customers
+
+>>>markdown
+## A two-row table
+
+The smallest table there is: the cell should be as tall as these two rows and
+nothing more.
+>>>malloy
+run: order_items -> top_products + { limit: 2 }

--- a/packages/app/tests/playwright/package-notebooks.spec.ts
+++ b/packages/app/tests/playwright/package-notebooks.spec.ts
@@ -93,7 +93,16 @@ test.describe("package-notebooks", () => {
       // row-height or font change, and over every table on the page rather
       // than the first, because the first one to settle is not deterministic.
       const tables = page.locator(".malloy-render > .malloy-table.root");
-      await expect(tables.first()).toBeVisible();
+      // Pin the count before measuring anything. Notebook cells render
+      // progressively, and the poll below succeeds the moment nothing it can
+      // see has dead space, so without this a run where only one table has
+      // painted is a pass - and that is the run least likely to reproduce the
+      // measurement race this test guards. Three is every untagged view in
+      // storefront.malloynb: top_products, top_customers, and the two-row
+      // top_products cell. Every other view carries a render tag, and the
+      // dashboard's nested tables match neither .root nor the direct-child
+      // step. Adding an untagged cell to that notebook means updating this.
+      await expect(tables).toHaveCount(3);
       await expect
          .poll(
             () =>

--- a/packages/app/tests/playwright/package-notebooks.spec.ts
+++ b/packages/app/tests/playwright/package-notebooks.spec.ts
@@ -79,4 +79,45 @@ test.describe("package-notebooks", () => {
       );
       await expect(page.getByText(/does not exist/i)).toHaveCount(0);
    });
+
+   test("a table cell is as tall as its table, not as tall as the cell cap", async ({
+      page,
+   }) => {
+      await page.goto(
+         `/${DEFAULT_ENV}/${PACKAGES.storefront}/storefront.malloynb`,
+      );
+
+      // Every notebook table, measured against the box the cell gives it. The
+      // renderer signals ready before a table's virtualized grid has settled,
+      // so the cell used to latch onto the height it read at that moment --
+      // scrollHeight 10028 for a four-row table -- clamp it to the 700px cap
+      // and paint ~390px of blank space under the rows. Asserted on the ratio
+      // rather than on a pixel count so it survives a row-height or font
+      // change, and over every table on the page rather than the first,
+      // because the first one to settle is not deterministic.
+      const tables = page.locator(".malloy-render > .malloy-table.root");
+      await expect(tables.first()).toBeVisible();
+      await expect
+         .poll(
+            () =>
+               tables.evaluateAll((nodes) =>
+                  nodes
+                     .map((node) => {
+                        const table = node as HTMLElement;
+                        const box = table.parentElement as HTMLElement;
+                        return {
+                           table: table.offsetHeight,
+                           box: box.offsetHeight,
+                        };
+                     })
+                     // Only the ones with dead space left under the table, so a
+                     // failure names the measurements rather than saying false.
+                     .filter(
+                        ({ table, box }) => table === 0 || box - table > 4,
+                     ),
+               ),
+            { timeout: 30_000 },
+         )
+         .toEqual([]);
+   });
 });

--- a/packages/app/tests/playwright/package-notebooks.spec.ts
+++ b/packages/app/tests/playwright/package-notebooks.spec.ts
@@ -87,14 +87,11 @@ test.describe("package-notebooks", () => {
          `/${DEFAULT_ENV}/${PACKAGES.storefront}/storefront.malloynb`,
       );
 
-      // Every notebook table, measured against the box the cell gives it. The
-      // renderer signals ready before a table's virtualized grid has settled,
-      // so the cell used to latch onto the height it read at that moment --
-      // scrollHeight 10028 for a four-row table -- clamp it to the 700px cap
-      // and paint ~390px of blank space under the rows. Asserted on the ratio
-      // rather than on a pixel count so it survives a row-height or font
-      // change, and over every table on the page rather than the first,
-      // because the first one to settle is not deterministic.
+      // Every notebook table, measured against the box the cell gives it: a
+      // cell must end up as tall as its table, not as tall as the 700px cap.
+      // Asserted on the ratio rather than on a pixel count so it survives a
+      // row-height or font change, and over every table on the page rather
+      // than the first, because the first one to settle is not deterministic.
       const tables = page.locator(".malloy-render > .malloy-table.root");
       await expect(tables.first()).toBeVisible();
       await expect

--- a/packages/sdk/src/components/RenderedResult/RenderedResult.tsx
+++ b/packages/sdk/src/components/RenderedResult/RenderedResult.tsx
@@ -40,6 +40,15 @@ type MalloyRenderElement = HTMLElement & Record<string, unknown>;
  * `@malloydata/render` if more methods are needed.
  */
 interface MalloyVizHandle extends DrillMetadataSource {
+   // Narrowed from `DrillMetadataSource`, which only declares the part the
+   // drill affordance reads. `getRootField().renderAs()` is what decides
+   // whether one measurement is enough; see `sizesToContent`.
+   getMetadata: () =>
+      | (NonNullable<ReturnType<DrillMetadataSource["getMetadata"]>> & {
+           getRootField: () => { renderAs: () => string };
+        })
+      | null
+      | undefined;
    setResult: (result: unknown) => void;
    render: (element: HTMLElement) => void;
    remove: () => void;
@@ -324,31 +333,36 @@ function injectRendererOverrides(): void {
  * than to the box it was handed, which decides whether measuring it once is
  * enough.
  *
- * It is not, for a table, and that is the bug this predicate exists for. The
- * renderer signals `onReady` as soon as it knows it can paint, and for a table
- * that is immediately — a chart waits for a non-zero parent size, a table does
- * not. The single measurement taken there therefore lands before the table's
- * virtualized grid has settled: measured, a four-row table reported
- * `scrollHeight` 10028 at that moment and 308 once settled. The cell latched
- * onto the 10028, clamped it to its 700px cap, and painted ~390px of blank
- * space under every table in a notebook.
+ * It is not, for a table. The renderer signals `onReady` as soon as it knows it
+ * can paint, and for a table that is immediately — a chart waits for a non-zero
+ * parent size, a table does not — so the single measurement taken there lands
+ * before the table's virtualized grid has laid out, and reads a height the
+ * table never keeps.
  *
- * Re-measuring a table terminates. `.malloy-table.root` is
+ * Re-measuring a table TERMINATES: `.malloy-table.root` is
  * `height: fit-content; max-height: 100%` in the renderer's own CSS and the
- * wrappers between it and the container add no padding (measured), so shrinking
- * the container to the table's content height is the exact point at which the
- * cap stops binding: the next measurement reports the same number.
+ * wrappers between it and the container add no padding, so shrinking the
+ * container to the table's content height is the exact point at which the cap
+ * stops binding and the next measurement reports the same number.
  *
- * A root that FILLS its container stays on the one-shot path deliberately. A
- * chart draws itself inset from the box it is given (8px, measured), so feeding
- * its height back as the new container height would ratchet the container down
- * by that inset on every pass and never converge.
+ * A root that FILLS its container stays on the one-shot path deliberately: a
+ * chart draws itself inset from the box it is given, so feeding its height back
+ * as the new container height would ratchet the container down by that inset
+ * every pass and never converge.
+ *
+ * A table is the only root that needs this, and the reason is the virtualized
+ * grid rather than the sizing strategy it shares with a `# size=` chart: that
+ * chart takes its dimensions from a lookup synchronously, so its first
+ * measurement is already right. Measured, for every size value and spelling.
  */
-function sizesToContent(rendered: HTMLElement): boolean {
-   return (
-      rendered.classList.contains("malloy-table") &&
-      rendered.classList.contains("root")
-   );
+function sizesToContent(viz: MalloyVizHandle): boolean {
+   try {
+      return viz.getMetadata()?.getRootField().renderAs() === "table";
+   } catch {
+      // Metadata unavailable: measure once, which is the behavior every
+      // non-table root gets anyway.
+      return false;
+   }
 }
 
 function RenderedResultInner({
@@ -465,9 +479,15 @@ function RenderedResultInner({
          if (!grandchild) return;
          // A table reports a height of its own, so it keeps being measured
          // even after the first one lands. Everything else measures once.
-         const contentSized = sizesToContent(grandchild);
+         const contentSized = viz !== undefined && sizesToContent(viz);
          if (hasMeasuredRef.current && !contentSized) return;
          const greatgrandchild = grandchild.firstElementChild as HTMLElement;
+         // `scrollHeight` is the CONTENT height, so this assumes the box adds
+         // no chrome of its own. True today: `.malloy-table.root` has no
+         // border, and a horizontal scrollbar costs no layout where scrollbars
+         // overlay. A wide table clipped by a few pixels on a platform that
+         // draws classic scrollbars would be this assumption breaking, and the
+         // fix is `+ (offsetHeight - clientHeight)`.
          let renderedHeight =
             grandchild.scrollHeight || grandchild.offsetHeight || 0;
 
@@ -562,6 +582,13 @@ function RenderedResultInner({
                // unconditionally gave up on a stage whose renderer output was
                // still empty at the first settle, leaving nothing to measure it
                // later.
+               //
+               // Staying connected cannot loop the way the version this
+               // disconnect was first added to guard (#531) could: THAT
+               // observer watched the container, with `attributes: true`, so
+               // reporting a height re-triggered it through the container's own
+               // style. This one watches `stage`, a descendant, which that
+               // style write is outside of.
                if (hasMeasuredRef.current) observer?.disconnect();
             }, 100);
          });

--- a/packages/sdk/src/components/RenderedResult/RenderedResult.tsx
+++ b/packages/sdk/src/components/RenderedResult/RenderedResult.tsx
@@ -319,6 +319,38 @@ function injectRendererOverrides(): void {
    document.head.appendChild(style);
 }
 
+/**
+ * Whether the renderer's top-level output sizes itself to its CONTENT rather
+ * than to the box it was handed, which decides whether measuring it once is
+ * enough.
+ *
+ * It is not, for a table, and that is the bug this predicate exists for. The
+ * renderer signals `onReady` as soon as it knows it can paint, and for a table
+ * that is immediately — a chart waits for a non-zero parent size, a table does
+ * not. The single measurement taken there therefore lands before the table's
+ * virtualized grid has settled: measured, a four-row table reported
+ * `scrollHeight` 10028 at that moment and 308 once settled. The cell latched
+ * onto the 10028, clamped it to its 700px cap, and painted ~390px of blank
+ * space under every table in a notebook.
+ *
+ * Re-measuring a table terminates. `.malloy-table.root` is
+ * `height: fit-content; max-height: 100%` in the renderer's own CSS and the
+ * wrappers between it and the container add no padding (measured), so shrinking
+ * the container to the table's content height is the exact point at which the
+ * cap stops binding: the next measurement reports the same number.
+ *
+ * A root that FILLS its container stays on the one-shot path deliberately. A
+ * chart draws itself inset from the box it is given (8px, measured), so feeding
+ * its height back as the new container height would ratchet the container down
+ * by that inset on every pass and never converge.
+ */
+function sizesToContent(rendered: HTMLElement): boolean {
+   return (
+      rendered.classList.contains("malloy-table") &&
+      rendered.classList.contains("root")
+   );
+}
+
 function RenderedResultInner({
    result,
    height: inputHeight,
@@ -411,6 +443,11 @@ function RenderedResultInner({
       let drillFocusIn: ((event: FocusEvent) => void) | null = null;
       let observer: MutationObserver | null = null;
       let measureTimeout: NodeJS.Timeout | null = null;
+      // Keeps a table's height honest after `onReady` has lied about it; see
+      // `sizesToContent` above.
+      let sizeObserver: ResizeObserver | null = null;
+      let observedNode: HTMLElement | null = null;
+      let lastReportedHeight = 0;
       // Safety net so a render that never signals ready (an async renderer
       // error that only reaches onError) can't leave a previous chart showing
       // stale data forever; see the setTimeout below.
@@ -422,11 +459,14 @@ function RenderedResultInner({
       // wraps the renderer output) and report it up. Same grandchild/dashboard
       // HACK as before, just anchored on the stage wrapper.
       const measureRenderedSize = (root: HTMLElement) => {
-         if (hasMeasuredRef.current || cancelled || !root.firstElementChild)
-            return;
+         if (cancelled || !root.firstElementChild) return;
          const child = root.firstElementChild as HTMLElement;
          const grandchild = child.firstElementChild as HTMLElement;
          if (!grandchild) return;
+         // A table reports a height of its own, so it keeps being measured
+         // even after the first one lands. Everything else measures once.
+         const contentSized = sizesToContent(grandchild);
+         if (hasMeasuredRef.current && !contentSized) return;
          const greatgrandchild = grandchild.firstElementChild as HTMLElement;
          let renderedHeight =
             grandchild.scrollHeight || grandchild.offsetHeight || 0;
@@ -444,9 +484,19 @@ function RenderedResultInner({
 
          if (renderedHeight > 0) {
             hasMeasuredRef.current = true;
-            if (onSizeChange) {
+            if (onSizeChange && renderedHeight !== lastReportedHeight) {
+               lastReportedHeight = renderedHeight;
                onSizeChange(renderedHeight);
             }
+         }
+         // Watch the table from here on. Attached after the first measurement
+         // rather than at render time because the node does not exist until
+         // the renderer builds it, and this is the callback that first sees it.
+         if (contentSized && observedNode !== grandchild) {
+            observedNode = grandchild;
+            sizeObserver?.disconnect();
+            sizeObserver = new ResizeObserver(() => measureRenderedSize(root));
+            sizeObserver.observe(grandchild);
          }
       };
 
@@ -508,7 +558,11 @@ function RenderedResultInner({
             if (measureTimeout) clearTimeout(measureTimeout);
             measureTimeout = setTimeout(() => {
                measureRenderedSize(stageNode);
-               observer?.disconnect();
+               // Only once a measurement actually landed. Disconnecting
+               // unconditionally gave up on a stage whose renderer output was
+               // still empty at the first settle, leaving nothing to measure it
+               // later.
+               if (hasMeasuredRef.current) observer?.disconnect();
             }, 100);
          });
          observer.observe(stage, {
@@ -736,6 +790,7 @@ function RenderedResultInner({
          } catch (error) {
             console.error("Error rendering visualization:", error);
             observer?.disconnect();
+            sizeObserver?.disconnect();
             drillObserver?.disconnect();
             viz.remove();
             viz = undefined;
@@ -748,6 +803,7 @@ function RenderedResultInner({
       return () => {
          cancelled = true;
          observer?.disconnect();
+         sizeObserver?.disconnect();
          if (measureTimeout) clearTimeout(measureTimeout);
          if (readyFallback) clearTimeout(readyFallback);
          // If this render built a stage but never swapped it into `liveRef`


### PR DESCRIPTION
## The bug

A notebook table painted its cell at the 700px cap however few rows it had. A two-row table got 700px of cell for 84px of table.

## Why

A cell renders its result into a box capped at `CELL_MAX_HEIGHT`, measures the result, and shrinks the box to fit. The measurement ran **once**, from the renderer's `onReady` — and for a table `onReady` is not a paint signal. The renderer fires it as soon as it knows it can paint, which for a table is immediately (a chart waits for a non-zero parent size, a table does not), so the one measurement landed before the table's virtualized grid had laid out.

Measured in Chromium against `examples/storefront/storefront.malloynb`: a four-row table reported `scrollHeight` **10028** at that moment and **308** once settled. The cell latched onto the 10028, clamped it to 700, and never looked again.

## The fix

A table now keeps a `ResizeObserver` and reports each settled height, not only the first.

That **terminates**, rather than merely converging in practice: `.malloy-table.root` is `height: fit-content; max-height: 100%` in the renderer's own CSS, and the wrappers between it and the container add no padding (measured), so shrinking the container to the table's content height is the exact point at which the cap stops binding — the next measurement reports the same number. A table taller than the cap reports its full `scrollHeight`, the container clamps to the cap, and nothing resizes.

A root that **fills** its container stays on the one-shot path deliberately. A chart draws itself 4px-per-side inset from the box it is given, so feeding its height back as the new container height would ratchet the container down by that inset every pass and never converge.

Which root is which comes from the renderer's own typed API — `viz.getMetadata().getRootField().renderAs() === "table"` — not from sniffing its CSS class names. `getMetadata()` is already used here for the drill affordance; `renderAs()` is declared on `FieldBase` and inherited by `RootField`.

Also: the `MutationObserver` fallback now disconnects only once a measurement has actually landed. Disconnecting unconditionally gave up on a stage whose renderer output was still empty at the first settle, leaving nothing to measure it later. That cannot recreate the loop the unconditional disconnect was added to guard in #531 — *that* observer watched the container with `attributes: true`, so reporting a height re-triggered it through the container's own style; this one watches `stage`, a descendant, which that write is outside of.

## Measured, before → after

Same notebook, same build:

| cell | before | after |
| --- | --- | --- |
| 10-row table | 700 | 308 |
| 2-row table | 700 | 84 |
| chart | 692 | 692 |
| `# dashboard` | 700 | 700 |

The two-row cell is added to `storefront.malloynb` in this PR, so the second row is reproducible and the smallest table reaches CI. It had been living only in a local `publisher_data` copy, which is gitignored.

No console errors, no `ResizeObserver` loop warnings.

## Is a `# size=` chart affected too?

No, and it was worth checking, because a `# size=` other than `fill` puts a **chart** on the same "fixed" sizing strategy a table gets, so it signals ready just as early. But a tag-sized chart takes its dimensions from a synchronous lookup, so its first measurement is already correct. Measured against the real renderer, cell box vs rendered height, zero dead space in every case:

```
size=xs 112/112   sm 168/168   md 252/252   lg 336/336
size=xl 448/448   2xl 560/560  spark 28/28
viz=bar viz.size=lg 336/336    viz=line viz.size=2xl 560/560
bar_chart size=lg 336/336
```

Fill charts in the same run measured 692/684 — the renderer's own inset, which is why they stay on the one-shot path. What sets a table apart is not its sizing strategy but its virtualized grid, which lays out after the ready signal. So the predicate is `renderAs() === "table"` on purpose, not as an approximation of something broader.

## One assumption, named rather than defended

`scrollHeight` is the content height, so the measurement assumes the table's box adds no chrome of its own. Neither source exists today: `.malloy-table.root` declares no border, and a horizontal scrollbar costs no layout where scrollbars overlay. A wide table clipped by a few pixels on a platform that draws classic scrollbars would be this assumption breaking, and the fix is `+ (offsetHeight - clientHeight)`.

A correction term was written and then removed: it was a no-op in every reachable case and could not be tested here, because headless Chromium would not give up overlay scrollbars. There is a comment at the measurement site naming the symptom and the one-line fix, which is more useful than an untestable branch.

## Tests

New Playwright case in `package-notebooks.spec.ts`, asserted against the real renderer in a real browser and on the table-to-box ratio rather than a pixel count, so a row-height or font change doesn't break it. It runs over every table on the page, and pins the count at 3 first — notebook cells render progressively and the poll succeeds the moment nothing it can see has dead space, so without the count a run with one table painted would pass. Three is every untagged view in `storefront.malloynb` (`top_products`, `top_customers`, and the two-row cell this PR adds); the dashboard's nested tables are excluded by both `.root` and the direct-child step in the selector.

Confirmed it isn't passing for free: reverting only the SDK change makes it fail with `{box: 700, table: 308}` and `{box: 700, table: 84}`, past the count assertion. Note it names two tables, not three — one of the three shows no dead space even with the bug, which is why pinning the count matters.

Full app Playwright suite: **111 passed, 2 failed**. Both failures are in `environment-connections.spec.ts` and need the stub `bigquery` connection the CI workflow injects into `publisher.config.json` before the suite (`app-playwright.yml:86`); they fail the same way on a clean tree locally. `test:sdk` 384 pass, `test:examples` 72 pass. Lint and typecheck clean on both packages. I did not run `test:server` — it binds port 4000 and nothing here touches the server.

## Not in this PR

The sidebar change that was originally bundled here now lives on its own branch, since it is an unrelated product judgment that deserves to be judged separately.

