### PR TITLE
fix(app): move Visualization theme to the bottom of the sidebar

### DIFF
--- a/packages/app/src/components/layout/Sidebar/Sidebar.tsx
+++ b/packages/app/src/components/layout/Sidebar/Sidebar.tsx
@@ -65,8 +65,8 @@ export default function Sidebar({
          <Box sx={{ flex: 1, overflowY: "auto", overflowX: "hidden", py: 1 }}>
             <PrimaryNav isCollapsed={isCollapsed} />
             <EnvironmentsSection isCollapsed={isCollapsed} />
-            <SettingsSection isCollapsed={isCollapsed} />
          </Box>
+         <SettingsSection isCollapsed={isCollapsed} />
          <DocsFooter isCollapsed={isCollapsed} />
       </Box>
    );
@@ -240,39 +240,27 @@ function EnvironmentsSection({ isCollapsed }: { isCollapsed: boolean }) {
    );
 }
 
+/**
+ * Pinned to the bottom with the docs links rather than sitting under
+ * Environments, and with no section heading of its own. Visualization theme is
+ * the only setting there is (`/settings` is a redirect to it), so a headed
+ * SETTINGS section directly beneath the environment list gave one operator
+ * preference the same weight as the data the sidebar exists to navigate.
+ */
 function SettingsSection({ isCollapsed }: { isCollapsed: boolean }) {
    const location = useLocation();
    const isThemeRoute = location.pathname.startsWith("/settings/theme");
 
    return (
-      <Box sx={{ mt: 1 }}>
-         {!isCollapsed && (
-            <Typography
-               variant="caption"
-               sx={{
-                  display: "block",
-                  px: 3,
-                  py: 1,
-                  color: "text.secondary",
-                  fontWeight: 500,
-                  textTransform: "uppercase",
-                  fontSize: "0.6875rem",
-                  letterSpacing: "0.5px",
-               }}
-            >
-               Settings
-            </Typography>
-         )}
-         <List sx={{ py: 0 }}>
-            <SidebarItem
-               icon={<PaletteOutlinedIcon fontSize="small" />}
-               label="Visualization theme"
-               to="/settings/theme"
-               selected={isThemeRoute}
-               isCollapsed={isCollapsed}
-            />
-         </List>
-      </Box>
+      <List sx={{ pt: 1, pb: 0 }}>
+         <SidebarItem
+            icon={<PaletteOutlinedIcon fontSize="small" />}
+            label="Visualization theme"
+            to="/settings/theme"
+            selected={isThemeRoute}
+            isCollapsed={isCollapsed}
+         />
+      </List>
    );
 }
 


### PR DESCRIPTION
## What

Moves **Visualization theme** out of a headed `SETTINGS` section under the environment list and into the pinned bottom group with the docs links, dropping the heading.

## Why

Visualization theme is the only setting there is — `/settings` is a redirect to `/settings/theme` — so a headed section directly beneath the environment list gave one operator preference the same visual weight as the data the sidebar exists to navigate. The bottom group is where the other persistent, non-navigational links already live.

## Notes

Split out of #1105, where it was originally bundled with an unrelated SDK measurement fix. It is a product judgment about sidebar weighting rather than a bug fix, so it is easier to agree or disagree with on its own.

`Typography` is still imported and used elsewhere in the file, so nothing is left dead.

## Tests

Full app Playwright suite run on the combined branch before the split: 111 passed, 2 failed — both in `environment-connections.spec.ts`, which needs the stub `bigquery` connection CI injects before the suite (`app-playwright.yml:86`); they fail the same way on a clean tree locally. Lint and typecheck clean.
