### PR TITLE
docs(readme): size the tagline heading between the title and body text

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ SPDX-License-Identifier: MIT
 
 <h1 align="center">Malloy Publisher</h1>
 
-<p align="center"><b>The Analytics Engine for <a href="https://malloydata.dev">Malloy</a></b><br>
-A post modern data stack — built for the AI era.<br>
+<h3 align="center">The Analytics Engine for <a href="https://malloydata.dev">Malloy</a></h3>
+
+<p align="center">A post modern data stack — built for the AI era.<br>
 One data model, served over MCP and REST to AI agents, applications, and BI tools.<br>
 <sub>Created and maintained by <a href="https://www.credibledata.com">Credible</a>, the company behind the AI Analytics Engine.</sub></p>
 


### PR DESCRIPTION
## Summary

- Promote "The Analytics Engine for Malloy" from a bold body-text line to a centered `<h3>`, so it renders between the title and the tagline lines in size. GitHub strips inline font-size styles, so a heading tag is the only way to get an in-between size; `<h3>` avoids the underline `<h2>` draws.
- The two tagline lines and the small-print Credible attribution are unchanged.

Follow-up to #1122, which merged before this commit was pushed.

## Test plan

- [x] `prettier --check README.md` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)