### PR TITLE
fix(connections): finalize eligible ad hoc SQL so plain statements work on Postgres

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,6 +31,39 @@ One behaviour change to know about: `skills-npm.yml` now publishes only from `ma
 
 ---
 
+## [Unreleased] — plain SQL through `sqlQuery` now returns rows on Postgres
+
+`POST /api/v0/environments/{env}/connections/{conn}/sqlQuery` failed for every
+plain statement against a Postgres connection, `SELECT 1` included, with
+`The "string" argument must be of type string or an instance of Buffer or
+ArrayBuffer. Received undefined` and HTTP 502.
+
+Malloy's Postgres dialect finalizes a query by collapsing its result into a
+single JSON column named `row`, and `@malloydata/db-postgres` unwraps that
+column from every row it returns. A statement the caller wrote does not project
+it, so the driver handed back nothing readable. It had never worked through this
+endpoint; before the response caps landed it returned an array of nulls rather
+than failing, so nothing said so.
+
+An eligible statement is now finalized on the way in, for any dialect whose
+connector expects it -- read off `Dialect.hasFinalStage`, which is Postgres
+alone today, rather than hardcoded. No request change: `SELECT 1` returns a row.
+
+What is deliberately NOT finalized, and still runs exactly as sent:
+
+- DDL, `SET`, `EXPLAIN`, `SHOW`, a data-modifying CTE, and Postgres'
+  `SELECT ... INTO`. None can sit in the subquery position the wrapper uses, and
+  they returned no rows to unwrap in the first place, so they already worked.
+- A statement that already projects the column. This is what a `publisher` proxy
+  connection forwards: it reports the REMOTE's dialect, so the Malloy compiler
+  on the far side finalized the statement before it was sent. Finalizing it
+  again would add a level the connector does not strip, and the caller would
+  read nulls off `{"row": {...}}` with no error to notice. The Malloy CLI and
+  the VS Code extensions reach Publisher this way.
+
+A statement in neither group that still produces rows the driver cannot read now
+answers 400 naming the wrapper to apply by hand, instead of the 502 above.
+
 ## [0.2.7] — bound how far the Snowflake driver reads ahead of a slow consumer
 
 The Docker image now installs a small shim in front of the ADBC Snowflake driver

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -802,6 +802,16 @@ paths:
         Executes a SQL statement against the specified database connection and returns the results.
         The results include data, metadata, and execution information.
 
+        Some dialects finalize a query by collapsing its result into a single
+        JSON column named `row`, and their connectors unwrap that column on the
+        way back out (Postgres is the only one today). An eligible statement is
+        finalized for them on the way in, so a plain `SELECT 1` returns a row.
+        A statement that cannot be finalized -- DDL, `SET`, `EXPLAIN`, a
+        data-modifying CTE, or one that already projects the column, which is
+        what a `publisher` proxy connection forwards -- is run exactly as sent.
+        When such a statement produces rows the driver cannot read, the response
+        is 400 naming the wrapper to apply by hand.
+
         Rows returned are capped at PUBLISHER_MAX_QUERY_ROWS (default 100,000).
         The cap is forwarded to the connector as a rowLimit on RunSQLOptions;
         queries that return more rows than the cap fail with HTTP 413 rather
@@ -1170,8 +1180,8 @@ paths:
         Executes a SQL statement against the specified database connection,
         resolved in the context of the named package, and returns the results.
 
-        Subject to the same PUBLISHER_MAX_QUERY_ROWS row cap as the
-        environment-level sqlQuery endpoint.
+        Subject to the same PUBLISHER_MAX_QUERY_ROWS row cap, and the same
+        dialect finalization, as the environment-level sqlQuery endpoint.
       parameters:
         - name: environmentName
           in: path

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -229,6 +229,16 @@ enforcement; the proxy itself does not reject writes. A missing `connectionUri`
 fails at startup with an actionable error rather than a generic
 `Unsupported connection type`.
 
+> **The proxy forwards SQL verbatim, and that is load-bearing.** A `publisher`
+> connection reports the REMOTE connection's `dialectName`, so the local Malloy
+> compiler generates SQL for that dialect and the remote runs it as sent. Where
+> the dialect finalizes a query -- Postgres collapses its result into a single
+> `row` column, which its connector unwraps -- the statement arrives already
+> finalized, and the remote's `sqlQuery` endpoint deliberately leaves it alone.
+> Finalizing it a second time would not fail; it would return
+> `{"row": {...}}` and the caller would read nulls off a level nothing strips.
+> Pinned in `connection.controller.spec.ts`.
+
 **Known limitation:** the `accessToken` is user-scoped and short-lived. The
 server uses the token as configured and does not refresh it, so a long-running
 `--watch-env` session can outlive the token. Token refresh/expiry is owned by the

--- a/hammer/scenarios/connections/01-raw-sql-postgres/scenario.md
+++ b/hammer/scenarios/connections/01-raw-sql-postgres/scenario.md
@@ -1,0 +1,137 @@
+---
+id: raw-sql-postgres
+tags: connections
+package: rawsql
+---
+<!--
+Copyright (c) Credible Data Inc.
+SPDX-License-Identifier: MIT
+-->
+
+# Raw SQL through `sqlQuery` returns rows on Postgres
+
+`POST /connections/<c>/sqlQuery` runs a caller's statement through the
+connection's Malloy connector, and on Postgres that connector unwraps a `row`
+column from every row it yields — the contract it has with the Postgres
+dialect, whose `sqlFinalStage` projects exactly that column. A statement the
+caller wrote does not project it, so the driver hands back nothing readable and
+`SELECT 1` fails. The endpoint finalizes an eligible statement on the way in to
+close that gap.
+
+The suite reaches this endpoint elsewhere only through DuckDB and DuckLake
+connections, whose dialect has no final stage and so never needed it. Nothing
+pushed a row through the Postgres streaming branch, which is how the byte cap
+came to raise `The "string" argument must be of type string or an instance of
+Buffer or ArrayBuffer. Received undefined` on every plain statement without
+anyone noticing.
+
+## Data orders_pg.rawsql_orders
+
+| order_id:int | order_date:date | region:text | amount:num |
+| ------------ | --------------- | ----------- | ---------- |
+| 1            | 2026-01-01      | US          | 100        |
+| 2            | 2026-01-02      | EU          | 200        |
+
+## Model rawsql.malloy
+
+A package so the environment exists; the connection endpoints are what this
+scenario exercises, not the model.
+
+```malloy
+source: orders is orders_pg.table('public.rawsql_orders')
+```
+
+## Connection orders_pg
+
+The reported statement: no table, no `row` column, nothing to unwrap.
+
+```sql
+SELECT 1 AS x
+```
+
+Expect:
+
+| x   |
+| --- |
+| 1   |
+
+## Connection orders_pg
+
+A real projection reads back by column name, so the wrapper is transparent
+rather than merely non-fatal.
+
+```sql
+SELECT region, amount FROM rawsql_orders ORDER BY order_id
+```
+
+Expect:
+
+| region | amount |
+| ------ | ------ |
+| US     | 100    |
+| EU     | 200    |
+
+## Connection orders_pg
+
+A CTE, which the wrapper nests inside its own.
+
+```sql
+WITH totals AS (SELECT region, SUM(amount) AS total FROM rawsql_orders GROUP BY region)
+SELECT region, total FROM totals ORDER BY region
+```
+
+Expect:
+
+| region | total |
+| ------ | ----- |
+| EU     | 200   |
+| US     | 100   |
+
+## Connection orders_pg
+
+The transport contract, which is the one that must NOT be finalized. A
+`publisher` proxy connection reports the REMOTE connection's dialect, so the
+Malloy compiler on the far side finalizes the statement before it is sent and
+what arrives here is the shape below -- `@malloydata/db-publisher` forwards it
+verbatim and does no unwrapping of its own. Passed through, the connector's
+unwrap yields the plain columns the caller compiled for. Finalized a second
+time it would yield `{"row": {...}}`: not an error, just nulls read off a level
+nothing strips. The Malloy CLI and the VS Code extensions reach a Publisher
+this way, and their versions are not ours to coordinate.
+
+```sql
+WITH __stage0 AS (SELECT region, amount FROM rawsql_orders WHERE order_id = 1)
+SELECT row_to_json(finalStage) as row FROM __stage0 AS finalStage
+```
+
+Expect:
+
+| region | amount |
+| ------ | ------ |
+| US     | 100    |
+
+## Connection orders_pg (rows=0)
+
+DDL is passed through, not finalized: it cannot sit in the subquery position
+the wrapper puts a statement in, and it returns no rows for the connector to
+unwrap, so it already worked. Wrapping it would turn a working statement into
+a syntax error.
+
+```sql
+CREATE TABLE rawsql_ddl_probe (a int)
+```
+
+## Connection orders_pg
+
+The table the step above created — proof the DDL ran rather than being quietly
+swallowed.
+
+```sql
+SELECT count(*) AS n FROM information_schema.tables WHERE table_name = 'rawsql_ddl_probe'
+```
+
+Expect:
+
+| n   |
+| --- |
+| 1   |

--- a/packages/server/src/controller/connection.controller.spec.ts
+++ b/packages/server/src/controller/connection.controller.spec.ts
@@ -436,15 +436,17 @@ describe("ConnectionController.getConnectionQueryData streaming", () => {
    function buildStreamingController(opts: {
       rows: QueryRecord[];
       honorRowLimit?: boolean;
+      dialectName?: string;
    }): {
       controller: ConnectionController;
       seenSql: { value: string | undefined };
       seenOptions: { value: RunSQLOptions | undefined };
    } {
-      const { rows, honorRowLimit = true } = opts;
+      const { rows, honorRowLimit = true, dialectName } = opts;
       const seenSql = { value: undefined as string | undefined };
       const seenOptions = { value: undefined as RunSQLOptions | undefined };
       const fakeConnection = {
+         dialectName,
          canStream(): true {
             return true;
          },
@@ -632,6 +634,85 @@ describe("ConnectionController.getConnectionQueryData streaming", () => {
       const signal = seenOptions.value?.abortSignal;
       expect(signal).toBeInstanceOf(AbortSignal);
       expect(signal?.aborted).toBe(false);
+   });
+
+   // The dialect/connector final-stage contract. Postgres' connector unwraps a
+   // `row` column from every row, so a caller's plain SELECT has to be
+   // finalized on the way in or it comes back as nullish rows. Eligibility
+   // itself is covered in service/final_stage_sql.spec.ts; these pin that the
+   // controller applies the verdict, and what a statement it cannot finalize
+   // reports back.
+   it("finalizes a plain SELECT for a dialect whose connector unwraps a row column", async () => {
+      const { controller, seenSql } = buildStreamingController({
+         rows: [{ x: 1 }],
+         dialectName: "postgres",
+      });
+
+      await controller.getConnectionQueryData(
+         "env",
+         "conn",
+         "SELECT 1 AS x",
+         "",
+      );
+
+      expect(seenSql.value).not.toBe("SELECT 1 AS x");
+      expect(seenSql.value).toContain("SELECT 1 AS x");
+      expect(seenSql.value).toContain("row_to_json");
+   });
+
+   it("passes an already-finalized statement through untouched", async () => {
+      // A `publisher` proxy connection reports the remote's dialect, so the SQL
+      // arriving here is already finalized by the compiler on the far side.
+      // Finalizing it again would return `{"row": {...}}` -- nulls read off a
+      // level the connector does not strip, with no error to notice.
+      const compiled =
+         'WITH __stage0 AS (SELECT 1 AS "x")\nSELECT row_to_json(finalStage) as row FROM __stage0 AS finalStage';
+      const { controller, seenSql } = buildStreamingController({
+         rows: [{ x: 1 }],
+         dialectName: "postgres",
+      });
+
+      await controller.getConnectionQueryData("env", "conn", compiled, "");
+
+      expect(seenSql.value).toBe(compiled);
+   });
+
+   it("passes DDL through untouched", async () => {
+      const { controller, seenSql } = buildStreamingController({
+         rows: [],
+         dialectName: "postgres",
+      });
+
+      await controller.getConnectionQueryData(
+         "env",
+         "conn",
+         "CREATE TABLE t (a int)",
+         "",
+      );
+
+      expect(seenSql.value).toBe("CREATE TABLE t (a int)");
+   });
+
+   it("answers a nullish row with an actionable 400 rather than a driver fault", async () => {
+      // What the caller used to get here was a 502 reading `The "string"
+      // argument must be of type string or an instance of Buffer or
+      // ArrayBuffer. Received undefined` -- the byte cap's
+      // `Buffer.byteLength(JSON.stringify(undefined))`, which names nothing the
+      // caller can act on and does not fire at all when the byte cap is off.
+      process.env.PUBLISHER_MAX_RESPONSE_BYTES = "0";
+      const { controller } = buildStreamingController({
+         rows: [undefined as unknown as QueryRecord],
+         dialectName: "postgres",
+      });
+
+      const call = controller.getConnectionQueryData(
+         "env",
+         "conn",
+         "SELECT row_to_json(t) AS payload FROM t",
+         "",
+      );
+      await expect(call).rejects.toBeInstanceOf(BadRequestError);
+      await expect(call).rejects.toThrow("row_to_json");
    });
 });
 

--- a/packages/server/src/controller/connection.controller.ts
+++ b/packages/server/src/controller/connection.controller.ts
@@ -27,6 +27,11 @@ import {
    listTablesForSchema,
 } from "../service/db_utils";
 import {
+   finalStageContractMessage,
+   shouldWrapFinalStage,
+   wrapFinalStage,
+} from "../service/final_stage_sql";
+import {
    mergeQueryMetadata,
    mintCorrelationId,
    parseQueryClass,
@@ -751,6 +756,17 @@ export class ConnectionController {
          );
       }
 
+      // Finalize the statement for dialects whose connector unwraps a `row`
+      // column from every row, so a caller's plain SELECT survives the round
+      // trip. Not every statement is eligible, and the ones that are not are
+      // sent through untouched -- service/final_stage_sql.ts carries the
+      // reasoning, including why a proxied Malloy query must never be wrapped
+      // a second time.
+      const dialectName = malloyConnection.dialectName;
+      const sqlToRun = shouldWrapFinalStage(dialectName, sqlStatement)
+         ? wrapFinalStage(dialectName, sqlStatement)
+         : sqlStatement;
+
       // Streaming-capable connections (Postgres, DuckDB, ...) go through
       // streamSqlWithBudget so the byte cap can fire mid-stream. Other
       // connections fall back to the buffered path; client-side byte
@@ -771,12 +787,16 @@ export class ConnectionController {
             try {
                return await streamSqlWithBudget(
                   malloyConnection,
-                  sqlStatement,
+                  sqlToRun,
                   optionsWithSignal,
                   { maxRows, maxBytes },
+                  () => finalStageContractMessage(dialectName),
                );
             } catch (error) {
                if (error instanceof PayloadTooLargeError) throw error;
+               // A verdict on the caller's statement, not a driver failure:
+               // keep its 400 rather than reporting it as an upstream 502.
+               if (error instanceof BadRequestError) throw error;
                // If runWithQueryTimeout is about to wrap this in a
                // QueryTimeoutError (because the timer fired), the
                // ConnectionError we'd throw here is discarded — the
@@ -794,10 +814,7 @@ export class ConnectionController {
             abortSignal: signal,
          };
          try {
-            return await malloyConnection.runSQL(
-               sqlStatement,
-               optionsWithSignal,
-            );
+            return await malloyConnection.runSQL(sqlToRun, optionsWithSignal);
          } catch (error) {
             throw new ConnectionError((error as Error).message);
          }

--- a/packages/server/src/service/final_stage_sql.spec.ts
+++ b/packages/server/src/service/final_stage_sql.spec.ts
@@ -1,0 +1,136 @@
+// Copyright (c) Credible Data Inc.
+// SPDX-License-Identifier: MIT
+
+// Eligibility for the dialect final-stage wrapper on ad hoc `sqlQuery` SQL.
+// The upstream facts this rests on -- Postgres is the only dialect with a final
+// stage, and its final stage is a `row_to_json` call -- are pinned in
+// incremental_compiler_contract.spec.ts, so a compiler bump that moves either
+// fails there rather than silently changing what gets wrapped here.
+import { PostgresDialect } from "@malloydata/malloy";
+import { describe, expect, it } from "bun:test";
+import {
+   dialectHasFinalStage,
+   finalStageContractMessage,
+   shouldWrapFinalStage,
+   wrapFinalStage,
+} from "./final_stage_sql";
+
+/** The shape `@malloydata/malloy` compiles a Postgres query into. */
+const COMPILED_QUERY = `WITH __stage0 AS (
+  SELECT "category" as "category", COUNT(1) as "n" FROM orders GROUP BY 1
+)
+SELECT row_to_json(finalStage) as row FROM __stage0 AS finalStage`;
+
+describe("dialectHasFinalStage", () => {
+   it("is true for postgres and false for the dialects that do not finalize", () => {
+      expect(dialectHasFinalStage("postgres")).toBe(true);
+      for (const name of [
+         "duckdb",
+         "standardsql",
+         "snowflake",
+         "trino",
+         "mysql",
+         "databricks",
+      ]) {
+         expect(dialectHasFinalStage(name)).toBe(false);
+      }
+   });
+
+   it("is false for a dialect it does not know", () => {
+      expect(dialectHasFinalStage("nonesuch")).toBe(false);
+      expect(dialectHasFinalStage("")).toBe(false);
+   });
+});
+
+describe("shouldWrapFinalStage", () => {
+   it("wraps a plain SELECT on a finalizing dialect", () => {
+      // The reported bug: `SELECT 1` came back as a nullish row because the
+      // connector unwrapped a column the statement never projected.
+      expect(shouldWrapFinalStage("postgres", "SELECT 1 AS x")).toBe(true);
+      expect(
+         shouldWrapFinalStage("postgres", "select a, b from t where a > 1"),
+      ).toBe(true);
+      expect(shouldWrapFinalStage("postgres", "VALUES (1), (2)")).toBe(true);
+      expect(
+         shouldWrapFinalStage("postgres", "(SELECT 1) UNION (SELECT 2)"),
+      ).toBe(true);
+      expect(
+         shouldWrapFinalStage(
+            "postgres",
+            "WITH t AS (SELECT 1 AS x) SELECT * FROM t",
+         ),
+      ).toBe(true);
+   });
+
+   it("never wraps on a dialect whose connector does not unwrap a row column", () => {
+      for (const name of ["duckdb", "snowflake", "standardsql", "nonesuch"]) {
+         expect(shouldWrapFinalStage(name, "SELECT 1 AS x")).toBe(false);
+      }
+   });
+
+   it("leaves an already-finalized statement alone", () => {
+      // The load-bearing case. A `publisher` connection reports the REMOTE's
+      // dialect, so the Malloy compiler on the far side has already finalized
+      // the statement before it reaches this endpoint. Wrapping it again adds a
+      // level the connector does not strip and the caller reads nulls off
+      // `{"row": {...}}` -- a wrong answer, not an error.
+      expect(shouldWrapFinalStage("postgres", COMPILED_QUERY)).toBe(false);
+   });
+
+   it("leaves a statement that cannot sit in a subquery alone", () => {
+      for (const sql of [
+         "CREATE TABLE t (a int)",
+         "SET search_path = public",
+         "EXPLAIN SELECT 1",
+         "SHOW search_path",
+         "INSERT INTO t VALUES (1)",
+         "TRUNCATE t",
+         "SELECT a INTO snapshot FROM t",
+         "WITH moved AS (DELETE FROM t RETURNING *) SELECT * FROM moved",
+      ]) {
+         expect(shouldWrapFinalStage("postgres", sql)).toBe(false);
+      }
+   });
+
+   it("reads past leading comments and whitespace to find the statement", () => {
+      expect(
+         shouldWrapFinalStage("postgres", "-- a note\n  SELECT 1 AS x"),
+      ).toBe(true);
+      expect(
+         shouldWrapFinalStage("postgres", "/* a note */\n/* two */ SELECT 1"),
+      ).toBe(true);
+      expect(
+         shouldWrapFinalStage("postgres", "-- CREATE TABLE t\nSELECT 1"),
+      ).toBe(true);
+   });
+});
+
+describe("wrapFinalStage", () => {
+   it("finalizes the statement the way the dialect finalizes a query", () => {
+      const wrapped = wrapFinalStage("postgres", "SELECT 1 AS x");
+      expect(wrapped).toContain("SELECT 1 AS x");
+      expect(wrapped).toContain(
+         new PostgresDialect().sqlFinalStage("__publisher_raw_sql", []),
+      );
+   });
+
+   it("drops a trailing semicolon, which is legal alone and illegal in the CTE", () => {
+      expect(wrapFinalStage("postgres", "SELECT 1;  ")).not.toContain(";");
+   });
+
+   it("is a no-op on a dialect with no final stage", () => {
+      expect(wrapFinalStage("duckdb", "SELECT 1")).toBe("SELECT 1");
+   });
+});
+
+describe("finalStageContractMessage", () => {
+   it("names the wrapper in the dialect's own terms", () => {
+      const message = finalStageContractMessage("postgres");
+      expect(message).toContain("row_to_json");
+      expect(message).toContain("postgres");
+   });
+
+   it("omits the example for a dialect that has no final stage", () => {
+      expect(finalStageContractMessage("duckdb")).not.toContain("Wrap it as");
+   });
+});

--- a/packages/server/src/service/final_stage_sql.ts
+++ b/packages/server/src/service/final_stage_sql.ts
@@ -1,0 +1,177 @@
+// Copyright (c) Credible Data Inc.
+// SPDX-License-Identifier: MIT
+
+/**
+ * The dialect/connector contract for ad hoc SQL sent to the connection
+ * `sqlQuery` endpoints.
+ *
+ * Some dialects finalize a query by collapsing its result into a single JSON
+ * column named `row` (`Dialect.hasFinalStage`; Postgres is the only one today,
+ * pinned by the TRIPWIRE in incremental_compiler_contract.spec.ts). Their
+ * connectors unwrap that column on the way back out -- `PostgresConnection`
+ * does `rows[i] = rows[i].row` in `runSQL` and yields `row.row` from
+ * `runSQLStream` -- so a statement that does NOT produce the column comes back
+ * as nullish rows rather than data. `service/db_utils.ts` and
+ * `incremental_apply.ts`'s `probeSelect` both honor this for the SQL they
+ * author themselves; this module is the same contract for SQL the CALLER
+ * authors, where the statement's shape is not known in advance.
+ *
+ * The hard part is not the wrapper, it is deciding when to apply it. The
+ * endpoint carries two contracts at once:
+ *
+ *   - Raw SQL from a human, an agent, or the hammer harness, which wants the
+ *     wrapper applied so `SELECT 1` returns a row.
+ *   - `@malloydata/db-publisher`'s transport: a `publisher` connection reports
+ *     the REMOTE's dialectName, so the local Malloy compiler has ALREADY
+ *     finalized the statement before it is sent. Wrapping again adds a level
+ *     the connector does not strip, and the caller reads fields off
+ *     `{"row": {...}}` -- nulls, not an error. That path is used by the Malloy
+ *     CLI and the VS Code extensions, whose versions this server does not
+ *     control, so silently corrupting it is not an available trade.
+ *
+ * Nothing in the request distinguishes them, so eligibility is decided from
+ * the statement itself, and every test below fails toward passing the
+ * statement through unchanged. A statement wrongly passed through returns the
+ * actionable 400 raised in stream_helpers; a statement wrongly wrapped returns
+ * wrong data.
+ */
+
+import {
+   DatabricksDialect,
+   type Dialect,
+   DuckDBDialect,
+   MySQLDialect,
+   PostgresDialect,
+   SnowflakeDialect,
+   StandardSQLDialect,
+   TrinoDialect,
+} from "@malloydata/malloy";
+
+/**
+ * Dialect instances by `dialectName`, built from the classes the SDK exports
+ * (`getDialect` is not on the package's public surface). Same construction as
+ * the compiler-contract tripwire, so the two agree on which dialects exist.
+ */
+let dialectsByName: Map<string, Dialect> | undefined;
+
+function dialectFor(dialectName: string): Dialect | undefined {
+   if (!dialectsByName) {
+      dialectsByName = new Map(
+         [
+            new PostgresDialect(),
+            new StandardSQLDialect(),
+            new DuckDBDialect(),
+            new SnowflakeDialect(),
+            new TrinoDialect(),
+            new MySQLDialect(),
+            new DatabricksDialect(),
+         ].map((d) => [d.name, d] as const),
+      );
+   }
+   return dialectsByName.get(dialectName);
+}
+
+/**
+ * The distinctive call in a dialect's final stage -- `row_to_json` for
+ * Postgres -- read off the dialect rather than hardcoded, so a dialect that
+ * gains a differently-named final stage is covered without an edit here.
+ * Undefined when the final stage has no leading call to key on, which makes
+ * the statement ineligible and so passes it through.
+ */
+function finalStageMarker(dialect: Dialect): string | undefined {
+   return /(\w+)\s*\(/.exec(dialect.sqlFinalStage("__probe", []))?.[1];
+}
+
+/** Leading whitespace and comments removed, so the first keyword is readable. */
+function statementHead(sql: string): string {
+   let rest = sql;
+   for (;;) {
+      const trimmed = rest
+         .replace(/^\s+/, "")
+         .replace(/^--[^\n]*(?:\n|$)/, "")
+         .replace(/^\/\*[\s\S]*?\*\//, "");
+      if (trimmed === rest) return trimmed;
+      rest = trimmed;
+   }
+}
+
+/**
+ * Statements that can legally sit in the subquery position the wrapper puts
+ * them in. Everything else -- DDL, `SET`, `EXPLAIN`, `SHOW`, `CALL` -- is
+ * passed through, which is also what those statements need: they return no
+ * rows for the connector to unwrap, so they already work.
+ */
+const WRAPPABLE_HEAD = /^(?:select|with|values|\()/i;
+
+/**
+ * Keywords that make a statement illegal in a subquery position even when it
+ * opens with a wrappable head: a data-modifying CTE
+ * (`WITH x AS (INSERT ... RETURNING ...) SELECT ...`) and Postgres's
+ * `SELECT ... INTO`, which is table creation rather than projection. Both work
+ * through this endpoint today, so wrapping them would turn a working statement
+ * into a syntax error. Matched as bare words anywhere in the statement: a hit
+ * inside a string literal or an identifier costs a passthrough, which is the
+ * safe direction.
+ */
+const NOT_SUBQUERY_SAFE = /\b(?:insert|update|delete|merge|into)\b/i;
+
+/** True when this dialect's connector unwraps a `row` column from every row. */
+export function dialectHasFinalStage(dialectName: string): boolean {
+   return dialectFor(dialectName)?.hasFinalStage ?? false;
+}
+
+/**
+ * Whether `sql` should be finalized by {@link wrapFinalStage} before it is
+ * handed to the connector.
+ *
+ * The already-finalized test is "mentions the dialect's final-stage call at
+ * all" rather than a match on the shape Malloy emits. It is deliberately the
+ * blunter of the two: a compiled query always mentions it, so the transport
+ * path is safe by construction and stays safe if Malloy changes how the final
+ * stage is composed. The cost is that a caller's own SQL mentioning
+ * `row_to_json` is passed through and answered with the 400, rather than being
+ * wrapped -- a loud failure for a rare hand-written statement, traded against
+ * a silent one for every proxied query.
+ */
+export function shouldWrapFinalStage(
+   dialectName: string,
+   sql: string,
+): boolean {
+   const dialect = dialectFor(dialectName);
+   if (!dialect?.hasFinalStage) return false;
+
+   const marker = finalStageMarker(dialect);
+   if (marker === undefined) return false;
+   if (new RegExp(`\\b${marker}\\b`, "i").test(sql)) return false;
+
+   if (!WRAPPABLE_HEAD.test(statementHead(sql))) return false;
+   if (NOT_SUBQUERY_SAFE.test(sql)) return false;
+   return true;
+}
+
+/**
+ * `sql` finalized the way the dialect finalizes a compiled query, so the
+ * connector's unwrap finds the column it expects and the caller gets plain row
+ * objects. The trailing semicolon a caller may include is dropped: it is legal
+ * on its own and illegal inside the CTE.
+ */
+export function wrapFinalStage(dialectName: string, sql: string): string {
+   const dialect = dialectFor(dialectName);
+   if (!dialect?.hasFinalStage) return sql;
+   const stage = "__publisher_raw_sql";
+   const body = sql.replace(/;\s*$/, "");
+   return `WITH ${stage} AS (\n${body}\n) ${dialect.sqlFinalStage(stage, [])}`;
+}
+
+/**
+ * The message for a statement that reached the connector without the column
+ * its unwrap expects. Names the wrapper in the dialect's own terms so the
+ * caller can apply it by hand.
+ */
+export function finalStageContractMessage(dialectName: string): string {
+   const dialect = dialectFor(dialectName);
+   const example = dialect?.hasFinalStage
+      ? ` Wrap it as: WITH t AS (<your statement>) ${dialect.sqlFinalStage("t", [])}`
+      : "";
+   return `The statement returned rows the ${dialectName} driver could not read. This connection's driver unwraps a single column named "row" from every row, which the statement did not produce.${example}`;
+}

--- a/packages/server/src/stream_helpers.ts
+++ b/packages/server/src/stream_helpers.ts
@@ -30,7 +30,7 @@ import type {
    StreamingConnection,
 } from "@malloydata/malloy";
 
-import { PayloadTooLargeError } from "./errors";
+import { BadRequestError, PayloadTooLargeError } from "./errors";
 import { recordQueryCapExceeded } from "./query_cap_metrics";
 
 /**
@@ -91,6 +91,14 @@ export async function streamSqlWithBudget(
    sql: string,
    runSQLOptions: RunSQLOptions,
    budget: StreamBudget,
+   /**
+    * Message for a nullish row (see the guard below). The caller supplies it
+    * because the reason is a property of the connection's dialect, which this
+    * helper deliberately knows nothing about, and supplies it lazily so the
+    * success path -- every proxied query -- does not build a string it throws
+    * away.
+    */
+   nullRowMessage?: () => string,
 ): Promise<MalloyQueryData> {
    const { maxRows, maxBytes } = budget;
    const capAc = new AbortController();
@@ -127,6 +135,21 @@ export async function streamSqlWithBudget(
          ...runSQLOptions,
          abortSignal: composedSignal,
       })) {
+         // A nullish row is never data. It means the connector unwrapped a
+         // column the statement did not project -- the dialect/connector
+         // final-stage contract (see service/final_stage_sql.ts), which
+         // `sqlQuery` cannot always satisfy on the caller's behalf. Caught
+         // here rather than left to the byte cap's
+         // `Buffer.byteLength(JSON.stringify(undefined))`, which throws a
+         // TypeError about a "string" argument that names nothing the caller
+         // can act on -- and which does not throw at all when the byte cap is
+         // disabled, leaving a response full of nulls.
+         if (row === null || row === undefined) {
+            throw new BadRequestError(
+               nullRowMessage?.() ??
+                  "The statement returned rows the driver could not read.",
+            );
+         }
          rows.push(row);
          if (maxBytes > 0) {
             // Measure exactly what the eventual response body will
@@ -155,7 +178,10 @@ export async function streamSqlWithBudget(
       // versions. Swallow it iff we triggered the abort ourselves —
       // otherwise it's a real connection error (or the caller's
       // timeout, which the controller's runWithQueryTimeout will
-      // surface as a 504) that the controller must see.
+      // surface as a 504) that the controller must see. A
+      // BadRequestError is ours and always propagates: it is a verdict
+      // on the statement, not a transport failure.
+      if (err instanceof BadRequestError) throw err;
       if (!overflowMessage) throw err;
    }
 


### PR DESCRIPTION
Fixes #1141.

`POST /api/v0/environments/{env}/connections/{conn}/sqlQuery` failed for every plain statement against a Postgres connection, `SELECT 1` included, with `The "string" argument must be of type string or an instance of Buffer or ArrayBuffer. Received undefined` and HTTP 502.

Malloy's Postgres dialect finalizes a query by collapsing its result into a single JSON column named `row`, and `@malloydata/db-postgres` unwraps that column from every row it returns — the contract between dialect and connector. A statement the caller wrote does not project it, so the driver handed back nothing readable. It had never worked through this endpoint; before the response caps landed it returned an array of nulls rather than failing, so nothing said so.

## What changed

`service/final_stage_sql.ts` decides eligibility and builds the wrapper. Both are read off the dialect rather than hardcoded: `Dialect.hasFinalStage` gates it, `sqlFinalStage()` supplies the wrapper text, and the token to look for is extracted from `sqlFinalStage()` output rather than spelled `row_to_json`. Postgres is the only dialect with a final stage today, pinned by the existing tripwire in `incremental_compiler_contract.spec.ts`.

`db_utils.ts` and `incremental_apply.ts`'s `probeSelect` already honour this contract for SQL they author themselves. Neither is touched here; this is the same contract for SQL the caller authors, where the statement's shape is not known in advance.

## What is deliberately not wrapped

The endpoint carries two contracts at once, and nothing in the request distinguishes them, so eligibility is decided from the statement.

**Already-finalized SQL.** This is what a `publisher` proxy connection forwards: it reports the remote connection's `dialectName`, so the Malloy compiler on the caller's side finalized the statement before it was sent, and `db-publisher` does no unwrapping of its own. Passing it through is what makes that path work — the remote's connector strips the one `row` level the compiler added. Wrapping adds a second level that nothing strips, and the caller reads nulls off `{"row": {...}}`: a wrong answer rather than an error. The Malloy CLI and the VS Code extensions reach a Publisher over this connection type.

**Statements that cannot sit in a subquery** — DDL, `SET`, `EXPLAIN`, `SHOW`, a data-modifying CTE, Postgres' `SELECT ... INTO`. They return no rows for the connector to unwrap, so they already worked; wrapping turns a working statement into a syntax error.

Every test fails toward passing the statement through. A statement wrongly passed through can be reported; a statement wrongly wrapped returns wrong data. So a statement in neither group that still yields nullish rows now answers 400 naming the wrapper to apply by hand, rather than the 502 above — a nullish row is never data, and the guard fires whether or not the byte cap is enabled (with the cap disabled the old code returned a response full of nulls and said nothing).

## Tests

`hammer/scenarios/connections/01-raw-sql-postgres/` runs against a real Postgres: the reported `SELECT 1`, a projection read back by column name, a CTE, DDL that must pass through *and actually run*, and the compiled-query shape a proxy forwards, which must come back as plain columns.

Both halves were checked by reverting rather than assumed. Without the wrapper the scenario fails with the new 400. With the marker check removed — the blanket wrap the issue originally suggested — the proxy step fails `expected "US", got null`, which is the silent corruption that motivates the gating.

`final_stage_sql.spec.ts` covers eligibility; `connection.controller.spec.ts` pins that the controller applies the verdict and what an unfinalizable statement reports.

Server suite green: 3662 unit, 410 integration. Two hammer scenarios (`quoted-persist-name`, `quoted-persist-name-colocated`) are red on `main` and untouched here — they fail at `createMaterialization` with the 424 introduced by #1106, which deliberately changed the behaviour they pin.

## Docs

`api-doc.yaml` on both `sqlQuery` endpoints, a `[Unreleased]` note, and `docs/connections.md` writes down the proxy passthrough as load-bearing, which nothing recorded before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
