### PR TITLE
fix(preaggregation): memoize the violation walk, which /status re-ran for every package on every poll

### DIFF
--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -369,6 +369,11 @@ export function bindingsAllowDegradeToLive(
    );
 }
 
+/** The one empty result {@link Model.preaggregateViolations} hands back, so its
+ *  identity contract holds on the branch that never reaches the memo. */
+const NO_PREAGGREGATE_VIOLATIONS: readonly Readonly<PreaggregateViolation>[] =
+   Object.freeze([]);
+
 export class Model {
    private packageName: string;
    private modelPath: string;
@@ -460,7 +465,7 @@ export class Model {
       | undefined;
    /** Memo for {@link preaggregateViolations}. */
    private preaggregateViolationsMemo:
-      | readonly PreaggregateViolation[]
+      | readonly Readonly<PreaggregateViolation>[]
       | undefined;
    /** Given names (`$NAME`) referenced by any authorize gate reachable
     *  anywhere in this model -- every top-level source's own gate, and every
@@ -3795,12 +3800,16 @@ export class Model {
     * source. A compiled model's annotations never change — a reload replaces the
     * `Model` object outright — so the memo needs no invalidation.
     *
-    * `readonly` because callers now share one array rather than each getting a
-    * fresh walk: a caller that sorted or spliced the result would be editing
-    * every later caller's copy.
+    * `readonly` down to the element because callers now share one array rather
+    * than each getting a fresh walk: a caller that sorted the array, or edited a
+    * violation's message, would be editing every later caller's copy. Enforced by
+    * the type rather than `Object.freeze` — the sharing is what makes this cheap,
+    * and a deep freeze would put back a per-element cost.
     */
-   public preaggregateViolations(): readonly PreaggregateViolation[] {
-      if (!this.modelDef) return [];
+   public preaggregateViolations(): readonly Readonly<PreaggregateViolation>[] {
+      // Shared rather than a fresh `[]`, so the identity contract above holds on
+      // this branch too (a model that failed to compile has no `modelDef`).
+      if (!this.modelDef) return NO_PREAGGREGATE_VIOLATIONS;
       if (this.preaggregateViolationsMemo === undefined) {
          this.preaggregateViolationsMemo = validateModelPreaggregation(
             this.modelDef.contents as Record<string, unknown>,

--- a/packages/server/src/service/model.ts
+++ b/packages/server/src/service/model.ts
@@ -458,6 +458,10 @@ export class Model {
    private declaredSourceQueryMetadataMemo:
       | { sourceName: string; queryMetadata: QueryMetadata }[]
       | undefined;
+   /** Memo for {@link preaggregateViolations}. */
+   private preaggregateViolationsMemo:
+      | readonly PreaggregateViolation[]
+      | undefined;
    /** Given names (`$NAME`) referenced by any authorize gate reachable
     *  anywhere in this model -- every top-level source's own gate, and every
     *  gate a top-level source carries in from what it derives from (the same
@@ -3783,12 +3787,26 @@ export class Model {
     * Returned rather than thrown: the owning Package joins these across its
     * models into one rejection, so an author fixing a package sees every bad
     * declaration at once instead of one per publish.
+    *
+    * Memoized for the same reason as {@link getDeclaredQueryMetadata}, and it
+    * matters more here: `preaggregateAccessWarnings` puts this on
+    * `getPackageMetadata()`, which `/status` reaches for every package on every
+    * poll, and the walk below re-parses the annotations on every field of every
+    * source. A compiled model's annotations never change — a reload replaces the
+    * `Model` object outright — so the memo needs no invalidation.
+    *
+    * `readonly` because callers now share one array rather than each getting a
+    * fresh walk: a caller that sorted or spliced the result would be editing
+    * every later caller's copy.
     */
-   public preaggregateViolations(): PreaggregateViolation[] {
+   public preaggregateViolations(): readonly PreaggregateViolation[] {
       if (!this.modelDef) return [];
-      return validateModelPreaggregation(
-         this.modelDef.contents as Record<string, unknown>,
-      );
+      if (this.preaggregateViolationsMemo === undefined) {
+         this.preaggregateViolationsMemo = validateModelPreaggregation(
+            this.modelDef.contents as Record<string, unknown>,
+         );
+      }
+      return this.preaggregateViolationsMemo;
    }
 
    /**

--- a/packages/server/src/service/package.ts
+++ b/packages/server/src/service/package.ts
@@ -1040,6 +1040,14 @@ export class Package {
       });
    }
 
+   /**
+    * ON THE `/status` POLL PATH: this runs for every package in every
+    * environment, every few seconds, because `EnvironmentStore.getStatus()`
+    * serializes each environment through `listPackages()`. Anything added to the
+    * computed spreads below must be trivially cheap or memoized on the Model --
+    * an unmemoized walk over model fields here reached seconds of synchronous
+    * CPU per poll and blocked the event loop for every other request.
+    */
    public getPackageMetadata(): ApiPackage {
       // Overlay the server-computed fields onto the stored metadata: the
       // explores misconfig warnings (loading is fail-safe — the package still

--- a/packages/server/src/service/preaggregate_violations_memo.spec.ts
+++ b/packages/server/src/service/preaggregate_violations_memo.spec.ts
@@ -20,7 +20,9 @@ import { Model } from "./model";
  * whether or not the memo exists.
  */
 
-function sourceWithPreaggregateNote(name: string): SourceDef {
+// Same shape the other synthetic-ModelDef specs build (authorize_gate_walk,
+// partition_resolution); each keeps its own copy rather than sharing a fixture.
+function tableSource(name: string, extra: object = {}): SourceDef {
    return {
       type: "table",
       name,
@@ -28,6 +30,12 @@ function sourceWithPreaggregateNote(name: string): SourceDef {
       tablePath: name,
       connection: "duckdb",
       fields: [],
+      ...extra,
+   } as unknown as SourceDef;
+}
+
+function sourceWithPreaggregateNote(name: string): SourceDef {
+   return tableSource(name, {
       // A source-level declaration, which is a rejection: the grain would have
       // no measure to apply to. Used here only because it is the cheapest
       // annotation that makes the walk produce a finding.
@@ -45,21 +53,28 @@ function sourceWithPreaggregateNote(name: string): SourceDef {
             },
          ],
       },
-   } as unknown as SourceDef;
+   });
 }
 
-function modelWith(contents: Record<string, SourceDef>): Model {
+function modelWith(
+   contents: Record<string, SourceDef>,
+   onContentsRead?: () => void,
+): Model {
+   const modelDef = {
+      name: "synthetic.malloy",
+      exports: [],
+      get contents() {
+         onContentsRead?.();
+         return contents;
+      },
+   };
    return new Model(
       "test-pkg",
       "synthetic.malloy",
       {},
       "model",
       undefined,
-      {
-         name: "synthetic.malloy",
-         exports: [],
-         contents,
-      } as unknown as ModelDef,
+      modelDef as unknown as ModelDef,
       undefined,
       undefined,
       undefined,
@@ -93,16 +108,7 @@ describe("Model.preaggregateViolations memoization", () => {
    it("memoizes a clean model too, so the common case is not the slow path", () => {
       // The hot path in production is a package with nothing wrong with it, so
       // an empty result must be memoized as well as a non-empty one.
-      const model = modelWith({
-         orders: {
-            type: "table",
-            name: "orders",
-            dialect: "duckdb",
-            tablePath: "orders",
-            connection: "duckdb",
-            fields: [],
-         } as unknown as SourceDef,
-      });
+      const model = modelWith({ orders: tableSource("orders") });
       const first = model.preaggregateViolations();
       expect(first).toEqual([]);
       expect(model.preaggregateViolations()).toBe(first);
@@ -123,6 +129,25 @@ describe("Model.preaggregateViolations memoization", () => {
 
       expect(model.preaggregateViolations()).toHaveLength(1);
       expect(model.preaggregateViolations()[0].sourceName).toBe("orders");
+   });
+
+   it("reads the model contents once, however many times it is called", () => {
+      // The assertions above pin the returned VALUE as cached, which a
+      // recompute-and-discard implementation would also satisfy while burning
+      // exactly the CPU this change exists to remove. Counting reads of
+      // `contents` -- the walk's only entry into the model -- pins the work.
+      const contents = { orders: sourceWithPreaggregateNote("orders") };
+      let reads = 0;
+      const model = modelWith(contents, () => {
+         reads += 1;
+      });
+      reads = 0; // Ignore whatever construction itself touched.
+
+      model.preaggregateViolations();
+      model.preaggregateViolations();
+      model.preaggregateViolations();
+
+      expect(reads).toBe(1);
    });
 
    it("keeps each model's memo to itself", () => {

--- a/packages/server/src/service/preaggregate_violations_memo.spec.ts
+++ b/packages/server/src/service/preaggregate_violations_memo.spec.ts
@@ -1,0 +1,135 @@
+// Copyright (c) Credible Data Inc.
+// SPDX-License-Identifier: MIT
+
+import { type ModelDef, type SourceDef } from "@malloydata/malloy";
+import { describe, expect, it } from "bun:test";
+
+import { Model } from "./model";
+
+/**
+ * `Model.preaggregateViolations()` is memoized, and this pins that.
+ *
+ * It is not a micro-optimization. `Package.preaggregateAccessWarnings()` puts
+ * this walk on `getPackageMetadata()`, which `/status` reaches for every package
+ * in every environment on every poll — and the walk re-parses the annotations on
+ * every field of every source. Unmemoized, a worker holding real packages spent
+ * seconds of main-thread CPU per poll, which blocked the event loop and pushed
+ * multi-second latency onto every unrelated request.
+ *
+ * Identity rather than equality is the assertion, because equality passes
+ * whether or not the memo exists.
+ */
+
+function sourceWithPreaggregateNote(name: string): SourceDef {
+   return {
+      type: "table",
+      name,
+      dialect: "duckdb",
+      tablePath: name,
+      connection: "duckdb",
+      fields: [],
+      // A source-level declaration, which is a rejection: the grain would have
+      // no measure to apply to. Used here only because it is the cheapest
+      // annotation that makes the walk produce a finding.
+      annotations: {
+         notes: [
+            {
+               text: '#@ preaggregate grain="category"\n',
+               at: {
+                  url: "synthetic.malloy",
+                  range: {
+                     start: { line: 0, character: 0 },
+                     end: { line: 0, character: 0 },
+                  },
+               },
+            },
+         ],
+      },
+   } as unknown as SourceDef;
+}
+
+function modelWith(contents: Record<string, SourceDef>): Model {
+   return new Model(
+      "test-pkg",
+      "synthetic.malloy",
+      {},
+      "model",
+      undefined,
+      {
+         name: "synthetic.malloy",
+         exports: [],
+         contents,
+      } as unknown as ModelDef,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      // Supplied so the constructor does not derive it from this partial def.
+      {} as never,
+   );
+}
+
+describe("Model.preaggregateViolations memoization", () => {
+   // Guards the fixture rather than the validator, which has its own spec: if
+   // the synthetic annotation ever stops parsing, the walk returns [] and the
+   // identity assertions below would still pass while measuring nothing.
+   it("computes the violations", () => {
+      const model = modelWith({ orders: sourceWithPreaggregateNote("orders") });
+      const violations = model.preaggregateViolations();
+      expect(violations.map((v) => v.code)).toEqual(["misplaced_on_source"]);
+   });
+
+   it("returns the same array on a second call rather than re-walking", () => {
+      const model = modelWith({ orders: sourceWithPreaggregateNote("orders") });
+      const first = model.preaggregateViolations();
+      const second = model.preaggregateViolations();
+      // Reference identity: an unmemoized walk builds a fresh array each call.
+      expect(second).toBe(first);
+   });
+
+   it("memoizes a clean model too, so the common case is not the slow path", () => {
+      // The hot path in production is a package with nothing wrong with it, so
+      // an empty result must be memoized as well as a non-empty one.
+      const model = modelWith({
+         orders: {
+            type: "table",
+            name: "orders",
+            dialect: "duckdb",
+            tablePath: "orders",
+            connection: "duckdb",
+            fields: [],
+         } as unknown as SourceDef,
+      });
+      const first = model.preaggregateViolations();
+      expect(first).toEqual([]);
+      expect(model.preaggregateViolations()).toBe(first);
+   });
+
+   it("does not re-walk when the underlying contents change", () => {
+      // Identity alone would also hold for an implementation that recomputed and
+      // refilled a retained array, so this pins the walk itself as not re-run.
+      // Reaching into `contents` is safe to rely on only because nothing in the
+      // server ever writes to it -- that immutability is what the memo rests on.
+      const source = sourceWithPreaggregateNote("orders");
+      const contents: Record<string, SourceDef> = { orders: source };
+      const model = modelWith(contents);
+      expect(model.preaggregateViolations()).toHaveLength(1);
+
+      delete (source as unknown as { annotations?: unknown }).annotations;
+      contents.extra = sourceWithPreaggregateNote("extra");
+
+      expect(model.preaggregateViolations()).toHaveLength(1);
+      expect(model.preaggregateViolations()[0].sourceName).toBe("orders");
+   });
+
+   it("keeps each model's memo to itself", () => {
+      // A memo parked on the wrong scope (module-level, or a shared static)
+      // would leak one model's findings into another's.
+      const a = modelWith({ orders: sourceWithPreaggregateNote("orders") });
+      const b = modelWith({ orders: sourceWithPreaggregateNote("orders") });
+      expect(a.preaggregateViolations()).not.toBe(b.preaggregateViolations());
+   });
+});


### PR DESCRIPTION
`/api/v0/status` re-runs a full `#@ preaggregate` annotation walk for every package on every poll. On a 10s probe interval that is a few seconds of synchronous main-thread CPU per call, which blocks the event loop and adds seconds of queuing delay to every unrelated request the server process is serving.

This memoizes the walk.

## How it reaches `/status`

`Package.preaggregateAccessWarnings()` is spread into `getPackageMetadata()`, and `/status` walks every package in every environment through it:

```
GET /api/v0/status
  -> EnvironmentStore.getStatus() -> listEnvironments() -> Environment.serialize()
  -> listPackages() -> Package.getPackageMetadata()
  -> preaggregateAccessWarnings() -> preaggregateFindings()
  -> Model.preaggregateViolations()        <- no memo
  -> validateModelPreaggregation()         <- re-parses annotations on every
                                              field of every source
```

`getPackageMetadata()` was already on the poll path; what changed in 0.2.4 is that the preaggregate walk was added to it. The cost scales with total field count in a server process's loaded packages, so an idle server process is unaffected and one holding real packages is not.

## Measured

A customer cell, before and after 0.2.4 rolled out. Request volume was identical across the boundary — the load is a fixed-cadence prober.

| | 0.2.3 | 0.2.4 |
|---|---|---|
| `GET /api/v0/status`, worst pod | ~0.5ms | up to 5.8s |
| Server-process CPU, fleet | 0.62 cores | 2.6 cores |
| p95 on unrelated package-metadata routes | ~13ms | ~3.5s |
| Node heap, hot pods | flat | sawtooth 2.4 -> 3.14 GB |

Per-pod CPU tracks that pod's `/status` duration almost exactly: a pod spending 5.8s per 10s poll burns ~0.6 cores, while pods with nothing loaded stay at 0.04 cores and answer in 0.5ms.

## Why the memo needs no invalidation

`this.modelDef` is assigned once, in the constructor, and a reload replaces the `Model` object outright rather than mutating it. Nothing in the server writes to `modelDef.contents` either — every reference is a read. This is the same argument `getDeclaredQueryMetadata` already documents a few methods above; that method was given a memo for exactly this reason and the preaggregate path added later was not.

## `readonly`

Callers now share one array instead of each getting a fresh walk, so a caller that sorted or spliced the result would be editing every later caller's copy. The return type says `readonly` to make that a compile error. Type-level only — a runtime freeze would cost something on the path this change exists to make cheap, and a shallow freeze would not protect the entries anyway.

There is one caller today (`Package.preaggregateFindings`), and it only iterates.

## Tests

The validator has its own spec; these pin the memo.

Identity alone would also hold for an implementation that recomputed and refilled a retained array, so `does not re-walk when the underlying contents change` mutates the contents between two calls and asserts the answer does not move. `keeps each model's memo to itself` checks two models do not share an array, so a memo parked on the wrong scope cannot pass. The first test guards the fixture: if the synthetic annotation ever stops parsing, the walk returns `[]` and the identity assertions would pass while measuring nothing.

Removing the memo fails three of the five, each for the right reason — the two identity tests report equal content at a different reference, and the re-walk test picks up the mutated source.

Full server unit suite green (3645 pass, 3 skip, 0 fail); typecheck and lint clean.
