### PR TITLE
fix(server): keep a reloaded package's warm embedding index

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -59,6 +59,48 @@ wild was doing this.
 
 ---
 
+## [Unreleased] — a reloaded package keeps its warm semantic index, and `embeddingIndex.status` means what it says
+
+**Reloading a package no longer costs you a lexically-ranked answer.** A reload
+never dropped a package's vectors — they are keyed by package name in
+`publisher.db` — but it did throw away the server's record that they were
+current, because that record was tied to the in-memory package object a reload
+replaces. So the first `get_context` after every `reload_package`, every REST
+`?reload=true`, and every watch-mode save was ranked lexically while the server
+re-checked hashes that all still matched. If you author models with watch mode
+on, that was one degraded answer per save, including saves that changed nothing
+relevant. Now a reload whose files hash the same keeps the warm index and is
+ranked semantically on its first call; an edit still re-embeds, and still only
+the parts whose text changed.
+
+**`embeddingIndex.status` keeps its name and changes its basis, so read this if
+you poll it.** On the package resource
+(`GET /api/v0/environments/{env}/packages/{pkg}`), `ready` used to be derived
+from whether cached rows covered the package's current entity *names*. Vectors
+outlive a restart and a reload, so that reported `ready` immediately — while the
+next question was still answered lexically. Anything following the documented
+"poll until `ready` before measuring retrieval quality" could therefore measure a
+lexical run and record it as a semantic one, which is a wrong number rather than
+a slow start. `ready` now means one thing: the next `get_context` question about
+this package will be ranked semantically. It is decided by the same completed
+sync the search path itself gates on.
+
+**What to do.** If you poll for readiness, keep polling `status` — it is now
+accurate, and it is the field to trust. If you instead inferred readiness from
+`embeddedEntities == totalEntities`, stop: those count coverage by entity name,
+so they can be equal while `status` is `indexing` (an edit that rewrote every
+doc without renaming anything leaves each entity holding its stale name vector).
+Expect `status` to read `indexing` in two places it previously read `ready`:
+just after a server restart, until the first question re-establishes the sync,
+and after a doc-only edit. Both clear on the next `get_context` question. The
+unchanged caveat still applies — a package nothing has ever queried does not warm
+on its own, so poll a package you are about to query rather than one you have not
+touched.
+
+Unrelated to the above, and unchanged: `--init` still drops the vector cache
+along with the rest of persisted storage. It resets the server root, and it
+remains the reclaim path for rows orphaned by a configuration change.
+
 ## [0.2.4] (BREAKING) — every MCP tool loses its `malloy_` prefix, and get_context answers in one shape
 
 **Every MCP tool is renamed.** The `malloy_` prefix is gone and the names are bare

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,7 +13,7 @@ The `Release (NPM + Docker)` workflow (`.github/workflows/release.yml`) creates 
 
 For releases that warrant narrative — redesigns, breaking changes, migration steps — write a `## [Unreleased]` section below, in the PR that changes the behaviour. **The release workflow does almost all of the rest**: `gh-release` appends every `[Unreleased]` section to the release page alongside the generated PR list, then pushes a `release-notes-stamp-<version>` branch restamping those headings with the version that shipped them. Nothing to paste, and nothing to remember while writing.
 
-One step is a human's, and it is the one that bites when it is skipped: someone has to open that branch as a PR and merge it. `main` requires a pull request, so the release cannot land the stamp itself, and the job summary prints the link. Until it merges the headings still read `[Unreleased]`, which is exactly what the *next* release matches — so the narrative here lands on that release's page too, and on every one after it. Whoever cuts the release owns that click; the `publisher-release` skill makes it a step.
+One step is a human's, and it is the one that bites when it is skipped: someone has to open that branch as a PR and merge it. `main` requires a pull request, so the release cannot land the stamp itself, and the job summary prints the link. Until it merges the headings still read `[Unreleased]`, which is exactly what the _next_ release matches — so the narrative here lands on that release's page too, and on every one after it. Whoever cuts the release owns that click; the `publisher-release` skill makes it a step.
 
 Both steps handle several sections, which matters because unrelated narratives accumulate between releases: they are separate entries in the same release rather than alternatives. That is precisely what the old manual process got wrong. It also simply stopped happening — 0.0.243 through 0.0.247 each shipped with none of their narrative, and the pages were backfilled by hand afterwards.
 
@@ -35,7 +35,7 @@ One behaviour change to know about: `skills-npm.yml` now publishes only from `ma
 
 `#@ persist name=` accepts the table name a source materializes into, and that
 value is pasted into the `CREATE OR REPLACE TABLE` and `DROP TABLE IF EXISTS`
-statements the builder runs. It was only ever checked for being *quoted*, never
+statements the builder runs. It was only ever checked for being _quoted_, never
 for what the quotes contained, so a name carrying its own quote character closed
 the identifier early and the rest of the value continued as SQL.
 
@@ -76,7 +76,7 @@ the parts whose text changed.
 **`embeddingIndex.status` keeps its name and changes its basis, so read this if
 you poll it.** On the package resource
 (`GET /api/v0/environments/{env}/packages/{pkg}`), `ready` used to be derived
-from whether cached rows covered the package's current entity *names*. Vectors
+from whether cached rows covered the package's current entity _names_. Vectors
 outlive a restart and a reload, so that reported `ready` immediately — while the
 next question was still answered lexically. Anything following the documented
 "poll until `ready` before measuring retrieval quality" could therefore measure a
@@ -97,6 +97,15 @@ unchanged caveat still applies — a package nothing has ever queried does not w
 on its own, so poll a package you are about to query rather than one you have not
 touched.
 
+**If your embedding provider ignores `EMBEDDING_DIMENSIONS`, the coverage counts
+now match reality.** The `dims` column records the length the provider actually
+returned, and some providers (Ollama among them) ignore the requested value.
+`embeddedRows` and `embeddedEntities` were counted against the _configured_
+value instead, so for those providers they read 0 while retrieval was reading
+those same vectors happily — and that also pinned `status` at `indexing`. Both
+now count the rows retrieval actually reads, on the same rule the sync itself
+uses to decide a row is current.
+
 Unrelated to the above, and unchanged: `--init` still drops the vector cache
 along with the rest of persisted storage. It resets the server root, and it
 remains the reclaim path for rows orphaned by a configuration change.
@@ -107,15 +116,15 @@ remains the reclaim path for rows orphaned by a configuration change.
 snake_case. There is no alias and no deprecation window: the old names are removed,
 so an agent or client that calls them gets an unknown-tool error until it is updated.
 
-| Before | Now |
-|---|---|
-| `malloy_getContext` | `get_context` |
-| `malloy_executeQuery` | `execute_query` |
-| `malloy_compile` | `compile_model` |
-| `malloy_reloadPackage` | `reload_package` |
-| `malloy_getStatus` | `get_status` |
+| Before                        | Now                      |
+| ----------------------------- | ------------------------ |
+| `malloy_getContext`           | `get_context`            |
+| `malloy_executeQuery`         | `execute_query`          |
+| `malloy_compile`              | `compile_model`          |
+| `malloy_reloadPackage`        | `reload_package`         |
+| `malloy_getStatus`            | `get_status`             |
 | `malloy_searchDatabaseSchema` | `search_database_schema` |
-| `malloy_searchDocs` | `search_malloy_docs` |
+| `malloy_searchDocs`           | `search_malloy_docs`     |
 
 **What to do.** Hosts that discover tools at connect time (Claude Code, Cursor, Codex)
 pick the new names up on reconnect with no config change — the names appear in the
@@ -164,7 +173,7 @@ before rotating to the next one. Unset, nothing changes: no option is set and th
 issues exactly the SQL it issued before.
 
 This is a **second, separate** term from the row group bound in 0.2.3 below, not a
-replacement. The row group bounds the per-column buffer *within* a file; this bounds how much
+replacement. The row group bounds the per-column buffer _within_ a file; this bounds how much
 of the file is resident. Writing to object storage, DuckDB copies each multipart part into a
 buffer it allocates itself and holds it until the file completes, so a file's bytes stay
 resident however they are grouped inside it. Peak memory therefore tracks the FILE size —
@@ -178,14 +187,14 @@ Measured on a 72-column, 20,000,000-row DuckLake write to GCS, sampling cgroup
 `memory.stat` `anon` — all six cells in one batch, since this number moves with link speed
 and with catalog state left by earlier runs:
 
-| `PUBLISHER_DUCKLAKE_TARGET_FILE_SIZE_BYTES` | files | peak anon |
-|---|---|---|
-| unset — DuckLake's own default, ~512MB files | 6 | 650 MiB |
-| `1024MB` | 3 | 892 MiB |
-| `512MB` | 6 | 550 MiB |
-| `256MB` | 12 | 373 MiB |
-| `128MB` | 23 | 262 MiB |
-| `64MB` | 45 | 255 MiB |
+| `PUBLISHER_DUCKLAKE_TARGET_FILE_SIZE_BYTES`  | files | peak anon |
+| -------------------------------------------- | ----- | --------- |
+| unset — DuckLake's own default, ~512MB files | 6     | 650 MiB   |
+| `1024MB`                                     | 3     | 892 MiB   |
+| `512MB`                                      | 6     | 550 MiB   |
+| `256MB`                                      | 12    | 373 MiB   |
+| `128MB`                                      | 23    | 262 MiB   |
+| `64MB`                                       | 45    | 255 MiB   |
 
 So the realistic gain is **650 → 373 MiB, about 1.74×** — DuckLake already rotates files, and
 this option moves where it rotates. The underlying effect is much larger than that ratio
@@ -286,7 +295,6 @@ is offered whether or not it has been built yet, so adding a coarse grain to a p
 that already has a built finer rollup costs acceleration until the new one builds —
 answers are unaffected, and it lasts one build.
 
-
 ## [0.2.3] — bound the memory a wide DuckLake write spends buffering Parquet
 
 `PUBLISHER_DUCKLAKE_ROW_GROUP_SIZE_BYTES` caps how much column data DuckLake buffers
@@ -306,12 +314,12 @@ throughout. If that is familiar, the source that killed it is almost certainly y
 Measured on a 72-column, 5,000,000-row `CREATE TABLE AS` into DuckLake, sampling cgroup
 `memory.stat` `anon`:
 
-| `PUBLISHER_DUCKLAKE_ROW_GROUP_SIZE_BYTES` | peak anon | rows per row group |
-|---|---|---|
-| unset (DuckLake's default of 122,880 rows) | 2772 MiB | ~122,880 |
-| `64MB` | 1530 MiB | ~42,300 |
-| `32MB` | 1360 MiB | ~21,900 |
-| `16MB` | 1006 MiB | ~11,700 |
+| `PUBLISHER_DUCKLAKE_ROW_GROUP_SIZE_BYTES`  | peak anon | rows per row group |
+| ------------------------------------------ | --------- | ------------------ |
+| unset (DuckLake's default of 122,880 rows) | 2772 MiB  | ~122,880           |
+| `64MB`                                     | 1530 MiB  | ~42,300            |
+| `32MB`                                     | 1360 MiB  | ~21,900            |
+| `16MB`                                     | 1006 MiB  | ~11,700            |
 
 If you measure this yourself, read `anon` and not `memory.current`: the latter includes the
 page cache of the Parquet being written, which scales with output size, roughly doubles the
@@ -363,12 +371,11 @@ rows it overwrote.
 
 ### New metrics
 
-| Counter | Meaning |
-|---|---|
-| `publisher_materialization_duplicate_target_skipped_total` | A source whose table this run already wrote. Ordinary for a package that extends a persisted source — a volume signal, not a fault. |
-| `publisher_materialization_shared_address_instructions_total` | One content address instructed to build more than one table. Wasteful, not wrong: the content is the same either way. |
-| `publisher_materialization_table_collision_total` | Two definitions materializing into one table — serve-time wrong data. **This is the one to alert on.** Its rate is also what enabling `PERSIST_COLLISION_ENFORCE` would begin refusing, so a rollout can be measured before it is turned on. |
-
+| Counter                                                       | Meaning                                                                                                                                                                                                                                      |
+| ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `publisher_materialization_duplicate_target_skipped_total`    | A source whose table this run already wrote. Ordinary for a package that extends a persisted source — a volume signal, not a fault.                                                                                                          |
+| `publisher_materialization_shared_address_instructions_total` | One content address instructed to build more than one table. Wasteful, not wrong: the content is the same either way.                                                                                                                        |
+| `publisher_materialization_table_collision_total`             | Two definitions materializing into one table — serve-time wrong data. **This is the one to alert on.** Its rate is also what enabling `PERSIST_COLLISION_ENFORCE` would begin refusing, so a rollout can be measured before it is turned on. |
 
 ## [0.2.2] — a boolean query param you misspell now fails instead of doing nothing
 
@@ -418,7 +425,7 @@ the right place and then moved to the wrong one. Two ways it showed up:
 - **Silently.** The build reported success and the manifest recorded
   `analytics.orders`, while the table sat in the default container. Anything
   serving that source then resolved a path holding no table.
-- **As a nonsense error.** ``Object '"orders"' already exists`` when something of
+- **As a nonsense error.** `Object '"orders"' already exists` when something of
   that name was already in the default container — while `analytics` was empty.
 
 The rename target is now qualified on the dialects that resolve a bare one against
@@ -597,7 +604,7 @@ ungated. The load succeeds, and a warning names the entry point whose gate is no
 so you find out before a caller does.
 
 One narrower hole replaces it, and is worth knowing while you migrate: drop the gated column and then
-`rename:` a *different* column onto that exact name. That grafts successfully and binds the gate to
+`rename:` a _different_ column onto that exact name. That grafts successfully and binds the gate to
 the **wrong** column. It takes a drop, plus a rename onto the exact gated name, plus colliding data,
 and it fails closed unless the data collides — but do not recycle a gated column's name.
 
@@ -605,7 +612,7 @@ and it fails closed unless the data collides — but do not recycle a gated colu
 
 1. Find every `#(authorize) "<expr>"` and `##(authorize)` in your packages. Load the package — every
    `.malloy` file in the tree compiles and any failure aborts the load, so the refusal will name
-   each declaring source. The one case that escapes it is a declaring file *outside* the package
+   each declaring source. The one case that escapes it is a declaring file _outside_ the package
    tree: nothing compiles it, so it loads and then denies every request — and it increments no
    metric, since the request-time lift failure carries no `cause` at all. That gate is invisible
    except in a debug log naming the graft target, so grep your packages rather than waiting for a
@@ -627,8 +634,8 @@ constant-`false` lock does not hold there and `includeSql` returns the ungrafted
   Malloy's own failure named the one that could not bind — "Given 'ROLE' has no value and no default.
   To fix: supply it via `.run({givens: {ROLE: ...}})`" — reaching the caller as a 400. That is exactly
   what `docs/authorize.md` promises never happens. It now maps back to the opaque `Access denied for
-  source "…"` 403.
-- **A membership test checks given reachability on both operands.** The membership *candidate*
+source "…"` 403.
+- **A membership test checks given reachability on both operands.** The membership _candidate_
   position skipped the check every other operand position makes, so a gate naming a given two import
   hops away bound that given's declaration **default** at request time instead of the caller's value.
   It is now refused (`unreachable_given`) like every other unreachable reference.
@@ -636,8 +643,8 @@ constant-`false` lock does not hold there and `includeSql` returns the ungrafted
   compile — a list literal is not valid in that position. Write the disjunction out
   (`$ROLE = 'analyst' or $ROLE = 'admin'`), or compare a row field to an array-typed given with `in`.
 - **`/compile` no longer denies a gated source unconditionally.** Denying it made a gated source
-  un-authorable while protecting nothing, since the query path answers a gated source with *filtered
-  rows* rather than a 403. `/compile` never runs the query, so it now admits a gate it can decide
+  un-authorable while protecting nothing, since the query path answers a gated source with _filtered
+  rows_ rather than a 403. `/compile` never runs the query, so it now admits a gate it can decide
   without running one. **"Decidable" is presence, not truth:** a gate referencing no given is
   admitted whichever way it resolves — a constant `false` included — as is one whose every given the
   caller supplied, right or wrong. Only an unsupplied given denies. `includeSql` then returns the
@@ -1175,7 +1182,7 @@ This is a **breaking release for SDK consumers**: five removals and one narrowed
 ### What changed
 
 - **A notebook's parameters live in its URL.** `Notebook` takes `givens` and `onGivensChange`, and the Console wires them to the query string. Opening a notebook at `?REGION=West` runs every cell with that value on the first pass rather than running bare and running again. The host is handed the names the notebook manages alongside the values, so it can update its own query string without disturbing parameters that are not its business.
-- **`# drill { to=self }` works in a notebook cell.** A cell that groups by a dimension carrying the tag becomes clickable and filters the notebook in place with the clicked value, provided the notebook declares the given the tag names: one that names a given the document does not declare stays plain rather than offering a click that cannot be honoured. Drillable cells read as links on hover, via a new mode-keyed `drillLink` theme colour. Two cases are deliberately left unmarked: a blank cell, whose click is refused anyway (a blank value is far likelier a misclick than a request for the rows that are blank), and every cell of a `# transpose` table, because the renderer lays that layout out without the per-cell `grid-column` the marking matches on. A transposed table's drill still WORKS when clicked; it is undiscoverable, which is the one place on this surface where the affordance and the behaviour disagree. A drill naming a *dashboard* destination is honoured too, now that the dashboard route exists: the cell is marked, and clicking it opens that dashboard with the value seeded. On a host that has not wired the navigation the destination stays unmarked and inert rather than painting a cell as a link to a page that answers "Nothing to open at this path".
+- **`# drill { to=self }` works in a notebook cell.** A cell that groups by a dimension carrying the tag becomes clickable and filters the notebook in place with the clicked value, provided the notebook declares the given the tag names: one that names a given the document does not declare stays plain rather than offering a click that cannot be honoured. Drillable cells read as links on hover, via a new mode-keyed `drillLink` theme colour. Two cases are deliberately left unmarked: a blank cell, whose click is refused anyway (a blank value is far likelier a misclick than a request for the rows that are blank), and every cell of a `# transpose` table, because the renderer lays that layout out without the per-cell `grid-column` the marking matches on. A transposed table's drill still WORKS when clicked; it is undiscoverable, which is the one place on this surface where the affordance and the behaviour disagree. A drill naming a _dashboard_ destination is honoured too, now that the dashboard route exists: the cell is marked, and clicking it opens that dashboard with the value seeded. On a host that has not wired the navigation the destination stays unmarked and inert rather than painting a cell as a link to a page that answers "Nothing to open at this path".
 - **`select` / `multiselect` controls backed by `suggest`.** The option list comes from an ordinary query on the governed query endpoint, so row caps and `#(authorize)` gates apply to a dropdown exactly as they do to the surface's own queries. A suggest query that fails now says so on the control instead of rendering as a dimension with no values, and the generated query carries an explicit `limit:` and ordering rather than relying on the server's default row cap to truncate it in whatever order the warehouse returned.
 - **Filter values are escaped by Malloy's own filter package.** A `filter<…>` value picked in a control is now printed with `@malloydata/malloy-filter`'s `StringFilterExpression.unparse`, and read back with its parser. The previous scheme wrapped values in double quotes, which Malloy's string-filter grammar has no notion of: backslash is its only escape, so the quoting escaped nothing and several ordinary values silently meant something else. Measured against the `storefront` model, filtering its `category` dimension: a picked `-Outerwear` ran as a negation and returned 22,821 of 25,356 rows instead of the 2,535 that category holds; `%` bypassed the filter and returned all 25,356; `null` hit the null operator and returned 0; and `Ben & Jerry, Inc` was read as two brands. All of these now match themselves, pinned by a round-trip test against the real parser.
 - **The notebook's controls are `given:` only.** The Filters panel that rendered `#(filter)` and `##(filters)` annotations is gone, and the notebook no longer sends `filterParams`. **This is a behaviour change for a model that uses `#(filter)`, and the deprecation note under 0.0.201 said otherwise.** Concretely: a cell fails when its run target is a source that declares a `required` filter, because the server still refuses one with no value and there is no longer a UI that can supply it. That is narrower than "every cell" in two ways worth knowing before you audit a model: enforcement is per run-target source, so cells querying a source with no filters are unaffected, and a **block-form** `#(filter) … required` is not collected at all, so it never raised the error in the first place (`source_extraction.ts` documents that gap deliberately). A model with only optional `#(filter)` annotations still runs, but is no longer filterable from the notebook. The REST parameters, the `Deprecation` header, and the server-side enforcement are all unchanged: this is the UI half of the migration landing ahead of the server half. Migrate to `given:`: [docs/givens.md](docs/givens.md) has a **"Coming from `#(filter)`"** section with a worked conversion and the three things that do not map across.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,7 +13,7 @@ The `Release (NPM + Docker)` workflow (`.github/workflows/release.yml`) creates 
 
 For releases that warrant narrative — redesigns, breaking changes, migration steps — write a `## [Unreleased]` section below, in the PR that changes the behaviour. **The release workflow does almost all of the rest**: `gh-release` appends every `[Unreleased]` section to the release page alongside the generated PR list, then pushes a `release-notes-stamp-<version>` branch restamping those headings with the version that shipped them. Nothing to paste, and nothing to remember while writing.
 
-One step is a human's, and it is the one that bites when it is skipped: someone has to open that branch as a PR and merge it. `main` requires a pull request, so the release cannot land the stamp itself, and the job summary prints the link. Until it merges the headings still read `[Unreleased]`, which is exactly what the _next_ release matches — so the narrative here lands on that release's page too, and on every one after it. Whoever cuts the release owns that click; the `publisher-release` skill makes it a step.
+One step is a human's, and it is the one that bites when it is skipped: someone has to open that branch as a PR and merge it. `main` requires a pull request, so the release cannot land the stamp itself, and the job summary prints the link. Until it merges the headings still read `[Unreleased]`, which is exactly what the *next* release matches — so the narrative here lands on that release's page too, and on every one after it. Whoever cuts the release owns that click; the `publisher-release` skill makes it a step.
 
 Both steps handle several sections, which matters because unrelated narratives accumulate between releases: they are separate entries in the same release rather than alternatives. That is precisely what the old manual process got wrong. It also simply stopped happening — 0.0.243 through 0.0.247 each shipped with none of their narrative, and the pages were backfilled by hand afterwards.
 
@@ -35,7 +35,7 @@ One behaviour change to know about: `skills-npm.yml` now publishes only from `ma
 
 `#@ persist name=` accepts the table name a source materializes into, and that
 value is pasted into the `CREATE OR REPLACE TABLE` and `DROP TABLE IF EXISTS`
-statements the builder runs. It was only ever checked for being _quoted_, never
+statements the builder runs. It was only ever checked for being *quoted*, never
 for what the quotes contained, so a name carrying its own quote character closed
 the identifier early and the rest of the value continued as SQL.
 
@@ -76,14 +76,16 @@ the parts whose text changed.
 **`embeddingIndex.status` keeps its name and changes its basis, so read this if
 you poll it.** On the package resource
 (`GET /api/v0/environments/{env}/packages/{pkg}`), `ready` used to be derived
-from whether cached rows covered the package's current entity _names_. Vectors
+from whether cached rows covered the package's current entity *names*. Vectors
 outlive a restart and a reload, so that reported `ready` immediately — while the
 next question was still answered lexically. Anything following the documented
 "poll until `ready` before measuring retrieval quality" could therefore measure a
 lexical run and record it as a semantic one, which is a wrong number rather than
-a slow start. `ready` now means one thing: the next `get_context` question about
-this package will be ranked semantically. It is decided by the same completed
-sync the search path itself gates on.
+a slow start. `ready` now means one thing: the index is warm, so the next
+`get_context` question about this package is ranked semantically. It is decided
+by the same completed sync the search path itself gates on. It describes the
+index, not the next response — a question whose own query embedding fails still
+falls back, with `retrieval_reason: provider-error`.
 
 **What to do.** If you poll for readiness, keep polling `status` — it is now
 accurate, and it is the field to trust. If you instead inferred readiness from
@@ -100,11 +102,18 @@ touched.
 **If your embedding provider ignores `EMBEDDING_DIMENSIONS`, the coverage counts
 now match reality.** The `dims` column records the length the provider actually
 returned, and some providers (Ollama among them) ignore the requested value.
-`embeddedRows` and `embeddedEntities` were counted against the _configured_
+`embeddedRows` and `embeddedEntities` were counted against the *configured*
 value instead, so for those providers they read 0 while retrieval was reading
 those same vectors happily — and that also pinned `status` at `indexing`. Both
-now count the rows retrieval actually reads, on the same rule the sync itself
-uses to decide a row is current.
+now count on the same rule the sync uses to decide a row is current: the current
+model, any vector length.
+
+That makes them a count of what is cached, not a prediction of what a search can
+read — the scan also matches on vector length, which only a real question knows.
+So after a change to `EMBEDDING_DIMENSIONS` that no question has probed yet, the
+old rows are still counted until the next search discards them. `status` is
+already `indexing` throughout that window, which is why it, and not the counts,
+is the field to poll.
 
 Unrelated to the above, and unchanged: `--init` still drops the vector cache
 along with the rest of persisted storage. It resets the server root, and it
@@ -116,15 +125,15 @@ remains the reclaim path for rows orphaned by a configuration change.
 snake_case. There is no alias and no deprecation window: the old names are removed,
 so an agent or client that calls them gets an unknown-tool error until it is updated.
 
-| Before                        | Now                      |
-| ----------------------------- | ------------------------ |
-| `malloy_getContext`           | `get_context`            |
-| `malloy_executeQuery`         | `execute_query`          |
-| `malloy_compile`              | `compile_model`          |
-| `malloy_reloadPackage`        | `reload_package`         |
-| `malloy_getStatus`            | `get_status`             |
+| Before | Now |
+|---|---|
+| `malloy_getContext` | `get_context` |
+| `malloy_executeQuery` | `execute_query` |
+| `malloy_compile` | `compile_model` |
+| `malloy_reloadPackage` | `reload_package` |
+| `malloy_getStatus` | `get_status` |
 | `malloy_searchDatabaseSchema` | `search_database_schema` |
-| `malloy_searchDocs`           | `search_malloy_docs`     |
+| `malloy_searchDocs` | `search_malloy_docs` |
 
 **What to do.** Hosts that discover tools at connect time (Claude Code, Cursor, Codex)
 pick the new names up on reconnect with no config change — the names appear in the
@@ -173,7 +182,7 @@ before rotating to the next one. Unset, nothing changes: no option is set and th
 issues exactly the SQL it issued before.
 
 This is a **second, separate** term from the row group bound in 0.2.3 below, not a
-replacement. The row group bounds the per-column buffer _within_ a file; this bounds how much
+replacement. The row group bounds the per-column buffer *within* a file; this bounds how much
 of the file is resident. Writing to object storage, DuckDB copies each multipart part into a
 buffer it allocates itself and holds it until the file completes, so a file's bytes stay
 resident however they are grouped inside it. Peak memory therefore tracks the FILE size —
@@ -187,14 +196,14 @@ Measured on a 72-column, 20,000,000-row DuckLake write to GCS, sampling cgroup
 `memory.stat` `anon` — all six cells in one batch, since this number moves with link speed
 and with catalog state left by earlier runs:
 
-| `PUBLISHER_DUCKLAKE_TARGET_FILE_SIZE_BYTES`  | files | peak anon |
-| -------------------------------------------- | ----- | --------- |
-| unset — DuckLake's own default, ~512MB files | 6     | 650 MiB   |
-| `1024MB`                                     | 3     | 892 MiB   |
-| `512MB`                                      | 6     | 550 MiB   |
-| `256MB`                                      | 12    | 373 MiB   |
-| `128MB`                                      | 23    | 262 MiB   |
-| `64MB`                                       | 45    | 255 MiB   |
+| `PUBLISHER_DUCKLAKE_TARGET_FILE_SIZE_BYTES` | files | peak anon |
+|---|---|---|
+| unset — DuckLake's own default, ~512MB files | 6 | 650 MiB |
+| `1024MB` | 3 | 892 MiB |
+| `512MB` | 6 | 550 MiB |
+| `256MB` | 12 | 373 MiB |
+| `128MB` | 23 | 262 MiB |
+| `64MB` | 45 | 255 MiB |
 
 So the realistic gain is **650 → 373 MiB, about 1.74×** — DuckLake already rotates files, and
 this option moves where it rotates. The underlying effect is much larger than that ratio
@@ -295,6 +304,7 @@ is offered whether or not it has been built yet, so adding a coarse grain to a p
 that already has a built finer rollup costs acceleration until the new one builds —
 answers are unaffected, and it lasts one build.
 
+
 ## [0.2.3] — bound the memory a wide DuckLake write spends buffering Parquet
 
 `PUBLISHER_DUCKLAKE_ROW_GROUP_SIZE_BYTES` caps how much column data DuckLake buffers
@@ -314,12 +324,12 @@ throughout. If that is familiar, the source that killed it is almost certainly y
 Measured on a 72-column, 5,000,000-row `CREATE TABLE AS` into DuckLake, sampling cgroup
 `memory.stat` `anon`:
 
-| `PUBLISHER_DUCKLAKE_ROW_GROUP_SIZE_BYTES`  | peak anon | rows per row group |
-| ------------------------------------------ | --------- | ------------------ |
-| unset (DuckLake's default of 122,880 rows) | 2772 MiB  | ~122,880           |
-| `64MB`                                     | 1530 MiB  | ~42,300            |
-| `32MB`                                     | 1360 MiB  | ~21,900            |
-| `16MB`                                     | 1006 MiB  | ~11,700            |
+| `PUBLISHER_DUCKLAKE_ROW_GROUP_SIZE_BYTES` | peak anon | rows per row group |
+|---|---|---|
+| unset (DuckLake's default of 122,880 rows) | 2772 MiB | ~122,880 |
+| `64MB` | 1530 MiB | ~42,300 |
+| `32MB` | 1360 MiB | ~21,900 |
+| `16MB` | 1006 MiB | ~11,700 |
 
 If you measure this yourself, read `anon` and not `memory.current`: the latter includes the
 page cache of the Parquet being written, which scales with output size, roughly doubles the
@@ -371,11 +381,12 @@ rows it overwrote.
 
 ### New metrics
 
-| Counter                                                       | Meaning                                                                                                                                                                                                                                      |
-| ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `publisher_materialization_duplicate_target_skipped_total`    | A source whose table this run already wrote. Ordinary for a package that extends a persisted source — a volume signal, not a fault.                                                                                                          |
-| `publisher_materialization_shared_address_instructions_total` | One content address instructed to build more than one table. Wasteful, not wrong: the content is the same either way.                                                                                                                        |
-| `publisher_materialization_table_collision_total`             | Two definitions materializing into one table — serve-time wrong data. **This is the one to alert on.** Its rate is also what enabling `PERSIST_COLLISION_ENFORCE` would begin refusing, so a rollout can be measured before it is turned on. |
+| Counter | Meaning |
+|---|---|
+| `publisher_materialization_duplicate_target_skipped_total` | A source whose table this run already wrote. Ordinary for a package that extends a persisted source — a volume signal, not a fault. |
+| `publisher_materialization_shared_address_instructions_total` | One content address instructed to build more than one table. Wasteful, not wrong: the content is the same either way. |
+| `publisher_materialization_table_collision_total` | Two definitions materializing into one table — serve-time wrong data. **This is the one to alert on.** Its rate is also what enabling `PERSIST_COLLISION_ENFORCE` would begin refusing, so a rollout can be measured before it is turned on. |
+
 
 ## [0.2.2] — a boolean query param you misspell now fails instead of doing nothing
 
@@ -425,7 +436,7 @@ the right place and then moved to the wrong one. Two ways it showed up:
 - **Silently.** The build reported success and the manifest recorded
   `analytics.orders`, while the table sat in the default container. Anything
   serving that source then resolved a path holding no table.
-- **As a nonsense error.** `Object '"orders"' already exists` when something of
+- **As a nonsense error.** ``Object '"orders"' already exists`` when something of
   that name was already in the default container — while `analytics` was empty.
 
 The rename target is now qualified on the dialects that resolve a bare one against
@@ -604,7 +615,7 @@ ungated. The load succeeds, and a warning names the entry point whose gate is no
 so you find out before a caller does.
 
 One narrower hole replaces it, and is worth knowing while you migrate: drop the gated column and then
-`rename:` a _different_ column onto that exact name. That grafts successfully and binds the gate to
+`rename:` a *different* column onto that exact name. That grafts successfully and binds the gate to
 the **wrong** column. It takes a drop, plus a rename onto the exact gated name, plus colliding data,
 and it fails closed unless the data collides — but do not recycle a gated column's name.
 
@@ -612,7 +623,7 @@ and it fails closed unless the data collides — but do not recycle a gated colu
 
 1. Find every `#(authorize) "<expr>"` and `##(authorize)` in your packages. Load the package — every
    `.malloy` file in the tree compiles and any failure aborts the load, so the refusal will name
-   each declaring source. The one case that escapes it is a declaring file _outside_ the package
+   each declaring source. The one case that escapes it is a declaring file *outside* the package
    tree: nothing compiles it, so it loads and then denies every request — and it increments no
    metric, since the request-time lift failure carries no `cause` at all. That gate is invisible
    except in a debug log naming the graft target, so grep your packages rather than waiting for a
@@ -634,8 +645,8 @@ constant-`false` lock does not hold there and `includeSql` returns the ungrafted
   Malloy's own failure named the one that could not bind — "Given 'ROLE' has no value and no default.
   To fix: supply it via `.run({givens: {ROLE: ...}})`" — reaching the caller as a 400. That is exactly
   what `docs/authorize.md` promises never happens. It now maps back to the opaque `Access denied for
-source "…"` 403.
-- **A membership test checks given reachability on both operands.** The membership _candidate_
+  source "…"` 403.
+- **A membership test checks given reachability on both operands.** The membership *candidate*
   position skipped the check every other operand position makes, so a gate naming a given two import
   hops away bound that given's declaration **default** at request time instead of the caller's value.
   It is now refused (`unreachable_given`) like every other unreachable reference.
@@ -643,8 +654,8 @@ source "…"` 403.
   compile — a list literal is not valid in that position. Write the disjunction out
   (`$ROLE = 'analyst' or $ROLE = 'admin'`), or compare a row field to an array-typed given with `in`.
 - **`/compile` no longer denies a gated source unconditionally.** Denying it made a gated source
-  un-authorable while protecting nothing, since the query path answers a gated source with _filtered
-  rows_ rather than a 403. `/compile` never runs the query, so it now admits a gate it can decide
+  un-authorable while protecting nothing, since the query path answers a gated source with *filtered
+  rows* rather than a 403. `/compile` never runs the query, so it now admits a gate it can decide
   without running one. **"Decidable" is presence, not truth:** a gate referencing no given is
   admitted whichever way it resolves — a constant `false` included — as is one whose every given the
   caller supplied, right or wrong. Only an unsupplied given denies. `includeSql` then returns the
@@ -1182,7 +1193,7 @@ This is a **breaking release for SDK consumers**: five removals and one narrowed
 ### What changed
 
 - **A notebook's parameters live in its URL.** `Notebook` takes `givens` and `onGivensChange`, and the Console wires them to the query string. Opening a notebook at `?REGION=West` runs every cell with that value on the first pass rather than running bare and running again. The host is handed the names the notebook manages alongside the values, so it can update its own query string without disturbing parameters that are not its business.
-- **`# drill { to=self }` works in a notebook cell.** A cell that groups by a dimension carrying the tag becomes clickable and filters the notebook in place with the clicked value, provided the notebook declares the given the tag names: one that names a given the document does not declare stays plain rather than offering a click that cannot be honoured. Drillable cells read as links on hover, via a new mode-keyed `drillLink` theme colour. Two cases are deliberately left unmarked: a blank cell, whose click is refused anyway (a blank value is far likelier a misclick than a request for the rows that are blank), and every cell of a `# transpose` table, because the renderer lays that layout out without the per-cell `grid-column` the marking matches on. A transposed table's drill still WORKS when clicked; it is undiscoverable, which is the one place on this surface where the affordance and the behaviour disagree. A drill naming a _dashboard_ destination is honoured too, now that the dashboard route exists: the cell is marked, and clicking it opens that dashboard with the value seeded. On a host that has not wired the navigation the destination stays unmarked and inert rather than painting a cell as a link to a page that answers "Nothing to open at this path".
+- **`# drill { to=self }` works in a notebook cell.** A cell that groups by a dimension carrying the tag becomes clickable and filters the notebook in place with the clicked value, provided the notebook declares the given the tag names: one that names a given the document does not declare stays plain rather than offering a click that cannot be honoured. Drillable cells read as links on hover, via a new mode-keyed `drillLink` theme colour. Two cases are deliberately left unmarked: a blank cell, whose click is refused anyway (a blank value is far likelier a misclick than a request for the rows that are blank), and every cell of a `# transpose` table, because the renderer lays that layout out without the per-cell `grid-column` the marking matches on. A transposed table's drill still WORKS when clicked; it is undiscoverable, which is the one place on this surface where the affordance and the behaviour disagree. A drill naming a *dashboard* destination is honoured too, now that the dashboard route exists: the cell is marked, and clicking it opens that dashboard with the value seeded. On a host that has not wired the navigation the destination stays unmarked and inert rather than painting a cell as a link to a page that answers "Nothing to open at this path".
 - **`select` / `multiselect` controls backed by `suggest`.** The option list comes from an ordinary query on the governed query endpoint, so row caps and `#(authorize)` gates apply to a dropdown exactly as they do to the surface's own queries. A suggest query that fails now says so on the control instead of rendering as a dimension with no values, and the generated query carries an explicit `limit:` and ordering rather than relying on the server's default row cap to truncate it in whatever order the warehouse returned.
 - **Filter values are escaped by Malloy's own filter package.** A `filter<…>` value picked in a control is now printed with `@malloydata/malloy-filter`'s `StringFilterExpression.unparse`, and read back with its parser. The previous scheme wrapped values in double quotes, which Malloy's string-filter grammar has no notion of: backslash is its only escape, so the quoting escaped nothing and several ordinary values silently meant something else. Measured against the `storefront` model, filtering its `category` dimension: a picked `-Outerwear` ran as a negation and returned 22,821 of 25,356 rows instead of the 2,535 that category holds; `%` bypassed the filter and returned all 25,356; `null` hit the null operator and returned 0; and `Ben & Jerry, Inc` was read as two brands. All of these now match themselves, pinned by a round-trip test against the real parser.
 - **The notebook's controls are `given:` only.** The Filters panel that rendered `#(filter)` and `##(filters)` annotations is gone, and the notebook no longer sends `filterParams`. **This is a behaviour change for a model that uses `#(filter)`, and the deprecation note under 0.0.201 said otherwise.** Concretely: a cell fails when its run target is a source that declares a `required` filter, because the server still refuses one with no value and there is no longer a UI that can supply it. That is narrower than "every cell" in two ways worth knowing before you audit a model: enforcement is per run-target source, so cells querying a source with no filters are unaffected, and a **block-form** `#(filter) … required` is not collected at all, so it never raised the error in the first place (`source_extraction.ts` documents that gap deliberately). A model with only optional `#(filter)` annotations still runs, but is no longer filterable from the notebook. The REST parameters, the `Deprecation` header, and the server-side enforcement are all unchanged: this is the UI half of the migration landing ahead of the server half. Migrate to `given:`: [docs/givens.md](docs/givens.md) has a **"Coming from `#(filter)`"** section with a worked conversion and the three things that do not map across.

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3430,7 +3430,11 @@ components:
         State of a package's semantic discovery index. Poll `status` until
         `ready` to know retrieval is warm - before this, that state existed
         only as a server log line, so anything waiting on a warm index had to
-        scrape logs. Every count is scoped to the embedding model currently
+        scrape logs. One caveat on the poll: a package nothing has ever
+        queried stays `indexing` until a `get_context` question triggers the
+        sync that builds its index, so poll a package you are about to query,
+        not one you have not touched. Every count is scoped to the embedding
+        model currently
         configured, matching what the search path reads, so a server pointed
         at a new model reports the index as not yet ready rather than
         reporting rows retrieval would reject. Reading it takes no locks, so
@@ -3446,12 +3450,22 @@ components:
             - cooldown
             - too-many-entities
           description: >-
-            `indexing` = at least one current entity has no usable vector yet.
-            Retrieval answers lexically meanwhile. This clears once a
-            `get_context` question triggers a sync, which is what builds
-            the index; it does not clear on its own for a package nothing has
-            queried. `ready` = every entity the package exposes has a vector
-            under the current model and the cache is serving semantic ranking.
+            `ready` = the next `get_context` question about this package will
+            be ranked semantically. That is the whole meaning, and it is what
+            makes the field answerable: it is decided by the same completed
+            sync the search path gates on, not by whether cached rows happen
+            to cover the current entity names. Those two differ exactly where
+            it matters - the rows outlive a restart and a reload, so a
+            coverage test called an index warm while the next question was
+            still answered lexically.
+            `indexing` = no completed sync covers the package's current
+            content under the current model, so retrieval answers lexically
+            meanwhile. A reload whose files did not change stays `ready`,
+            because the vectors still describe that content; an edit, a new
+            package, or a changed `EMBEDDING_MODEL` moves it to `indexing`. It
+            clears when a `get_context` question triggers a sync, which is
+            what builds the index; a package nothing has ever queried does not
+            warm on its own.
             `cooldown` = the provider failed recently, so the semantic path is
             short-circuited for a window. `too-many-entities` = the package has
             more entities than the embedding cap, so it stays lexical
@@ -3470,11 +3484,14 @@ components:
         embeddedEntities:
           type: integer
           description: >-
-            Of `totalEntities`, how many have at least one usable vector. The
-            two are equal exactly when `status` is `ready`. Reported because a
-            row count cannot show a model edit that removes two entities and
-            adds two others: the row total is unchanged while the new entities
-            have no vector at all.
+            Of `totalEntities`, how many have at least one usable vector.
+            Reported because a row count cannot show a model edit that removes
+            two entities and adds two others: the row total is unchanged while
+            the new entities have no vector at all. Coverage by identity, so
+            equality does NOT imply `ready`: an edit that rewrote every doc
+            without renaming anything leaves each entity holding its stale
+            name vector. Read `status` for readiness and this pair for how
+            much of the package is covered.
         lastSyncedAt:
           type: string
           format: date-time

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -3434,10 +3434,10 @@ components:
         queried stays `indexing` until a `get_context` question triggers the
         sync that builds its index, so poll a package you are about to query,
         not one you have not touched. Every count is scoped to the embedding
-        model currently
-        configured, matching what the search path reads, so a server pointed
-        at a new model reports the index as not yet ready rather than
-        reporting rows retrieval would reject. Reading it takes no locks, so
+        model currently configured, so rows left behind by an earlier model
+        are never counted. Read `status` for readiness and the counts for
+        coverage: they answer different questions, and only `status` tracks
+        what the search path will do. Reading it takes no locks, so
         polling cannot perturb an indexing run; note that the first read after
         a package loads or reloads builds the package's entity index, which is
         work a metadata read would not otherwise do.
@@ -3450,19 +3450,24 @@ components:
             - cooldown
             - too-many-entities
           description: >-
-            `ready` = the next `get_context` question about this package will
-            be ranked semantically. That is the whole meaning, and it is what
-            makes the field answerable: it is decided by the same completed
-            sync the search path gates on, not by whether cached rows happen
-            to cover the current entity names. Those two differ exactly where
-            it matters - the rows outlive a restart and a reload, so a
-            coverage test called an index warm while the next question was
-            still answered lexically.
+            `ready` = the index is warm, so the next `get_context` question
+            about this package is ranked semantically rather than lexically.
+            (It is a statement about the index, not a promise about the next
+            response: a question whose own query embedding fails still falls
+            back, reporting `retrieval_reason: provider-error`.) It is decided
+            by the same completed sync the search path gates on, not by
+            whether cached rows happen to cover the current entity names.
+            Those two differ exactly where it matters - the rows outlive a
+            restart and a reload, so a coverage test called an index warm
+            while the next question was still answered lexically.
             `indexing` = no completed sync covers the package's current
             content under the current model, so retrieval answers lexically
             meanwhile. A reload whose files did not change stays `ready`,
-            because the vectors still describe that content; an edit, a new
-            package, or a changed `EMBEDDING_MODEL` moves it to `indexing`. It
+            because the vectors still describe that content. Four things move
+            a package to `indexing`: an edit, a new package, a changed
+            `EMBEDDING_MODEL`, and a server restart - the sync is recorded in
+            memory, so a restart reports `indexing` until the first question
+            re-establishes it, even though the vectors are still on disk. It
             clears when a `get_context` question triggers a sync, which is
             what builds the index; a package nothing has ever queried does not
             warm on its own.
@@ -3477,7 +3482,12 @@ components:
             Cached vectors for this package under the current embedding model.
             An entity contributes one row for its name plus one per chunk of
             its documentation, so this exceeds `totalEntities` on a documented
-            model and is not a count of entities.
+            model and is not a count of entities. Scoped by model only, not by
+            vector length, so it counts what is cached rather than what a
+            search could read today: after a change to `EMBEDDING_DIMENSIONS`
+            that no question has probed yet, rows of the old length are still
+            counted here until the next search discards them. `status` is
+            already `indexing` in that window.
         totalEntities:
           type: integer
           description: Entities the package currently exposes to retrieval.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -245,24 +245,31 @@ What to know before turning it on:
   cache along with the rest of persisted storage; the only cost of a wipe is re-embedding. A server
   upgrading from a release that embedded one vector per entity discards its cache once, on the
   first boot after the upgrade, and re-embeds each package on its next question.
-- First query per package: the first question kicks off the embedding sync in the background and
-  answers lexically; once the sync lands, later questions are ranked semantically. Responses carry
-  a `retrieval` field (`"semantic"` or `"lexical"`) whenever the provider is configured, and a
-  lexical one adds `retrieval_reason` saying why: `indexing` (still building — clears on its own,
-  worth one retry), `cooldown` (a recent provider failure is being short-circuited),
-  `too-many-entities`, `provider-error`, or `unavailable`. Only `indexing` is worth retrying.
+- First query per package: the first question about content nothing has embedded yet kicks off the
+  embedding sync in the background and answers lexically; once the sync lands, later questions are
+  ranked semantically. A reload does not repeat that: `reload_package`, `?reload=true` and a
+  watch-mode save all keep the warm index as long as the saved files hash the same, so the next
+  question is ranked semantically on its first call. An edit re-syncs, and re-embeds only the parts
+  whose text changed. Responses carry a `retrieval` field (`"semantic"` or `"lexical"`) whenever the
+  provider is configured, and a lexical one adds `retrieval_reason` saying why: `indexing` (still
+  building — clears on its own, worth one retry), `cooldown` (a recent provider failure is being
+  short-circuited), `too-many-entities`, `provider-error`, or `unavailable`. Only `indexing` is
+  worth retrying.
 - Checking readiness without watching the log: `GET /api/v0/environments/{env}/packages/{pkg}`
   carries an `embeddingIndex` object with `status` (`indexing` / `ready` / `cooldown` /
   `too-many-entities`, the same words `retrieval_reason` uses), `embeddedRows`, `totalEntities`,
   `embeddedEntities`, and `lastSyncedAt`. Poll it until `ready` before measuring retrieval quality,
-  so you are not measuring a half-built index. `ready` means every entity the package exposes has a
-  vector under the model you have configured now, so a server pointed at a new `EMBEDDING_MODEL`
-  reports `indexing` until it has re-embedded rather than reporting rows retrieval would reject.
-  Two things worth knowing: the sync runs on a `get_context` question, so a package nothing
-  has queried stays at `indexing` rather than warming on its own; and the first read after a
-  package loads or reloads builds that package's entity index, which is work a plain metadata read
-  would not otherwise do. It is absent when no provider is configured, and reading it takes no
-  locks, so polling cannot slow an indexing run.
+  so you are not measuring a half-built index. `ready` means the next question about the package
+  will be ranked semantically, and nothing weaker: it is decided by the same completed sync the
+  search path gates on, so a server pointed at a new `EMBEDDING_MODEL` reports `indexing` until it
+  has re-embedded, and a restart reports `indexing` until the first question re-establishes the
+  sync, even though the vectors are still on disk. Do not read readiness off `embeddedEntities ==
+  totalEntities`: those count coverage by entity name, so they can be equal while a doc edit is
+  still unembedded. Two things worth knowing: the sync runs on a `get_context` question, so a
+  package nothing has queried stays at `indexing` rather than warming on its own; and the first
+  read after a package loads or reloads builds that package's entity index, which is work a plain
+  metadata read would not otherwise do. It is absent when no provider is configured, and reading it
+  takes no locks, so polling cannot slow an indexing run.
 - Failure behavior: if the endpoint is down, times out, or rejects the key, retrieval falls back
   to lexical (with a warning in the server log) and retries after a cool-down. A package with more
   than 5,000 entities stays lexical.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -259,13 +259,17 @@ What to know before turning it on:
   carries an `embeddingIndex` object with `status` (`indexing` / `ready` / `cooldown` /
   `too-many-entities`, the same words `retrieval_reason` uses), `embeddedRows`, `totalEntities`,
   `embeddedEntities`, and `lastSyncedAt`. Poll it until `ready` before measuring retrieval quality,
-  so you are not measuring a half-built index. `ready` means the next question about the package
-  will be ranked semantically, and nothing weaker: it is decided by the same completed sync the
+  so you are not measuring a half-built index. `ready` means the index is warm, so the next
+  question about the package is ranked semantically: it is decided by the same completed sync the
   search path gates on, so a server pointed at a new `EMBEDDING_MODEL` reports `indexing` until it
   has re-embedded, and a restart reports `indexing` until the first question re-establishes the
-  sync, even though the vectors are still on disk. Do not read readiness off `embeddedEntities ==
-  totalEntities`: those count coverage by entity name, so they can be equal while a doc edit is
-  still unembedded. Two things worth knowing: the sync runs on a `get_context` question, so a
+  sync, even though the vectors are still on disk. It describes the index, not the next response —
+  a question whose own query embedding fails still falls back, with `retrieval_reason:
+  provider-error`. Do not read readiness off `embeddedEntities == totalEntities`: those count
+  coverage by entity name, so they can be equal while a doc edit is still unembedded. Nor off
+  `embeddedRows`, which counts every cached vector under the current model regardless of its
+  length, so a change to `EMBEDDING_DIMENSIONS` that no question has probed yet still counts the
+  old rows. Two things worth knowing: the sync runs on a `get_context` question, so a
   package nothing has queried stays at `indexing` rather than warming on its own; and the first
   read after a package loads or reloads builds that package's entity index, which is work a plain
   metadata read would not otherwise do. It is absent when no provider is configured, and reading it

--- a/packages/server/src/mcp/tools/embedding_index.spec.ts
+++ b/packages/server/src/mcp/tools/embedding_index.spec.ts
@@ -122,6 +122,15 @@ function entityOfKind(kind: string, name: string): EmbeddableEntity {
    return { kind, name, source: "src", modelPath: "m.malloy", embedDoc: "" };
 }
 
+/**
+ * A stand-in Package instance. Identity is all the index uses it for, so a
+ * fresh one models exactly what a reload does: replace the instance while the
+ * cached rows, and the package's name, stay put.
+ */
+function instance(): Package {
+   return {} as unknown as Package;
+}
+
 /** Poll through the cold-start "indexing" response until the sync lands. */
 async function searchReady(
    args: Parameters<typeof trySemanticSearch>[0],
@@ -384,9 +393,86 @@ describe("trySemanticSearch", () => {
       await searchReady({ ...base, pkg: {} as unknown as Package });
       expect(counts.get("alpha")).toBe(1);
 
-      // A "reload": same package name, new instance. The sync re-runs but
-      // the content hashes match, so nothing re-embeds.
-      await searchReady({ ...base, pkg: {} as unknown as Package });
+      // A "reload": same package name, new instance. The recorded sync
+      // covers this exact content, so no sync runs at all and nothing
+      // re-embeds. (It used to re-run and find every hash unchanged.)
+      await searchReady({ ...base, pkg: instance() });
+      expect(counts.get("alpha")).toBe(1);
+      expect(counts.get("beta")).toBe(1);
+   });
+
+   it("ranks a reloaded package semantically on its first call", async () => {
+      // The reload cost this removes. The rows always survived a reload --
+      // the test above is what proves nothing re-embeds -- but the record
+      // that they were current was memoized per Package instance, and every
+      // reload allocates a new one. So the first question after any reload
+      // was answered lexically while the diff re-discovered that every hash
+      // still matched. reload_package, REST ?reload=true and every
+      // watch-mode save paid it, including saves that changed nothing.
+      const { provider, counts } = mapProvider({
+         ...ENTITY_VECTORS,
+         ...QUERY_VECTORS,
+      });
+      const entities = [entity("alpha", "src"), entity("beta", "src")];
+      const base = {
+         db,
+         provider,
+         environmentName: "env",
+         packageName: "reload-warm",
+         entities,
+         queries: [{ targetIndex: 0, text: "find alpha", kinds: ["measure"] }],
+         limit: 10,
+      };
+
+      await searchReady({ ...base, pkg: instance() });
+
+      // Deliberately NOT searchReady: one single call on a fresh instance,
+      // which is exactly what the next question after a reload gets. Polling
+      // here would hide the regression this pins.
+      const reloaded = await trySemanticSearch({ ...base, pkg: instance() });
+      if (!("hits" in reloaded)) {
+         throw new Error(`expected semantic hits, got ${reloaded.unavailable}`);
+      }
+      expect(reloaded.hits[0]?.name).toBe("alpha");
+      expect(counts.get("alpha")).toBe(1);
+   });
+
+   it("re-syncs a reloaded package whose content did change", async () => {
+      // The other half: the fingerprint must not be so forgiving that an
+      // edit rides through on the previous instance's record.
+      const { provider, counts } = mapProvider({
+         ...ENTITY_VECTORS,
+         ...QUERY_VECTORS,
+         "alpha: second draft": [0, 1, 0],
+      });
+      const base = {
+         db,
+         provider,
+         environmentName: "env",
+         packageName: "reload-edited",
+         queries: [{ targetIndex: 0, text: "find alpha", kinds: ["measure"] }],
+         limit: 10,
+      };
+
+      await searchReady({
+         ...base,
+         pkg: instance(),
+         entities: [entity("alpha", "src"), entity("beta", "src")],
+      });
+      expect(counts.get("alpha")).toBe(1);
+
+      // A reload that added documentation to alpha: a new doc facet, so the
+      // fingerprint moves and the package re-syncs.
+      await searchReady({
+         ...base,
+         pkg: instance(),
+         entities: [
+            entity("alpha", "src", "second draft"),
+            entity("beta", "src"),
+         ],
+      });
+      expect(counts.get("alpha: second draft")).toBe(1);
+      // Only the new facet was embedded: the name rows were already current.
       expect(counts.get("alpha")).toBe(1);
       expect(counts.get("beta")).toBe(1);
    });
@@ -495,6 +581,96 @@ describe("trySemanticSearch", () => {
       expect(warm.totalEntities).toBe(2);
       expect(warm.embeddedEntities).toBe(2);
       expect(warm.lastSyncedAt).toBeDefined();
+   });
+
+   it("is not ready when the rows are complete but no sync ran in this process", async () => {
+      // A restart, and the false-ready this fixes. The rows are persisted, so
+      // coverage by entity name is complete the instant the process starts --
+      // and reporting `ready` off that told a caller the index was warm while
+      // the very next question was still ranked lexically. That is worse than
+      // a slow start: a harness told to "poll until ready before measuring"
+      // measured a lexical run and recorded it as a semantic one.
+      const { provider } = mapProvider({ ...ENTITY_VECTORS, ...QUERY_VECTORS });
+      const entities = [entity("alpha", "src"), entity("beta", "src")];
+      await searchReady({
+         db,
+         provider,
+         pkg: instance(),
+         environmentName: "env",
+         packageName: "restart",
+         entities,
+         queries: [{ targetIndex: 0, text: "find alpha", kinds: ["measure"] }],
+         limit: 10,
+      });
+
+      // Drops every process-memory record of the sync while leaving the rows
+      // on disk: what a restart leaves behind.
+      _resetEmbeddingIndexStateForTests();
+
+      const status = await getEmbeddingIndexStatus(
+         db,
+         provider,
+         "env",
+         "restart",
+         entities,
+      );
+      expect(status.status).toBe("indexing");
+      // The rows really are all there. Coverage cannot tell this case from a
+      // warm index, which is why `status` no longer derives from it.
+      expect(status.embeddedEntities).toBe(2);
+      expect(status.totalEntities).toBe(2);
+   });
+
+   it("is not ready when a doc changed and nothing was renamed", async () => {
+      // The hole in coverage-by-name: every entity still holds a name vector,
+      // so `embeddedEntities` is complete, while the doc text the rows embed
+      // is the previous draft.
+      const { provider } = mapProvider({
+         ...ENTITY_VECTORS,
+         ...QUERY_VECTORS,
+         "alpha: first draft": [0, 1, 0],
+         "alpha: second draft": [0, 0, 1],
+      });
+      const base = {
+         db,
+         provider,
+         environmentName: "env",
+         packageName: "doc-edit",
+         queries: [{ targetIndex: 0, text: "find alpha", kinds: ["measure"] }],
+         limit: 10,
+      };
+      const before = [
+         entity("alpha", "src", "first draft"),
+         entity("beta", "src"),
+      ];
+      await searchReady({ ...base, pkg: instance(), entities: before });
+      expect(
+         (
+            await getEmbeddingIndexStatus(
+               db,
+               provider,
+               "env",
+               "doc-edit",
+               before,
+            )
+         ).status,
+      ).toBe("ready");
+
+      const after = [
+         entity("alpha", "src", "second draft"),
+         entity("beta", "src"),
+      ];
+      const status = await getEmbeddingIndexStatus(
+         db,
+         provider,
+         "env",
+         "doc-edit",
+         after,
+      );
+      expect(status.status).toBe("indexing");
+      // Both entities are still "covered", which is exactly the confusion.
+      expect(status.embeddedEntities).toBe(2);
+      expect(status.totalEntities).toBe(2);
    });
 
    it("is not ready when the rows belong to a different embedding model", async () => {

--- a/packages/server/src/mcp/tools/embedding_index.spec.ts
+++ b/packages/server/src/mcp/tools/embedding_index.spec.ts
@@ -583,6 +583,55 @@ describe("trySemanticSearch", () => {
       expect(warm.lastSyncedAt).toBeDefined();
    });
 
+   it("counts the rows a provider that ignored EMBEDDING_DIMENSIONS wrote", async () => {
+      // `dims` holds the length the provider actually returned, not the one
+      // requested, and some providers (Ollama) ignore the request parameter.
+      // The counts used to filter on the CONFIGURED value, which such rows
+      // never match. Once readiness moved to the recorded sync -- which does
+      // not consider dims, exactly as the sync diff does not -- that left the
+      // two halves of one response contradicting each other: `ready` beside
+      // `embeddedRows: 0`, for a package whose vectors the search path was
+      // reading happily. Both halves now describe the same rows.
+      const { provider } = mapProvider(
+         {
+            ...ENTITY_VECTORS,
+            ...QUERY_VECTORS,
+            "alpha: documented": [0, 1, 0],
+         },
+         // Requested 1536, stub answers with the 3-length vectors above.
+         { dimensions: 1536 },
+      );
+      const entities = [
+         entity("alpha", "src", "documented"),
+         entity("beta", "src"),
+      ];
+      const result = await searchReady({
+         db,
+         provider,
+         pkg: instance(),
+         environmentName: "env",
+         packageName: "dims-ignored",
+         queries: [{ targetIndex: 0, text: "find alpha", kinds: ["measure"] }],
+         limit: 10,
+         entities,
+      });
+      // The rows are usable: retrieval reads them by the observed length.
+      expect("unavailable" in result).toBe(false);
+
+      const status = await getEmbeddingIndexStatus(
+         db,
+         provider,
+         "env",
+         "dims-ignored",
+         entities,
+      );
+      expect(status.status).toBe("ready");
+      expect(status.embeddedRows).toBe(3);
+      expect(status.totalEntities).toBe(2);
+      expect(status.embeddedEntities).toBe(2);
+      expect(status.lastSyncedAt).toBeDefined();
+   });
+
    it("is not ready when the rows are complete but no sync ran in this process", async () => {
       // A restart, and the false-ready this fixes. The rows are persisted, so
       // coverage by entity name is complete the instant the process starts --

--- a/packages/server/src/mcp/tools/embedding_index.ts
+++ b/packages/server/src/mcp/tools/embedding_index.ts
@@ -394,17 +394,73 @@ export function facetRowKey(
    return entityRowKey(kind, source, name) + KEY_SEPARATOR + facet;
 }
 
+/** One desired embedding row: an entity's facet, its text, and that text's hash. */
+interface DesiredFacet {
+   entity: EmbeddableEntity;
+   facet: string;
+   text: string;
+   hash: string;
+}
+
+/**
+ * The full set of rows a package's entities SHOULD have, one per (entity,
+ * facet), each with the hash of the exact text that facet embeds.
+ *
+ * The single definition of "what this package wants cached". The sync diffs
+ * the table against it, and desiredFingerprint folds it into the readiness
+ * test, so neither can drift from the other -- a fingerprint that disagreed
+ * with the diff would either strand a package as `indexing` forever or claim
+ * a warm index over rows the sync would have rewritten.
+ *
+ * Hashing per facet is what keeps the diff cheap under faceting: editing a
+ * doc re-embeds that entity's doc rows and leaves its name row alone.
+ */
+function desiredFacets(entities: EmbeddableEntity[]): DesiredFacet[] {
+   return entities.flatMap((entity) =>
+      entityFacets(entity).map(({ facet, text: raw }) => {
+         const text = prepareEmbeddingInput(raw);
+         return { entity, facet, text, hash: contentHash(text) };
+      }),
+   );
+}
+
+/**
+ * One hash over the whole desired row set: every row's key and its content
+ * hash. Two entity sets share a fingerprint exactly when a sync over either
+ * is a no-op for the other, which is what lets a reloaded package keep the
+ * index the replaced instance built.
+ *
+ * Sorted before hashing so the fingerprint is a property of the SET. Entity
+ * order is a detail of how the caller walked the model, and a reload that
+ * merely reordered two sources must not read as a content change.
+ */
+function desiredFingerprint(desired: DesiredFacet[]): string {
+   const rows = desired.map(
+      (d) =>
+         facetRowKey(
+            d.entity.kind,
+            sourceColumn(d.entity.source),
+            d.entity.name,
+            d.facet,
+         ) +
+         KEY_SEPARATOR +
+         d.hash,
+   );
+   rows.sort();
+   return contentHash(rows.join("\n"));
+}
+
 // Sync state, two layers.
 //
 // Per package NAME (`syncMeta`): a mutex serializing every read-diff-write
 // section (sync AND the heal's purge) so a reload racing an in-flight sync
 // cannot tear rows; a `generation` counter bumped by every purge, so a
-// purge invalidates the memo of EVERY Package instance, not just the
-// caller's (a reloaded instance's `done` memo must not survive a purge
-// over a now-empty table); `lastPurgeAtMs`, which bounds how often the
-// heal may purge (a backend serving inconsistent dimensionalities
-// otherwise causes an unbounded purge / full-re-embed loop); and
-// `failureAtMs`, the per-package provider cool-down. The cool-down is
+// purge invalidates the recorded sync below (its rows are gone, so a
+// `synced` fact must not survive a purge over a now-empty table);
+// `lastPurgeAtMs`, which bounds how often the heal may purge (a backend
+// serving inconsistent dimensionalities otherwise causes an unbounded
+// purge / full-re-embed loop); `failureAtMs`, the per-package provider
+// cool-down; and `synced`, the last sync that completed. The cool-down is
 // scoped per package, NOT global: a query timeout or dims-mismatch on
 // one package must not force every other healthy, correctly-cached
 // package to lexical for the window. If the endpoint is genuinely down,
@@ -412,30 +468,53 @@ export function facetRowKey(
 // probe per package per window, negligible at the entity counts a single
 // Publisher serves).
 //
-// Per package INSTANCE (`syncState`, WeakMap): memoizes "this instance is
-// synced" (reload swaps the instance, so entity-set staleness clears
-// itself, same contract as the tool's lunr cache). A rejected sync
-// promise is evicted so one transient failure is not permanent.
+// `synced` is keyed on CONTENT, not on Package identity. An earlier form
+// memoized "this instance is synced" in a WeakMap keyed by the Package,
+// using instance identity as a proxy for "the entity set may have
+// changed". The proxy is never wrong, but it is coarse: every reload
+// allocates a new instance (reload_package, REST ?reload=true, and each
+// watch-mode recompile all reach Package.create), so a reload that changed
+// nothing threw the fact away, and the next question was ranked lexically
+// while the diff re-discovered that every hash still matched. Recording
+// the fingerprint of the desired row set makes the test exact instead: a
+// reload whose facet texts hash the same keeps the warm index.
 // `providerKey` records which model/dims request-config the sync used, so
 // switching EMBEDDING_MODEL or EMBEDDING_DIMENSIONS re-syncs promptly.
+//
+// Per package INSTANCE (`syncState`, WeakMap): the in-flight marker only,
+// so concurrent calls on one instance kick at most one sync. It is cleared
+// when the sync settles, which is what lets a later purge re-kick; a
+// rejected sync is evicted the same way, so one transient failure is not
+// permanent.
+interface SyncedFact {
+   /** {@link desiredFingerprint} of the entity set this sync covered. */
+   fingerprint: string;
+   providerKey: string;
+   /**
+    * The generation the sync ran under. A purge moves the package's
+    * generation, which invalidates this fact over the now-empty table.
+    */
+   generation: number;
+}
 interface PackageSyncMeta {
    mutex: Mutex;
    generation: number;
    lastPurgeAtMs: number;
    failureAtMs: number;
+   synced?: SyncedFact;
 }
+/** A sync in flight for one Package instance, keyed by what it covers. */
 interface SyncState {
-   done: boolean;
+   fingerprint: string;
    providerKey: string;
-   generation: number;
 }
 const syncState = new WeakMap<Package, SyncState>();
 const syncMeta = new Map<string, PackageSyncMeta>();
 // Every generation value ever issued is globally unique (drawn from this
 // counter, never incremented locally). That makes deleting a syncMeta
 // entry safe: a re-minted meta for the same name can never coincide with
-// a generation some live memo recorded under the old meta, which would
-// let that memo be trusted over a table the deletion just emptied.
+// a generation recorded under the old meta, which would let a `synced`
+// fact be trusted over a table the deletion just emptied.
 let generationCounter = 0;
 const oversizeWarned = new Set<string>();
 
@@ -474,6 +553,59 @@ function markProviderFailure(meta: PackageSyncMeta): void {
 
 function inCooldown(meta: PackageSyncMeta): boolean {
    return Date.now() - meta.failureAtMs < cooldownMs;
+}
+
+/**
+ * The model/dims request-config a sync ran under. Rows embedded under one
+ * config are not interchangeable with another's, so both the search path and
+ * the readiness test compare it; defined here so they cannot disagree.
+ */
+function providerKeyFor(provider: EmbeddingProvider): string {
+   return `${provider.model}${KEY_SEPARATOR}${provider.dimensions ?? ""}`;
+}
+
+/**
+ * The fingerprint of an entity set, computed fresh every call.
+ *
+ * Deliberately NOT memoized on the Package instance. That version read the
+ * cached value and ignored its `entities` argument, which is only correct
+ * while every caller passes the same set for a given instance -- an
+ * invariant nothing enforces. A caller that passed a SUBSET (a scope filter
+ * leaking into the sync's input, say) would then be handed the full set's
+ * fingerprint and silently read as synced, so the cache turned a wrong
+ * argument into a wrong answer instead of a re-sync.
+ *
+ * The cost is one pass of entityFacets plus a sha256 per facet: measured at
+ * 3ms for a 1,269-entity package, on a path whose next step is a network
+ * embedding call with a 5s timeout. If that ever matters, cache it beside the
+ * entity index it describes, where the set is genuinely immutable -- not here,
+ * keyed on something that only usually implies it.
+ */
+function fingerprintFor(entities: EmbeddableEntity[]): string {
+   return desiredFingerprint(desiredFacets(entities));
+}
+
+/**
+ * Whether a completed sync covers exactly this content under this provider
+ * config, and still stands over the current rows.
+ *
+ * All three parts are load-bearing: the fingerprint says the entity set and
+ * its text are the ones that were embedded, `providerKey` says they were
+ * embedded by the model now configured, and the generation says no purge has
+ * emptied the table since.
+ */
+function isSynced(
+   meta: PackageSyncMeta,
+   fingerprint: string,
+   providerKey: string,
+): boolean {
+   const synced = meta.synced;
+   return (
+      synced !== undefined &&
+      synced.fingerprint === fingerprint &&
+      synced.providerKey === providerKey &&
+      synced.generation === meta.generation
+   );
 }
 
 /** Test seam: forget cool-down, purge, timing, and oversize state. */
@@ -667,15 +799,7 @@ async function syncPackageEmbeddings(
          }
       }
 
-      // One desired row per (entity, facet). Hashing per facet is what keeps
-      // the diff cheap under faceting: editing a doc re-embeds that entity's
-      // doc rows and leaves its name row alone.
-      const desired = entities.flatMap((entity) =>
-         entityFacets(entity).map(({ facet, text: raw }) => {
-            const text = prepareEmbeddingInput(raw);
-            return { entity, facet, text, hash: contentHash(text) };
-         }),
-      );
+      const desired = desiredFacets(entities);
       const desiredKeys = new Set(
          desired.map((d) =>
             facetRowKey(
@@ -788,6 +912,17 @@ async function syncPackageEmbeddings(
          }
       }
 
+      // Recorded here, inside the mutex and after the generation settles, so
+      // the fact and the rows it describes are written atomically with
+      // respect to a purge. The early return above records nothing on
+      // purpose: a sync that aborted as orphaned wrote no rows, so the next
+      // call must re-sync under the fresh meta.
+      meta.synced = {
+         fingerprint: desiredFingerprint(desired),
+         providerKey: providerKeyFor(provider),
+         generation: meta.generation,
+      };
+
       logger.debug("[MCP Tool getContext] Synced entity embeddings", {
          environmentName,
          packageName,
@@ -800,14 +935,95 @@ async function syncPackageEmbeddings(
 }
 
 /**
+ * Start a sync for this content unless one is already in flight for this
+ * Package instance.
+ *
+ * The promise is deliberately dropped: nothing may ever await it, because a
+ * cold start answers lexically rather than holding a question behind a bulk
+ * embed. Completion is observed through `meta.synced`, which the sync records
+ * itself under the mutex; only failure is handled here.
+ */
+function kickSync(args: {
+   db: DuckDBConnection;
+   provider: EmbeddingProvider;
+   pkg: Package;
+   environmentName: string;
+   packageName: string;
+   entities: EmbeddableEntity[];
+   meta: PackageSyncMeta;
+   fingerprint: string;
+   providerKey: string;
+}): void {
+   const {
+      db,
+      provider,
+      pkg,
+      environmentName,
+      packageName,
+      entities,
+      meta,
+      fingerprint,
+      providerKey,
+   } = args;
+
+   const inFlight = syncState.get(pkg);
+   if (
+      inFlight &&
+      inFlight.fingerprint === fingerprint &&
+      inFlight.providerKey === providerKey
+   ) {
+      return;
+   }
+   // No await between the get above and the set below: single-threaded JS
+   // therefore guarantees concurrent calls cannot both kick a sync for the
+   // same instance. (The per-name mutex still guards the cross-instance
+   // reload race.)
+   const tracked: SyncState = { fingerprint, providerKey };
+   syncState.set(pkg, tracked);
+
+   syncPackageEmbeddings(
+      db,
+      provider,
+      environmentName,
+      packageName,
+      entities,
+   ).then(
+      () => {
+         // Cleared on success too, not just on failure: the marker means
+         // "in flight", so leaving it would stop a later purge -- which
+         // invalidates meta.synced without changing the content -- from
+         // ever kicking a re-sync for this same fingerprint.
+         if (syncState.get(pkg) === tracked) {
+            syncState.delete(pkg);
+         }
+      },
+      (error: unknown) => {
+         if (syncState.get(pkg) === tracked) {
+            syncState.delete(pkg);
+         }
+         markProviderFailure(meta);
+         logger.warn(
+            "[MCP Tool getContext] Embedding sync failed; semantic ranking cooling down",
+            {
+               environmentName,
+               packageName,
+               error: error instanceof Error ? error.message : String(error),
+            },
+         );
+      },
+   );
+}
+
+/**
  * Semantic retrieval for tier 4 of get_context. Returns ranked
  * hits, or a reason the semantic path is unavailable so the caller can
  * fall back to lexical. Never throws.
  *
- * Cold-start contract: the first call for a Package instance kicks off
- * the embedding sync in the background and reports `indexing`, so no
- * call ever waits on a bulk embed; subsequent calls are semantic once the
- * sync lands.
+ * Cold-start contract: a call whose content has no completed sync kicks one
+ * off in the background and reports `indexing`, so no call ever waits on a
+ * bulk embed; subsequent calls are semantic once the sync lands. "Content",
+ * not "Package instance": a reload whose facet texts hash the same keeps the
+ * index the replaced instance built and is semantic on its first call.
  */
 export async function trySemanticSearch(args: {
    db: DuckDBConnection;
@@ -862,7 +1078,7 @@ export async function trySemanticSearch(args: {
       return { unavailable: "too-many-entities" };
    }
 
-   const providerKey = `${provider.model}\x00${provider.dimensions ?? ""}`;
+   const providerKey = providerKeyFor(provider);
    const meta = metaFor(environmentName, packageName);
    // Per-package cool-down: a recent provider failure for THIS package
    // (sync, query embed, or a dims-mismatch backoff) keeps it lexical for
@@ -874,56 +1090,19 @@ export async function trySemanticSearch(args: {
    // is searching, the generation moves and this call must not assert
    // anything about the (now-changed) table; see the re-check below.
    const entryGeneration = meta.generation;
-   let state = syncState.get(pkg);
-   if (
-      !state ||
-      state.providerKey !== providerKey ||
-      // A purge bumped the generation after this instance synced: its
-      // rows are gone, so a `done` memo must not be trusted.
-      (state.done && state.generation !== meta.generation)
-   ) {
-      // No await between the get above and the set below: single-threaded
-      // JS therefore guarantees concurrent calls cannot both kick a sync
-      // for the same instance. (The per-name mutex still guards the
-      // cross-instance reload race.)
-      const tracked: SyncState = {
-         done: false,
-         providerKey,
-         generation: meta.generation,
-      };
-      // The sync promise is deliberately not stored: nothing may ever
-      // await it (cold starts answer lexically); completion is observed
-      // through `done` and failure through the handler below.
-      syncPackageEmbeddings(
+   const fingerprint = fingerprintFor(entities);
+   if (!isSynced(meta, fingerprint, providerKey)) {
+      kickSync({
          db,
          provider,
+         pkg,
          environmentName,
          packageName,
          entities,
-      ).then(
-         (generation) => {
-            tracked.generation = generation;
-            tracked.done = true;
-         },
-         (error: unknown) => {
-            if (syncState.get(pkg) === tracked) {
-               syncState.delete(pkg);
-            }
-            markProviderFailure(meta);
-            logger.warn(
-               "[MCP Tool getContext] Embedding sync failed; semantic ranking cooling down",
-               {
-                  environmentName,
-                  packageName,
-                  error: error instanceof Error ? error.message : String(error),
-               },
-            );
-         },
-      );
-      syncState.set(pkg, tracked);
-      state = tracked;
-   }
-   if (!state.done) {
+         meta,
+         fingerprint,
+         providerKey,
+      });
       return { unavailable: "indexing" };
    }
 
@@ -1260,9 +1439,9 @@ export async function trySemanticSearch(args: {
             outcome = "busy";
          }
          if (outcome === "purged" || outcome === "busy") {
-            if (outcome === "purged") {
-               syncState.delete(pkg);
-            }
+            // Nothing to evict: the purge bumped the generation, which is
+            // what invalidates meta.synced, so the next call re-kicks on its
+            // own. (This used to have to clear a per-instance `done` memo.)
             return { unavailable: "indexing" };
          }
          if (outcome === "backoff") {
@@ -1300,13 +1479,6 @@ export async function trySemanticSearch(args: {
    }
 }
 
-/** The identity fields getEmbeddingIndexStatus needs from a live entity. */
-export interface IndexedEntity {
-   kind: string;
-   name: string;
-   source: string | undefined;
-}
-
 /** What a package's semantic index is currently doing. */
 export interface EmbeddingIndexStatus {
    status: "indexing" | "ready" | "cooldown" | "too-many-entities";
@@ -1319,7 +1491,14 @@ export interface EmbeddingIndexStatus {
    embeddedRows: number;
    /** Entities the package currently exposes to retrieval. */
    totalEntities: number;
-   /** Current entities with at least one usable vector. */
+   /**
+    * Current entities with at least one usable vector.
+    *
+    * Coverage by identity, so it can equal `totalEntities` while `status` is
+    * `indexing`: an edit that rewrote every doc without renaming anything
+    * leaves each entity holding its (stale) name vector. `status` is the
+    * readiness signal; this pair says how much of the package is touched.
+    */
    embeddedEntities: number;
    /** Most recent row write, absent when nothing is cached yet. */
    lastSyncedAt?: string;
@@ -1333,6 +1512,14 @@ export interface EmbeddingIndexStatus {
  * retrieval, an operator checking an upgrade re-embedded — had to scrape the
  * server log. This reads the same state the search path uses.
  *
+ * `ready` means the next question will be ranked semantically, which is the
+ * only reading a caller can act on -- it is what "poll until ready before
+ * measuring retrieval quality" has to mean. So it is decided by the same
+ * recorded sync the search path gates on, NOT by whether rows happen to
+ * cover the current entity names. Those differ exactly where it matters: the
+ * rows survive a restart and a reload, so name coverage reported `ready`
+ * while the next question was still answered lexically.
+ *
  * Derived, never authoritative: it takes no mutex and writes nothing, so
  * calling it cannot perturb or serialize behind a sync in flight.
  */
@@ -1341,7 +1528,7 @@ export async function getEmbeddingIndexStatus(
    provider: EmbeddingProvider,
    environmentName: string,
    packageName: string,
-   entities: IndexedEntity[],
+   entities: EmbeddableEntity[],
 ): Promise<EmbeddingIndexStatus> {
    const entityCount = entities.length;
    // Scoped to the provider's current model, because the search path is
@@ -1391,9 +1578,16 @@ export async function getEmbeddingIndexStatus(
          ? "too-many-entities"
          : meta && inCooldown(meta)
            ? "cooldown"
-           : // Every current entity has a usable vector and nothing is
-             // mid-write: the cache is serving what retrieval will read.
-             embeddedEntities >= entityCount && !meta?.mutex.isLocked()
+           : // A sync covering exactly this content completed and still
+             // stands, and nothing is mid-write: the next question reads
+             // these rows and is ranked semantically.
+             meta &&
+               isSynced(
+                  meta,
+                  fingerprintFor(entities),
+                  providerKeyFor(provider),
+               ) &&
+               !meta.mutex.isLocked()
              ? "ready"
              : "indexing";
 

--- a/packages/server/src/mcp/tools/embedding_index.ts
+++ b/packages/server/src/mcp/tools/embedding_index.ts
@@ -1531,21 +1531,21 @@ export async function getEmbeddingIndexStatus(
    entities: EmbeddableEntity[],
 ): Promise<EmbeddingIndexStatus> {
    const entityCount = entities.length;
-   // Scoped to the provider's current model, because the search path is
-   // (see trySemanticSearch) and the stale-row heal purges anything else.
-   // Counting rows this query would reject is what let an index report ready
-   // while retrieval had nothing to serve.
+   // Scoped to the provider's current model but NOT to its configured
+   // `dimensions`: `dims` holds the ACTUAL response vector length, and a
+   // provider that ignores the `dimensions` request parameter (e.g. Ollama)
+   // writes rows the configured value never matches. These counts use the
+   // same currency rule as the sync diff and isSynced, which is what keeps
+   // them describing the rows readiness is decided over: `ready` beside
+   // `embeddedRows: 0` is not a state this can report.
    const scope = [environmentName, packageName, provider.model];
-   const dimsClause = provider.dimensions !== undefined ? " AND dims = ?" : "";
-   const dimsParam =
-      provider.dimensions !== undefined ? [provider.dimensions] : [];
 
    const row = await db.get<{ n: number; last: string | null }>(
       `SELECT CAST(COUNT(*) AS INTEGER) AS n,
               CAST(MAX(updated_at) AS VARCHAR) AS last
        FROM entity_embeddings
-       WHERE environment_name = ? AND package_name = ? AND embedding_model = ?${dimsClause}`,
-      [...scope, ...dimsParam],
+       WHERE environment_name = ? AND package_name = ? AND embedding_model = ?`,
+      scope,
    );
    const embeddedRows = row?.n ?? 0;
    const lastSyncedAt = row?.last ?? undefined;
@@ -1560,8 +1560,8 @@ export async function getEmbeddingIndexStatus(
    }>(
       `SELECT DISTINCT entity_kind, entity_source, entity_name
        FROM entity_embeddings
-       WHERE environment_name = ? AND package_name = ? AND embedding_model = ?${dimsClause}`,
-      [...scope, ...dimsParam],
+       WHERE environment_name = ? AND package_name = ? AND embedding_model = ?`,
+      scope,
    );
    const coveredKeys = new Set(
       covered.map((r) =>

--- a/packages/server/src/mcp/tools/embedding_index.ts
+++ b/packages/server/src/mcp/tools/embedding_index.ts
@@ -729,7 +729,9 @@ export async function deleteEnvironmentEmbeddings(
  * current entity set: embed new/changed entities (content-hash diff, so
  * unchanged entities never re-embed, across restarts too), upsert them,
  * and delete rows for entities that no longer exist. Runs under the
- * package-name mutex. Returns the package generation the sync ran under.
+ * package-name mutex. Completion is recorded on the package's meta
+ * (`meta.synced`), not returned: nothing awaits this call, so that record is
+ * the only channel by which the sync's result is observed. See kickSync.
  * Throws on provider or storage failure; partial writes are safe because
  * the hash diff self-heals on the next sync.
  */
@@ -739,7 +741,7 @@ async function syncPackageEmbeddings(
    environmentName: string,
    packageName: string,
    entities: EmbeddableEntity[],
-): Promise<number> {
+): Promise<void> {
    const meta = metaFor(environmentName, packageName);
    return meta.mutex.runExclusive(async () => {
       // The meta may have been orphaned while this sync waited on the
@@ -747,16 +749,16 @@ async function syncPackageEmbeddings(
       // package was deleted with this call already in flight). A sync
       // under an orphaned meta is no longer serialized against syncs
       // under a re-minted meta for the same name, so it must not write.
-      // Aborting is safe: the caller's memo records this orphaned
-      // generation, which can never match a fresh meta's (generations
-      // are globally unique), so the next call re-syncs under the fresh
-      // meta.
+      // Aborting is safe because it also records nothing: `meta.synced` is
+      // set only at the bottom of this function, so an orphaned meta never
+      // carries a `synced` fact, and the next call -- which fetches a
+      // freshly minted meta for this name -- re-syncs under that one.
       if (syncMeta.get(metaKey(environmentName, packageName)) !== meta) {
          logger.debug(
             "[MCP Tool getContext] Skipping embedding sync for a deleted package",
             { environmentName, packageName },
          );
-         return meta.generation;
+         return;
       }
 
       // Everything here runs under the package mutex: a purge (same
@@ -819,6 +821,8 @@ async function syncPackageEmbeddings(
       // Ollama) would otherwise mismatch the configured value forever
       // and re-embed the whole package on every instance swap. A real
       // dims change is caught at query time by the stale-row heal.
+      // This is the CACHED rule; the READABLE rule the scan and the heal
+      // use is the other one. Both are set out above getEmbeddingIndexStatus.
       const toEmbed = desired.filter((d) => {
          const row = existing.get(
             facetRowKey(
@@ -930,7 +934,6 @@ async function syncPackageEmbeddings(
          embedded: toEmbed.length,
          deleted,
       });
-      return meta.generation;
    });
 }
 
@@ -1441,7 +1444,7 @@ export async function trySemanticSearch(args: {
          if (outcome === "purged" || outcome === "busy") {
             // Nothing to evict: the purge bumped the generation, which is
             // what invalidates meta.synced, so the next call re-kicks on its
-            // own. (This used to have to clear a per-instance `done` memo.)
+            // own.
             return { unavailable: "indexing" };
          }
          if (outcome === "backoff") {
@@ -1484,9 +1487,15 @@ export interface EmbeddingIndexStatus {
    status: "indexing" | "ready" | "cooldown" | "too-many-entities";
    /**
     * Rows cached for this package under the provider's CURRENT model, across
-    * all entities and facets. Rows left by an earlier model are excluded,
-    * because the search path excludes them too and a number that counted them
-    * would not agree with `status`.
+    * all entities and facets. Rows left by an earlier model are excluded.
+    *
+    * Scoped by model only, NOT by vector length, so this is not a count of
+    * rows the search path could read today: that scan also matches
+    * `dims = <query vector length>` (see trySemanticSearch), and a dims
+    * change no question has probed yet leaves rows counted here that the
+    * stale-row heal will purge on the next search. Deliberate -- the two
+    * rules are described above getEmbeddingIndexStatus. Read `status` for
+    * readiness; read this for how much of the package is cached.
     */
    embeddedRows: number;
    /** Entities the package currently exposes to retrieval. */
@@ -1522,6 +1531,28 @@ export interface EmbeddingIndexStatus {
  *
  * Derived, never authoritative: it takes no mutex and writes nothing, so
  * calling it cannot perturb or serialize behind a sync in flight.
+ *
+ * Two DIFFERENT row rules live in this file, and collapsing them is the
+ * mistake to avoid -- it has been made twice already, once on the sync diff
+ * and once on these counts:
+ *
+ *   CACHED (model + content hash, dims ignored): "would the sync rewrite
+ *   this row?" Used by the sync diff and by the counts below. Dims is
+ *   excluded on purpose -- `dims` records the length the provider RETURNED,
+ *   and a provider that ignores the requested `dimensions` (Ollama) never
+ *   matches the configured value, which would re-embed every package on
+ *   every reload and pin these counts at 0.
+ *
+ *   READABLE (model + dims == the query vector's length): "can the cosine
+ *   scan use this row?" Used by trySemanticSearch and by the stale-row heal.
+ *   Only a real question knows that length, so this path cannot apply the
+ *   rule without embedding something, which it must not do.
+ *
+ * So the counts report CACHED and `status` reports readiness from the
+ * recorded sync; neither one predicts READABLE. A dims change no question
+ * has probed yet is the gap that leaves: `status` is already correct there
+ * (providerKeyFor carries the configured dims, so isSynced goes false), and
+ * the counts keep describing rows until a search fires the heal.
  */
 export async function getEmbeddingIndexStatus(
    db: DuckDBConnection,
@@ -1531,13 +1562,10 @@ export async function getEmbeddingIndexStatus(
    entities: EmbeddableEntity[],
 ): Promise<EmbeddingIndexStatus> {
    const entityCount = entities.length;
-   // Scoped to the provider's current model but NOT to its configured
-   // `dimensions`: `dims` holds the ACTUAL response vector length, and a
-   // provider that ignores the `dimensions` request parameter (e.g. Ollama)
-   // writes rows the configured value never matches. These counts use the
-   // same currency rule as the sync diff and isSynced, which is what keeps
-   // them describing the rows readiness is decided over: `ready` beside
-   // `embeddedRows: 0` is not a state this can report.
+   // The CACHED rule (see above): current model, any dims. Scoping these to
+   // the configured `dimensions` is what once pinned them at 0 for a provider
+   // that ignores the request parameter, reporting `ready` beside
+   // `embeddedRows: 0`.
    const scope = [environmentName, packageName, provider.model];
 
    const row = await db.get<{ n: number; last: string | null }>(

--- a/packages/server/src/mcp/tools/get_context_tool.spec.ts
+++ b/packages/server/src/mcp/tools/get_context_tool.spec.ts
@@ -1689,6 +1689,81 @@ describe("get_context semantic retrieval", () => {
          }),
       );
 
+   it("a source-scoped call does not delete the rest of the package's vectors", async () => {
+      // The destructive shape this must never regress into. syncPackageEmbeddings
+      // reads EVERY row for the package and deletes the ones absent from the
+      // desired set it is handed, so handing it a scope-filtered entity list
+      // means "make the cache match this subset" -- and it obliges, deleting
+      // every other source's vectors. Reported against an older build as one
+      // scoped question dropping 2448 of 2603 rows and taking the package
+      // lexical for the life of the Package instance.
+      //
+      // What keeps it correct is that the scope is applied INSIDE the scan
+      // (trySemanticSearch's `sourceName`), while the sync is handed the whole
+      // package: getContext passes Array.from(byId.values()), and the filtered
+      // list is a separate `inScope` used only for the enumeration tiers. This
+      // pins that separation from the outside, where a future refactor that
+      // collapsed the two would be caught.
+      _setEmbeddingProviderForTests(stubProviderFor(SIBLING_VECTORS));
+      const handler = captureHandler(
+         semanticStoreFor({
+            listModels: async () => [{ path: "s.malloy" }],
+            getModel: () => siblingSourcesModel(GATED_DOC),
+         }),
+      );
+      const target = [
+         { target_type: "measure", search_text: "total order amount" },
+      ];
+      const scope = { environment: "specs", package: "scope-safety" };
+
+      // Warm the whole package, so there are other sources' rows to lose.
+      await callUntilSemantic(handler, {
+         search_targets: target,
+         scopes: [scope],
+      });
+      const rowsFor = async () =>
+         (
+            await db.all<{ n: number }>(
+               "SELECT CAST(COUNT(*) AS INTEGER) AS n FROM entity_embeddings WHERE package_name = 'scope-safety'",
+            )
+         )[0].n;
+      const warmRows = await rowsFor();
+      // Both sources and both measures are cached, or there is nothing for a
+      // scoped call to delete and this test would pass vacuously.
+      expect(warmRows).toBeGreaterThan(2);
+      const sourcesCached = await db.all<{ entity_source: string }>(
+         "SELECT DISTINCT entity_source FROM entity_embeddings WHERE package_name = 'scope-safety'",
+      );
+      expect(sourcesCached.map((r) => r.entity_source).sort()).toEqual([
+         "sales",
+         "sales_secured",
+      ]);
+
+      // Now the scoped question, repeated: a fire-and-forget sync started by
+      // any one of these would have landed by the last. Retrieval modes are
+      // collected rather than asserted here, so the row check below is what
+      // fails first -- losing the siblings' vectors is the harm, and going
+      // lexical is only how it shows up on the next call.
+      const modes: unknown[] = [];
+      for (let i = 0; i < 5; i++) {
+         modes.push(
+            parse(
+               await handler({
+                  search_targets: target,
+                  scopes: [{ ...scope, source: "sales" }],
+               }),
+            ).retrieval,
+         );
+         await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+
+      // Nothing was deleted: the scope narrowed the SCAN, not the cache.
+      expect(await rowsFor()).toBe(warmRows);
+      // And the scoped calls stayed semantic throughout, which they cannot be
+      // if the cache was rewritten underneath them.
+      expect(modes).toEqual(Array(5).fill("semantic"));
+   });
+
    it("embeds every target in ONE provider request and scans once", async () => {
       // The claim the multi-target design rests on: N targets cost one round
       // trip, not N. embedBatch already batches and the scan cross-joins the

--- a/packages/server/tests/integration/mcp/mcp_get_context_semantic.integration.spec.ts
+++ b/packages/server/tests/integration/mcp/mcp_get_context_semantic.integration.spec.ts
@@ -258,6 +258,39 @@ describe.serial("MCP getContext semantic retrieval (E2E Integration)", () => {
       { timeout: 30000 },
    );
 
+   it(
+      "keeps the warm index across a package reload",
+      async () => {
+         // A reload swaps the Package instance. The vectors never move -- they
+         // are keyed by package name in publisher.db -- but the record that
+         // they were current used to live on the replaced instance, so the
+         // first question after any reload was ranked lexically while the diff
+         // re-discovered that every hash still matched. reload_package,
+         // ?reload=true and every watch-mode save paid that.
+         const before = stubRequests;
+         const reloaded = (await mcpClient.callTool({
+            name: "reload_package",
+            arguments: {
+               environmentName: ENVIRONMENT_NAME,
+               packageName: PACKAGE_NAME,
+            },
+         })) as { isError?: boolean };
+         expect(reloaded.isError).toBeFalsy();
+
+         // The FIRST call after the reload, deliberately without the polling
+         // loop the first test uses: polling here would hide the regression.
+         const payload = await callGetContext({
+            targetType: "view",
+            searchText: "orders by month",
+         });
+         expect(payload.retrieval).toBe("semantic");
+         // Exactly one stub call, the query embedding. The reload recompiled
+         // the package and re-embedded nothing.
+         expect(stubRequests).toBe(before + 1);
+      },
+      { timeout: 60000 },
+   );
+
    // Keep this test LAST: the induced failure starts the provider
    // cool-down, which short-circuits the semantic path for its window.
    it(


### PR DESCRIPTION
Closes the reload half of #1130, and adds a regression test for the scoped-`get_context` cache deletion reported separately (already fixed on `main` by #1028 — see below).

## What was wrong

A reload never dropped a package's vectors — they are keyed by package name in `publisher.db`, and a test already pinned that nothing re-embeds across one. What a reload threw away was the *record* that they were current: a `WeakMap` keyed on the `Package` object, and every reload allocates a new instance (`reload_package`, REST `?reload=true`, and each watch-mode recompile all reach `Package.create`).

That cost two things.

**The first question after any reload was ranked lexically** while the diff re-discovered that every content hash still matched. With watch mode on, that is one degraded answer per save, including saves that changed nothing relevant.

**`embeddingIndex.status` reported `ready` the whole time.** It derived readiness from whether cached rows covered the current entity *names*, and rows outlive a restart and a reload — so the first poll returned `ready` while the next question was still answered lexically. That defeats the polling loop the field was added for: `package.controller.ts` puts `embeddingIndex` on the `?reload=true` response precisely because that is the request which invalidates the index. A harness following the documented "poll until `ready` before measuring retrieval quality" measured a lexical run and recorded it as a semantic one — a wrong number, not a slow start.

## The change

Instance identity was a proxy for "the entity set may have changed". The proxy is never wrong, just coarse. This records what the sync already computes instead: one fingerprint over the desired `(entity, facet, content_hash)` row set, stored on the per-name `syncMeta` entry that already survives a reload.

- A reload whose facet texts hash the same keeps the warm index and is ranked semantically on its first call.
- An edit moves the fingerprint and re-syncs, re-embedding only the facets whose text changed.
- `status` is decided by that same recorded sync, so `ready` now means one thing: the next question about this package will be ranked semantically.

`desiredFacets` becomes the single definition of the desired row set, shared by the diff and the fingerprint so the two cannot drift. The in-flight bookkeeping moves into `kickSync`, taking the search gate from ~45 lines to 15. Existing invariants are kept and still commented: the `generation` counter still invalidates a recorded sync across a purge, a failed sync still evicts and arms the per-package cooldown, and the per-name mutex still serializes every read-diff-write section.

**The fingerprint is computed fresh per call, not memoized on the `Package`.** A first cut did memoize it, and that read the cached value while ignoring its `entities` argument — correct only while every caller passes the same set for a given instance, which nothing enforces. Reproducing the scoped-sync bug below showed what that shortcut costs: the caller was handed the full set's fingerprint, read as synced, and a wrong argument became a wrong answer instead of a re-sync. Measured cost of dropping it: **3ms for a 1,269-entity package**, on a path whose next step is a network embedding call with a 5s timeout. If it ever needs caching it belongs beside the entity index, where the set is genuinely immutable.

## The scoped-`get_context` report: already fixed, now pinned

A separate report described one `sourceName`-scoped call deleting 2448 of 2603 cached vectors and taking the package lexical for the life of the `Package` instance. `syncPackageEmbeddings` reads every row for a package and deletes the ones absent from the desired set it is handed, so handing it a scope-filtered entity list means "make the cache match this subset" — and it obliges.

**That is already fixed on `main`, by #1028, not by this PR.** `getContext` passes `Array.from(byId.values())` — the whole package — and applies the scope inside the SQL scan via `trySemanticSearch`'s `sourceName`; the filtered list is a separate `inScope` used only for the enumeration tiers. The report's line numbers are against a pre-#1028 build.

Nothing pinned that separation, so this PR adds the test. Re-introducing the scoped sync input makes it fail with **half the package's rows deleted**, naming the harm rather than the symptom.

## Behaviour change worth flagging in review

`embeddingIndex.status` keeps its name and changes its basis, so it is a public-surface change even though the enum is untouched. It now reads `indexing` in two places it previously read `ready`: just after a restart, until the first question re-establishes the sync, and after a doc-only edit. Both clear on the next `get_context`. `embeddedRows` and `embeddedEntities` keep their meanings and are now documented as coverage rather than readiness, since they can equal `totalEntities` while `status` is `indexing`.

They also stop being scoped to the *configured* `EMBEDDING_DIMENSIONS`, which review caught. `dims` records the length a provider actually returned, and the sync diff deliberately ignores it, so a provider that ignores the request parameter (Ollama) writes rows the configured value never matches. Moving readiness to the recorded sync while leaving the counts on the configured value let the two halves of one response contradict each other: `status: ready` beside `embeddedRows: 0`, for a package whose vectors the search scan was reading happily by their observed length. That also contradicted the schema text this PR adds, which calls `embeddedEntities` the entities holding at least one usable vector. Both halves now use the sync's own currency rule.

Before this branch the same filter pinned `status` at `indexing` for those providers, because readiness was derived from that same dims-filtered coverage query. That was on the deferred list below; removing the clause closes it, so it is off the list rather than left open.

`api-doc.yaml`, `docs/configuration.md` and `RELEASE_NOTES.md` are updated for this.

## Verification

Every pin was checked by mutation rather than assumed to be meaningful:

| Mutation | Fails |
|---|---|
| Restore the per-instance gate | exactly the new reload tests |
| Restore name-coverage `status` | exactly the two new status tests |
| Re-introduce the scoped sync input | exactly the new scope test |
| Restore the configured-dims filter on the counts | exactly the new dims test, on the row count, after its `ready` assertion has already passed |

The integration test is the real oracle — real server, real DuckDB, stub HTTP embeddings endpoint. It calls `reload_package` for real, then asserts `retrieval: "semantic"` on the first call and **exactly one** embedding request (the query embedding, no bulk re-sync). It also fails under the first mutation.

`embedding_index.spec.ts` + `get_context_tool.spec.ts` 167 pass, `tests/integration/mcp` 31 pass, `tsc --noEmit`, `bun run lint` and prettier all clean.

Pre-existing failures, reproduced on pristine `main` by reverting this branch's files: `config.spec.ts` (28) and `config.theme.spec.ts` (5). `rate_limit.spec.ts` and `oom_guards.integration.spec.ts` flake under load — a different test in them fails on each run, and they pass in isolation.

## Not in this PR

The other half of #1130, `--init` dropping `entity_embeddings`, is working as intended and is left alone. `--init` resets the server root, and it is also the only stated reclaim path for rows orphaned by a config change — two docstrings in `embedding_index.ts` name it as exactly that. (The secondary suggestion to drop it from `dropAllTables` would make `--init` a partial wipe with no full option and delete that reclaim path.)

Three adjacent findings, all pre-existing, are worth their own issues rather than folding in: `--init` also drops `themes`, which has no config source and so is unrecoverable rather than merely expensive; there is no MCP surface for index readiness at all; and a non-`--init` boot that finds an environment gone from config cleans up nothing. (A fourth, the configured-versus-observed `dims` split, is fixed above rather than deferred.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

