### PR TITLE
docs: README follow-ups — quieter agent pointer, readiness contract moves to the docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT
 
 # Working with Malloy Publisher
 
-Publisher is the open-source AI Analytics Engine for [Malloy](https://malloydata.dev), created and maintained by [Credible](https://www.credibledata.com). It serves one or more Malloy model packages over a REST API and a single MCP endpoint. If you are an AI agent working in this repo, here is what you can do with it and how to start.
+Publisher is the Analytics Engine for [Malloy](https://malloydata.dev), created and maintained by [Credible](https://www.credibledata.com). It serves one or more Malloy model packages over a REST API and a single MCP endpoint. If you are an AI agent working in this repo, here is what you can do with it and how to start.
 
 ## What you can do
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,14 +21,20 @@ All of it runs against a local server you start in step 1 and reach over MCP in 
 
 The MCP tools talk to a running server, so nothing works until it is up.
 
-From a clone:
+The fastest way, with nothing cloned and no Bun installed:
+
+```bash
+npx @malloy-publisher/server@latest --port 4000        # REST on :4000, MCP on :4040
+```
+
+From a clone of this repo:
 
 ```bash
 bun install
-bun run build && bun run start        # REST on :4000, MCP on :4040
+bun run build && bun run start
 ```
 
-To re-initialize the sample storage on a later run, build first and then start with `--init`: `bun run build && bun run start:init`. Without cloning, `npx @malloy-publisher/server@latest --port 4000` runs the published build. Start one npx server at a time: concurrent first runs can race in the shared npx cache and corrupt the install ([docs/deployment.md](docs/deployment.md#run-with-npx) has the recovery step).
+To re-initialize the sample storage on a later run, build first and then start with `--init`: `bun run build && bun run start:init`. Start one npx server at a time: concurrent first runs can race in the shared npx cache and corrupt the install ([docs/deployment.md](docs/deployment.md#run-with-npx) has the recovery step).
 
 Keep the `@latest`. `npx` resolves through a shared cache and will happily re-run a build it downloaded weeks ago, so a bare `npx @malloy-publisher/server` can serve an old version while looking like a fresh start. The server does not report its own version, so a stale build is invisible until it behaves like one — a fixed bug that appears to still be there is the usual first sign.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT
 
 # Working with Malloy Publisher
 
-Publisher is the open-source semantic model server for [Malloy](https://malloydata.dev), created and maintained by [Credible](https://www.credibledata.com). It serves one or more Malloy model packages over a REST API and a single MCP endpoint. If you are an AI agent working in this repo, here is what you can do with it and how to start.
+Publisher is the open-source AI Analytics Engine for [Malloy](https://malloydata.dev), created and maintained by [Credible](https://www.credibledata.com). It serves one or more Malloy model packages over a REST API and a single MCP endpoint. If you are an AI agent working in this repo, here is what you can do with it and how to start.
 
 ## What you can do
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT
 
 # Working with Malloy Publisher
 
-Publisher is the Analytics Engine for [Malloy](https://malloydata.dev), created and maintained by [Credible](https://www.credibledata.com). It serves one or more Malloy model packages over a REST API and a single MCP endpoint. If you are an AI agent working in this repo, here is what you can do with it and how to start.
+Publisher is the analytics engine for [Malloy](https://malloydata.dev), created and maintained by [Credible](https://www.credibledata.com). It serves one or more Malloy model packages over a REST API and a single MCP endpoint. If you are an AI agent working in this repo, here is what you can do with it and how to start.
 
 ## What you can do
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ The complete user guide also lives at
 Publisher is created and maintained by [Credible](https://www.credibledata.com), the company behind
 the **AI Analytics Engine**. The two fit together like this:
 
-- **Publisher is the open-source server.** It serves Malloy models over REST and MCP, and everything
+- **Publisher is the open-source analytics engine.** It serves Malloy models over REST and MCP, and everything
   an agent needs from the language and the server — the modeling and analysis skills, the MCP tools —
   ships here in the open. Run it on a laptop, in Docker, or wherever you like.
 - **Credible is the hosted, governed engine built around it.** You write down what your data means
@@ -213,7 +213,7 @@ the **AI Analytics Engine**. The two fit together like this:
   dashboards and workspaces, the data apps and APIs in your product — from one model.
 
 Run Publisher yourself, or let Credible run it: the model is the same Malloy either way, and moving
-between them is a publish, not a rewrite. Where the server ends and the engine begins:
+between them is a publish, not a rewrite. Where the open-source engine ends and the hosted one begins:
 [credibledata.com/malloy](https://www.credibledata.com/malloy) ·
 [Inside the AI Analytics Engine](https://www.credibledata.com/blog/posts/inside-the-ai-analytics-engine).
 

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ AI agents: read <a href="AGENTS.md">AGENTS.md</a> first.</sub></p>
 </p>
 <p align="center"><sub>A 60-second walkthrough — model in your IDE with the Malloy skills, serve with Publisher, build a data app, materialize on a schedule, and analyze. <a href="https://github.com/user-attachments/assets/376a809d-8016-41a7-9464-a5634ea0589d">Watch the video</a> for playback controls.</sub></p>
 
-**Problem:** pointed at a raw database, an AI writes SQL from scratch — the wrong join, an invented
-column, a fan-out that double-counts but still looks plausible — and the same question tomorrow
-yields a different query and different numbers.
+**Publisher is the open-source AI Analytics Engine: the modern data stack in a box, built AI-first.**
+Modeling, a query engine, materialization, access control, and an API — the pieces you used to assemble
+from five vendors — ship as one server, and the first consumer of everything it serves is an agent.
 
-**Solution:** put a [Malloy](https://malloydata.dev) model — what the industry calls a semantic
-layer — between the AI and your data. Measures, dimensions, and joins are defined once, correctly;
-applications, BI tools, and **AI agents** compose queries against the model instead of writing SQL,
-so the numbers come back **right by construction**, the same way every time.
-
-Publisher is the open-source server that serves that model, over a REST API and a single MCP endpoint.
+Write down what your data means once, in [Malloy](https://malloydata.dev): the sources, the joins, the
+measures, who may see what. Publisher serves that model to every surface — over MCP to Claude, Cursor,
+Codex, or an agent you build; over REST to applications and BI tools. Agents compose queries against
+the model instead of writing SQL from scratch, so there is no wrong join, no invented column, no
+fan-out that double-counts but looks plausible — and the same question returns the same numbers
+tomorrow.
 
 - **Any AI, one endpoint** — Claude, Cursor, Codex, VS Code, or an agent you build connect over MCP;
   an agent running unattended uses REST.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ npm start
 This writes a package to `./sales` — plus, in the current directory, a small workspace: start and
 reset scripts, an MCP config, agent instructions, and the Malloy skills as files your agent can read.
 `npm start` serves the package in watch mode, so edits take effect as you save. Keep the `@latest`:
-without it npm may reuse a cached, older version.
+without it npm may reuse a cached, older version. The finer points of `npm create` — caching, workspace
+layout, the bare `npx` form — are in [docs/scaffolding.md](docs/scaffolding.md).
 
 ### Bring local data files
 
@@ -88,10 +89,15 @@ CSV, Parquet, JSON, newline-delimited JSON, or Excel `.xlsx` — DuckDB reads al
 `--` is required, and the path is relative to where you run the command. A seeded package starts
 small: a row count and an overview, which is the moment to point an agent at it.
 
-A package is just Malloy, so it is not limited to a file: point its model at a
-[database connection](docs/connections.md) and the same workspace serves a warehouse. The finer points
-of `npm create` — caching, workspace layout, the bare `npx` form — are in
-[docs/scaffolding.md](docs/scaffolding.md).
+### Connect a database
+
+A package is just Malloy, so it is not limited to local files. Add a
+[connection](docs/connections.md) — BigQuery, Snowflake, Postgres, Databricks, MotherDuck, and more —
+and point the model at it; the same workspace serves a warehouse. Have the warehouse but no model yet?
+Ask the agent what is in it: `malloy_searchDatabaseSchema` ranks a connection's tables against a
+plain-English description and hands back the `source:` line for each. Ranking needs no API key; the
+optional embedding-backed mode is in
+[docs/configuration.md](docs/configuration.md#semantic-ranking-for-malloy_searchdatabaseschema).
 
 ## Point your agent at it
 
@@ -142,13 +148,6 @@ curl -s -X POST \
 ```
 
 The running server serves its full OpenAPI spec at `http://localhost:4000/api-doc.yaml`.
-
-### Starting from a database instead of a model
-
-Have a warehouse but no model yet? Add a [connection](docs/connections.md) and ask the agent what is
-in it: `malloy_searchDatabaseSchema` ranks a connection's tables against a plain-English description
-and hands back the `source:` line for each. Ranking needs no API key; the optional embedding-backed
-mode is in [docs/configuration.md](docs/configuration.md#semantic-ranking-for-malloy_searchdatabaseschema).
 
 > **Security.** The server — MCP and REST alike — is stateless and unauthenticated, and it can read any
 > data your models connect to. Bind it to loopback (`--host 127.0.0.1`) for local use, and put an

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ AI agents: read <a href="AGENTS.md">AGENTS.md</a> first.</sub></p>
 <p align="center"><sub>A 60-second walkthrough — model in your IDE with the Malloy skills, serve with Publisher, build a data app, materialize on a schedule, and analyze. <a href="https://github.com/user-attachments/assets/376a809d-8016-41a7-9464-a5634ea0589d">Watch the video</a> for playback controls.</sub></p>
 
 Modeling, a query engine, materialization, access control, and an API — the pieces you used to assemble
-from five tools and projects — ship as one server, built assuming the first builder or consumer is an
+from five projects — ship as one server, built assuming the first builder or consumer is an
 agent.
 
 Write down what your data means, in [Malloy](https://malloydata.dev): the sources, the joins, the

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ SPDX-License-Identifier: MIT
 
 <p align="center"><b>The open-source semantic model server for <a href="https://malloydata.dev">Malloy</a></b><br>
 Serve governed data models to applications, BI tools, and AI agents — over REST and MCP.<br>
-<sub>Created and maintained by <a href="https://www.credibledata.com">Credible</a>, the company behind the AI Analytics Engine.</sub></p>
+<sub>Created and maintained by <a href="https://www.credibledata.com">Credible</a>, the company behind the AI Analytics Engine.<br>
+AI agents: read <a href="AGENTS.md">AGENTS.md</a> first.</sub></p>
 
 <p align="center">
   <a href="https://github.com/malloydata/publisher/actions/workflows/build.yml"><img src="https://github.com/malloydata/publisher/actions/workflows/build.yml/badge.svg" alt="build"></a>
@@ -17,8 +18,6 @@ Serve governed data models to applications, BI tools, and AI agents — over RES
   <a href="https://github.com/user-attachments/assets/376a809d-8016-41a7-9464-a5634ea0589d"><img src="docs/malloy-publisher-demo.gif" alt="Malloy Publisher serving the bundled storefront dashboard" width="800"></a>
 </p>
 <p align="center"><sub>A 60-second walkthrough — model in your IDE with the Malloy skills, serve with Publisher, build a data app, materialize on a schedule, and analyze. <a href="https://github.com/user-attachments/assets/376a809d-8016-41a7-9464-a5634ea0589d">Watch the video</a> for playback controls.</sub></p>
-
-> **AI agents:** read [AGENTS.md](AGENTS.md) first.
 
 **Problem:** pointed at a raw database, an AI writes SQL from scratch — the wrong join, an invented
 column, a fan-out that double-counts but still looks plausible — and the same question tomorrow

--- a/README.md
+++ b/README.md
@@ -64,21 +64,9 @@ Open **http://localhost:4000**. Three example packages are bundled — [`storefr
 [`html-data-app`](examples/html-data-app) (a no-build dashboard) — all DuckDB-backed, no credentials
 required. The first run fetches them from GitHub.
 
-### Know when it's ready
-
-The server prints one line to stderr when it is serving, which scripts can wait for instead of polling:
-
-```
-PUBLISHER_READY url=http://localhost:4000 mcp=http://localhost:4040 environments=1 packages=3 load_errors=0
-```
-
-`load_errors` counts packages and environments that failed to load; `/api/v0/status` names them. The
-failure lines, and what each means, are in
-[docs/configuration.md](docs/configuration.md#startup-signals).
-
 ## Start from your own data
 
-### Scaffold a package
+### Create a package
 
 ```bash
 mkdir my-data && cd my-data
@@ -89,9 +77,9 @@ npm start
 This writes a package to `./sales` — plus, in the current directory, a small workspace: start and
 reset scripts, an MCP config, agent instructions, and the Malloy skills as files your agent can read.
 `npm start` serves the package in watch mode, so edits take effect as you save. Keep the `@latest`:
-without it npm may reuse a cached, older scaffolder.
+without it npm may reuse a cached, older version.
 
-### Bring a file
+### Bring local data files
 
 ```bash
 npm create @malloy-publisher/malloy-package@latest sales -- --data ./orders.csv
@@ -103,7 +91,7 @@ small: a row count and an overview, which is the moment to point an agent at it.
 
 A package is just Malloy, so it is not limited to a file: point its model at a
 [database connection](docs/connections.md) and the same workspace serves a warehouse. The finer points
-of the scaffolder — caching, workspace layout, the bare `npx` form — are in
+of `npm create` — caching, workspace layout, the bare `npx` form — are in
 [docs/scaffolding.md](docs/scaffolding.md).
 
 ## Point your agent at it

--- a/README.md
+++ b/README.md
@@ -20,14 +20,16 @@ AI agents: read <a href="AGENTS.md">AGENTS.md</a> first.</sub></p>
 <p align="center"><sub>A 60-second walkthrough — model in your IDE with the Malloy skills, serve with Publisher, build a data app, materialize on a schedule, and analyze. <a href="https://github.com/user-attachments/assets/376a809d-8016-41a7-9464-a5634ea0589d">Watch the video</a> for playback controls.</sub></p>
 
 Modeling, a query engine, materialization, access control, and an API — the pieces you used to assemble
-from five vendors — ship as one server, and the first consumer of everything it serves is an agent.
+from five tools and projects — ship as one server, built assuming the first builder or consumer is an
+agent.
 
-Write down what your data means once, in [Malloy](https://malloydata.dev): the sources, the joins, the
-measures, who may see what. Publisher serves that model to every surface — over MCP to Claude, Cursor,
-Codex, or an agent you build; over REST to applications and BI tools. Agents compose queries against
-the model instead of writing SQL from scratch, so there is no wrong join, no invented column, no
-fan-out that double-counts but looks plausible — and the same question returns the same numbers
-tomorrow.
+Write down what your data means, in [Malloy](https://malloydata.dev): the sources, the joins, the
+measures, who may see what. The open-source Malloy [skills](skills/) ship alongside, so an agent can do
+the writing — build the model, then the dashboards, notebooks, and data apps on top of it. Publisher
+serves that model to every surface — over MCP to Claude, Cursor, Codex, or an agent you build; over
+REST to applications and BI tools. Agents compose queries against the model instead of writing SQL
+from scratch, so there is no wrong join, no invented column, no fan-out that double-counts but looks
+plausible — and the same question returns the same numbers tomorrow.
 
 - **Any AI, one endpoint** — Claude, Cursor, Codex, VS Code, or an agent you build connect over MCP;
   an agent running unattended uses REST.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ Serve governed data models to applications, BI tools, and AI agents — over RES
 </p>
 <p align="center"><sub>A 60-second walkthrough — model in your IDE with the Malloy skills, serve with Publisher, build a data app, materialize on a schedule, and analyze. <a href="https://github.com/user-attachments/assets/376a809d-8016-41a7-9464-a5634ea0589d">Watch the video</a> for playback controls.</sub></p>
 
-> **Working with an AI agent?** Start with [AGENTS.md](AGENTS.md) — the canonical, step-by-step
-> guide to running Publisher and connecting over MCP. Most coding hosts read it automatically; Claude
-> Code reads it through [CLAUDE.md](CLAUDE.md). This README is the map for people.
+> **AI agents:** read [AGENTS.md](AGENTS.md) first.
 
 **Problem:** pointed at a raw database, an AI writes SQL from scratch — the wrong join, an invented
 column, a fan-out that double-counts but still looks plausible — and the same question tomorrow

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: MIT
 <h1 align="center">Malloy Publisher</h1>
 
 <p align="center"><b>The Analytics Engine for <a href="https://malloydata.dev">Malloy</a></b><br>
-The modern data stack in a box, built AI-first: one data model, served to AI agents, applications, and BI tools over MCP and REST.<br>
+A more modern data stack in a box, built AI-first: one data model, served to AI agents, applications, and BI tools over MCP and REST.<br>
 <sub>Created and maintained by <a href="https://www.credibledata.com">Credible</a>, the company behind the AI Analytics Engine.<br>
 AI agents: read <a href="AGENTS.md">AGENTS.md</a> first.</sub></p>
 

--- a/README.md
+++ b/README.md
@@ -116,20 +116,17 @@ The agent discovers what exists (`malloy_getContext`), grounds itself in real so
 names, runs the query (`malloy_executeQuery`), and answers from your model — no schema spelunking, no
 hallucinated columns.
 
-### When the config isn't written
-
-The server skips a directory that already has a `.mcp.json`, anything inside a git working tree, and
-your home directory, and says so in its startup log along with the one command that connects an agent
-anyway. To register the server for yourself rather than one directory:
+If the agent reports no `malloy_*` tools, register the server for yourself instead of relying on that
+file:
 
 ```bash
 claude mcp add --transport http malloy http://127.0.0.1:4040/mcp -s user
 ```
 
-That is also the fix when an agent reports no `malloy_*` tools. The file the server writes outlives
-it and is never corrected, so a stale one can point an agent at whatever later holds that port —
-[docs/configuration.md](docs/configuration.md#the-mcpjson-the-server-writes) has the full story.
-`--no-mcp-config` turns the whole thing off.
+The server skips writing the file in some directories (a git working tree, your home directory, one
+that already has a `.mcp.json`) and says so in its startup log. When it is written, why it can go
+stale, and how to turn it off:
+[docs/configuration.md](docs/configuration.md#the-mcpjson-the-server-writes).
 
 ### Other clients, and unattended agents
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: MIT
 <h1 align="center">Malloy Publisher</h1>
 
 <p align="center"><b>The Analytics Engine for <a href="https://malloydata.dev">Malloy</a></b><br>
-A more modern data stack in a box, built AI-first: one data model, served to AI agents, applications, and BI tools over MCP and REST.<br>
+A more modern data stack in a single engine, built AI-first: one data model, served to AI agents, applications, and BI tools over MCP and REST.<br>
 <sub>Created and maintained by <a href="https://www.credibledata.com">Credible</a>, the company behind the AI Analytics Engine.<br>
 AI agents: read <a href="AGENTS.md">AGENTS.md</a> first.</sub></p>
 

--- a/README.md
+++ b/README.md
@@ -98,14 +98,10 @@ of `npm create` — caching, workspace layout, the bare `npx` form — are in
 
 ### Connect Claude Code
 
-In one terminal:
-
-```bash
-npx @malloy-publisher/server --port 4000 --host 127.0.0.1
-```
-
-On startup the server writes a `.mcp.json` into the directory you ran it in, pointing at the MCP port
-it bound. In a second terminal, **in that same directory**:
+Keep the server from [Quick start](#quick-start) running — or `npm start` from
+[Create a package](#create-a-package). On startup it wrote a `.mcp.json` into the directory you ran it
+in, pointing at the MCP port it bound. Open a second terminal, **in that same directory**, and start
+the agent:
 
 ```bash
 claude

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ SPDX-License-Identifier: MIT
 
 <h1 align="center">Malloy Publisher</h1>
 
-<p align="center"><b>The open-source semantic model server for <a href="https://malloydata.dev">Malloy</a></b><br>
-Serve governed data models to applications, BI tools, and AI agents — over REST and MCP.<br>
+<p align="center"><b>The open-source AI Analytics Engine for <a href="https://malloydata.dev">Malloy</a></b><br>
+The modern data stack in a box, built AI-first: one data model, served to AI agents, applications, and BI tools over MCP and REST.<br>
 <sub>Created and maintained by <a href="https://www.credibledata.com">Credible</a>, the company behind the AI Analytics Engine.<br>
 AI agents: read <a href="AGENTS.md">AGENTS.md</a> first.</sub></p>
 
@@ -19,7 +19,6 @@ AI agents: read <a href="AGENTS.md">AGENTS.md</a> first.</sub></p>
 </p>
 <p align="center"><sub>A 60-second walkthrough — model in your IDE with the Malloy skills, serve with Publisher, build a data app, materialize on a schedule, and analyze. <a href="https://github.com/user-attachments/assets/376a809d-8016-41a7-9464-a5634ea0589d">Watch the video</a> for playback controls.</sub></p>
 
-**Publisher is the open-source AI Analytics Engine: the modern data stack in a box, built AI-first.**
 Modeling, a query engine, materialization, access control, and an API — the pieces you used to assemble
 from five vendors — ship as one server, and the first consumer of everything it serves is an agent.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ SPDX-License-Identifier: MIT
 <h1 align="center">Malloy Publisher</h1>
 
 <p align="center"><b>The Analytics Engine for <a href="https://malloydata.dev">Malloy</a></b><br>
-A more modern data stack in a single engine, built AI-first: one data model, served to AI agents, applications, and BI tools over MCP and REST.<br>
+A more modern data stack in a single engine, built AI-first.<br>
+One data model, served over MCP and REST to AI agents, applications, and BI tools.<br>
 <sub>Created and maintained by <a href="https://www.credibledata.com">Credible</a>, the company behind the AI Analytics Engine.<br>
 AI agents: read <a href="AGENTS.md">AGENTS.md</a> first.</sub></p>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT
 
 <h1 align="center">Malloy Publisher</h1>
 
-<p align="center"><b>The open-source AI Analytics Engine for <a href="https://malloydata.dev">Malloy</a></b><br>
+<p align="center"><b>The Analytics Engine for <a href="https://malloydata.dev">Malloy</a></b><br>
 The modern data stack in a box, built AI-first: one data model, served to AI agents, applications, and BI tools over MCP and REST.<br>
 <sub>Created and maintained by <a href="https://www.credibledata.com">Credible</a>, the company behind the AI Analytics Engine.<br>
 AI agents: read <a href="AGENTS.md">AGENTS.md</a> first.</sub></p>

--- a/README.md
+++ b/README.md
@@ -157,20 +157,68 @@ The running server serves its full OpenAPI spec at `http://localhost:4000/api-do
 
 ## What you can do
 
+### Model
+
+- **Build the model with an agent.** The bundled open-source [skills](skills/) carry the whole loop —
+  discover what a database holds, define sources and measures, model as you go, review, document,
+  publish. A LookML review skill covers coming from Looker.
+- **Start from a warehouse.** `malloy_searchDatabaseSchema` ranks a connection's tables against a
+  plain-English description and returns the `source:` line for each.
+- **Validate without a restart.** `malloy_compile` checks an edit without running it;
+  `malloy_reloadPackage` recompiles a package from disk. Watch mode does the same for a human editing
+  in an IDE.
+
+### Analyze
+
+- **Ask in plain English.** An agent grounds itself with `malloy_getContext`, runs
+  `malloy_executeQuery`, and answers from the model, never from raw tables. Analysis skills teach it the
+  pitfalls and how to write up a finding — [docs/ai-agents.md](docs/ai-agents.md).
+- **Work in notebooks.** `.malloynb` notebooks live inside a package, mix prose and queries, and run on
+  the same governed endpoints — [docs/choosing-a-surface.md](docs/choosing-a-surface.md).
 - **Explore, no code.** Build and drill into queries visually with [Malloy Explorer](docs/explorer.md);
   every action generates valid Malloy, so metrics stay correct across joins.
-- **Answer questions with AI.** Connect an agent over MCP and ask in plain English —
-  [docs/ai-agents.md](docs/ai-agents.md).
-- **Surface analytics your way.** Explore and share in the [Publisher Console](docs/console.md), or
-  ship a no-build [HTML data app](docs/html-data-apps.md) that Publisher hosts inside a package.
-- **Build and validate models.** Author with the bundled [skills](skills/), then publish. Agents get the
-  same loop over MCP: `malloy_compile` checks an edit without running it; `malloy_reloadPackage`
-  recompiles a package from disk, no restart.
-- **Govern access.** [Givens](docs/givens.md) power filter widgets,
-  [row-level access](docs/row-level-access.md), and [`#(authorize)`](docs/authorize.md) gates; curate
-  what is [discoverable and queryable](docs/discovery-and-access.md) separately.
-- **Materialize for cost and speed.** `#@ persist` turns an expensive source into a table, rebuilt on
-  demand or on a cron with the opt-in scheduler — [docs/materialization.md](docs/materialization.md).
+
+### Surface
+
+- **Dashboards declared in Malloy.** A `dashboards/*.malloy` file *is* the dashboard: filterable,
+  clickable, grid-laid-out, no code and no build step — [docs/dashboards.md](docs/dashboards.md).
+- **No-build HTML data apps.** Ship HTML, CSS, and JavaScript inside a package and Publisher hosts it
+  against the model — [docs/html-data-apps.md](docs/html-data-apps.md).
+- **The Publisher Console.** Browse packages, models, and every artifact in the built-in web UI, with
+  your own [colors, fonts, and dark mode](docs/theming.md) — [docs/console.md](docs/console.md).
+- **Your own applications.** The REST API serves any language; a Python client ships in
+  [`packages/python-client`](packages/python-client), and the running server publishes its OpenAPI spec.
+
+### Govern
+
+- **Decide who sees what.** [Givens](docs/givens.md) declare runtime parameters and drive filter
+  widgets; [row-level access](docs/row-level-access.md) and [`#(authorize)`](docs/authorize.md) gate
+  which rows a caller gets and whether they may query a source at all.
+- **Decide what is visible.** Curate what is [discoverable and queryable](docs/discovery-and-access.md)
+  separately, so an agent sees only the sources you meant it to.
+- **Know the boundary.** [docs/security-posture.md](docs/security-posture.md) lists what Publisher
+  defends against and what it leaves to the gateway in front of it.
+
+### Perform
+
+- **Materialize.** One `#@ persist` annotation turns an expensive source into a table, rebuilt on
+  demand, from the `malloy-pub` CLI, or on a cron with the opt-in scheduler —
+  [docs/materialization.md](docs/materialization.md).
+- **Pre-aggregate.** `#@ preaggregate` rolls a measure up to a coarse grain so covered queries read a
+  small table instead of the fact table — [docs/preaggregation.md](docs/preaggregation.md).
+- **Store it where you like.** Persist into a [DuckLake](docs/ducklake.md) storage tier, attach a
+  DuckLake catalog read-only, and run offline or air-gapped —
+  [docs/persist-storage-tutorial.md](docs/persist-storage-tutorial.md).
+- **Attribute every query.** [Query metadata](docs/query-metadata.md) tags each statement with a team,
+  a workload, a request id, so the warehouse's own reporting can say who asked.
+
+### Run anywhere
+
+- **Any data.** DuckDB is built in for CSV, Parquet, JSON, and Excel; connect BigQuery, Snowflake,
+  Postgres, MySQL, Trino, Databricks, MotherDuck, and DuckLake — [docs/connections.md](docs/connections.md).
+- **Any host.** `npx`, Docker, or Docker Compose, in minutes — [docs/deployment.md](docs/deployment.md).
+- **Alongside dbt.** Where Malloy and dbt fit together, and the plan to close the gaps —
+  [docs/dbt-roadmap.md](docs/dbt-roadmap.md).
 
 ## Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: MIT
 > guide to running Publisher and connecting over MCP.
 >
 > Publisher is created and maintained by [Credible](https://www.credibledata.com), the company
-> behind the AI Analytics Engine. For where the open-source server ends and Credible's hosted engine
+> behind the AI Analytics Engine. For where the open-source engine ends and Credible's hosted engine
 > begins, see [credibledata.com/malloy](https://www.credibledata.com/malloy).
 
 ## Examples

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,7 @@ a `<malloy-render>` web component.
 
 ## Publisher
 
-The open-source AI Analytics Engine for Malloy. Publisher serves Malloy models over the network — to
+The Analytics Engine for Malloy. Publisher serves Malloy models over the network — to
 agents, applications, and BI tools — and provides a professional UI for data exploration.
 
 - **Server:** REST API for listing content, managing database connections, compiling models, and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,7 @@ a `<malloy-render>` web component.
 
 ## Publisher
 
-The Analytics Engine for Malloy. Publisher serves Malloy models over the network — to
+The analytics engine for Malloy. Publisher serves Malloy models over the network — to
 agents, applications, and BI tools — and provides a professional UI for data exploration.
 
 - **Server:** REST API for listing content, managing database connections, compiling models, and
@@ -55,7 +55,7 @@ notes. To surface analytics, prefer the [Publisher Console](console.md), an
 ## Credible (hosted)
 
 [Credible](https://www.credibledata.com) creates and maintains Publisher, and runs it as the core of
-the **AI Analytics Engine** — the hosted, governed service built around the server. Everything
+the **AI Analytics Engine** — the hosted, governed service built around Publisher. Everything
 described above is the same there: the same Malloy, the same package format, the same REST and MCP
 surfaces. What Credible adds is the engine around them: managed materialization and indexing in
 storage it brings along, one gateway that enforces access on every query, a concept index that gives

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,8 +33,8 @@ a `<malloy-render>` web component.
 
 ## Publisher
 
-An open-source semantic model server for Malloy. Publisher makes Malloy models accessible over the
-network and provides a professional UI for data exploration.
+The open-source AI Analytics Engine for Malloy. Publisher serves Malloy models over the network — to
+agents, applications, and BI tools — and provides a professional UI for data exploration.
 
 - **Server:** REST API for listing content, managing database connections, compiling models, and
   executing queries. Also provides an MCP API for AI-agent integration, including the


### PR DESCRIPTION
Follow-up to #1118, which merged before these landed on its branch.

- **The agent pointer is a line of small print in the README header** — `AI agents: read AGENTS.md first.` — instead of a callout box. Agents that arrive from the GitHub page still hit it in the first dozen lines; people skimming pass over it.
- **AGENTS.md leads with the no-clone start.** `npx @malloy-publisher/server@latest --port 4000` comes first, labelled as needing nothing cloned and no Bun; the clone-and-build path follows. An agent sent to the repo by URL has no clone, and the old order pointed it at installing Bun.
- **"Know when it's ready" leaves the README.** The `PUBLISHER_READY` contract is detail an agent needs and a first-time reader does not. It already lives in full at `docs/configuration.md#startup-signals`, and AGENTS.md links there; nothing was removed from the docs.
- **Headings say what the reader does.** *Scaffold a package* → *Create a package*; *Bring a file* → *Bring local data files*. The body stops calling the tool "the scaffolder" where it meant the command.
- **Connect Claude Code no longer restarts the server.** Quick start and Create a package both leave one running; the section now says to keep it up and open `claude` in a second terminal in the same directory.
- **The header and opener use the engine framing.** The tagline is now *The Analytics Engine for Malloy* — a more modern data stack in a single engine, built AI-first — and the opener replaces the problem/solution pair about semantic layers. The failure modes of SQL-from-scratch stay, as the reason the model matters.
- **"When the config isn't written" folds into Connect Claude Code.** The one command a stuck reader needs (`claude mcp add …`) stays as a short paragraph; the skip rules and the stale-file caveat live in `docs/configuration.md#the-mcpjson-the-server-writes` and AGENTS.md.
- **Publisher is an analytics engine throughout** — AGENTS.md, docs/architecture.md, docs/README.md, and the *Publisher and Credible* section say so instead of "the open-source server". Credible keeps its own name, the AI Analytics Engine, for the hosted one.
- **Start from your own data has three doors**: *Create a package*, *Bring local data files*, *Connect a database*. The database subsection moves up from *Point your agent at it* and absorbs the sentence about database connections that the files subsection repeated.
- **What you can do is fleshed out** into six subsections — Model, Analyze, Surface, Govern, Perform, Run anywhere — covering Malloy-declared dashboards, notebooks, pre-aggregation, DuckLake storage, query metadata, the Python client, theming, and the dbt roadmap, which the old six bullets skipped. Every link resolves.

README is under 280 lines; the growth is all in that section. Every commit is DCO signed-off.
