### PR TITLE
docs(readme): drop the spacer above the Credible byline

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ SPDX-License-Identifier: MIT
 <p align="center">A post modern data stack — built for the AI era.<br>
 One data model, served over MCP and REST to AI agents, applications, and BI tools.</p>
 
-<br>
-
 <p align="center">Created and maintained by <a href="https://www.credibledata.com">Credible</a>, the company behind the AI Analytics Engine.</p>
 
 <p align="center"><sub><strong>AI agents:</strong> read <a href="AGENTS.md">AGENTS.md</a> first (raw: <code>https://raw.githubusercontent.com/malloydata/publisher/main/AGENTS.md</code>).<br>


### PR DESCRIPTION
## Summary

Follow-up to #1124. The `<br>` between the tagline and the "Created and maintained by Credible" line added more vertical space than the header needs. This removes it so the byline sits as the next paragraph, like the text above it.

## Test plan

- [x] `prettier --check README.md` passes
- [ ] Confirm header spacing on the rendered README

🤖 Generated with [Claude Code](https://claude.com/claude-code)
