### PR TITLE
chore(release): stamp 0.2.2 on main

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,7 +31,7 @@ One behaviour change to know about: `skills-npm.yml` now publishes only from `ma
 
 ---
 
-## [Unreleased] — one materialized table, written once and readable by every source that shares it
+## [0.2.2] — one materialized table, written once and readable by every source that shares it
 
 Malloy [#3029](https://github.com/malloydata/malloy/pull/3029) settled that several sources naming one
 physical table is the design, not a defect: `#@ persist` is inherited through `extend`, `extend` never
@@ -65,7 +65,7 @@ rows it overwrote.
 | `publisher_materialization_table_collision_total` | Two definitions materializing into one table — serve-time wrong data. **This is the one to alert on.** Its rate is also what enabling `PERSIST_COLLISION_ENFORCE` would begin refusing, so a rollout can be measured before it is turned on. |
 
 
-## [Unreleased] — a boolean query param you misspell now fails instead of doing nothing
+## [0.2.2] — a boolean query param you misspell now fails instead of doing nothing
 
 `reload`, `dropTables` and `bypass_filters` were each read as `=== "true"`, so
 every other spelling — `?reload=1`, `?dropTables=yes`, `?reload=TRUE`, or the

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/app",
    "description": "Malloy Publisher Console (the built-in web UI)",
-   "version": "0.2.1",
+   "version": "0.2.2",
    "type": "module",
    "main": "dist/index.cjs.js",
    "module": "dist/index.es.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/sdk",
    "description": "Malloy Publisher SDK",
-   "version": "0.2.1",
+   "version": "0.2.2",
    "type": "module",
    "main": "dist/index.cjs.js",
    "module": "dist/index.es.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/server",
    "description": "Malloy Publisher Server",
-   "version": "0.2.1",
+   "version": "0.2.2",
    "main": "dist/server.mjs",
    "bin": {
       "malloy-publisher": "dist/server.mjs"


### PR DESCRIPTION
Pushed by `gh-release` during the 0.2.2 release. Two halves:

- `RELEASE_NOTES.md`: the two sections 0.2.2 shipped are stamped `[0.2.2]`, so the next release's `extract` no longer re-appends them to its own page.
- `packages/{sdk,app,server}/package.json`: reset to `0.2.2`, so `main` declares what shipped.

Release: https://github.com/malloydata/publisher/releases/tag/v0.2.2