### PR TITLE
fix(runtime): coalesce publisher:resize into one message per frame

### DIFF
--- a/packages/server/src/runtime/publisher.js
+++ b/packages/server/src/runtime/publisher.js
@@ -251,27 +251,62 @@
             var pad = parseFloat(bodyStyle.paddingBottom) || 0;
             return Math.ceil(maxBottom + scrollTop + pad);
          }
-         function postSize() {
+         // Smallest change worth reporting. Below this is sub-pixel reflow, which
+         // the host cannot act on without the resize itself becoming a layout
+         // change inside this frame — the feedback loop.
+         var RESIZE_EPSILON = 8;
+         var resizePending = false;
+
+         function emitSize() {
             var h = measureContentHeight();
-            if (h !== lastHeight) {
-               lastHeight = h;
-               try {
-                  window.parent.postMessage(
-                     { type: "publisher:resize", height: h },
-                     "*",
-                  );
-               } catch (_e) {
-                  /* ignore */
-               }
+            if (Math.abs(h - lastHeight) < RESIZE_EPSILON) return;
+            lastHeight = h;
+            try {
+               window.parent.postMessage(
+                  { type: "publisher:resize", height: h },
+                  "*",
+               );
+            } catch (_e) {
+               /* ignore */
             }
          }
-         // Initial + observe content changes
-         if (document.readyState === "loading") {
-            document.addEventListener("DOMContentLoaded", postSize);
-         } else {
-            postSize();
+
+         // Coalesce a burst into one message per frame.
+         //
+         // ResizeObserver on documentElement fires on EVERY layout change, so a
+         // dashboard whose tiles resolve one by one used to post a height per
+         // tile. The host resized on each, which is what made an embedded app
+         // visibly jitter while it loaded. Same `pending`-flag idiom as the SSE
+         // reload debounce below; rAF rather than a timeout because the next
+         // paint is exactly when a coalesced layout is worth measuring.
+         //
+         // Trailing edge, not leading: the last measurement in a burst is the
+         // settled one, and reporting the first would send a stale height.
+         function postSize() {
+            if (resizePending) return;
+            resizePending = true;
+            var schedule =
+               typeof requestAnimationFrame === "function"
+                  ? requestAnimationFrame
+                  : function (fn) {
+                       setTimeout(fn, 16);
+                    };
+            schedule(function () {
+               resizePending = false;
+               emitSize();
+            });
          }
-         window.addEventListener("load", postSize);
+         // Initial + observe content changes
+         // The first report goes out synchronously: the host shows a
+         // MIN_EMBED_HEIGHT placeholder until one arrives, so deferring it by a
+         // frame would leave a collapsed frame for no benefit. Only the bursts
+         // that follow need coalescing.
+         if (document.readyState === "loading") {
+            document.addEventListener("DOMContentLoaded", emitSize);
+         } else {
+            emitSize();
+         }
+         window.addEventListener("load", emitSize);
          if (typeof ResizeObserver !== "undefined") {
             var ro = new ResizeObserver(postSize);
             // Observe documentElement so we catch any layout change

--- a/packages/server/src/runtime/publisher.js
+++ b/packages/server/src/runtime/publisher.js
@@ -251,15 +251,26 @@
             var pad = parseFloat(bodyStyle.paddingBottom) || 0;
             return Math.ceil(maxBottom + scrollTop + pad);
          }
-         // Smallest change worth reporting. Below this is sub-pixel reflow, which
-         // the host cannot act on without the resize itself becoming a layout
-         // change inside this frame — the feedback loop.
+         // Smallest SHRINK worth reporting. measureContentHeight already ceils,
+         // so nothing sub-pixel reaches here; what this absorbs is a 1-2px
+         // rounding flip-flop between two layout passes, which the host cannot
+         // act on without the resize itself becoming a layout change inside this
+         // frame — the feedback loop.
+         //
+         // Applied to shrinks ONLY, deliberately. A frame a few pixels too tall
+         // shows dead space; a few pixels too short CLIPS, and the frame has no
+         // internal scrollbar. The asymmetry also stops the two sides' bands
+         // compounding: the host runs its own epsilon against ITS height, which
+         // its MIN clamp guarantees can differ from lastHeight here, so two
+         // symmetric 8px bands leave a dead zone wider than either. Growing at
+         // 1px precision keeps the host's band the only one that applies.
          var RESIZE_EPSILON = 8;
          var resizePending = false;
 
          function emitSize() {
             var h = measureContentHeight();
-            if (Math.abs(h - lastHeight) < RESIZE_EPSILON) return;
+            if (h < lastHeight && lastHeight - h < RESIZE_EPSILON) return;
+            if (h === lastHeight) return;
             lastHeight = h;
             try {
                window.parent.postMessage(


### PR DESCRIPTION
## Summary

An embedded data app visibly jitters while its tiles load. This is the publisher-side half of the cause. The host-side half is [ms2data/service#6355](https://github.com/ms2data/service/pull/6355); either fix helps alone, and they compose.

## Cause

`setUpEmbedResize` observes `document.documentElement` with an undebounced `ResizeObserver`:

```js
var ro = new ResizeObserver(postSize);
ro.observe(document.documentElement);   // fires on ANY layout change
```

`postSize` posted a `publisher:resize` whenever the measured height differed at all. A dashboard whose tiles resolve one by one therefore emits a height per tile, and a host that resizes the iframe on each report steps visibly through them.

The measurement itself is already careful — the `measureContentHeight` comment explains why it sums child bottom edges rather than trusting `scrollHeight`, to avoid a ratchet loop. This is the same class of problem one level up: not *what* is measured, but how often it is announced.

## Changes

**Coalesce to one message per animation frame.** Same `pending`-flag idiom as the SSE reload debounce further down this file. `requestAnimationFrame` rather than a timeout, because the next paint is exactly when a coalesced layout is worth measuring, with a `setTimeout(fn, 16)` fallback where rAF is unavailable.

Trailing edge, not leading: `measureContentHeight` re-reads the live DOM, so the deferred call reports the *settled* height rather than the first of the burst.

**Ignore changes under 8px.** Below that is sub-pixel reflow, which a host cannot act on without the resize itself becoming a layout change inside this frame.

**Initial reports still emit synchronously.** `DOMContentLoaded` and `load` call `emitSize` directly. The host shows a min-height placeholder until the first message arrives, so deferring that one by a frame would leave a collapsed frame for no benefit. Only the bursts that follow need coalescing.

No behaviour change for a page whose height is stable: it posts once and goes quiet.

## Testing

There are no tests around `packages/server/src/runtime/` — it ships as a browser script rather than through the module graph — so I verified the logic against a fake clock outside the tree:

| Scenario | Result |
|---|---|
| Burst of 9 layout changes in one frame | 1 message, carrying the settled height (690, not the leading 300) |
| Sub-epsilon noise (+3px, then +5px) | 0 messages |
| Real change (+200px) | 1 message |
| Exactly +8px | 1 message (boundary is inclusive) |

Worth recording: the first version of that harness advanced a queue on each measure instead of re-reading live state, and reported the *leading* height. The harness was wrong, not the runtime — but it is the kind of check that can quietly confirm the wrong thing.

## Reviewer notes

- **The 8px epsilon is a judgement call.** It needs to sit above sub-pixel reflow and below perceptible movement. If a page legitimately changes height by less than 8px, that change is now not reported until a larger one follows.
- **Happy to add a test** if the project wants coverage here; it would need a jsdom or Playwright harness for this file, which does not exist today, so I did not add one speculatively.
- **Not fixed here:** an embedded app's `position: fixed` drawer opens scrolled down, because the frame is sized to full content height and so has no internal viewport to anchor to. That needs a host-to-iframe scroll message, and the protocol is currently one-way (height up, nothing down). Separate change if wanted.
