### PR TITLE
docs: Publisher is created and maintained by Credible; where the server ends and the engine begins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT
 
 # Working with Malloy Publisher
 
-Publisher is the open-source semantic model server for [Malloy](https://malloydata.dev). It serves one or more Malloy model packages over a REST API and a single MCP endpoint. If you are an AI agent working in this repo, here is what you can do with it and how to start.
+Publisher is the open-source semantic model server for [Malloy](https://malloydata.dev), created and maintained by [Credible](https://www.credibledata.com). It serves one or more Malloy model packages over a REST API and a single MCP endpoint. If you are an AI agent working in this repo, here is what you can do with it and how to start.
 
 ## What you can do
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ SPDX-License-Identifier: MIT
 <h1 align="center">Malloy Publisher</h1>
 
 <p align="center"><b>The open-source semantic model server for <a href="https://malloydata.dev">Malloy</a></b><br>
-Serve governed data models to applications, BI tools, and AI agents — over REST and MCP.</p>
+Serve governed data models to applications, BI tools, and AI agents — over REST and MCP.<br>
+<sub>Created and maintained by <a href="https://www.credibledata.com">Credible</a>, the company behind the AI Analytics Engine.</sub></p>
 
 <p align="center">
   <a href="https://github.com/malloydata/publisher/actions/workflows/build.yml"><img src="https://github.com/malloydata/publisher/actions/workflows/build.yml/badge.svg" alt="build"></a>
@@ -19,8 +20,8 @@ Serve governed data models to applications, BI tools, and AI agents — over RES
 
 When an AI queries your database directly, it writes its own SQL — and gets it subtly wrong: the wrong
 join, an invented column, a fan-out that double-counts but still looks plausible. Publisher puts a
-Malloy semantic layer in front of your data, where measures, dimensions, and joins are defined once,
-correctly. Applications, BI tools, and **AI agents** compose queries against that model instead of
+Malloy model — what the industry calls a semantic layer — in front of your data, where measures,
+dimensions, and joins are defined once, correctly. Applications, BI tools, and **AI agents** compose queries against that model instead of
 writing raw SQL, so the numbers come back **right by construction**. Agents work through the sources
 the model defines — not your raw tables — and you decide exactly what each caller can see.
 
@@ -281,6 +282,25 @@ The [`docs/`](docs/) folder is the reference hub — see its [index](docs/README
 
 The complete user guide also lives at
 **[docs.malloydata.dev](https://docs.malloydata.dev/documentation/user_guides/publishing/publishing)**.
+
+## Publisher and Credible
+
+Publisher is created and maintained by [Credible](https://www.credibledata.com), the company behind
+the **AI Analytics Engine**. The two fit together like this:
+
+- **Publisher is the open-source server.** It serves Malloy models over REST and MCP, and everything
+  an agent needs from the language and the server — the modeling and analysis skills, the MCP tools —
+  ships here in the open. Run it on a laptop, in Docker, or wherever you like.
+- **Credible is the hosted, governed engine built around it.** You write down what your data means
+  once, in Malloy; the engine owns the how — it materializes and indexes the model in storage it
+  brings along, enforces access at one gateway on every query, compresses each model into a concept
+  index so an agent gets just the slice a question needs, and serves every surface — agents over MCP,
+  dashboards and workspaces, the data apps and APIs in your product — from one model.
+
+Run Publisher yourself, or let Credible run it: the model is the same Malloy either way, and moving
+between them is a publish, not a rewrite. Where the server ends and the engine begins:
+[credibledata.com/malloy](https://www.credibledata.com/malloy) ·
+[Inside the AI Analytics Engine](https://www.credibledata.com/blog/posts/inside-the-ai-analytics-engine).
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,10 @@ SPDX-License-Identifier: MIT
 > Start at the [project README](../README.md) for the 60-second quick start. This folder holds the
 > deeper reference. If you're an AI agent, read [AGENTS.md](../AGENTS.md) first — it's the canonical
 > guide to running Publisher and connecting over MCP.
+>
+> Publisher is created and maintained by [Credible](https://www.credibledata.com), the company
+> behind the AI Analytics Engine. For where the open-source server ends and Credible's hosted engine
+> begins, see [credibledata.com/malloy](https://www.credibledata.com/malloy).
 
 ## Examples
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MIT
 > What this is: the mental model for Publisher and the Malloy stack it sits on. Read it when you
 > want to know which repo owns what, or how a query flows from a `.malloy` file to a rendered chart.
 
-Publisher is one layer in the Malloy stack. From the bottom up:
+Publisher is one component of the Malloy stack. From the bottom up:
 
 ## Malloy
 
@@ -51,6 +51,21 @@ entirely from it**, so it's best understood as the Console's internal toolkit ra
 external integration path. See [embedded-data-apps.md](embedded-data-apps.md) for the advanced/internal
 notes. To surface analytics, prefer the [Publisher Console](console.md), an
 [HTML data app](html-data-apps.md), or the [REST/MCP APIs](api-overview.md).
+
+## Credible (hosted)
+
+[Credible](https://www.credibledata.com) creates and maintains Publisher, and runs it as the core of
+the **AI Analytics Engine** — the hosted, governed service built around the server. Everything
+described above is the same there: the same Malloy, the same package format, the same REST and MCP
+surfaces. What Credible adds is the engine around them: managed materialization and indexing in
+storage it brings along, one gateway that enforces access on every query, a concept index that gives
+an agent just the slice of a model its question needs, and every surface — agents, dashboards and
+workspaces, data apps and APIs — served from one model. A package published to a local Publisher and
+one published to Credible are the same artifact; the [`publisher` connection type](connections.md#publisher-proxy-connections-type-publisher)
+is how a local authoring loop talks to a hosted environment.
+
+**Read more:** [credibledata.com/malloy](https://www.credibledata.com/malloy) ·
+[Inside the AI Analytics Engine](https://www.credibledata.com/blog/posts/inside-the-ai-analytics-engine)
 
 ## Packages in this repo
 

--- a/docs/choosing-a-surface.md
+++ b/docs/choosing-a-surface.md
@@ -157,7 +157,7 @@ filter wiring, and error handling. Guide:
 
 - It's still code, even when an agent writes it. The filter widgets, loading states, error
   handling, and responsive layout that notebooks and dashboards give you for free are the app's
-  to get right. The skills cover them, but they live in your page, not the platform.
+  to get right. The skills cover them, but they live in your page, not in Publisher.
 - Nothing is derived from the model: add a given, and the UI has to be updated to match (another
   agent pass, but a pass someone has to remember to make).
 - Highest maintenance cost of the three, and quality depends on the author, human or agent.

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -188,8 +188,8 @@ Connection names must be unique within a single environment. Duplicate names aft
 ## Publisher proxy connections (`type: "publisher"`)
 
 A `publisher` connection does not talk to a warehouse directly. Instead it
-**proxies SQL to a remote Publisher dataplane** (e.g. a hosted Credible
-environment), which runs the query against its own connection and returns the
+**proxies SQL to a remote Publisher dataplane** (e.g. an environment on
+Credible, the hosted engine built on Publisher), which runs the query against its own connection and returns the
 rows. This is the local-dev authoring loop: run a local Publisher with
 `--watch-env` to serve a package's `public/` app with live-reload, while queries
 proxy to your real remote connection — no need to replicate warehouse

--- a/skills/README.md
+++ b/skills/README.md
@@ -29,8 +29,8 @@ Most of these skills are **shared, open-source Malloy skills**, and **this repos
 
 Two rules make it work:
 
-- **`credible-*` skills never land here.** Anything named `credible-*` in the upstream repo is Credible-platform-specific and is never copied into this open-source repo. The copy keys off the `credible-` prefix. If you ever see a `credible-*` file under this tree, it is a stray: it should be git-ignored, not committed (`git ls-files | grep credible-` must stay empty).
-- **Shared skills carry no Credible-platform-specific answers.** They describe generic Malloy and the open-source Publisher only, with no hosted draft/publish flow, retrieval-engine annotations (`#(index)`/`#(agent-hidden)`), or platform tools like `execute_query_draft`. Open-source Publisher features (`publisher.json` `explores`/`queryableSources`, `export {}`) are fair game. The Publisher-only authoring tools `malloy_compile` / `malloy_reloadPackage` stay in the host/router skills, not the shared set (see the tool-names section below).
+- **`credible-*` skills never land here.** Anything named `credible-*` in the upstream repo is specific to Credible's hosted engine and is never copied into this open-source repo. The copy keys off the `credible-` prefix. If you ever see a `credible-*` file under this tree, it is a stray: it should be git-ignored, not committed (`git ls-files | grep credible-` must stay empty).
+- **Shared skills carry no answers specific to Credible's hosted engine.** They describe generic Malloy and the open-source Publisher only, with no hosted draft/publish flow, retrieval-engine annotations (`#(index)`/`#(agent-hidden)`), or hosted-engine tools like `execute_query_draft`. Open-source Publisher features (`publisher.json` `explores`/`queryableSources`, `export {}`) are fair game. The Publisher-only authoring tools `malloy_compile` / `malloy_reloadPackage` stay in the host/router skills, not the shared set (see the tool-names section below).
 
 ## Shared vs Publisher-specific
 


### PR DESCRIPTION
Publisher's docs never said who builds it. This adds the attribution and the relationship, without turning the README into a pitch:

- **README**: a one-line credit under the title; the intro keeps "semantic layer" as the term people search for while naming the thing itself a Malloy model; a short *Publisher and Credible* section before Contributing — Publisher is the open-source server, Credible is the hosted, governed engine built around it (materialization and indexing, one gateway, concept index, every surface), and a package is the same artifact in both.
- **docs/README.md** and **AGENTS.md**: the same attribution in one line each.
- **docs/architecture.md**: Publisher is a *component* of the Malloy stack (not a "layer"), and a new *Credible (hosted)* section closes the stack, pointing at the `publisher` connection type as the bridge between a local authoring loop and a hosted environment.
- **docs/connections.md**, **docs/choosing-a-surface.md**, **skills/README.md**: "platform" gives way to "Publisher" or "the hosted engine" where it described one of the two.

Links go to credibledata.com/malloy and the *Inside the AI Analytics Engine* post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Second commit: the README, tightened

315 lines → 250, most of the cut being caveats that now live where they belong. Nothing was thrown away.

- **Opener** shares Malloyyo's framing: a problem/solution pair (an AI pointed at raw data writes different SQL for the same question; a Malloy model between the AI and the data makes the numbers right by construction, the same way every time), then a bullet list of what Publisher is for — thin by design, any AI over one endpoint, tight control, readable queries, DuckDB built in with no warehouse required, materialization, the skills, runs anywhere.
- **Focused subsections**: Quick start → *Run the examples* / *Know when it's ready*; Start from your own data → *Scaffold a package* / *Bring a file*; Point your agent at it → *Connect Claude Code* / *When the config isn't written* / *Other clients, and unattended agents* / *Starting from a database instead of a model*.
- **Moved, not deleted**: the `PUBLISHER_READY` / `PUBLISHER_INIT_FAILED` / `PUBLISHER_UNSUPPORTED_NODE` contract → `docs/configuration.md#startup-signals`; the scaffolder's finer points (the `@latest` rule, workspace layout, seeding, the bare `npx` form) → new `docs/scaffolding.md`, indexed in `docs/README.md`; the `.mcp.json` staleness detail already lived in `configuration.md` and is linked.

Every `docs/` link and anchor in the README resolves. Both commits carry the DCO sign-off.
