### PR TITLE
chore(release): stamp 0.2.4 on main

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,7 +31,7 @@ One behaviour change to know about: `skills-npm.yml` now publishes only from `ma
 
 ---
 
-## [Unreleased] (BREAKING) — every MCP tool loses its `malloy_` prefix, and get_context answers in one shape
+## [0.2.4] (BREAKING) — every MCP tool loses its `malloy_` prefix, and get_context answers in one shape
 
 **Every MCP tool is renamed.** The `malloy_` prefix is gone and the names are bare
 snake_case. There is no alias and no deprecation window: the old names are removed,
@@ -87,7 +87,7 @@ spellings in the docs indefinitely.
 
 ---
 
-## [Unreleased] — bound the memory a LARGE DuckLake write spends holding Parquet
+## [0.2.4] — bound the memory a LARGE DuckLake write spends holding Parquet
 
 `PUBLISHER_DUCKLAKE_TARGET_FILE_SIZE_BYTES` caps how large a Parquet file DuckLake writes
 before rotating to the next one. Unset, nothing changes: no option is set and the attach
@@ -152,7 +152,7 @@ so until it ships in a release, this is the lever available.
 
 ---
 
-## [Unreleased] — a pre-aggregation rollup can be built into and served from a storage destination
+## [0.2.4] — a pre-aggregation rollup can be built into and served from a storage destination
 
 `storage=` now works on a `#@ preaggregate` line: the rollup is built into that
 destination and served from it, and a query that names the base source is unchanged — it

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/app",
    "description": "Malloy Publisher Console (the built-in web UI)",
-   "version": "0.2.3",
+   "version": "0.2.4",
    "type": "module",
    "main": "dist/index.cjs.js",
    "module": "dist/index.es.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/sdk",
    "description": "Malloy Publisher SDK",
-   "version": "0.2.3",
+   "version": "0.2.4",
    "type": "module",
    "main": "dist/index.cjs.js",
    "module": "dist/index.es.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/server",
    "description": "Malloy Publisher Server",
-   "version": "0.2.3",
+   "version": "0.2.4",
    "main": "dist/server.mjs",
    "bin": {
       "malloy-publisher": "dist/server.mjs"


### PR DESCRIPTION
Post-release stamp branch pushed by `gh-release` for v0.2.4.

Marks the three release-notes sections that shipped in 0.2.4 with the version that carried them, and resets `packages/{sdk,app,server}/package.json` to the released version so `main` declares what is on npm.

Headings only in `RELEASE_NOTES.md`; no prose changes.