### PR TITLE
fix(connections): answer a bad table reference with 404 or 400, not 502

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -731,6 +731,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Table"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -1089,6 +1091,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Table"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -5347,12 +5351,29 @@ components:
       type: object
       description: Standard error response format
       properties:
+        code:
+          type: integer
+          description: HTTP status code, repeated in the body for convenience
         message:
           type: string
           description: Human-readable error message describing what went wrong
         details:
           type: string
           description: Additional error details or context
+        reason:
+          type: string
+          description: |
+            Machine-readable discriminator, for callers that must branch on
+            which error they got rather than on prose. Absent unless a caller is
+            expected to act on it, so treat absence as "no special handling".
+
+            TABLE_NOT_FOUND distinguishes a table that is not in the database
+            from the other conditions that also answer 404 on these routes --
+            an environment or connection this server does not host. The former
+            says nothing about whether the caller reached the right server; the
+            latter is a routing problem worth retrying elsewhere.
+          enum:
+            - TABLE_NOT_FOUND
       required:
         - message
 

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -781,6 +781,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SqlSource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -1147,6 +1149,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SqlSource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -5376,8 +5376,13 @@ components:
             an environment or connection this server does not host. The former
             says nothing about whether the caller reached the right server; the
             latter is a routing problem worth retrying elsewhere.
-          enum:
-            - TABLE_NOT_FOUND
+
+            Deliberately an open string rather than an enum. Generators render
+            an enum closed, so adding a second value here would break every
+            client generated before it -- on the one field whose purpose is to
+            grow. Callers must treat an unrecognized value as absent.
+
+            Known values: TABLE_NOT_FOUND.
       required:
         - message
 

--- a/packages/server/src/controller/connection.controller.spec.ts
+++ b/packages/server/src/controller/connection.controller.spec.ts
@@ -952,6 +952,25 @@ describe("ConnectionController getTable not-found mapping", () => {
       );
    });
 
+   it("classifies DuckDB's rejected catalog errors, which never resolve falsy", async () => {
+      // DuckDBCommon.fetchTableSchema returns a structDef or throws -- it never
+      // resolves empty -- so the falsy check above cannot see a DuckDB miss and
+      // the sandbox, Azure and DuckLake connections all arrive here instead.
+      // Strings verbatim from the installed driver.
+      for (const message of [
+         "Catalog Error: Table with name no_such_table does not exist!",
+         'Catalog Error: Table with name "s.t" does not exist because schema "s" does not exist.',
+         'Binder Error: Catalog "a" does not exist!',
+      ]) {
+         const { controller } = buildTableController(
+            sinon.stub().rejects(new Error(message)),
+         );
+         await expect(getTable(controller)).rejects.toBeInstanceOf(
+            TableNotFoundError,
+         );
+      }
+   });
+
    it("still reports an unrecognized driver failure as a 502-class fault", async () => {
       // The floor: anything the classifier does not recognize stays a server
       // error. Guessing wider would hide real outages behind a 404.
@@ -977,6 +996,82 @@ describe("ConnectionController getTable not-found mapping", () => {
       );
       await expect(getTable(controller)).rejects.toBeInstanceOf(
          TableNotFoundError,
+      );
+   });
+});
+
+/**
+ * getConnectionSqlSource runs the same classification as getTable. It had no
+ * tests before, so the behavior below was unverified in either direction.
+ */
+describe("ConnectionController getConnectionSqlSource error mapping", () => {
+   afterEach(() => sinon.restore());
+
+   function buildSqlController(fetchSelectSchema: sinon.SinonStub): {
+      controller: ConnectionController;
+   } {
+      const fakeConnection = { fetchSelectSchema } as unknown as Connection;
+      const fakeStore = {
+         getEnvironment: sinon.stub().resolves({
+            getApiConnection: sinon
+               .stub()
+               .returns({ name: "warehouse", type: "postgres" }),
+         }),
+      } as unknown as EnvironmentStore;
+      const controller = new ConnectionController(fakeStore);
+      sinon
+         .stub(
+            controller as unknown as {
+               getMalloyConnection: (...args: unknown[]) => Promise<Connection>;
+            },
+            "getMalloyConnection",
+         )
+         .resolves(fakeConnection);
+      return { controller };
+   }
+
+   const getSqlSource = (controller: ConnectionController) =>
+      controller.getConnectionSqlSource("env", "warehouse", "SELECT 1");
+
+   it("classifies a returned not-found string as TableNotFoundError", async () => {
+      const { controller } = buildSqlController(
+         sinon.stub().resolves("Not found: Table proj:ds.missing"),
+      );
+      await expect(getSqlSource(controller)).rejects.toBeInstanceOf(
+         TableNotFoundError,
+      );
+   });
+
+   it("classifies a THROWN not-found the same way", async () => {
+      // The gap this round closed: the catch rethrew only already-typed errors,
+      // so every driver that rejects kept answering 502 here.
+      const { controller } = buildSqlController(
+         sinon.stub().rejects(new Error("Not found: Table proj:ds.missing")),
+      );
+      await expect(getSqlSource(controller)).rejects.toBeInstanceOf(
+         TableNotFoundError,
+      );
+   });
+
+   it("keeps an unrecognized failure a 502-class fault", async () => {
+      const { controller } = buildSqlController(
+         sinon.stub().rejects(new Error("ECONNREFUSED 10.0.0.1:443")),
+      );
+      await expect(getSqlSource(controller)).rejects.toBeInstanceOf(
+         ConnectionError,
+      );
+   });
+
+   it("preserves the message of a thrown string", async () => {
+      // `(error as Error).message` on a thrown string is undefined, which lost
+      // the only diagnostic the caller had.
+      // Not sinon's .rejects("..."), which sets the Error NAME and leaves the
+      // message empty -- this has to be a genuinely thrown string.
+      const { controller } = buildSqlController(
+         sinon.stub().callsFake(() => Promise.reject("plain string failure")),
+      );
+      await expect(getSqlSource(controller)).rejects.toThrow(
+         "plain string failure",
       );
    });
 });

--- a/packages/server/src/controller/connection.controller.spec.ts
+++ b/packages/server/src/controller/connection.controller.spec.ts
@@ -971,6 +971,43 @@ describe("ConnectionController getTable not-found mapping", () => {
       }
    });
 
+   it("classifies a missing file-backed table, which reports an IO error", async () => {
+      // The Azure branch hands fetchTable a blob URL, and DuckDB answers an
+      // absent file with an IO error rather than a catalog one -- so the catalog
+      // patterns never see it, and the wrappers' own "Azure file not found"
+      // throw is unreachable. Verbatim from the installed driver.
+      const { controller } = buildTableController(
+         sinon
+            .stub()
+            .rejects(
+               new Error(
+                  'IO Error: No files found that match the pattern "/tmp/gone.parquet"',
+               ),
+            ),
+      );
+      await expect(getTable(controller)).rejects.toBeInstanceOf(
+         TableNotFoundError,
+      );
+   });
+
+   it("leaves a missing DuckDB extension a fault, not a missing table", async () => {
+      // DuckDB words a missing EXTENSION exactly like a missing table, and
+      // httpfs/azure/iceberg are what the DuckLake and Azure connections run on.
+      // A 404 here would report a broken deployment as a mistyped table. Strings
+      // verbatim from the installed driver.
+      for (const message of [
+         "Catalog Error: Table Function with name no_such_fn does not exist!",
+         "Catalog Error: Scalar Function with name no_such_scalar does not exist!",
+      ]) {
+         const { controller } = buildTableController(
+            sinon.stub().rejects(new Error(message)),
+         );
+         await expect(getTable(controller)).rejects.toBeInstanceOf(
+            ConnectionError,
+         );
+      }
+   });
+
    it("still reports an unrecognized driver failure as a 502-class fault", async () => {
       // The floor: anything the classifier does not recognize stays a server
       // error. Guessing wider would hide real outages behind a 404.

--- a/packages/server/src/controller/connection.controller.spec.ts
+++ b/packages/server/src/controller/connection.controller.spec.ts
@@ -971,23 +971,22 @@ describe("ConnectionController getTable not-found mapping", () => {
       }
    });
 
-   it("classifies a missing file-backed table, which reports an IO error", async () => {
-      // The Azure branch hands fetchTable a blob URL, and DuckDB answers an
-      // absent file with an IO error rather than a catalog one -- so the catalog
-      // patterns never see it, and the wrappers' own "Azure file not found"
-      // throw is unreachable. Verbatim from the installed driver.
-      const { controller } = buildTableController(
-         sinon
-            .stub()
-            .rejects(
-               new Error(
-                  'IO Error: No files found that match the pattern "/tmp/gone.parquet"',
-               ),
-            ),
-      );
-      await expect(getTable(controller)).rejects.toBeInstanceOf(
-         TableNotFoundError,
-      );
+   it("leaves an absent file-backed table a fault, not a missing table", async () => {
+      // A file-backed table is DuckLake or an Azure blob: an absent parquet is
+      // corruption or a bad mount, not a mistyped name, so it stays 502. The
+      // second string is a bad hostname, which shares the `IO Error:` prefix --
+      // both verbatim from the installed driver.
+      for (const message of [
+         'IO Error: No files found that match the pattern "/tmp/gone.parquet"',
+         "IO Error: Could not resolve hostname error for HTTP HEAD to 'https://nope.example.com/a.parquet'",
+      ]) {
+         const { controller } = buildTableController(
+            sinon.stub().rejects(new Error(message)),
+         );
+         await expect(getTable(controller)).rejects.toBeInstanceOf(
+            ConnectionError,
+         );
+      }
    });
 
    it("leaves a missing DuckDB extension a fault, not a missing table", async () => {

--- a/packages/server/src/controller/connection.controller.spec.ts
+++ b/packages/server/src/controller/connection.controller.spec.ts
@@ -10,7 +10,13 @@ import type {
 import { afterEach, describe, expect, it } from "bun:test";
 import sinon from "sinon";
 
-import { BadRequestError, PayloadTooLargeError } from "../errors";
+import {
+   BadRequestError,
+   ConnectionError,
+   InvalidArgumentError,
+   PayloadTooLargeError,
+   TableNotFoundError,
+} from "../errors";
 import type { EnvironmentStore } from "../service/environment_store";
 import { ConnectionController } from "./connection.controller";
 
@@ -848,5 +854,129 @@ describe("ConnectionController.getConnectionTemporaryTable guards", () => {
       await expect(
          controller.getConnectionTemporaryTable("env", "conn", "SELECT 1"),
       ).rejects.toBeInstanceOf(QueryTimeoutError);
+   });
+});
+
+/**
+ * A table that is not in the database must answer 404, not 502.
+ *
+ * The router counts 5xx against its server-error budget and pages on-call, so
+ * mapping a caller's bad reference to 502 turns a typo in someone's model into
+ * a production page -- which is what happened on 2026-09-08, when a Malloy
+ * compiler refetched one unresolved table on every recompile and drove the
+ * router to a 21.6% error rate.
+ */
+describe("ConnectionController getTable not-found mapping", () => {
+   afterEach(() => sinon.restore());
+
+   function buildTableController(fetchTableSchema: sinon.SinonStub): {
+      controller: ConnectionController;
+   } {
+      const fakeConnection = { fetchTableSchema } as unknown as Connection;
+      const fakeEnv = {
+         getApiConnection: sinon
+            .stub()
+            .returns({ name: "warehouse", type: "postgres" }),
+      };
+      const fakeStore = {
+         getEnvironment: sinon.stub().resolves(fakeEnv),
+      } as unknown as EnvironmentStore;
+      const controller = new ConnectionController(fakeStore);
+      sinon
+         .stub(
+            controller as unknown as {
+               getMalloyConnection: (...args: unknown[]) => Promise<Connection>;
+            },
+            "getMalloyConnection",
+         )
+         .resolves(fakeConnection);
+      return { controller };
+   }
+
+   const getTable = (controller: ConnectionController) =>
+      controller.getTable("env", "warehouse", "ds", "ds.missing");
+
+   it("classifies BigQuery's returned not-found string as TableNotFoundError", async () => {
+      // BigQuery's driver RETURNS the message instead of throwing, discarding
+      // the structured 404 it was handed.
+      const { controller } = buildTableController(
+         sinon.stub().resolves("Not found: Table proj:ds.missing"),
+      );
+      await expect(getTable(controller)).rejects.toBeInstanceOf(
+         TableNotFoundError,
+      );
+   });
+
+   it("leaves a BigQuery auth failure as a 502-class ConnectionError", async () => {
+      // The guard against over-reading the string: only absence is a 404.
+      const { controller } = buildTableController(
+         sinon.stub().resolves("Permission denied while getting table proj:ds"),
+      );
+      await expect(getTable(controller)).rejects.toBeInstanceOf(
+         ConnectionError,
+      );
+   });
+
+   it("classifies a path BigQuery cannot parse as a bad argument, not a fault", async () => {
+      // Every prefix typed before the first dot has one segment, so this arrives
+      // constantly while a path is being written. Verbatim from prod 2026-09-08.
+      const { controller } = buildTableController(
+         sinon
+            .stub()
+            .resolves(
+               "Improper table path: sal. A table path requires 2 or 3 segments",
+            ),
+      );
+      await expect(getTable(controller)).rejects.toBeInstanceOf(
+         InvalidArgumentError,
+      );
+   });
+
+   it("treats an empty schema result as not found", async () => {
+      const { controller } = buildTableController(
+         sinon.stub().resolves(undefined),
+      );
+      await expect(getTable(controller)).rejects.toBeInstanceOf(
+         TableNotFoundError,
+      );
+   });
+
+   it("classifies a driver that THREW its not-found instead of returning it", async () => {
+      // BigQuery returns the message; every other dialect throws. Both have to
+      // reach the same classification, or the fix covers one dialect only.
+      const { controller } = buildTableController(
+         sinon.stub().rejects(new Error("Not found: Table proj:ds.missing")),
+      );
+      await expect(getTable(controller)).rejects.toBeInstanceOf(
+         TableNotFoundError,
+      );
+   });
+
+   it("still reports an unrecognized driver failure as a 502-class fault", async () => {
+      // The floor: anything the classifier does not recognize stays a server
+      // error. Guessing wider would hide real outages behind a 404.
+      const { controller } = buildTableController(
+         sinon.stub().rejects(new Error("ECONNREFUSED 10.0.0.1:443")),
+      );
+      await expect(getTable(controller)).rejects.toBeInstanceOf(
+         ConnectionError,
+      );
+   });
+
+   it("preserves a TableNotFoundError thrown by the connection wrapper", async () => {
+      // Regression guard for the trap this fix exists to close: fetchTable's
+      // catch used to rewrap EVERYTHING as ConnectionError, so the Azure and
+      // DuckLake wrappers -- which throw not-found directly rather than
+      // returning a string -- would still have surfaced as 502. Asserting the
+      // CLASS rather than a status is deliberate: only the class proves the
+      // rethrow branch ran instead of the rewrap.
+      const { controller } = buildTableController(
+         sinon
+            .stub()
+            .rejects(new TableNotFoundError("Table ds.missing not found")),
+      );
+      await expect(getTable(controller)).rejects.toBeInstanceOf(
+         TableNotFoundError,
+      );
    });
 });

--- a/packages/server/src/controller/connection.controller.ts
+++ b/packages/server/src/controller/connection.controller.ts
@@ -170,14 +170,43 @@ const BIGQUERY_NOT_FOUND = /^Not found: (Table|Dataset)\b/;
  */
 const BIGQUERY_IMPROPER_PATH = /^Improper table path\b/;
 
+/**
+ * DuckDB -- the sandbox, and the Azure and DuckLake connections built on it --
+ * rejects rather than resolving empty, so a missing table arrives as a thrown
+ * catalog error. Covers all three shapes the driver produces: a missing table,
+ * a missing schema, and a missing catalog on a three-part path.
+ */
+const DUCKDB_NOT_FOUND = /^(Catalog|Binder) Error: .*does not exist/;
+
 function driverErrorToPublisherError(message: string): Error {
-   if (BIGQUERY_NOT_FOUND.test(message)) {
+   if (BIGQUERY_NOT_FOUND.test(message) || DUCKDB_NOT_FOUND.test(message)) {
       return new TableNotFoundError(message);
    }
    if (BIGQUERY_IMPROPER_PATH.test(message)) {
       return new InvalidArgumentError(message);
    }
    return new ConnectionError(message);
+}
+
+/**
+ * Shared by the two schema-introspection catches. Both take a driver failure
+ * that may be a thrown Error, a thrown string, or an already-classified error,
+ * and answer with the narrowest error the message supports.
+ */
+function classifyDriverFailure(error: unknown): Error {
+   if (
+      error instanceof TableNotFoundError ||
+      error instanceof InvalidArgumentError
+   ) {
+      return error;
+   }
+   const message =
+      error instanceof Error
+         ? error.message
+         : typeof error === "string"
+           ? error
+           : JSON.stringify(error);
+   return driverErrorToPublisherError(message);
 }
 
 export class ConnectionController {
@@ -331,21 +360,11 @@ export class ConnectionController {
             })),
          };
       } catch (error) {
-         const errorMessage =
-            error instanceof Error
-               ? error.message
-               : typeof error === "string"
-                 ? error
-                 : JSON.stringify(error);
-         // Two ways in. The wrappers above throw an already-classified error and
-         // must survive unchanged -- the blanket rewrap this replaces turned them
-         // back into 502s. A driver that throws its message rather than returning
-         // it (every dialect except BigQuery) is classified here instead.
-         const classified =
-            error instanceof TableNotFoundError ||
-            error instanceof InvalidArgumentError
-               ? error
-               : driverErrorToPublisherError(errorMessage);
+         // Where most not-founds actually land. BigQuery returns its message, but
+         // every other driver -- DuckDB included -- rejects, so the falsy checks
+         // above never see them and the blanket rewrap this replaces turned them
+         // all into 502s.
+         const classified = classifyDriverFailure(error);
          if (!(classified instanceof ConnectionError)) {
             // A caller's bad reference, not a fault: warn, so a mistyped path
             // cannot fill the error log while it is being typed.
@@ -481,13 +500,11 @@ export class ConnectionController {
             source: JSON.stringify(schema),
          };
       } catch (error) {
-         if (
-            error instanceof TableNotFoundError ||
-            error instanceof InvalidArgumentError
-         ) {
-            throw error;
-         }
-         throw new ConnectionError((error as Error).message);
+         // Same classification as fetchTable: a driver that rejects has to reach
+         // it too, or this route keeps answering 502 for a reference that is
+         // merely absent. `(error as Error).message` also dropped the message
+         // entirely for a thrown string.
+         throw classifyDriverFailure(error);
       }
    }
 

--- a/packages/server/src/controller/connection.controller.ts
+++ b/packages/server/src/controller/connection.controller.ts
@@ -188,21 +188,17 @@ const DUCKDB_TABLE_NOT_FOUND =
 const DUCKDB_CATALOG_NOT_FOUND = /^Binder Error: Catalog .+ does not exist/;
 
 /**
- * A file-backed DuckDB table -- the Azure blob branch of getTable, and any
- * parquet/csv path -- reports an absent file as an IO error rather than a
- * catalog one, so the patterns above never see it. Without this the wrappers'
- * own "Azure file not found" throw is unreachable and a missing blob answers
- * 502.
+ * Deliberately no pattern for `IO Error: No files found that match the
+ * pattern`. A file-backed table is DuckLake or an Azure blob, where an absent
+ * parquet means corruption or a misconfigured mount rather than a name the
+ * caller mistyped -- the same reason the extension errors above stay 502.
  */
-const DUCKDB_FILE_NOT_FOUND =
-   /^IO Error: No files found that match the pattern/;
 
 function driverErrorToPublisherError(message: string): Error {
    if (
       BIGQUERY_NOT_FOUND.test(message) ||
       DUCKDB_TABLE_NOT_FOUND.test(message) ||
-      DUCKDB_CATALOG_NOT_FOUND.test(message) ||
-      DUCKDB_FILE_NOT_FOUND.test(message)
+      DUCKDB_CATALOG_NOT_FOUND.test(message)
    ) {
       return new TableNotFoundError(message);
    }

--- a/packages/server/src/controller/connection.controller.ts
+++ b/packages/server/src/controller/connection.controller.ts
@@ -12,7 +12,9 @@ import {
 import {
    BadRequestError,
    ConnectionError,
+   InvalidArgumentError,
    PayloadTooLargeError,
+   TableNotFoundError,
 } from "../errors";
 import { recordQueryCapExceeded } from "../query_cap_metrics";
 import { logger } from "../logger";
@@ -140,6 +142,42 @@ function validateAdminAuthoredConnection(
          );
       }
    }
+}
+
+/**
+ * BigQuery's driver signals failure by RETURNING `error.message` instead of
+ * throwing, discarding the structured `code: 404` the Google client gave it
+ * (`@malloydata/db-bigquery` fetchTableSchema). That text is the only surviving
+ * signal, so a missing table is told apart from a broken connection by matching
+ * BigQuery's own API wording.
+ *
+ * Deliberately not generalized to other dialects. Postgres reports a missing
+ * table as the generic "Unable to read schema.", indistinguishable from any
+ * other failure, and Snowflake's DESCRIBE TABLE answers "does not exist or not
+ * authorized", conflating absence with denial by design. Guessing on either
+ * would be worse than leaving them 502.
+ */
+const BIGQUERY_NOT_FOUND = /^Not found: (Table|Dataset)\b/;
+
+/**
+ * A path that cannot name a table in this dialect at all -- BigQuery needs
+ * `dataset.table`, so a bare `sales` is rejected before any lookup happens. The
+ * caller's argument is malformed, which is a 400, not a 404: the answer is "that
+ * is not a table path", not "no such table".
+ *
+ * Reached constantly while a path is being typed, since every prefix before the
+ * first dot has one segment.
+ */
+const BIGQUERY_IMPROPER_PATH = /^Improper table path\b/;
+
+function driverErrorToPublisherError(message: string): Error {
+   if (BIGQUERY_NOT_FOUND.test(message)) {
+      return new TableNotFoundError(message);
+   }
+   if (BIGQUERY_IMPROPER_PATH.test(message)) {
+      return new InvalidArgumentError(message);
+   }
+   return new ConnectionError(message);
 }
 
 export class ConnectionController {
@@ -277,11 +315,11 @@ export class ConnectionController {
             }
          ).fetchTableSchema(tableKey, tablePath);
          if (!source) {
-            throw new ConnectionError(`Table ${tablePath} not found`);
+            throw new TableNotFoundError(`Table ${tablePath} not found`);
          }
          // BigQueryConnection returns `error.message` as a string on failure instead of throwing.
          if (typeof source === "string") {
-            throw new ConnectionError(source);
+            throw driverErrorToPublisherError(source);
          }
 
          return {
@@ -299,12 +337,31 @@ export class ConnectionController {
                : typeof error === "string"
                  ? error
                  : JSON.stringify(error);
+         // Two ways in. The wrappers above throw an already-classified error and
+         // must survive unchanged -- the blanket rewrap this replaces turned them
+         // back into 502s. A driver that throws its message rather than returning
+         // it (every dialect except BigQuery) is classified here instead.
+         const classified =
+            error instanceof TableNotFoundError ||
+            error instanceof InvalidArgumentError
+               ? error
+               : driverErrorToPublisherError(errorMessage);
+         if (!(classified instanceof ConnectionError)) {
+            // A caller's bad reference, not a fault: warn, so a mistyped path
+            // cannot fill the error log while it is being typed.
+            logger.warn("table not resolvable", {
+               tableKey,
+               tablePath,
+               reason: classified.constructor.name,
+            });
+            throw classified;
+         }
          logger.error("fetchTableSchema error", {
             error,
             tableKey,
             tablePath,
          });
-         throw new ConnectionError(errorMessage);
+         throw classified;
       }
    }
 
@@ -417,13 +474,19 @@ export class ConnectionController {
 
          // BigQueryConnection returns `error.message` as a string on failure instead of throwing.
          if (typeof schema === "string") {
-            throw new ConnectionError(schema);
+            throw driverErrorToPublisherError(schema);
          }
 
          return {
             source: JSON.stringify(schema),
          };
       } catch (error) {
+         if (
+            error instanceof TableNotFoundError ||
+            error instanceof InvalidArgumentError
+         ) {
+            throw error;
+         }
          throw new ConnectionError((error as Error).message);
       }
    }

--- a/packages/server/src/controller/connection.controller.ts
+++ b/packages/server/src/controller/connection.controller.ts
@@ -173,13 +173,37 @@ const BIGQUERY_IMPROPER_PATH = /^Improper table path\b/;
 /**
  * DuckDB -- the sandbox, and the Azure and DuckLake connections built on it --
  * rejects rather than resolving empty, so a missing table arrives as a thrown
- * catalog error. Covers all three shapes the driver produces: a missing table,
- * a missing schema, and a missing catalog on a three-part path.
+ * catalog error. These two cover the three shapes it produces for an absent
+ * object: a missing table, a missing schema behind a table lookup, and a missing
+ * catalog on a three-part path.
+ *
+ * Deliberately not `Catalog Error: .* does not exist`. DuckDB words a missing
+ * EXTENSION the same way -- "Catalog Error: Table Function with name read_csv
+ * does not exist!" -- and that is a misconfigured deployment, not an absent
+ * table. Answering it 404 would hide a broken Azure or DuckLake connection
+ * behind the one status nobody investigates.
  */
-const DUCKDB_NOT_FOUND = /^(Catalog|Binder) Error: .*does not exist/;
+const DUCKDB_TABLE_NOT_FOUND =
+   /^Catalog Error: Table with name .+ does not exist/;
+const DUCKDB_CATALOG_NOT_FOUND = /^Binder Error: Catalog .+ does not exist/;
+
+/**
+ * A file-backed DuckDB table -- the Azure blob branch of getTable, and any
+ * parquet/csv path -- reports an absent file as an IO error rather than a
+ * catalog one, so the patterns above never see it. Without this the wrappers'
+ * own "Azure file not found" throw is unreachable and a missing blob answers
+ * 502.
+ */
+const DUCKDB_FILE_NOT_FOUND =
+   /^IO Error: No files found that match the pattern/;
 
 function driverErrorToPublisherError(message: string): Error {
-   if (BIGQUERY_NOT_FOUND.test(message) || DUCKDB_NOT_FOUND.test(message)) {
+   if (
+      BIGQUERY_NOT_FOUND.test(message) ||
+      DUCKDB_TABLE_NOT_FOUND.test(message) ||
+      DUCKDB_CATALOG_NOT_FOUND.test(message) ||
+      DUCKDB_FILE_NOT_FOUND.test(message)
+   ) {
       return new TableNotFoundError(message);
    }
    if (BIGQUERY_IMPROPER_PATH.test(message)) {

--- a/packages/server/src/errors.spec.ts
+++ b/packages/server/src/errors.spec.ts
@@ -7,6 +7,8 @@ import {
    BadRequestError,
    ConnectionAuthError,
    ConnectionError,
+   InvalidArgumentError,
+   TableNotFoundError,
    internalErrorToHttpError,
    ModelCompilationError,
    NotImplementedError,
@@ -65,6 +67,33 @@ describe("internalErrorToHttpError", () => {
       );
       expect(status).toBe(424);
       expect(json).toEqual({ code: 424, message: "compile failed" });
+   });
+
+   it("maps TableNotFoundError to 404 with a machine-readable reason", () => {
+      const { status, json } = internalErrorToHttpError(
+         new TableNotFoundError("Not found: Table proj:ds.missing"),
+      );
+      expect(status).toBe(404);
+      expect(json).toEqual({
+         code: 404,
+         message: "Not found: Table proj:ds.missing",
+         reason: "TABLE_NOT_FOUND",
+      });
+   });
+
+   it("maps InvalidArgumentError to 400", () => {
+      const { status, json } = internalErrorToHttpError(
+         new InvalidArgumentError("Improper table path: sal"),
+      );
+      expect(status).toBe(400);
+      expect(json).toEqual({ code: 400, message: "Improper table path: sal" });
+   });
+
+   it("omits reason entirely on errors that carry none", () => {
+      const { json } = internalErrorToHttpError(
+         new ConnectionError("upstream broken"),
+      );
+      expect(json).not.toHaveProperty("reason");
    });
 
    it("maps ConnectionError to 502 (distinct from auth, still retryable)", () => {

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -5,6 +5,20 @@ import { MalloyError } from "@malloydata/malloy";
 import { PUBLISHER_CONFIG_NAME } from "./constants";
 import type { EligibilityRefusalReason } from "./materialization_metrics";
 
+/**
+ * Machine-readable discriminator on an error response, for callers that must
+ * branch on *which* 404 they got rather than on prose.
+ *
+ * The router retries a 404 by invalidating its cached worker location and
+ * asking the control plane again, because a 404 normally means the worker it
+ * called no longer hosts that environment or connection. A table that is not in
+ * the database is also a 404 but carries no such implication -- retrying it
+ * re-queries the same absent table and throws away a cache entry every other
+ * caller on that connection is using. Only reasons that a caller is expected to
+ * branch on are emitted; absence is the norm and means "no special handling".
+ */
+export type ErrorReason = "TABLE_NOT_FOUND";
+
 export function internalErrorToHttpError(error: Error) {
    if (error instanceof BadRequestError) {
       return httpError(400, error.message);
@@ -24,6 +38,8 @@ export function internalErrorToHttpError(error: Error) {
       return httpError(404, error.message);
    } else if (error instanceof MalloyError) {
       return httpError(400, error.message);
+   } else if (error instanceof TableNotFoundError) {
+      return httpError(404, error.message, "TABLE_NOT_FOUND");
    } else if (error instanceof ConnectionNotFoundError) {
       return httpError(404, error.message);
    } else if (error instanceof DestinationNotFoundError) {
@@ -61,12 +77,15 @@ export function internalErrorToHttpError(error: Error) {
    }
 }
 
-function httpError(code: number, message: string) {
+function httpError(code: number, message: string, reason?: ErrorReason) {
    return {
       status: code,
       json: {
          code,
          message: message,
+         // Omitted rather than undefined so existing toStrictEqual assertions
+         // on reason-less errors keep passing.
+         ...(reason ? { reason } : {}),
       },
    };
 }
@@ -130,6 +149,24 @@ export class DashboardNotFoundError extends Error {
 }
 
 export class ConnectionNotFoundError extends Error {
+   constructor(message: string) {
+      super(message);
+   }
+}
+
+/**
+ * The connection is reachable and authenticated, but it holds no table at that
+ * path. A caller's bad reference, not a server or upstream fault, so it maps to
+ * 404 -- which is what every spec declaring this route has always documented
+ * (502 appears in none of them).
+ *
+ * Distinct from {@link ConnectionError}, which stays 502 for genuine transport
+ * failures: unreachable database, expired credentials, exhausted quota. The
+ * split matters beyond tidiness, because a 5xx here is counted against the
+ * router's server-error budget and pages on-call for what is a typo in someone's
+ * model.
+ */
+export class TableNotFoundError extends Error {
    constructor(message: string) {
       super(message);
    }

--- a/packages/server/src/service/connection.ts
+++ b/packages/server/src/service/connection.ts
@@ -47,6 +47,7 @@ import {
 } from "../ducklake_version";
 import {
    ConnectionNotFoundError,
+   TableNotFoundError,
    UnsupportedCatalogFormatError,
 } from "../errors";
 import { logAxiosError, logger } from "../logger";
@@ -1671,7 +1672,9 @@ class AzureDuckDBConnection extends DuckDBConnection {
             });
             const result = await super.fetchTableSchema(tableKey, azureUrl);
             if (!result) {
-               throw new Error(`Azure file not found: ${azureUrl}`);
+               throw new TableNotFoundError(
+                  `Azure file not found: ${azureUrl}`,
+               );
             }
             return result;
          }
@@ -1679,7 +1682,7 @@ class AzureDuckDBConnection extends DuckDBConnection {
 
       const result = await super.fetchTableSchema(tableKey, tablePath);
       if (!result) {
-         throw new Error(`Table ${tablePath} not found`);
+         throw new TableNotFoundError(`Table ${tablePath} not found`);
       }
       return result;
    }
@@ -1780,7 +1783,7 @@ class DuckLakeConnection extends DuckDBConnection {
          });
          const result = await super.fetchTableSchema(tableKey, prefixedPath);
          if (!result) {
-            throw new Error(
+            throw new TableNotFoundError(
                `Table ${prefixedPath} not found in connection ${this.connectionName}`,
             );
          }
@@ -1790,7 +1793,7 @@ class DuckLakeConnection extends DuckDBConnection {
       // For attached databases, in the future
       const result = await super.fetchTableSchema(tableKey, tablePath);
       if (!result) {
-         throw new Error(
+         throw new TableNotFoundError(
             `Table ${tablePath} not found in connection ${this.connectionName}`,
          );
       }


### PR DESCRIPTION
A table path that names nothing, or that the dialect cannot parse at all, is the caller's mistake. Both were answered with **502**, so browsing for a table that turned out not to exist read as a server fault.

That has a downstream cost beyond tidiness: a 5xx is counted against a server-error budget. On Credible's deployment it paged on-call **twice in one afternoon** — 616 errors in one 30-minute window, then 415 in another — for what was, both times, a modeler typing a table name into an editor. A compiler re-resolves an unresolved `table()` reference on every recompile, so one bad reference in an open file becomes hundreds of requests.

## What changes

| Condition | Before | After |
|---|---|---|
| `Not found: Table\|Dataset …` | 502 | **404** + `reason: "TABLE_NOT_FOUND"` |
| `Improper table path …` | 502 | **400** |
| Publisher-authored not-found (Azure, DuckDB, DuckLake) | 502 | **404** |
| Anything else (unreachable, credentials, quota) | 502 | **502**, unchanged |

**404 was already the declared contract** — 502 appears in no spec for these routes — so that half is conformance, not a break. 400 is newly declared alongside it.

## Why match on message text

BigQuery's driver signals failure by **returning** `error.message` instead of throwing, discarding the structured `code: 404` the Google client gave it:

```js
// @malloydata/db-bigquery — fetchTableSchema
catch (error) { return error.message; }
```

The text is the only surviving signal, so two of BigQuery's own API messages are matched. The second one, `Improper table path`, is not an edge case: BigQuery needs `dataset.table`, so **every prefix typed before the first dot** has one segment and lands here. It was 42% of the errors in the second incident.

Anything unrecognized stays `ConnectionError`/502, so a real outage is still loud.

**Deliberately not generalized to other dialects.** Postgres reports a missing table as the generic `Unable to read schema.`, indistinguishable from any other failure; Snowflake's `DESCRIBE TABLE` answers *"does not exist or not authorized"*, conflating absence with denial **by design**. Guessing on either would be worse than leaving them 502. The publisher's own wrappers need no matching and are converted directly.

## The trap this closes

`fetchTable`'s catch rewrapped *everything* as `ConnectionError`. Classifying without touching it would have silently undone the fix — and would have missed every dialect that throws rather than returning. It now preserves an already-classified error and classifies a thrown message the same way.

A not-found is logged at `warn` rather than `error`, so a path being typed cannot fill the error log. (Route handlers still log at error; this removes one of two lines per miss.)

## `reason` on the response

`TableNotFoundError` carries `reason: "TABLE_NOT_FOUND"`. A caller that retries a 404 by re-resolving which server hosts a resource — as Credible's router does, invalidating a shared cache entry and re-asking its control plane — needs to tell that case apart from a table that is simply absent, and status alone cannot say which. Optional and additive; callers that ignore it are unaffected.

## Testing

`bun test packages/server/src` — 3546 pass, 7 pre-existing failures unchanged against a clean baseline (`build_targets_address_equality`, `service/package` xlsx; unrelated to this change).

Six new tests, and I verified they fail for the right reason: reverting the catch to its blanket rewrap fails **5 of 6**, while the "unrecognized failure stays 502" floor test correctly stays green.

- BigQuery's returned not-found string → `TableNotFoundError`
- `Improper table path` → `InvalidArgumentError`
- a driver that **threw** its not-found → `TableNotFoundError` (the non-BigQuery path)
- an empty schema result → `TableNotFoundError`
- a `TableNotFoundError` thrown by a wrapper survives the catch — asserting the **class**, since a status assertion would not prove the rethrow branch ran
- `ECONNREFUSED` → still `ConnectionError`
- a BigQuery **auth** failure → still `ConnectionError`, so the match cannot swallow a credentials problem

## Follow-up, not in this PR

`db-publisher` implements only `fetchTableSchema` and never overrides `fetchSchemaForTables`, and the base implementation awaits each iteration — so a cold 40-table model is **40 serialized HTTP round trips**. Measured p95 on the affected route was 181 ms for a miss but **3.22 s for a hit**, so batching (or even parallelizing) is the real latency lever. Separate change.

The cleanest fix of all is upstream of this repo: `@malloydata/db-bigquery` should preserve the structured error instead of returning prose, which would make this classification unnecessary.
