### PR TITLE
docs(readme): built for the AI era

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: MIT
 <h1 align="center">Malloy Publisher</h1>
 
 <p align="center"><b>The Analytics Engine for <a href="https://malloydata.dev">Malloy</a></b><br>
-A more modern data stack in a single engine, built AI-first.<br>
+A more modern data stack in a single engine — built for the AI era.<br>
 One data model, served over MCP and REST to AI agents, applications, and BI tools.<br>
 <sub>Created and maintained by <a href="https://www.credibledata.com">Credible</a>, the company behind the AI Analytics Engine.<br>
 AI agents: read <a href="AGENTS.md">AGENTS.md</a> first.</sub></p>


### PR DESCRIPTION
Follow-up to #1120, which merged just before this landed on its branch.

The README header's second line now reads *A more modern data stack in a single engine — built for the AI era.* DCO signed-off.