### PR TITLE
chore(release): stamp 0.2.7 on main

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,7 +31,7 @@ One behaviour change to know about: `skills-npm.yml` now publishes only from `ma
 
 ---
 
-## [Unreleased] — bound how far the Snowflake driver reads ahead of a slow consumer
+## [0.2.7] — bound how far the Snowflake driver reads ahead of a slow consumer
 
 The Docker image now installs a small shim in front of the ADBC Snowflake driver
 that can set `adbc.rpc.result_queue_size` on every Snowflake statement. It is
@@ -71,7 +71,7 @@ implies ([adbc-drivers/snowflake#197](https://github.com/adbc-drivers/snowflake/
 
 ---
 
-## [Unreleased] — 500 and 502 responses no longer echo the internal error
+## [0.2.7] — 500 and 502 responses no longer echo the internal error
 
 A 500 or a 502 returned `error.message` verbatim. That message is not always
 something a caller should see: an unrecognised internal failure carries a stack

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/app",
    "description": "Malloy Publisher Console (the built-in web UI)",
-   "version": "0.2.6",
+   "version": "0.2.7",
    "type": "module",
    "main": "dist/index.cjs.js",
    "module": "dist/index.es.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/sdk",
    "description": "Malloy Publisher SDK",
-   "version": "0.2.6",
+   "version": "0.2.7",
    "type": "module",
    "main": "dist/index.cjs.js",
    "module": "dist/index.es.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@malloy-publisher/server",
    "description": "Malloy Publisher Server",
-   "version": "0.2.6",
+   "version": "0.2.7",
    "main": "dist/server.mjs",
    "bin": {
       "malloy-publisher": "dist/server.mjs"


### PR DESCRIPTION
Stamps the two `[Unreleased]` sections that shipped in v0.2.7 with their version, and resets `packages/{sdk,app,server}/package.json` to the released version.

Pushed by `gh-release` during [run 34531699955](https://github.com/malloydata/publisher/actions/runs/34531699955); it stops at a branch so that a human-opened PR runs the check suite.

Sections stamped, matching the [v0.2.7 release page](https://github.com/malloydata/publisher/releases/tag/v0.2.7):

- bound how far the Snowflake driver reads ahead of a slow consumer
- 500 and 502 responses no longer echo the internal error

🤖 Generated with [Claude Code](https://claude.com/claude-code)