### PR TITLE
chore(release): stamp 0.2.5 on main

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,7 +31,7 @@ One behaviour change to know about: `skills-npm.yml` now publishes only from `ma
 
 ---
 
-## [Unreleased] — a persist name must now be a plain identifier path
+## [0.2.5] — a persist name must now be a plain identifier path
 
 `#@ persist name=` accepts the table name a source materializes into, and that
 value is pasted into the `CREATE OR REPLACE TABLE` and `DROP TABLE IF EXISTS`

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/app",
    "description": "Malloy Publisher Console (the built-in web UI)",
-   "version": "0.2.4",
+   "version": "0.2.5",
    "type": "module",
    "main": "dist/index.cjs.js",
    "module": "dist/index.es.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/sdk",
    "description": "Malloy Publisher SDK",
-   "version": "0.2.4",
+   "version": "0.2.5",
    "type": "module",
    "main": "dist/index.cjs.js",
    "module": "dist/index.es.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/server",
    "description": "Malloy Publisher Server",
-   "version": "0.2.4",
+   "version": "0.2.5",
    "main": "dist/server.mjs",
    "bin": {
       "malloy-publisher": "dist/server.mjs"


### PR DESCRIPTION
Stamps the 0.2.5 release notes heading and resets main's declared package versions to 0.2.5. Recovered per the publisher-release skill's step 3 recovery path — this branch was pushed by the gh-release job for v0.2.5 but never opened as a PR.